### PR TITLE
Refactor GroupCreateService to allow passing authority_provided_id

### DIFF
--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -96,7 +96,7 @@ class GroupCreateService(object):
                             )
 
     def _create(self, name, userid, description, type_flags,
-                origins, add_creator_as_member=False, organization=None):
+                origins, add_creator_as_member, organization=None):
         """
         Create a group and save it to the DB.
 

--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -23,7 +23,7 @@ class GroupCreateService(object):
         self.user_fetcher = user_fetcher
         self.publish = publish
 
-    def create_private_group(self, name, userid, description=None, organization=None):
+    def create_private_group(self, name, userid, **kwargs):
         """
         Create a new private group.
 
@@ -31,22 +31,19 @@ class GroupCreateService(object):
 
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
-        :param description: the description of the group
-        :param organization: the organization that this group belongs to
-        :type organization: h.models.Organization
+        :param kwargs: optional attributes to set on the group, as keyword
+            arguments
 
         :returns: the created group
         """
         return self._create(name=name,
                             userid=userid,
-                            description=description,
                             type_flags=PRIVATE_GROUP_TYPE_FLAGS,
                             origins=[],
                             add_creator_as_member=True,
-                            organization=organization,
-                            )
+                            **kwargs)
 
-    def create_open_group(self, name, userid, origins, description=None, organization=None):
+    def create_open_group(self, name, userid, origins, **kwargs):
         """
         Create a new open group.
 
@@ -55,22 +52,19 @@ class GroupCreateService(object):
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
         :param origins: the list of origins that the group will be scoped to
-        :param description: the description of the group
-        :param organization: the organization that this group belongs to
-        :type organization: h.models.Organization
+        :param kwargs: optional attributes to set on the group, as keyword
+            arguments
 
         :returns: the created group
         """
         return self._create(name=name,
                             userid=userid,
-                            description=description,
                             type_flags=OPEN_GROUP_TYPE_FLAGS,
                             origins=origins,
                             add_creator_as_member=False,
-                            organization=organization,
-                            )
+                            **kwargs)
 
-    def create_restricted_group(self, name, userid, origins, description=None, organization=None):
+    def create_restricted_group(self, name, userid, origins, **kwargs):
         """
         Create a new restricted group.
 
@@ -80,52 +74,51 @@ class GroupCreateService(object):
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
         :param origins: the list of origins that the group will be scoped to
-        :param description: the description of the group
-        :param organization: the organization that this group belongs to
-        :type organization: h.models.Organization
+        :param kwargs: optional attributes to set on the group, as keyword
+            arguments
 
         :returns: the created group
         """
         return self._create(name=name,
                             userid=userid,
-                            description=description,
                             type_flags=RESTRICTED_GROUP_TYPE_FLAGS,
                             origins=origins,
                             add_creator_as_member=True,
-                            organization=organization,
-                            )
+                            **kwargs)
 
-    def _create(self, name, userid, description, type_flags,
-                origins, add_creator_as_member, organization=None):
+    def _create(
+        self, name, userid, type_flags, origins, add_creator_as_member, **kwargs
+    ):
         """
         Create a group and save it to the DB.
 
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
-        :param description: the description of the group
         :param type_flags: the type of this group
         :param origins: the list of origins that the group will be scoped to
         :param add_creator_as_member: if the group creator should be added as a member
-        :param organization: the organization that this group belongs to
-        :type organization: h.models.Organization
+        :param kwargs: optional attributes to set on the group, as keyword
+            arguments
         """
         if origins is None:
             origins = []
 
         creator = self.user_fetcher(userid)
+
         scopes = [GroupScope(origin=o) for o in origins]
-        if organization is not None:
-            self._validate_authorities_match(creator.authority, organization.authority)
+
+        if "organization" in kwargs:
+            self._validate_authorities_match(creator.authority,
+                                             kwargs["organization"].authority)
+
         group = Group(name=name,
                       authority=creator.authority,
                       creator=creator,
-                      description=description,
                       joinable_by=type_flags.joinable_by,
                       readable_by=type_flags.readable_by,
                       writeable_by=type_flags.writeable_by,
                       scopes=scopes,
-                      organization=organization,
-                      )
+                      **kwargs)
         self.session.add(group)
 
         if add_creator_as_member:

--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -41,6 +41,7 @@ class GroupCreateService(object):
                             userid=userid,
                             description=description,
                             type_flags=PRIVATE_GROUP_TYPE_FLAGS,
+                            origins=[],
                             add_creator_as_member=True,
                             organization=organization,
                             )
@@ -95,7 +96,7 @@ class GroupCreateService(object):
                             )
 
     def _create(self, name, userid, description, type_flags,
-                origins=None, add_creator_as_member=False, organization=None):
+                origins, add_creator_as_member=False, organization=None):
         """
         Create a group and save it to the DB.
 

--- a/tests/h/services/group_create_test.py
+++ b/tests/h/services/group_create_test.py
@@ -42,7 +42,9 @@ class TestCreatePrivateGroup(object):
         assert group.creator == creator
 
     def test_it_sets_description_when_present(self, svc, creator):
-        group = svc.create_private_group('Anteater fans', creator.userid, 'all about ant eaters')
+        group = svc.create_private_group(
+            "Anteater fans", creator.userid, description="all about ant eaters"
+        )
 
         assert group.description == 'all about ant eaters'
 


### PR DESCRIPTION
1. Make `origins` and `add_creator_as_member` required arguments to `_create()`, and make sure the three `create_*_group()` methods always pass them
2. Replace the optional arguments `description` and `organization` on all four methods with `**kwargs`.

The four methods still list their _required_ arguments separately as positional arguments:

* `name` and `userid`
* `origins` (for open and restricted groups only)
* `type_flags` and `add_creator_as_member` for `_create()`. These two can't be set by the caller of `CreateGroupService`, the correct values are hard-coded in the `create_*_group()` methods that pass them in to `_create()`

This means we can add new attributes in the future by just passing them in as `kwargs`, without modifying the `GroupCreateService` code.

## Interface change

The interface of the `create_*_group()` methods has changed slightly in that `description` and `organization` can no longer be passed as positional arguments, must be passed as keyword arguments.

## Usage

```python
>>> pg = group_create_svc.create_private_group("my_group", "acct:user@hypothes.is", authority_provided_id="abc321")
>>> pg.groupid
'group:abc321@hypothes.is'
```

## New crashes and invalid data possibilities

This change does mean that it's possible to set some attributes on `Group` objects that it wasn't possible to set before because `kwargs` are passed through to the model blindly, and we're relying on code that calls `CreateGroupService` to pass sensible values for `kwargs`. This is also true of the existing `GroupUpdateService`.

For example this will successfully create a group in the DB with `pubid` `"foo"`:

```python
>>> group_create_svc.create_private_group("my_group", "acct:user@hypothes.is", pubid="foo")
```

You can also set `Group.id` directly.

If you pass `authority`, `scopes`, `creator`, `joinable_by`, etc to `create_*_group()` you'll get:

```python
>>> group_create_svc.create_private_group("my_group", "acct:user@hypothes.is", authority="partner.org")
TypeError: DeclarativeMeta object got multiple values for keyword argument 'authority'
```

If you pass `type_flags`, `origins` or `add_creator_as_member` you'll get:

```python
>>> group_create_svc.create_private_group("my_group", "acct:user@hypothes.is", type_flags=OPEN_GROUP_TYPE_FLAGS)
TypeError: _create() got multiple values for keyword argument 'type_flags'
```

Trying to pass `origins` to `create_private_group()` will also crash (private groups can't be scoped) but `origins` is valid for `create_open_group()` or `create_restricted_group()`.

## Removed arguments documentation

We're also no longer documenting the valid optional arguments to `create_*_group()` (`description`, `organization`, `authority_provided_id`) in the docstring, even though they're a limited subset of `models.Group` attributes that isn't documented anywhere.

## Tests

I haven't added any. I moved `description` and `organization` into `kwargs` and, since there are already tests for `description` and `organization`, there are already tests for `kwargs`. Adding a test for e.g. `authority_provided_id` wouldn't add anything.