### PR TITLE
Make group traversal take `groupid` as well as `pubid`

### DIFF
--- a/h/services/group.py
+++ b/h/services/group.py
@@ -24,13 +24,12 @@ class GroupService(object):
 
     def fetch(self, pubid_or_groupid):
         """
-        Fetch a group, using either a groupid or a pubid
+        Fetch a group using either a groupid or a pubid.
 
-        :param pubid_or_groupid: a string in either :mod:`~h.pubid` format
-                                 or as :attribute:`~h.models.group.Group.groupid`
-        :rtype:`~h.models.group.Group` or None
+        :arg pubid_or_groupid: a string in either :mod:`~h.pubid` format
+            or as :attr:`h.models.Group.groupid`
+        :rtype: :class:`~h.models.Group` or ``None``
         """
-
         if group_util.is_groupid(pubid_or_groupid):
             return self.fetch_by_groupid(pubid_or_groupid)
         return self.fetch_by_pubid(pubid_or_groupid)

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -6,6 +6,7 @@ import sqlalchemy as sa
 
 from h.models import Group, User
 from h.models.group import ReadableBy
+from h.util import group as group_util
 
 
 class GroupService(object):
@@ -25,6 +26,25 @@ class GroupService(object):
         """Fetch a group by ``pubid``"""
 
         return self.session.query(Group).filter_by(pubid=pubid).one_or_none()
+
+    def fetch_by_groupid(self, groupid):
+        """
+        Return a group with the given ``groupid`` combination or None
+
+        :param groupid:     String in groupid format, e.g. ``group:foo@bar.com``
+                            See :mod:`~h.models.group.Group`
+        :raises ValueError: if ``groupid`` is not a valid groupid
+                            see :func:`h.util.group.split_groupid`
+        :rtype:             `~h.models.group.Group` or None
+        """
+
+        parts = group_util.split_groupid(groupid)
+        authority = parts['authority']
+        authority_provided_id = parts['authority_provided_id']
+
+        return (self.session.query(Group).filter_by(authority=authority)
+                                         .filter_by(authority_provided_id=authority_provided_id)
+                                         .one_or_none())
 
     def groupids_readable_by(self, user):
         """

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -22,8 +22,18 @@ class GroupService(object):
         self.session = session
         self.user_fetcher = user_fetcher
 
-    def fetch(self, pubid):
-        """Fetch a group by ``pubid``"""
+    def fetch(self, pubid_or_groupid):
+        """
+        Fetch a group, using either a groupid or a pubid
+
+        :param pubid_or_groupid: a string in either :mod:`~h.pubid` format
+                                 or as :attribute:`~h.models.group.Group.groupid`
+        :rtype:`~h.models.group.Group` or None
+        """
+
+        if group_util.is_groupid(pubid_or_groupid):
+            return self.fetch_by_groupid(pubid_or_groupid)
+        return self.fetch_by_pubid(pubid_or_groupid)
 
     def fetch_by_pubid(self, pubid):
         """Return a group with the given ``pubid`` or None"""

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -25,6 +25,8 @@ class GroupService(object):
     def fetch(self, pubid):
         """Fetch a group by ``pubid``"""
 
+    def fetch_by_pubid(self, pubid):
+        """Return a group with the given ``pubid`` or None"""
         return self.session.query(Group).filter_by(pubid=pubid).one_or_none()
 
     def fetch_by_groupid(self, groupid):

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -35,20 +35,19 @@ class GroupService(object):
         return self.fetch_by_pubid(pubid_or_groupid)
 
     def fetch_by_pubid(self, pubid):
-        """Return a group with the given ``pubid`` or None"""
+        """Return a group with the given ``pubid`` or ``None``."""
         return self.session.query(Group).filter_by(pubid=pubid).one_or_none()
 
     def fetch_by_groupid(self, groupid):
         """
-        Return a group with the given ``groupid`` combination or None
+        Return a group with the given ``groupid`` or ``None``.
 
-        :param groupid:     String in groupid format, e.g. ``group:foo@bar.com``
-                            See :mod:`~h.models.group.Group`
-        :raises ValueError: if ``groupid`` is not a valid groupid
-                            see :func:`h.util.group.split_groupid`
-        :rtype:             `~h.models.group.Group` or None
+        :arg groupid: String in groupid format, e.g. ``group:foo@bar.com``.
+            See :class:`~h.models.Group`
+        :raises ValueError: if ``groupid`` is not a valid groupid.
+            See :func:`h.util.group.split_groupid`
+        :rtype: :class:`~h.models.Group` or ``None``
         """
-
         parts = group_util.split_groupid(groupid)
         authority = parts['authority']
         authority_provided_id = parts['authority_provided_id']

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -10,7 +10,6 @@ from h.util import group as group_util
 
 
 class GroupService(object):
-
     def __init__(self, session, user_fetcher):
         """
         Create a new groups service.
@@ -49,12 +48,15 @@ class GroupService(object):
         :rtype: :class:`~h.models.Group` or ``None``
         """
         parts = group_util.split_groupid(groupid)
-        authority = parts['authority']
-        authority_provided_id = parts['authority_provided_id']
+        authority = parts["authority"]
+        authority_provided_id = parts["authority_provided_id"]
 
-        return (self.session.query(Group).filter_by(authority=authority)
-                                         .filter_by(authority_provided_id=authority_provided_id)
-                                         .one_or_none())
+        return (
+            self.session.query(Group)
+            .filter_by(authority=authority)
+            .filter_by(authority_provided_id=authority_provided_id)
+            .one_or_none()
+        )
 
     def groupids_readable_by(self, user):
         """
@@ -65,13 +67,18 @@ class GroupService(object):
 
         :type user: `h.models.user.User`
         """
-        readable = (Group.readable_by == ReadableBy.world)
+        readable = Group.readable_by == ReadableBy.world
 
         if user is not None:
-            readable_member = sa.and_(Group.readable_by == ReadableBy.members, Group.members.any(User.id == user.id))
+            readable_member = sa.and_(
+                Group.readable_by == ReadableBy.members,
+                Group.members.any(User.id == user.id),
+            )
             readable = sa.or_(readable, readable_member)
 
-        return [record.pubid for record in self.session.query(Group.pubid).filter(readable)]
+        return [
+            record.pubid for record in self.session.query(Group.pubid).filter(readable)
+        ]
 
     def groupids_created_by(self, user):
         """
@@ -84,11 +91,12 @@ class GroupService(object):
         if user is None:
             return []
 
-        return [g.pubid for g in self.session.query(Group.pubid).filter_by(creator=user)]
+        return [
+            g.pubid for g in self.session.query(Group.pubid).filter_by(creator=user)
+        ]
 
 
 def groups_factory(context, request):
     """Return a GroupService instance for the passed context and request."""
-    user_service = request.find_service(name='user')
-    return GroupService(session=request.db,
-                        user_fetcher=user_service.fetch)
+    user_service = request.find_service(name="user")
+    return GroupService(session=request.db, user_fetcher=user_service.fetch)

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -209,8 +209,8 @@ class GroupRoot(object):
         self.request = request
         self.group_service = request.find_service(name='group')
 
-    def __getitem__(self, pubid):
-        group = self.group_service.fetch(pubid=pubid)
+    def __getitem__(self, pubid_or_groupid):
+        group = self.group_service.fetch(pubid_or_groupid)
         if group is None:
             raise KeyError()
         return group

--- a/h/util/group.py
+++ b/h/util/group.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 
 import re
 
+GROUPID_PATTERN = r'^group:([^@]+)@(.*)$'
+
 
 def split_groupid(groupid):
     """Return the ``authority_provided_id`` and ``authority`` from a ``groupid``
@@ -14,10 +16,20 @@ def split_groupid(groupid):
     :raises ValueError: if the given groupid isn't a valid groupid
 
     """
-    match = re.match(r'^group:([^@]+)@(.*)$', groupid)
+    match = re.match(GROUPID_PATTERN, groupid)
     if match:
         return {
             'authority_provided_id': match.groups()[0],
             'authority': match.groups()[1]
         }
     raise ValueError("{groupid} isn't a valid groupid".format(groupid=groupid))
+
+
+def is_groupid(maybe_groupid):
+    """
+    Helper function to determine if a string looks like it is a groupid
+
+    :type maybe_groupid: str
+    :rtype: bool
+    """
+    return re.match(GROUPID_PATTERN, maybe_groupid) is not None

--- a/h/util/group.py
+++ b/h/util/group.py
@@ -26,10 +26,5 @@ def split_groupid(groupid):
 
 
 def is_groupid(maybe_groupid):
-    """
-    Helper function to determine if a string looks like it is a groupid
-
-    :type maybe_groupid: str
-    :rtype: bool
-    """
+    """Return True if the given string looks like a groupid, else False."""
     return re.match(GROUPID_PATTERN, maybe_groupid) is not None

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -15,16 +15,18 @@ from tests.common.matchers import Matcher
 
 class TestGroupServiceFetch(object):
 
+class TestGroupServiceFetchByPubid(object):
+
     def test_it_returns_group_model(self, svc, factories):
         group = factories.Group()
 
-        fetched_group = svc.fetch(group.pubid)
+        fetched_group = svc.fetch_by_pubid(group.pubid)
 
         assert fetched_group == group
         assert isinstance(fetched_group, Group)
 
     def test_it_returns_None_if_no_group_found(self, svc):
-        group = svc.fetch('abcdeff')
+        group = svc.fetch_by_pubid('abcdeff')
 
         assert group is None
 

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -15,6 +15,23 @@ from tests.common.matchers import Matcher
 
 class TestGroupServiceFetch(object):
 
+    def test_it_proxies_to_fetch_by_groupid_if_groupid_valid(self, svc):
+        svc.fetch_by_groupid = mock.Mock()
+
+        result = svc.fetch('group:something@somewhere.com')
+
+        assert svc.fetch_by_groupid.called_once_with('group:something@somewhere.com')
+        assert result == svc.fetch_by_groupid.return_value
+
+    def test_it_proxies_to_fetch_by_pubid_if_not_groupid_syntax(self, svc):
+        svc.fetch_by_pubid = mock.Mock()
+
+        result = svc.fetch('abcdppp')
+
+        assert svc.fetch_by_pubid.called_once_with('abcdppp')
+        assert result == svc.fetch_by_pubid.return_value
+
+
 class TestGroupServiceFetchByPubid(object):
 
     def test_it_returns_group_model(self, svc, factories):

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -29,6 +29,24 @@ class TestGroupServiceFetch(object):
         assert group is None
 
 
+class TestGroupServiceFetchByGroupid(object):
+
+    def test_it_returns_group_model_of_matching_group(self, svc, factories):
+        group = factories.Group(authority_provided_id='dingdong',
+                                authority='foo.com')
+
+        fetched_group = svc.fetch_by_groupid(group.groupid)
+
+        assert isinstance(fetched_group, Group)
+
+    def test_it_raises_ValueError_if_invalid_groupid(self, svc):
+        with pytest.raises(ValueError, match="isn't a valid groupid"):
+            svc.fetch_by_groupid('fiddlesticks')
+
+    def test_it_returns_None_if_no_matching_group(self, svc):
+        assert svc.fetch_by_groupid('group:rando@dando.com') is None
+
+
 class TestGroupServiceGroupIds(object):
     """Unit tests for methods related to group IDs:
         - :py:meth:`GroupService.groupids_readable_by`

--- a/tests/h/util/group_test.py
+++ b/tests/h/util/group_test.py
@@ -34,3 +34,24 @@ class TestSplitGroupID(object):
     def test_it_raises_ValueError_on_invalid_groupids(self, groupid):
         with pytest.raises(ValueError, match='valid groupid'):
             group_util.split_groupid(groupid)
+
+
+class TestIsGroupid(object):
+
+    @pytest.mark.parametrize('maybe_groupid,result', [
+        ('group:flashbang@dingdong.com', True),
+        ('group::ffff@dingdong.com', True),
+        ('group:\\f!orklift@sprongle.co', True),
+        ('group:.@dingdong.com', True),
+        ('group:group:@yep.nope', True),
+        ('group:()@hi.co', True),
+        ("group:!.~--_*'@hi.co", True),
+        ('groupp:whatnot@dingdong.co', False),
+        ('grou:whatnot@dingdong.co', False),
+        ('group:@dingdog.com', False),
+        ('group:@', False),
+        ('whatnot@dingdong.co', False),
+        ('group:@@dingdong.com', False)
+        ])
+    def test_it_detects_groupid_validity(self, maybe_groupid, result):
+        assert group_util.is_groupid(maybe_groupid) is result


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/287

This PR updates the `group` service (and by extension group traversal) to be able to fetch a group by _either_ `pubid` or `groupid`. Nothing is making use of the `groupid` variant, yet, but we'll need to soon. 