### PR TITLE
Add rudimentary documentation for `groupid` in group responses

### DIFF
--- a/docs/_extra/api-reference/schemas/group.yaml
+++ b/docs/_extra/api-reference/schemas/group.yaml
@@ -7,6 +7,7 @@ Group:
     - organization
     - public
     - scoped
+    - groupid
     - type
   properties:
     id:
@@ -32,6 +33,9 @@ Group:
       type: boolean
       deprecated: true
       description: Indicates whether a group's annotations are world-readable
+    groupid:
+      type: string
+      description: <mark>NEW/EXPERIMENTAL</mark> Authority-unique identifier that may be set for groups that are owned by a third-party authority. This field is currently present but unused for first-party-authority groups.
     scoped:
       type: boolean
       description: Whether or not this group has URL restrictions for documents that may be annotated within it. Non-scoped groups allow annotation to documents at any URL


### PR DESCRIPTION
Merge https://github.com/hypothesis/h/pull/5404 first.

This PR adds very rudimentary documentation to the API docs for the `groupid` field in group responses. It does not add docs to the request body params for create-group yet as that is not quite yet supported.

I don't think these docs are great and are going to need expansion, but I think it'll be easier to draw a picture of what this field does once we accept it for AuthClient requests to create/update groups.

The new field shows up in the docs for the _responses_ of `POST /api/groups` and `GET /api/groups`:

![image](https://user-images.githubusercontent.com/439947/47919056-c3fd3200-de84-11e8-90de-d0ca2954227b.png)
