### PR TITLE
Enable psql expanded output in `make sql`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ shell:
 
 .PHONY: sql
 sql:
-	docker-compose exec postgres psql --expanded -U postgres
+	docker-compose exec postgres psql --pset expanded=auto -U postgres
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ shell:
 
 .PHONY: sql
 sql:
-	docker-compose exec postgres psql -U postgres
+	docker-compose exec postgres psql --expanded -U postgres
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
This makes it print out tables in a format that fits the width of terminal windows, instead of printing wide ASCII tables that get wrapped and become unreadable.

See https://hypothes-is.slack.com/archives/C4K6M7P5E/p1541603532176700