### PR TITLE
Add docs for `groupid` on `POST /api/groups`

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -364,6 +364,10 @@ paths:
           description: Could not create group from your request
           schema:
             $ref: '#/definitions/Error'
+        '409':
+          description: Conflict
+          schema:
+            $ref: '#/definitions/ConflictError'
       security:
         - authClientForwardedUser: []
         - developerAPIKey: []

--- a/docs/_extra/api-reference/schemas/new-group.yaml
+++ b/docs/_extra/api-reference/schemas/new-group.yaml
@@ -10,5 +10,15 @@ Group:
       type: string
       description: group description
       maxLength: 250
+    groupid:
+      type: string
+      pattern: "group:[a-zA-Z0-9._\\-+!~*()']{1,1024}@.*$"
+      description: >
+        <p><mark>NEW/EXPERIMENTAL</mark></p>
+        <p>For AuthClient-authenticated requests only.</p>
+
+        <p>Optional unique identifier for this group, in the format `"group:<unique_identifier>@<authority>"`, e.g.: `"group:my-own-unique-id-123@myauthority.com"`. The `authority` value must match the requesting client's authorized authority. </p>
+
+        <p>This property is intended to allow third-party authorized clients to set their own unique identifier for a group. As such, the value of the `unique_identifier` string must be unique within the `authority`. A uniqueness violation will result in an `HTTP 409: Conflict` response.</p>
   required:
     - name


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/287

This PR adds a bit of documentation for the `groupid` parameter on `POST /api/groups`, marking it out as new and experimental. It also adds `HTTP 409` to the list of possible responses.

![image](https://user-images.githubusercontent.com/439947/48159764-1e8ef780-e2a4-11e8-94b7-1ed447fdcfd0.png)

![image](https://user-images.githubusercontent.com/439947/48159785-2a7ab980-e2a4-11e8-9dc7-164f853b73d7.png)
