### PR TITLE
Record userid on each request made to h

### DIFF
--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -2,8 +2,8 @@
 
 from __future__ import unicode_literals
 import datetime
-import newrelic.agent
 
+import newrelic.agent
 from zope.interface import implementer
 
 from h._compat import text_type

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -62,4 +62,5 @@ def auth_token(request):
     # should reject it.
     if not token:
         return None
+
     return token

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 import datetime
+import newrelic.agent
 
 from zope.interface import implementer
 
@@ -26,6 +27,9 @@ class Token(object):
     def __init__(self, token_model):
         self.expires = token_model.expires
         self.userid = token_model.userid
+
+        # Associates the userid with a given transaction/web request.
+        newrelic.agent.add_custom_parameter("userid", self.userid)
 
     def is_valid(self):
         """Return ``True`` if this token is not expired, ``False`` if it is."""
@@ -58,5 +62,4 @@ def auth_token(request):
     # should reject it.
     if not token:
         return None
-
     return token


### PR DESCRIPTION
In order to accurately count the rate of requests per user, add
a custom parameter to each transaction in new relic called userid.
This is helpful for setting correct rate limits in
https://github.com/hypothesis/product-backlog/issues/849.

This is also useful for categorizing logged out vs logged in stats, 
debugging slow db queries (as often the userid/associated info are
parameters in the query), and finding/debugging reported issues by user.

Note this only adds a userid attribute to the request when a user is authenticated.
This is intentional, unauthenticated requests will not have a userid attribute
and can be identified by the missing attribute.

