### PR TITLE
Add schema and POST endpoint support for `groupid`

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -105,11 +105,18 @@ class Group(Base, mixins.Timestamps):
         Deconstruct a formatted ``groupid`` and set its constituent properties
         on the instance.
 
+        If ``groupid`` is set to None, set ``authority_provided_id`` to None
+        but leave authority untouched—this allows a caller to nullify the
+        ``authority_provided_id`` field.
+
         :raises ValueError: if ``groupid`` is an invalid format
         """
-        groupid_parts = split_groupid(value)
-        self.authority_provided_id = groupid_parts['authority_provided_id']
-        self.authority = groupid_parts['authority']
+        if value is None:
+            self.authority_provided_id = None
+        else:
+            groupid_parts = split_groupid(value)
+            self.authority_provided_id = groupid_parts['authority_provided_id']
+            self.authority = groupid_parts['authority']
 
     # Group membership
     members = sa.orm.relationship(

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -2,12 +2,14 @@
 
 from __future__ import unicode_literals
 
-from h.schemas.base import JSONSchema
+from h.schemas.base import JSONSchema, ValidationError
 from h.models.group import (
     GROUP_NAME_MIN_LENGTH,
     GROUP_NAME_MAX_LENGTH,
     GROUP_DESCRIPTION_MAX_LENGTH,
 )
+from h.util.group import GROUPID_PATTERN, split_groupid
+from h.i18n import TranslationString as _
 
 
 class CreateGroupAPISchema(JSONSchema):
@@ -24,8 +26,70 @@ class CreateGroupAPISchema(JSONSchema):
                 'type': 'string',
                 'maxLength': GROUP_DESCRIPTION_MAX_LENGTH,
             },
+            'groupid': {
+                'type': 'string',
+                'pattern': GROUPID_PATTERN,
+            },
         },
         'required': [
             'name'
         ],
     }
+
+    def __init__(self, group_authority=None, default_authority=None):
+        """
+        The ``group_authority`` and ``default_authority`` properties are used
+        to validate a ``groupid`` field in data. If the caller does not intend
+        to pass any data dicts that contain a ``groupid`` entry, these
+        properties are optional.
+
+        :param group_authority:   The authority that is be associated with the group
+        :param default_authority: The service's default authority; if it is the same as
+                                  ``group_authority``, then this is considered a
+                                  "first-party" group
+        """
+        super(CreateGroupAPISchema, self).__init__()
+        self.group_authority = group_authority
+        self.default_authority = default_authority
+
+    def validate(self, data):
+        """
+        Validate against the JSON schema and also valid any groupid present
+
+        :raises ValidationError: if any part of validation fails
+        """
+        appstruct = super(CreateGroupAPISchema, self).validate(data)
+        self._validate_groupid(appstruct)
+
+        return appstruct
+
+    def _validate_groupid(self, appstruct):
+        """
+        Validate the groupid property on appstruct and return its constituent
+        parts if successful. A non-None groupid is only allowed if the authority
+        the group will be associated with is not the default authority
+        (i.e. third-party authority only).
+
+
+        :raises ValidationError: * if ``groupid`` is not allowed for the applied authority
+                                 * if ``groupid`` is not in proper format
+                                 * if the ``authority`` part of ``groupid`` does not match
+                                   the group (client) authority
+        """
+        groupid = appstruct.get('groupid', None)
+        if groupid is None:
+            return None
+
+        if (self.group_authority is None) or (self.group_authority == self.default_authority):
+            raise ValidationError(
+                "{err_msg} '{authority}'".format(
+                    err_msg=_("groupid may only be set on groups oustide of the default authority"),
+                    authority=self.default_authority
+                ))
+
+        groupid_parts = split_groupid(groupid)
+
+        if groupid_parts['authority'] != self.group_authority:
+            raise ValidationError("{err_msg} '{groupid}'".format(
+                err_msg=_("Invalid authority specified in groupid"),
+                groupid=groupid))

--- a/h/util/group.py
+++ b/h/util/group.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import re
 
-GROUPID_PATTERN = r'^group:([^@]+)@(.*)$'
+GROUPID_PATTERN = r"^group:([a-zA-Z0-9._\-+!~*()']{1,1024})@(.*)$"
 
 
 def split_groupid(groupid):

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -18,6 +18,8 @@ from h.views.api.config import api_config
             link_name='groups.read',
             description="Fetch the user's groups")
 def groups(request):
+    """Retrieve the groups for this request's user."""
+
     authority = request.params.get('authority')
     document_uri = request.params.get('document_uri')
     expand = request.GET.getall('expand') or []
@@ -85,7 +87,7 @@ def remove_member(group, request):
 def add_member(group, request):
     """Add a member to a given group.
 
-    :raises HTTPNotFound: if the user is not found or if the use and group
+    :raise HTTPNotFound: if the user is not found or if the use and group
       authorities don't match.
     """
     user_svc = request.find_service(name='user')
@@ -109,8 +111,7 @@ def add_member(group, request):
 
 # @TODO This is a duplication of code in h.views.api — move to a util module
 def _json_payload(request):
-    """
-    Return a parsed JSON payload for the request.
+    """Return a parsed JSON payload for the request.
 
     :raises PayloadError: if the body has no valid JSON body
     """

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -88,6 +88,19 @@ class TestCreateGroup(object):
         assert 'groupid' in data
         assert data['groupid'] == "group:{groupid}@thirdparty.com".format(groupid='333vcdfkj~')
 
+    def test_it_returns_HTTP_Conflict_if_groupid_is_duplicate(self, app, auth_client_header, third_party_user):
+        headers = auth_client_header
+        headers[native_str('X-Forwarded-User')] = native_str(third_party_user.userid)
+        group = {
+            'name': 'My Group',
+            'groupid': 'group:333vcdfkj~@thirdparty.com',
+        }
+
+        res = app.post_json('/api/groups', group, headers=headers)
+        res = app.post_json('/api/groups', group, headers=headers, expect_errors=True)
+
+        assert res.status_code == 409
+
     def test_it_returns_http_404_with_invalid_forwarded_user_format(self, app, auth_client_header):
         # FIXME: This should return a 403
         headers = auth_client_header

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -35,6 +35,15 @@ class TestCreateGroup(object):
 
         assert res.status_code == 400
 
+    def test_it_returns_http_400_if_groupid_set_on_default_authority(self, app, token_auth_header):
+        group = {
+            'name': 'My Group',
+            'groupid': '3434kjkjk',
+        }
+        res = app.post_json('/api/groups', group, headers=token_auth_header, expect_errors=True)
+
+        assert res.status_code == 400
+
     def test_it_returns_http_404_if_no_authenticated_user(self, app, auth_client_header):
         # FIXME: This should return a 403
         group = {
@@ -53,9 +62,9 @@ class TestCreateGroup(object):
 
         assert res.status_code == 403
 
-    def test_it_allows_auth_client_with_forwarded_user(self, app, auth_client_header, user):
+    def test_it_allows_auth_client_with_forwarded_user(self, app, auth_client_header, third_party_user):
         headers = auth_client_header
-        headers[native_str('X-Forwarded-User')] = native_str(user.userid)
+        headers[native_str('X-Forwarded-User')] = native_str(third_party_user.userid)
         group = {
             'name': 'My Group'
         }
@@ -64,7 +73,22 @@ class TestCreateGroup(object):
 
         assert res.status_code == 200
 
-    def test_it_returns_http_404_with_invalid_forwarded_user_format(self, app, auth_client_header, user):
+    def test_it_allows_groupdid_from_auth_client_with_forwarded_user(self, app, auth_client_header, third_party_user):
+        headers = auth_client_header
+        headers[native_str('X-Forwarded-User')] = native_str(third_party_user.userid)
+        group = {
+            'name': 'My Group',
+            'groupid': 'group:333vcdfkj~@thirdparty.com',
+        }
+
+        res = app.post_json('/api/groups', group, headers=headers)
+        data = res.json
+
+        assert res.status_code == 200
+        assert 'groupid' in data
+        assert data['groupid'] == "group:{groupid}@thirdparty.com".format(groupid='333vcdfkj~')
+
+    def test_it_returns_http_404_with_invalid_forwarded_user_format(self, app, auth_client_header):
         # FIXME: This should return a 403
         headers = auth_client_header
         headers[native_str('X-Forwarded-User')] = native_str('floopflarp')
@@ -78,40 +102,45 @@ class TestCreateGroup(object):
 @pytest.mark.functional
 class TestAddMember(object):
 
-    def test_it_returns_http_204_when_successful(self, app, user, group, auth_client_header):
-        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
-                            headers=auth_client_header)
+    def test_it_returns_http_204_when_successful(self, app, third_party_user, third_party_group, auth_client_header):
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=third_party_group.pubid,
+                                                                          userid=third_party_user.userid),
+                                                                          headers=auth_client_header)
 
         assert res.status_code == 204
 
-    def test_it_adds_member_to_group(self, app, user, group, auth_client_header):
-        app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
-                            headers=auth_client_header)
+    def test_it_adds_member_to_group(self, app, third_party_user, third_party_group, auth_client_header):
+        app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=third_party_group.pubid,
+                                                                    userid=third_party_user.userid),
+                                                                    headers=auth_client_header)
 
-        assert user in group.members
+        assert third_party_user in third_party_group.members
 
-    def test_it_ignores_forwarded_user_header(self, app, user, factories, group, db_session, auth_client_header):
+    def test_it_ignores_forwarded_user_header(self, app, third_party_user, factories, third_party_group, db_session, auth_client_header):
         headers = auth_client_header
-        user2 = factories.User()
+        user2 = factories.User(authority='thirdparty.com')
         db_session.commit()
 
-        headers[native_str('X-Forwarded-User')] = native_str(user2.userid)
+        headers[native_str('X-Forwarded-User')] = native_str(third_party_user.userid)
 
-        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
-                            headers=auth_client_header)
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=third_party_group.pubid,
+                                                                          userid=third_party_user.userid),
+                                                                          headers=auth_client_header)
 
-        assert user in group.members
-        assert user2 not in group.members
+        assert third_party_user in third_party_group.members
+        assert user2 not in third_party_group.members
         assert res.status_code == 204
 
-    def test_it_is_idempotent(self, app, user, group, auth_client_header):
-        app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
-                            headers=auth_client_header)
+    def test_it_is_idempotent(self, app, third_party_user, third_party_group, auth_client_header):
+        app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=third_party_group.pubid,
+                                                                    userid=third_party_user.userid),
+                                                                    headers=auth_client_header)
 
-        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
-                            headers=auth_client_header)
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=third_party_group.pubid,
+                                                                          userid=third_party_user.userid),
+                                                                          headers=auth_client_header)
 
-        assert user in group.members
+        assert third_party_user in third_party_group.members
         assert res.status_code == 204
 
     def test_it_returns_404_if_authority_mismatch_on_user(self, app, factories, group, auth_client_header):
@@ -176,8 +205,15 @@ def user(db_session, factories):
 
 
 @pytest.fixture
+def third_party_user(db_session, factories):
+    user = factories.User(authority='thirdparty.com')
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
 def auth_client(db_session, factories):
-    auth_client = factories.ConfidentialAuthClient(authority='example.com',
+    auth_client = factories.ConfidentialAuthClient(authority='thirdparty.com',
                                                    grant_type=GrantType.client_credentials)
     db_session.commit()
     return auth_client
@@ -193,6 +229,13 @@ def auth_client_header(auth_client):
 @pytest.fixture
 def group(db_session, factories):
     group = factories.Group()
+    db_session.commit()
+    return group
+
+
+@pytest.fixture
+def third_party_group(db_session, factories):
+    group = factories.Group(authority='thirdparty.com')
     db_session.commit()
     return group
 

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -93,6 +93,16 @@ def test_groupid_setter_sets_consistuent_fields(factories):
     assert group.authority == 'threefour.com'
 
 
+def test_groupid_setter_accepts_None_and_nullifies_authority_provided_id(factories):
+    group = factories.Group()
+    group.groupid = 'group:onetwo@threefour.com'
+    group.groupid = None
+
+    assert group.groupid is None
+    assert group.authority == 'threefour.com'
+    assert group.authority_provided_id is None
+
+
 @pytest.mark.parametrize('authority_provided_id', [
     '%%&whatever',
     '^flop',

--- a/tests/h/schemas/api/group_test.py
+++ b/tests/h/schemas/api/group_test.py
@@ -7,6 +7,7 @@ from h.models.group import (
     GROUP_NAME_MIN_LENGTH,
     GROUP_NAME_MAX_LENGTH,
     GROUP_DESCRIPTION_MAX_LENGTH,
+    AUTHORITY_PROVIDED_ID_MAX_LENGTH,
 )
 
 from h.schemas.api.group import CreateGroupAPISchema
@@ -15,41 +16,34 @@ from h.schemas import ValidationError
 
 class TestCreateGroupSchema(object):
 
-    def test_it_raises_if_name_missing(self):
-        schema = CreateGroupAPISchema()
+    def test_it_sets_authority_properties(self, third_party_schema):
+        assert third_party_schema.group_authority == 'thirdparty.com'
+        assert third_party_schema.default_authority == 'hypothes.is'
+
+    def test_it_raises_if_name_missing(self, schema):
         with pytest.raises(ValidationError, match=".*is a required property.*"):
             schema.validate({})
 
-    def test_it_raises_if_name_too_short(self):
-        schema = CreateGroupAPISchema()
-        with pytest.raises(ValidationError) as exc:
+    def test_it_raises_if_name_too_short(self, schema):
+        with pytest.raises(ValidationError, match="name:.*is too short"):
             schema.validate({
                 'name': 'o' * (GROUP_NAME_MIN_LENGTH - 1)
             })
-        assert "name:" in str(exc.value)
-        assert "is too short" in str(exc.value)
 
-    def test_it_raises_if_name_too_long(self):
-        schema = CreateGroupAPISchema()
-        with pytest.raises(ValidationError) as exc:
+    def test_it_raises_if_name_too_long(self, schema):
+        with pytest.raises(ValidationError, match="name:.*is too long"):
             schema.validate({
                 'name': 'o' * (GROUP_NAME_MAX_LENGTH + 1)
             })
-        assert "name:" in str(exc.value)
-        assert "is too long" in str(exc.value)
 
-    def test_it_validates_with_valid_name(self):
-        schema = CreateGroupAPISchema()
-
+    def test_it_validates_with_valid_name(self, schema):
         appstruct = schema.validate({
             'name': 'Perfectly Fine'
         })
 
         assert 'name' in appstruct
 
-    def test_it_validates_with_valid_description(self):
-        schema = CreateGroupAPISchema()
-
+    def test_it_validates_with_valid_description(self, schema):
         appstruct = schema.validate({
             'name': 'This Seems Fine',
             'description': 'This description seems adequate'
@@ -57,12 +51,78 @@ class TestCreateGroupSchema(object):
 
         assert 'description' in appstruct
 
-    def test_it_raises_if_description_too_long(self):
-        schema = CreateGroupAPISchema()
-        with pytest.raises(ValidationError) as exc:
+    def test_it_raises_if_description_too_long(self, schema):
+        with pytest.raises(ValidationError, match="description:.*is too long"):
             schema.validate({
                 'name': 'Name not the Problem',
                 'description': 'o' * (GROUP_DESCRIPTION_MAX_LENGTH + 1)
             })
-        assert "description:" in str(exc.value)
-        assert "is too long" in str(exc.value)
+
+    def test_it_validates_with_valid_groupid_and_third_party_authority(self, third_party_schema):
+        appstruct = third_party_schema.validate({
+            'name': 'This Seems Fine',
+            'groupid': 'group:1234abcd!~*()@thirdparty.com',
+        })
+
+        assert 'groupid' in appstruct
+
+    def test_it_raises_if_groupid_too_long(self, schema):
+        # Because of the complexity of ``groupid`` formatting, the length of the
+        # ``authority_provided_id`` segment of it is defined in the pattern for
+        # valid ``groupid``s — not as a length constraint
+        # Note also that the groupid does not have a valid authority but validation
+        # will raise on the formatting error before that becomes a problem.
+        with pytest.raises(ValidationError, match="groupid:.*does not match"):
+            schema.validate({
+                'name': 'Name not the Problem',
+                'groupid': 'group:' + ('o' * (AUTHORITY_PROVIDED_ID_MAX_LENGTH + 1)) + '@foobar.com'
+            })
+
+    def test_it_raises_if_groupid_has_invalid_chars(self, schema):
+        with pytest.raises(ValidationError, match="groupid:.*does not match"):
+            schema.validate({
+                'name': 'Name not the Problem',
+                'groupid': 'group:&&?@thirdparty.com'
+            })
+
+    def test_validate_raises_ValidationError_on_groupid_if_first_party(self, schema):
+        with pytest.raises(ValidationError, match="groupid may only be set on groups oustide of the default authority"):
+            schema.validate({
+                'name': 'Less Good',
+                'groupid': 'group:delicacy@hypothes.is'
+            })
+
+    def test_validate_raises_ValidationError_if_no_group_authority(self):
+        schema = CreateGroupAPISchema(default_authority='hypothes.is')
+        with pytest.raises(ValidationError, match="groupid may only be set on groups oustide of the default authority"):
+            schema.validate({
+                'name': 'Blustery',
+                'groupid': 'group:delicacy@hypothes.is'
+            })
+
+    def test_validate_raises_ValidationError_groupid_authority_mismatch(self, third_party_schema):
+        with pytest.raises(ValidationError, match="Invalid authority.*in groupid"):
+            third_party_schema.validate({
+                'name': 'Shambles',
+                'groupid': 'group:valid_id@invalidauthority.com'
+            })
+
+    @pytest.fixture
+    def appstruct(self):
+        return {
+            'groupid': 'group:valid_id@thirdparty.com',
+            'name': 'DingDong!',
+            'description': 'OH, hello there',
+        }
+
+    @pytest.fixture
+    def schema(self):
+        schema = CreateGroupAPISchema(group_authority='hypothes.is',
+                                      default_authority='hypothes.is')
+        return schema
+
+    @pytest.fixture
+    def third_party_schema(self):
+        schema = CreateGroupAPISchema(group_authority='thirdparty.com',
+                                      default_authority='hypothes.is')
+        return schema

--- a/tests/h/util/group_test.py
+++ b/tests/h/util/group_test.py
@@ -10,10 +10,9 @@ from h.util import group as group_util
 class TestSplitGroupID(object):
     @pytest.mark.parametrize('groupid,authority_provided_id,authority', [
         ('group:flashbang@dingdong.com', 'flashbang', 'dingdong.com'),
-        ('group::ffff@dingdong.com', ':ffff', 'dingdong.com'),
-        ('group:\\f!orklift@sprongle.co', '\\f!orklift', 'sprongle.co'),
+        ('group:ffff@dingdong.com', 'ffff', 'dingdong.com'),
         ('group:.@dingdong.com', '.', 'dingdong.com'),
-        ('group:group:@yep.nope', 'group:', 'yep.nope'),
+        ('group:group@yep.nope', 'group', 'yep.nope'),
         ('group:()@hi.co', '()', 'hi.co'),
         ("group:!.~--_*'@hi.co", "!.~--_*'", 'hi.co'),
         ])
@@ -30,6 +29,8 @@ class TestSplitGroupID(object):
         'group:@',
         'whatnot@dingdong.co',
         'group:@@dingdong.com',
+        'group:\\f!orklift@sprongle.co',
+        'group:another:@ding.com',
     ])
     def test_it_raises_ValueError_on_invalid_groupids(self, groupid):
         with pytest.raises(ValueError, match='valid groupid'):
@@ -40,10 +41,10 @@ class TestIsGroupid(object):
 
     @pytest.mark.parametrize('maybe_groupid,result', [
         ('group:flashbang@dingdong.com', True),
-        ('group::ffff@dingdong.com', True),
-        ('group:\\f!orklift@sprongle.co', True),
+        ('group::ffff@dingdong.com', False),
+        ('group:\\f!orklift@sprongle.co', False),
         ('group:.@dingdong.com', True),
-        ('group:group:@yep.nope', True),
+        ('group:group@yep.nope', True),
         ('group:()@hi.co', True),
         ("group:!.~--_*'@hi.co", True),
         ('groupp:whatnot@dingdong.co', False),


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/287

This PR (redux) introduces `groupid` support in the API group schema and POST endpoint.

It also centralizes the `groupid` format validation and fixes an oversight in the group model `groupid` setter. Those two things (one commit each) are included in this PR for expediency but can be broken out into separate PRs if so desired.

Regarding the group model: in the [first go-around](https://github.com/hypothesis/h/pull/5409) of the model's `groupid` setter, I neglected to account for the need to be able to _unset_ the group's identifier. The setter needs to accept a `None` value—in this state I have opted to leave the `authority` value on the group alone but nullify the `authority_provided_id`. Again, can break this out into a separate PR if it's better.

In this PR, only the model deals in `authority_provided_id`s. Everyone else uses `groupid`s.