### PR TITLE
Bug/ie11 page formatting

### DIFF
--- a/h/static/styles/partials/_typography.scss
+++ b/h/static/styles/partials/_typography.scss
@@ -6,7 +6,7 @@
 // TODO: Implement base font sizes of 14px/15px/16px
 // TODO: Add margins to establish vertical baseline rhythm
 
-// Roughly matches <h1> site on web; may or may not be used in products
+// Roughly matches <h1> on web; may or may not be used in products
 .heading--xlarge {
   font-size: 2em;
   line-height: 1.25;

--- a/h/static/styles/partials/_typography.scss
+++ b/h/static/styles/partials/_typography.scss
@@ -24,6 +24,7 @@
 // Temporary style to preserve existing design
 .heading--medium-small {
   font-size: 1.25em;
+  line-height: 1.15;
 }
 
 .heading--small {

--- a/h/static/styles/partials/_typography.scss
+++ b/h/static/styles/partials/_typography.scss
@@ -1,0 +1,104 @@
+// Headings
+// --------
+// Heading sizes created using a modular scale.
+// TODO: Use system font stack
+// TODO: Add font-weights
+// TODO: Implement base font sizes of 14px/15px/16px
+// TODO: Add margins to establish vertical baseline rhythm
+
+.heading--xlarge {
+  font-size: 2em;
+  line-height: 1.25;
+}
+
+.heading--large {
+  font-size: 1.625em;
+  line-height: 1.15;
+}
+
+.heading--medium {
+  font-size: 1.375em;
+  line-height: 1.15;
+}
+
+// Temporary style to preserve existing design
+.heading--medium-small {
+  font-size: 1.25em;
+}
+
+.heading--small {
+  font-size: 1.125em;
+  line-height: 1.15;
+}
+
+.heading--xsmall {
+  font-size: 1em;
+  line-height: 1.15;
+}
+
+.heading--separator {
+  font-size: 0.9em;
+  line-height: 1.375;
+  text-transform: uppercase;
+}
+
+.heading--sub {
+  font-size: 1em;
+  line-height: 1.15;
+}
+
+.heading--sup {
+  font-size: 0.9em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+
+@media (min-width: 43.75em) {
+  .heading--xlarge {
+    font-size: 2.5em;
+    line-height: 1.25;
+  }
+
+  .heading--large {
+    font-size: 2em;
+    line-height: 1.25;
+  }
+
+  .heading--medium {
+    font-size: 1.5em;
+    line-height: 1.25;
+  }
+
+  // Temporary style to preserve existing design
+  .heading--medium-small {
+    font-size: 1.375em;
+  }
+
+  .heading--small {
+    line-height: 1.25;
+  }
+
+  .heading--xsmall {
+    line-height: 1.25;
+  }
+}
+
+@media (min-width: 56.25em) {
+  .heading--xlarge {
+    font-size: 3em;
+    line-height: 1.15;
+  }
+
+  .heading--large {
+    font-size: 2.25em;
+  }
+
+  .heading--medium {
+    font-size: 1.75em;
+  }
+
+  // Temporary style to preserve existing design
+  .heading--medium-small {
+    font-size: 1.5em;
+  }
+}

--- a/h/static/styles/partials/_typography.scss
+++ b/h/static/styles/partials/_typography.scss
@@ -6,6 +6,7 @@
 // TODO: Implement base font sizes of 14px/15px/16px
 // TODO: Add margins to establish vertical baseline rhythm
 
+// Roughly matches <h1> site on web; may or may not be used in products
 .heading--xlarge {
   font-size: 2em;
   line-height: 1.25;
@@ -37,17 +38,23 @@
   line-height: 1.15;
 }
 
+// For use in lists of lists, ex. "Annotators," "Tags," "URL," etc.
+// in the right sidebar of a document container on activity pages
 .heading--separator {
   font-size: 0.9em;
   line-height: 1.375;
   text-transform: uppercase;
 }
 
+// For use with meta/context information beneath titles,
+// ex. "In Hypothesis Reading" group identifier on an annotation card
 .heading--sub {
   font-size: 1em;
   line-height: 1.15;
 }
 
+// For use with "parent" info (conceptually or literally),
+// ex. domain name beside a document container on Activity pages
 .heading--sup {
   font-size: 0.9em;
   line-height: 1.15;

--- a/h/static/styles/site.scss
+++ b/h/static/styles/site.scss
@@ -1,6 +1,7 @@
 @import 'partials/base';
 @import 'partials/reset';
 @import 'partials/elements';
+@import 'partials/typography';
 @import 'partials/util';
 
 // Components

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -220,18 +220,18 @@
     <input type="hidden" name="q" value="{{ q }}">
     {% if organization %}
       <div class="search-result-sidebar__organization">
-        <span class="search-result-sidebar__org-logo"> 
+        <span class="search-result-sidebar__org-logo">
           {% if organization.logo %}
             <img src="{{ organization.logo }}" alt="Organization logo" class='search-result-sidebar__logo'></img>
           {% endif %}
         </span>
-        <span class="search-result-sidebar__org-name"> 
+        <span class="search-result-sidebar__org-name">
           {{ organization.name }}
         </span>
       </div>
     {% endif %}
 
-    <h1 class="search-result-sidebar__title">{{ title }}</h1>
+    <h1 class="search-result-sidebar__title heading--medium-small">{{ title }}</h1>
 
     {{ caller() }}
   </form>
@@ -315,7 +315,7 @@
           <p>{{ paragraph }}</p>
         {% endfor %}
       {% endif %}
-    
+
       <div class="search-result-sidebar__subsection">
       {% if stats.annotation_count %}
         <p class="search-result-sidebar__subsection-p">


### PR DESCRIPTION
_Partially fixes https://github.com/hypothesis/private-issues/issues/18_

This PR adds a set of heading styles based on a responsive modular scale, with a greater spread of sizes than currently available in `h`. One bespoke size has been inserted into the scale to more closely match the current design of the heading that prompted this bug, which was necessary in advance of a more complete effort to address general Hypothesis typography.

![ie11-page-formatting](https://user-images.githubusercontent.com/1348738/47687858-8f952780-db9f-11e8-82c8-7fa48a1c854e.png)

*Class naming*
Although these roughly approximate `<h1>` to `<h6>` (with a couple of extra specific cases), the styles are contained in classes rather than being applied to tags, to keep markup independent of presentation. Also, because the eventual aim is to have one general use set of headings across `h` and the `client`, the classes are named according to size (ex. `heading--small`).

*Responsive*
The scale is based on a 14px base font size by default, with steps up to 15px and 16px at larger screen sizes.

![responsive modular scale](https://user-images.githubusercontent.com/1348738/47689315-b30fa080-dba6-11e8-8922-ec923e4ab2fa.png)

*Notes:*
- The `--xlarge` size roughly matches the `<h1>` size on our marketing site, and may or may not be used in our products.
- `heading--separator` is intended for use in lists of lists, such as "Annotators" and "URL" in the right column of an annotated document container on Activity Pages.
- `heading--sub` is intended for meta information beneath a title, such as the group an annotation belongs to (ex. "In [••] Hypothesis Reading" under a username)
- `heading--sup` is intended for "parent" info above a title (conceptually or literally), such as the domain name beside a document container on Activity Pages, or an organization name above a group name.