### PR TITLE
Make `CreateGroupAPISchema` and `POST /api/groups` support `groupid` property

### DIFF
--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -35,20 +35,38 @@ class CreateGroupAPISchema(JSONSchema):
         ],
     }
 
-    @staticmethod
-    def validate_groupid(appstruct, group_authority, default_authority):
+    def __init__(self, group_authority=None, default_authority=None):
         """
-        Validate the groupid property. A non-None groupid is only allowed if the
-        authority the group will be associated with is not the default authority
-        (i.e. third-party authority only).
-
-        Mutates and returns ``appstruct``, adding ``groupid`` entries if present
-        and valid.
+        The ``group_authority`` and ``default_authority`` properties are used
+        to validate a ``groupid`` field in data. If the caller does not intend
+        to pass any data dicts that contain a ``groupid`` entry, these
+        properties are optional.
 
         :param group_authority:   The authority that is be associated with the group
         :param default_authority: The service's default authority; if it is the same as
                                   ``group_authority``, then this is considered a
                                   "first-party" group
+        """
+        super(CreateGroupAPISchema, self).__init__()
+        self.group_authority = group_authority
+        self.default_authority = default_authority
+
+    def validate(self, data):
+        appstruct = super(CreateGroupAPISchema, self).validate(data)
+        groupid_parts = self._validate_groupid(appstruct)
+        if groupid_parts is not None:
+            appstruct['authority_provided_id'] = groupid_parts['authority_provided_id']
+
+        return appstruct
+
+    def _validate_groupid(self, appstruct):
+        """
+        Validate the groupid property on appstruct and return its constituent
+        parts if successful. A non-None groupid is only allowed if the authority
+        the group will be associated with is not the default authority
+        (i.e. third-party authority only).
+
+
         :raises ValidationError: * if ``groupid`` is not allowed for the applied authority
                                  * if ``groupid`` is not in proper format
                                  * if the ``authority`` part of ``groupid`` does not match
@@ -58,22 +76,17 @@ class CreateGroupAPISchema(JSONSchema):
         """
         groupid = appstruct.get('groupid', None)
         if groupid is None:
-            return appstruct
+            return None
 
-        if (group_authority is None) or (group_authority == default_authority):
+        if (self.group_authority is None) or (self.group_authority == self.default_authority):
             raise ValidationError(
                 "groupid may only be set on groups oustide of the default authority '{authority}'".format(
-                    authority=default_authority
+                    authority=self.default_authority
                 ))
 
-        try:
-            groupid_parts = split_groupid(groupid)
-        except ValueError:
-            raise ValidationError("'{groupid}' does not match valid groupid format: '{pattern}'".format(
-                groupid=groupid,
-                pattern=GROUPID_PATTERN))
+        groupid_parts = split_groupid(groupid)
 
-        if groupid_parts['authority'] != group_authority:
+        if groupid_parts['authority'] != self.group_authority:
             raise ValidationError("Invalid authority '{authority}' in groupid '{groupid}'".format(
                 authority=groupid_parts['authority'],
                 groupid=groupid))

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -7,9 +7,8 @@ from h.models.group import (
     GROUP_NAME_MIN_LENGTH,
     GROUP_NAME_MAX_LENGTH,
     GROUP_DESCRIPTION_MAX_LENGTH,
-    AUTHORITY_PROVIDED_ID_PATTERN,
-    AUTHORITY_PROVIDED_ID_MAX_LENGTH,
 )
+from h.util.group import GROUPID_PATTERN
 
 
 class CreateGroupAPISchema(JSONSchema):
@@ -28,8 +27,7 @@ class CreateGroupAPISchema(JSONSchema):
             },
             'groupid': {
                 'type': 'string',
-                'pattern': AUTHORITY_PROVIDED_ID_PATTERN,
-                'maxLength': AUTHORITY_PROVIDED_ID_MAX_LENGTH,
+                'pattern': GROUPID_PATTERN,
             },
         },
         'required': [

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -7,6 +7,8 @@ from h.models.group import (
     GROUP_NAME_MIN_LENGTH,
     GROUP_NAME_MAX_LENGTH,
     GROUP_DESCRIPTION_MAX_LENGTH,
+    AUTHORITY_PROVIDED_ID_PATTERN,
+    AUTHORITY_PROVIDED_ID_MAX_LENGTH,
 )
 
 
@@ -23,6 +25,11 @@ class CreateGroupAPISchema(JSONSchema):
             'description': {
                 'type': 'string',
                 'maxLength': GROUP_DESCRIPTION_MAX_LENGTH,
+            },
+            'groupid': {
+                'type': 'string',
+                'pattern': AUTHORITY_PROVIDED_ID_PATTERN,
+                'maxLength': AUTHORITY_PROVIDED_ID_MAX_LENGTH,
             },
         },
         'required': [

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from h.schemas.base import JSONSchema
+from h.schemas.base import JSONSchema, ValidationError
 from h.models.group import (
     GROUP_NAME_MIN_LENGTH,
     GROUP_NAME_MAX_LENGTH,
@@ -36,3 +36,19 @@ class CreateGroupAPISchema(JSONSchema):
             'name'
         ],
     }
+
+    @staticmethod
+    def validate_groupid(appstruct, group_authority, default_authority):
+        """
+        Validate the groupid property. A non-None groupid is only allowed if the
+        authority the group will be associated with is not the default authority
+        (i.e. third-party authority only)
+
+        :raises ValidationError: if ``groupid`` is not allowed for the applied authority
+        """
+        groupid = appstruct.get('groupid', None)
+        if groupid is None:
+            return
+
+        if (group_authority is None) or (group_authority == default_authority):
+            raise ValidationError('`groupid` may not be set for groups in the default authority')

--- a/h/util/group.py
+++ b/h/util/group.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import re
 
-GROUPID_PATTERN = r'^group:([^@]+)@(.*)$'
+GROUPID_PATTERN = r"^group:([a-zA-Z0-9._\-+!~*()']{1,1024})@(.*)$"
 
 
 def split_groupid(groupid):

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -42,10 +42,10 @@ def groups(request):
             description='Create a new group')
 def create(request):
     """Create a group from the POST payload."""
-    appstruct = CreateGroupAPISchema().validate(_json_payload(request))
-    CreateGroupAPISchema.validate_groupid(appstruct=appstruct,
-                                          default_authority=request.default_authority,
-                                          group_authority=client_authority(request) or request.default_authority)
+    appstruct = CreateGroupAPISchema(
+        default_authority=request.default_authority,
+        group_authority=client_authority(request) or request.default_authority
+    ).validate(_json_payload(request))
 
     group_create_service = request.find_service(name='group_create')
 
@@ -53,7 +53,7 @@ def create(request):
         name=appstruct['name'],
         userid=request.user.userid,
         description=appstruct.get('description', None),
-        authority_provided_id=appstruct.get('groupid', None),
+        authority_provided_id=appstruct.get('authority_provided_id', None),
     )
     return GroupJSONPresenter(GroupContext(group, request)).asdict(expand=['organization'])
 

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -41,24 +41,16 @@ def groups(request):
             description='Create a new group')
 def create(request):
     """Create a group from the POST payload."""
-    schema = CreateGroupAPISchema()
-
-    appstruct = schema.validate(_json_payload(request))
-    group_properties = {
-        'name': appstruct['name'],
-        'description': appstruct.get('description', None),
-    }
+    appstruct = CreateGroupAPISchema().validate(_json_payload(request))
 
     group_create_service = request.find_service(name='group_create')
 
     group = group_create_service.create_private_group(
-        group_properties['name'],
-        request.user.userid,
-        description=group_properties['description'],
+        name=appstruct['name'],
+        userid=request.user.userid,
+        description=appstruct.get('description', None),
     )
-
-    group_context = GroupContext(group, request)
-    return GroupJSONPresenter(group_context).asdict(expand=['organization'])
+    return GroupJSONPresenter(GroupContext(group, request)).asdict(expand=['organization'])
 
 
 @api_config(route_name='api.group_member',

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -35,6 +35,15 @@ class TestCreateGroup(object):
 
         assert res.status_code == 400
 
+    def test_it_returns_http_400_if_groupid_set_on_default_authority(self, app, token_auth_header):
+        group = {
+            'name': 'My Group',
+            'groupid': '3434kjkjk',
+        }
+        res = app.post_json('/api/groups', group, headers=token_auth_header, expect_errors=True)
+
+        assert res.status_code == 400
+
     def test_it_returns_http_404_if_no_authenticated_user(self, app, auth_client_header):
         # FIXME: This should return a 403
         group = {
@@ -53,9 +62,9 @@ class TestCreateGroup(object):
 
         assert res.status_code == 403
 
-    def test_it_allows_auth_client_with_forwarded_user(self, app, auth_client_header, user):
+    def test_it_allows_auth_client_with_forwarded_user(self, app, auth_client_header, third_party_user):
         headers = auth_client_header
-        headers[native_str('X-Forwarded-User')] = native_str(user.userid)
+        headers[native_str('X-Forwarded-User')] = native_str(third_party_user.userid)
         group = {
             'name': 'My Group'
         }
@@ -64,7 +73,22 @@ class TestCreateGroup(object):
 
         assert res.status_code == 200
 
-    def test_it_returns_http_404_with_invalid_forwarded_user_format(self, app, auth_client_header, user):
+    def test_it_allows_groupdid_from_auth_client_with_forwarded_user(self, app, auth_client_header, third_party_user):
+        headers = auth_client_header
+        headers[native_str('X-Forwarded-User')] = native_str(third_party_user.userid)
+        group = {
+            'name': 'My Group',
+            'groupid': '333vcdfkj~',
+        }
+
+        res = app.post_json('/api/groups', group, headers=headers)
+        data = res.json
+
+        assert res.status_code == 200
+        assert 'groupid' in data
+        assert data['groupid'] == "group:{groupid}@thirdparty.com".format(groupid='333vcdfkj~')
+
+    def test_it_returns_http_404_with_invalid_forwarded_user_format(self, app, auth_client_header):
         # FIXME: This should return a 403
         headers = auth_client_header
         headers[native_str('X-Forwarded-User')] = native_str('floopflarp')
@@ -78,40 +102,45 @@ class TestCreateGroup(object):
 @pytest.mark.functional
 class TestAddMember(object):
 
-    def test_it_returns_http_204_when_successful(self, app, user, group, auth_client_header):
-        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
-                            headers=auth_client_header)
+    def test_it_returns_http_204_when_successful(self, app, third_party_user, third_party_group, auth_client_header):
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=third_party_group.pubid,
+                                                                          userid=third_party_user.userid),
+                                                                          headers=auth_client_header)
 
         assert res.status_code == 204
 
-    def test_it_adds_member_to_group(self, app, user, group, auth_client_header):
-        app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
-                            headers=auth_client_header)
+    def test_it_adds_member_to_group(self, app, third_party_user, third_party_group, auth_client_header):
+        app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=third_party_group.pubid,
+                                                                    userid=third_party_user.userid),
+                                                                    headers=auth_client_header)
 
-        assert user in group.members
+        assert third_party_user in third_party_group.members
 
-    def test_it_ignores_forwarded_user_header(self, app, user, factories, group, db_session, auth_client_header):
+    def test_it_ignores_forwarded_user_header(self, app, third_party_user, factories, third_party_group, db_session, auth_client_header):
         headers = auth_client_header
-        user2 = factories.User()
+        user2 = factories.User(authority='thirdparty.com')
         db_session.commit()
 
-        headers[native_str('X-Forwarded-User')] = native_str(user2.userid)
+        headers[native_str('X-Forwarded-User')] = native_str(third_party_user.userid)
 
-        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
-                            headers=auth_client_header)
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=third_party_group.pubid,
+                                                                          userid=third_party_user.userid),
+                                                                          headers=auth_client_header)
 
-        assert user in group.members
-        assert user2 not in group.members
+        assert third_party_user in third_party_group.members
+        assert user2 not in third_party_group.members
         assert res.status_code == 204
 
-    def test_it_is_idempotent(self, app, user, group, auth_client_header):
-        app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
-                            headers=auth_client_header)
+    def test_it_is_idempotent(self, app, third_party_user, third_party_group, auth_client_header):
+        app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=third_party_group.pubid,
+                                                                    userid=third_party_user.userid),
+                                                                    headers=auth_client_header)
 
-        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
-                            headers=auth_client_header)
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=third_party_group.pubid,
+                                                                          userid=third_party_user.userid),
+                                                                          headers=auth_client_header)
 
-        assert user in group.members
+        assert third_party_user in third_party_group.members
         assert res.status_code == 204
 
     def test_it_returns_404_if_authority_mismatch_on_user(self, app, factories, group, auth_client_header):
@@ -176,8 +205,15 @@ def user(db_session, factories):
 
 
 @pytest.fixture
+def third_party_user(db_session, factories):
+    user = factories.User(authority='thirdparty.com')
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
 def auth_client(db_session, factories):
-    auth_client = factories.ConfidentialAuthClient(authority='example.com',
+    auth_client = factories.ConfidentialAuthClient(authority='thirdparty.com',
                                                    grant_type=GrantType.client_credentials)
     db_session.commit()
     return auth_client
@@ -193,6 +229,13 @@ def auth_client_header(auth_client):
 @pytest.fixture
 def group(db_session, factories):
     group = factories.Group()
+    db_session.commit()
+    return group
+
+
+@pytest.fixture
+def third_party_group(db_session, factories):
+    group = factories.Group(authority='thirdparty.com')
     db_session.commit()
     return group
 

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -78,7 +78,7 @@ class TestCreateGroup(object):
         headers[native_str('X-Forwarded-User')] = native_str(third_party_user.userid)
         group = {
             'name': 'My Group',
-            'groupid': '333vcdfkj~',
+            'groupid': 'group:333vcdfkj~@thirdparty.com',
         }
 
         res = app.post_json('/api/groups', group, headers=headers)

--- a/tests/h/schemas/api/group_test.py
+++ b/tests/h/schemas/api/group_test.py
@@ -7,6 +7,7 @@ from h.models.group import (
     GROUP_NAME_MIN_LENGTH,
     GROUP_NAME_MAX_LENGTH,
     GROUP_DESCRIPTION_MAX_LENGTH,
+    AUTHORITY_PROVIDED_ID_MAX_LENGTH,
 )
 
 from h.schemas.api.group import CreateGroupAPISchema
@@ -66,3 +67,37 @@ class TestCreateGroupSchema(object):
             })
         assert "description:" in str(exc.value)
         assert "is too long" in str(exc.value)
+
+    def test_it_validates_with_valid_groupid(self):
+        schema = CreateGroupAPISchema()
+
+        appstruct = schema.validate({
+            'name': 'This Seems Fine',
+            'groupid': '1234abcd!~*()',
+        })
+
+        assert 'groupid' in appstruct
+
+    def test_it_raises_if_groupid_too_long(self):
+        schema = CreateGroupAPISchema()
+
+        with pytest.raises(ValidationError) as exc:
+            schema.validate({
+                'name': 'Name not the Problem',
+                'groupid': 'o' * (AUTHORITY_PROVIDED_ID_MAX_LENGTH + 1)
+            })
+
+        assert "groupid:" in str(exc.value)
+        assert "is too long" in str(exc.value)
+
+    def test_it_raises_if_groupid_has_invalid_chars(self):
+        schema = CreateGroupAPISchema()
+
+        with pytest.raises(ValidationError) as exc:
+            schema.validate({
+                'name': 'Name not the Problem',
+                'groupid': '&&?'
+            })
+
+        assert "groupid:" in str(exc.value)
+        assert "does not match" in str(exc.value)

--- a/tests/h/schemas/api/group_test.py
+++ b/tests/h/schemas/api/group_test.py
@@ -16,41 +16,34 @@ from h.schemas import ValidationError
 
 class TestCreateGroupSchema(object):
 
-    def test_it_raises_if_name_missing(self):
-        schema = CreateGroupAPISchema()
+    def test_it_sets_authority_properties(self, third_party_schema):
+        assert third_party_schema.group_authority == 'thirdparty.com'
+        assert third_party_schema.default_authority == 'hypothes.is'
+
+    def test_it_raises_if_name_missing(self, schema):
         with pytest.raises(ValidationError, match=".*is a required property.*"):
             schema.validate({})
 
-    def test_it_raises_if_name_too_short(self):
-        schema = CreateGroupAPISchema()
-        with pytest.raises(ValidationError) as exc:
+    def test_it_raises_if_name_too_short(self, schema):
+        with pytest.raises(ValidationError, match="name:.*is too short"):
             schema.validate({
                 'name': 'o' * (GROUP_NAME_MIN_LENGTH - 1)
             })
-        assert "name:" in str(exc.value)
-        assert "is too short" in str(exc.value)
 
-    def test_it_raises_if_name_too_long(self):
-        schema = CreateGroupAPISchema()
-        with pytest.raises(ValidationError) as exc:
+    def test_it_raises_if_name_too_long(self, schema):
+        with pytest.raises(ValidationError, match="name:.*is too long"):
             schema.validate({
                 'name': 'o' * (GROUP_NAME_MAX_LENGTH + 1)
             })
-        assert "name:" in str(exc.value)
-        assert "is too long" in str(exc.value)
 
-    def test_it_validates_with_valid_name(self):
-        schema = CreateGroupAPISchema()
-
+    def test_it_validates_with_valid_name(self, schema):
         appstruct = schema.validate({
             'name': 'Perfectly Fine'
         })
 
         assert 'name' in appstruct
 
-    def test_it_validates_with_valid_description(self):
-        schema = CreateGroupAPISchema()
-
+    def test_it_validates_with_valid_description(self, schema):
         appstruct = schema.validate({
             'name': 'This Seems Fine',
             'description': 'This description seems adequate'
@@ -58,102 +51,77 @@ class TestCreateGroupSchema(object):
 
         assert 'description' in appstruct
 
-    def test_it_raises_if_description_too_long(self):
-        schema = CreateGroupAPISchema()
-        with pytest.raises(ValidationError) as exc:
+    def test_it_raises_if_description_too_long(self, schema):
+        with pytest.raises(ValidationError, match="description:.*is too long"):
             schema.validate({
                 'name': 'Name not the Problem',
                 'description': 'o' * (GROUP_DESCRIPTION_MAX_LENGTH + 1)
             })
-        assert "description:" in str(exc.value)
-        assert "is too long" in str(exc.value)
 
-    def test_it_validates_with_valid_groupid(self):
-        schema = CreateGroupAPISchema()
-
-        appstruct = schema.validate({
+    def test_it_validates_with_valid_groupid_and_third_party_authority(self, third_party_schema):
+        appstruct = third_party_schema.validate({
             'name': 'This Seems Fine',
             'groupid': 'group:1234abcd!~*()@thirdparty.com',
         })
 
         assert 'groupid' in appstruct
 
-    def test_it_raises_if_groupid_too_long(self):
-        schema = CreateGroupAPISchema()
-
-        with pytest.raises(ValidationError) as exc:
+    def test_it_raises_if_groupid_too_long(self, schema):
+        # Because of the complexity of ``groupid`` formatting, the length of the
+        # ``authority_provided_id`` segment of it is defined in the pattern for
+        # valid ``groupid``s — not as a length constraint
+        # Note also that the groupid does not have a valid authority but validation
+        # will raise on the formatting error before that becomes a problem.
+        with pytest.raises(ValidationError, match="groupid:.*does not match"):
             schema.validate({
                 'name': 'Name not the Problem',
                 'groupid': 'group:' + ('o' * (AUTHORITY_PROVIDED_ID_MAX_LENGTH + 1)) + '@foobar.com'
             })
 
-        assert "groupid:" in str(exc.value)
-        # Because of the complexity of ``groupid`` formatting, the length of the
-        # ``authority_provided_id`` segment of it is defined in the pattern for
-        # valid ``groupid``s — not as a length constraint
-        assert "does not match" in str(exc.value)
-
-    def test_it_raises_if_groupid_has_invalid_chars(self):
-        schema = CreateGroupAPISchema()
-
-        with pytest.raises(ValidationError) as exc:
+    def test_it_raises_if_groupid_has_invalid_chars(self, schema):
+        with pytest.raises(ValidationError, match="groupid:.*does not match"):
             schema.validate({
                 'name': 'Name not the Problem',
                 'groupid': 'group:&&?@thirdparty.com'
             })
 
-        assert "groupid:" in str(exc.value)
-        assert "does not match" in str(exc.value)
+    def test_validate_adds_groupid_entries_to_appstruct_when_valid(self, third_party_schema):
+        appstruct = third_party_schema.validate({
+            'name': 'Hello There',
+            'groupid': 'group:finger@thirdparty.com'
+        })
 
-    def test_validate_groupid_does_not_raise_on_groupid_if_third_party(self, appstruct):
-        CreateGroupAPISchema.validate_groupid(appstruct=appstruct,
-                                              group_authority='thirdparty.com',
-                                              default_authority='hypothes.is')
+        assert 'authority_provided_id' in appstruct
+        assert appstruct['authority_provided_id'] == 'finger'
 
-    def test_validate_groupid_does_not_raise_when_groupid_is_None(self, appstruct):
-        appstruct['groupid'] = None
+    def test_authority_provided_id_not_present_in_appstruct_if_no_groupid(self, schema):
+        appstruct = schema.validate({
+            'name': 'Serendipity'
+        })
 
-        CreateGroupAPISchema.validate_groupid(appstruct=appstruct,
-                                              group_authority='hypothes.is',
-                                              default_authority='hypothes.is')
+        assert 'authority_provided_id' not in appstruct
 
-    def test_validate_groupid_raises_ValidationError_if_first_party(self, appstruct):
+    def test_validate_raises_ValidationError_on_groupid_if_first_party(self, schema):
         with pytest.raises(ValidationError, match="groupid may only be set on groups oustide of the default authority"):
-            CreateGroupAPISchema.validate_groupid(appstruct=appstruct,
-                                                  group_authority='hypothes.is',
-                                                  default_authority='hypothes.is')
+            schema.validate({
+                'name': 'Less Good',
+                'groupid': 'group:delicacy@hypothes.is'
+            })
 
-    def test_validate_groupid_raises_ValidationError_if_no_group_authority(self, appstruct):
+    def test_validate_raises_ValidationError_if_no_group_authority(self):
+        schema = CreateGroupAPISchema(default_authority='hypothes.is')
         with pytest.raises(ValidationError, match="groupid may only be set on groups oustide of the default authority"):
-            CreateGroupAPISchema.validate_groupid(appstruct=appstruct,
-                                                  group_authority=None,
-                                                  default_authority='hypothes.is')
+            schema.validate({
+                'name': 'Blustery',
+                'groupid': 'group:delicacy@hypothes.is'
+            })
 
-    def test_validate_groupid_raises_ValidationError_groupid_format_invalid(self, appstruct):
-        appstruct['groupid'] = 'group:++{{":}"}}@thirdparty.com'
-        with pytest.raises(ValidationError, match="does not match valid groupid format"):
-            CreateGroupAPISchema.validate_groupid(appstruct=appstruct,
-                                                  group_authority='thirdparty.com',
-                                                  default_authority='hypothes.is')
-
-    def test_validate_groupid_raises_ValidationError_groupid_authority_mismatch(self, appstruct):
-        appstruct['groupid'] = 'group:valid_id@invalidauthority.com'
+    def test_validate_raises_ValidationError_groupid_authority_mismatch(self, third_party_schema):
         with pytest.raises(ValidationError, match="Invalid authority.*in groupid"):
-            CreateGroupAPISchema.validate_groupid(appstruct=appstruct,
-                                                  group_authority='thirdparty.com',
-                                                  default_authority='hypothes.is')
-
-    def test_validate_groupid_returns_groupid_parts(self, appstruct):
-        appstruct['groupid'] = 'group:hullo@thirdparty.com'
-
-        parts = CreateGroupAPISchema.validate_groupid(appstruct=appstruct,
-                                                      group_authority='thirdparty.com',
-                                                      default_authority='hypothes.is')
-
-        assert 'authority_provided_id' in parts
-        assert 'authority' in parts
-        assert parts['authority_provided_id'] == 'hullo'
-        assert parts['authority'] == 'thirdparty.com'
+            third_party_schema.validate({
+                'name': 'Shambles',
+                'groupid': 'group:valid_id@invalidauthority.com'
+            })
 
     @pytest.fixture
     def appstruct(self):
@@ -162,3 +130,15 @@ class TestCreateGroupSchema(object):
             'name': 'DingDong!',
             'description': 'OH, hello there',
         }
+
+    @pytest.fixture
+    def schema(self):
+        schema = CreateGroupAPISchema(group_authority='hypothes.is',
+                                      default_authority='hypothes.is')
+        return schema
+
+    @pytest.fixture
+    def third_party_schema(self):
+        schema = CreateGroupAPISchema(group_authority='thirdparty.com',
+                                      default_authority='hypothes.is')
+        return schema

--- a/tests/h/schemas/api/group_test.py
+++ b/tests/h/schemas/api/group_test.py
@@ -101,3 +101,34 @@ class TestCreateGroupSchema(object):
 
         assert "groupid:" in str(exc.value)
         assert "does not match" in str(exc.value)
+
+    def test_validate_groupid_does_not_raise_on_groupid_if_third_party(self, appstruct):
+        CreateGroupAPISchema.validate_groupid(appstruct=appstruct,
+                                              group_authority='thirdparty.com',
+                                              default_authority='hypothes.is')
+
+    def test_validate_groupid_does_not_raise_when_groupid_None(self, appstruct):
+        appstruct['groupid'] = None
+        CreateGroupAPISchema.validate_groupid(appstruct=appstruct,
+                                              group_authority='hypothes.is',
+                                              default_authority='hypothes.is')
+
+    def test_validate_groupid_raises_ValidationError_if_first_party(self, appstruct):
+        with pytest.raises(ValidationError, match="groupid.*may not be set"):
+            CreateGroupAPISchema.validate_groupid(appstruct=appstruct,
+                                                  group_authority='hypothes.is',
+                                                  default_authority='hypothes.is')
+
+    def test_validate_groupid_raises_ValidationError_if_no_group_authority(self, appstruct):
+        with pytest.raises(ValidationError, match="groupid.*may not be set"):
+            CreateGroupAPISchema.validate_groupid(appstruct=appstruct,
+                                                  group_authority=None,
+                                                  default_authority='hypothes.is')
+
+    @pytest.fixture
+    def appstruct(self):
+        return {
+            'groupid': 'whatever',
+            'name': 'DingDong!',
+            'description': 'OH, hello there',
+        }

--- a/tests/h/schemas/api/group_test.py
+++ b/tests/h/schemas/api/group_test.py
@@ -73,7 +73,7 @@ class TestCreateGroupSchema(object):
 
         appstruct = schema.validate({
             'name': 'This Seems Fine',
-            'groupid': '1234abcd!~*()',
+            'groupid': 'group:1234abcd!~*()@thirdparty.com',
         })
 
         assert 'groupid' in appstruct
@@ -84,11 +84,14 @@ class TestCreateGroupSchema(object):
         with pytest.raises(ValidationError) as exc:
             schema.validate({
                 'name': 'Name not the Problem',
-                'groupid': 'o' * (AUTHORITY_PROVIDED_ID_MAX_LENGTH + 1)
+                'groupid': 'group:' + ('o' * (AUTHORITY_PROVIDED_ID_MAX_LENGTH + 1)) + '@foobar.com'
             })
 
         assert "groupid:" in str(exc.value)
-        assert "is too long" in str(exc.value)
+        # Because of the complexity of ``groupid`` formatting, the length of the
+        # ``authority_provided_id`` segment of it is defined in the pattern for
+        # valid ``groupid``s — not as a length constraint
+        assert "does not match" in str(exc.value)
 
     def test_it_raises_if_groupid_has_invalid_chars(self):
         schema = CreateGroupAPISchema()
@@ -96,7 +99,7 @@ class TestCreateGroupSchema(object):
         with pytest.raises(ValidationError) as exc:
             schema.validate({
                 'name': 'Name not the Problem',
-                'groupid': '&&?'
+                'groupid': 'group:&&?@thirdparty.com'
             })
 
         assert "groupid:" in str(exc.value)

--- a/tests/h/util/group_test.py
+++ b/tests/h/util/group_test.py
@@ -10,10 +10,9 @@ from h.util import group as group_util
 class TestSplitGroupID(object):
     @pytest.mark.parametrize('groupid,authority_provided_id,authority', [
         ('group:flashbang@dingdong.com', 'flashbang', 'dingdong.com'),
-        ('group::ffff@dingdong.com', ':ffff', 'dingdong.com'),
-        ('group:\\f!orklift@sprongle.co', '\\f!orklift', 'sprongle.co'),
+        ('group:ffff@dingdong.com', 'ffff', 'dingdong.com'),
         ('group:.@dingdong.com', '.', 'dingdong.com'),
-        ('group:group:@yep.nope', 'group:', 'yep.nope'),
+        ('group:group@yep.nope', 'group', 'yep.nope'),
         ('group:()@hi.co', '()', 'hi.co'),
         ("group:!.~--_*'@hi.co", "!.~--_*'", 'hi.co'),
         ])
@@ -30,6 +29,8 @@ class TestSplitGroupID(object):
         'group:@',
         'whatnot@dingdong.co',
         'group:@@dingdong.com',
+        'group:\\f!orklift@sprongle.co',
+        'group:another:@ding.com',
     ])
     def test_it_raises_ValueError_on_invalid_groupids(self, groupid):
         with pytest.raises(ValueError, match='valid groupid'):
@@ -40,10 +41,10 @@ class TestIsGroupid(object):
 
     @pytest.mark.parametrize('maybe_groupid,result', [
         ('group:flashbang@dingdong.com', True),
-        ('group::ffff@dingdong.com', True),
-        ('group:\\f!orklift@sprongle.co', True),
+        ('group::ffff@dingdong.com', False),
+        ('group:\\f!orklift@sprongle.co', False),
         ('group:.@dingdong.com', True),
-        ('group:group:@yep.nope', True),
+        ('group:group@yep.nope', True),
         ('group:()@hi.co', True),
         ("group:!.~--_*'@hi.co", True),
         ('groupp:whatnot@dingdong.co', False),

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -118,11 +118,6 @@ class TestCreateGroup(object):
 
         CreateGroupAPISchema.return_value.validate.assert_called_once_with({})
 
-    def test_it_validates_groupid(self, pyramid_request, CreateGroupAPISchema):
-        views.create(pyramid_request)
-
-        assert CreateGroupAPISchema.validate_groupid.call_count == 1
-
     # @TODO Move this test once _json_payload() has been moved to a reusable util module
     def test_it_raises_if_json_parsing_fails(self, pyramid_request):
         """It raises PayloadError if parsing of the request body fails."""
@@ -161,8 +156,9 @@ class TestCreateGroup(object):
         CreateGroupAPISchema.return_value.validate.return_value = {
           'name': 'My Group',
           'description': 'How about that?',
-          'groupid': 'something',
-         }
+          'groupid': 'group:something@example.com',
+          'authority_provided_id': 'something'
+        }
         views.create(pyramid_request)
 
         group_create_service.create_private_group.assert_called_once_with('My Group',

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -116,7 +116,12 @@ class TestCreateGroup(object):
     def test_it_inits_group_create_schema(self, pyramid_request, CreateGroupAPISchema):
         views.create(pyramid_request)
 
-        CreateGroupAPISchema.assert_called_once_with()
+        CreateGroupAPISchema.return_value.validate.assert_called_once_with({})
+
+    def test_it_validates_groupid(self, pyramid_request, CreateGroupAPISchema):
+        views.create(pyramid_request)
+
+        assert CreateGroupAPISchema.validate_groupid.call_count == 1
 
     # @TODO Move this test once _json_payload() has been moved to a reusable util module
     def test_it_raises_if_json_parsing_fails(self, pyramid_request):
@@ -142,7 +147,28 @@ class TestCreateGroup(object):
 
         group_create_service.create_private_group.assert_called_once_with('My Group',
                                                                           pyramid_request.user.userid,
-                                                                          description='How about that?')
+                                                                          description='How about that?',
+                                                                          authority_provided_id=None)
+
+    def test_it_passes_groupid_to_group_create_as_authority_provided_id(self,
+                                                                        pyramid_request,
+                                                                        CreateGroupAPISchema,
+                                                                        group_create_service):
+        # Note that CreateGroupAPISchema and its methods are mocked here, so
+        # ``groupid`` passes validation even though the request is not third party
+        # Tests for that are handled directly in the CreateGroupAPISchema unit tests
+        # and through functional tests
+        CreateGroupAPISchema.return_value.validate.return_value = {
+          'name': 'My Group',
+          'description': 'How about that?',
+          'groupid': 'something',
+         }
+        views.create(pyramid_request)
+
+        group_create_service.create_private_group.assert_called_once_with('My Group',
+                                                                          pyramid_request.user.userid,
+                                                                          description='How about that?',
+                                                                          authority_provided_id='something')
 
     def test_it_sets_description_to_none_if_not_present(self,
                                                         pyramid_request,
@@ -155,7 +181,8 @@ class TestCreateGroup(object):
 
         group_create_service.create_private_group.assert_called_once_with('My Group',
                                                                           pyramid_request.user.userid,
-                                                                          description=None)
+                                                                          description=None,
+                                                                          authority_provided_id=None)
 
     def test_it_creates_group_context_from_created_group(self,
                                                          pyramid_request,


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/287

Marking WIP for the moment because this ended up being a larger-than-usual diff and the approach changed several times during implementation so I could definitely bear re-looking at this with fresh eyes next week.

This PR does several things related to `groupid` support:

* It includes significant changes to `h.schemas.api.group.CreateGroupSchema` to internalize as much of the `groupid` validation as possible. That validation, however, does need to know something about authorities. I have avoided poisoning the class with `request`, but the constructor now optionally takes a couple of arguments that support the validation of `groupid`.
* The validation logic for `groupid` isn't _heinous_, but required some thought.
* The internalization of the validation logic within the schema has allowed me to keep the view thin. Good times.
* There were starting to be several "opinions" of what a valid `groupid` looks like. I've tried to centralize that logic some now.
* Had to refactor the functional tests for this endpoint some
* Cleaned up the schema's tests an made them more "modern"
