### PR TITLE
Bump CSS reset (normalize.css)

### DIFF
--- a/h/static/styles/mixins/_reset.scss
+++ b/h/static/styles/mixins/_reset.scss
@@ -1,15 +1,3 @@
-@mixin reset-font {
-  font: inherit;
-  font-size: 100%;
-  vertical-align: baseline;
-}
-
-@mixin reset-box-model {
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-
 /** Remove default border, background and padding from <button> elements. */
 @mixin reset-button {
   background: none;

--- a/h/static/styles/partials/_base.scss
+++ b/h/static/styles/partials/_base.scss
@@ -1,7 +1,20 @@
+// 1. Fixes for https://github.com/hypothesis/h/issues/4236
+// --------------------------------------------------------
+
+html {
+  display: flex; // 1
+}
+
 body {
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
+  min-height: 100vh; // 1
+  width: 100vw; // 1
+}
+
+main {
+  flex-grow: 1; // 1
 }
 
 // Color palette

--- a/h/static/styles/partials/_reset.scss
+++ b/h/static/styles/partials/_reset.scss
@@ -1,59 +1,28 @@
-/*
-  Consistency fixes
-  adopted from http://necolas.github.com/normalize.css/
-  */
+/*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
+@import "normalize.css/normalize";
 
-* {
+/**
+ * Legacy list rules from previous Hypothesis reset
+ * (also based on Normalize.css, but an earlier version)
+ * ========================================================================== */
+
+*,
+*:after,
+*:before {
   box-sizing: border-box;
 }
 
-html {
-  height: 100%;
-  text-size-adjust: 100%;
-}
-
-body {
-  min-height: 100%;
-  font-size: 100%;
-  margin: 0;
-}
-
-sub, sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-}
-
-sup {
-  top: -.5em;
-}
-
-sub {
-  bottom: -.25em;
-}
-
-pre {
-  white-space: pre;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-}
-
-b, strong {
-  font-weight: bold;
-}
-
-abbr[title] {
-  border-bottom: 1px dotted;
-}
-
-a img, img {
-  -ms-interpolation-mode: bicubic;
-}
-
 input, textarea, button, select {
-  @include reset-font;
-  line-height: normal;
+  font: inherit;
+  font-size: 100%;
+  vertical-align: baseline;
+}
+
+ul, ol, li {
+  border: 0;
+  list-style: none;
   margin: 0;
+  padding: 0;
 }
 
 button,
@@ -62,25 +31,4 @@ input[type="reset"],
 input[type="submit"] {
   cursor: pointer;
   -webkit-appearance: button;
-}
-
-textarea {
-  overflow: auto;
-}
-
-img::selection,
-img::-moz-selection {
-  background: transparent;
-}
-
-ul, ol, li {
-  @include reset-box-model;
-}
-
-ul, ol {
-  list-style: none;
-}
-
-blockquote {
-  margin: 0;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7769,6 +7769,11 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
+    "normalize.css": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.0.tgz",
+      "integrity": "sha512-iXcbM3NWr0XkNyfiSBsoPezi+0V92P9nj84yVV1/UZxRUrGczgX/X91KMAGM0omWLY2+2Q1gKD/XRn4gQRDB2A=="
+    },
     "now-and-later": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "keyboardevent-key-polyfill": "^1.0.2",
     "mkdirp": "^0.5.1",
     "node-sass": "^4.9.3",
+    "normalize.css": "^8.0.0",
     "popper.js": "^1.14.4",
     "postcss": "^6.0.21",
     "postcss-url": "^7.3.1",

--- a/scripts/gulp/create-style-bundle.js
+++ b/scripts/gulp/create-style-bundle.js
@@ -35,7 +35,10 @@ function compileSass(options) {
     sass.render({
       file: options.input,
       importer: options.onImport,
-      includePaths: [path.dirname(options.input)],
+      includePaths: [
+        path.dirname(options.input),
+        'node_modules',
+      ],
       outputStyle: options.minify ? 'compressed' : 'nested',
       sourceMap: sourcemapPath,
     }, (err, result) => {


### PR DESCRIPTION
_Fixes https://github.com/hypothesis/h/issues/4236_

Giving our reset a bump, since Normalize 8.0.0 has been released since our last update. In addressing a few small issues that cropped up with the revised reset, I came across https://github.com/hypothesis/h/issues/4236, which I'd seen before. Adding a few styles fixes the issue, tested and working in Chrome, Firefox and Safari on macOS; and IE11 and Chrome on Win7.

## Before:
![screen shot 2018-10-30 at 4 12 10 pm](https://user-images.githubusercontent.com/1348738/47756812-d8f97b80-dc60-11e8-9fc1-9e0f6cb96980.png)

## After:
![screen shot 2018-10-30 at 4 12 45 pm](https://user-images.githubusercontent.com/1348738/47756823-deef5c80-dc60-11e8-9784-c9d172d6c63e.png)

Also, two of the mixins in `mixins/_reset.scss` were used exactly once, so I moved those into the main file. If the need to reuse them elsewhere arises, we can abstract them again.