### PR TITLE
Add font-size and line-height to sidebar title

### DIFF
--- a/h/static/styles/partials/_search-result-sidebar.scss
+++ b/h/static/styles/partials/_search-result-sidebar.scss
@@ -6,6 +6,8 @@
 }
 
 .search-result-sidebar__title {
+  font-size: 20px;
+  line-height: 1;
   margin-top: 0;
   margin-bottom: 20px;
 }
@@ -120,7 +122,7 @@
 
 .search-result-sidebar__logo {
   height: 20px;
-  width: 20px; 
+  width: 20px;
 }
 
 @media screen and (max-width: $tablet-width + 250px) {


### PR DESCRIPTION
Partially fixes https://github.com/hypothesis/private-issues/issues/18

General heading work will come later, but for now, this targeted `font-size` and `line-height` address the heading problem mentioned in the issue above. Tested and working in win7/IE11.

<img width="242" alt="screen shot 2018-11-05 at 10 10 34 am" src="https://user-images.githubusercontent.com/1348738/48017711-db862600-e0e3-11e8-94d8-bcfa68b7a743.png">
