### PR TITLE
Add `GroupUpsertContext` and `GroupUpsertRoot`

### DIFF
--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -8,11 +8,11 @@ from h.traversal.roots import OrganizationRoot
 from h.traversal.roots import OrganizationLogoRoot
 from h.traversal.roots import ProfileRoot
 from h.traversal.roots import GroupRoot
+from h.traversal.roots import GroupUpsertRoot
 from h.traversal.roots import UserRoot
 from h.traversal.contexts import AnnotationContext
 from h.traversal.contexts import OrganizationContext
 from h.traversal.contexts import GroupContext
-
 from h.traversal.contexts import GroupUpsertContext
 
 __all__ = (
@@ -22,6 +22,7 @@ __all__ = (
     "OrganizationRoot",
     "OrganizationLogoRoot",
     "GroupRoot",
+    "GroupUpsertRoot",
     "ProfileRoot",
     "UserRoot",
     "AnnotationContext",

--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -13,6 +13,7 @@ from h.traversal.contexts import AnnotationContext
 from h.traversal.contexts import OrganizationContext
 from h.traversal.contexts import GroupContext
 
+from h.traversal.contexts import GroupUpsertContext
 
 __all__ = (
     "Root",
@@ -26,4 +27,5 @@ __all__ = (
     "AnnotationContext",
     "OrganizationContext",
     "GroupContext",
+    "GroupUpsertContext",
 )

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -216,6 +216,32 @@ class GroupRoot(object):
         return group
 
 
+class GroupUpsertRoot(object):
+    """
+    Root factory for group "UPSERT" API
+
+    This Root can support a route in which the traversal's ``__getitem__``
+    will attempt a lookup but will not raise if that fails.
+
+    This is to allow a single route that can accept and update an existing group
+    OR create a new one.
+    """
+
+    __acl__ = GroupRoot.__acl__
+
+    def __init__(self, request):
+        self._request = request
+        self._group_root = GroupRoot(request)
+
+    def __getitem__(self, pubid_or_groupid):
+        try:
+            group = self._group_root[pubid_or_groupid]
+        except KeyError:
+            group = None
+
+        return contexts.GroupUpsertContext(group=group, request=self._request)
+
+
 class ProfileRoot(object):
     """
     Simple Root for API profile endpoints


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/287

We need a special kind of traversal for our proposed UPSERT endpoint for groups. It needs to return a populated group context if the group referenced in the URL path param exists, or `None` if not, without raising an exception.