### PR TITLE
Refactor group API schema to support PATCH, PUT

### DIFF
--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -61,6 +61,7 @@ class CreateGroupAPISchema(JSONSchema):
 
         """
         appstruct = super(CreateGroupAPISchema, self).validate(data)
+        appstruct = self._whitelisted_fields_only(appstruct)
         self._validate_groupid(appstruct)
 
         return appstruct
@@ -96,3 +97,14 @@ class CreateGroupAPISchema(JSONSchema):
             raise ValidationError("{err_msg} '{groupid}'".format(
                 err_msg=_("Invalid authority specified in groupid"),
                 groupid=groupid))
+
+    def _whitelisted_fields_only(self, appstruct):
+        """Return a new appstruct containing only schema-defined fields"""
+
+        new_appstruct = {}
+
+        for allowed_field in self.schema['properties'].keys():
+            if allowed_field in appstruct:
+                new_appstruct[allowed_field] = appstruct[allowed_field]
+
+        return new_appstruct

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -12,33 +12,34 @@ from h.models.group import (
 from h.util.group import GROUPID_PATTERN, split_groupid
 from h.i18n import TranslationString as _
 
+GROUP_SCHEMA_PROPERTIES = {
+    'name': {
+        'type': 'string',
+        'minLength': GROUP_NAME_MIN_LENGTH,
+        'maxLength': GROUP_NAME_MAX_LENGTH,
+    },
+    'description': {
+        'type': 'string',
+        'maxLength': GROUP_DESCRIPTION_MAX_LENGTH,
+    },
+    'groupid': {
+        'type': 'string',
+        'pattern': GROUPID_PATTERN,
+    },
+}
 
-class CreateGroupAPISchema(JSONSchema):
+
+class GroupAPISchema(JSONSchema):
+    """Base class for validating group resource API data"""
 
     schema = {
         'type': 'object',
-        'properties': {
-            'name': {
-                'type': 'string',
-                'minLength': GROUP_NAME_MIN_LENGTH,
-                'maxLength': GROUP_NAME_MAX_LENGTH,
-            },
-            'description': {
-                'type': 'string',
-                'maxLength': GROUP_DESCRIPTION_MAX_LENGTH,
-            },
-            'groupid': {
-                'type': 'string',
-                'pattern': GROUPID_PATTERN,
-            },
-        },
-        'required': [
-            'name'
-        ],
+        'properties': GROUP_SCHEMA_PROPERTIES,
     }
 
     def __init__(self, group_authority=None, default_authority=None):
-        """Initialize a new group schema instance.
+        """
+        Initialize a new group schema instance.
 
         The ``group_authority`` and ``default_authority`` args are used for
         validating any ``groupid`` present in the data being validated.
@@ -48,26 +49,28 @@ class CreateGroupAPISchema(JSONSchema):
         :arg default_authority: The service's default authority (default None)
 
         """
-        super(CreateGroupAPISchema, self).__init__()
+        super(GroupAPISchema, self).__init__()
         self.group_authority = group_authority
         self.default_authority = default_authority
 
     def validate(self, data):
-        """Validate against the JSON schema and also valid any ``groupid`` present.
+        """
+        Validate against the JSON schema and also valid any ``groupid`` present.
 
         :raise h.schemas.ValidationError: if any part of validation fails
         :return: The validated data
         :rtype: dict
 
         """
-        appstruct = super(CreateGroupAPISchema, self).validate(data)
+        appstruct = super(GroupAPISchema, self).validate(data)
         appstruct = self._whitelisted_fields_only(appstruct)
         self._validate_groupid(appstruct)
 
         return appstruct
 
     def _validate_groupid(self, appstruct):
-        """Validate the ``groupid`` to make sure it adheres to authority restrictions.
+        """
+        Validate the ``groupid`` to make sure it adheres to authority restrictions.
 
         ``groupid`` is only allowed if the authority of the group associated
         with it is not the default authority—i.e. this is a third-party group.
@@ -103,8 +106,27 @@ class CreateGroupAPISchema(JSONSchema):
 
         new_appstruct = {}
 
-        for allowed_field in self.schema['properties'].keys():
+        for allowed_field in GROUP_SCHEMA_PROPERTIES.keys():
             if allowed_field in appstruct:
                 new_appstruct[allowed_field] = appstruct[allowed_field]
 
         return new_appstruct
+
+
+class CreateGroupAPISchema(GroupAPISchema):
+    """Schema for validating create-group API data"""
+    schema = {
+        'type': 'object',
+        'properties': GROUP_SCHEMA_PROPERTIES,
+        'required': [  # ``name`` is a required field when creating
+            'name'
+        ],
+    }
+
+
+class UpdateGroupAPISchema(GroupAPISchema):
+    """
+    Class for validating update-group API data
+
+    Currently identical to base schema
+    """

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -28,6 +28,16 @@ class TestCreateGroup(object):
 
         assert res.status_code == 200
 
+    def test_it_ignores_non_whitelisted_fields_in_payload(self, app, token_auth_header):
+        group = {
+            'name': 'My Group',
+            'organization': 'foobar',
+            'joinable_by': 'whoever',
+        }
+        res = app.post_json('/api/groups', group, headers=token_auth_header)
+
+        assert res.status_code == 200
+
     def test_it_returns_http_400_with_invalid_payload(self, app, token_auth_header):
         group = {}
 

--- a/tests/h/schemas/api/group_test.py
+++ b/tests/h/schemas/api/group_test.py
@@ -10,11 +10,15 @@ from h.models.group import (
     AUTHORITY_PROVIDED_ID_MAX_LENGTH,
 )
 
-from h.schemas.api.group import CreateGroupAPISchema
+from h.schemas.api.group import (
+    GroupAPISchema,
+    CreateGroupAPISchema,
+    UpdateGroupAPISchema,
+)
 from h.schemas import ValidationError
 
 
-class TestCreateGroupSchema(object):
+class TestGroupAPISchema(object):
 
     def test_it_sets_authority_properties(self, third_party_schema):
         assert third_party_schema.group_authority == 'thirdparty.com'
@@ -30,10 +34,6 @@ class TestCreateGroupSchema(object):
         assert 'name' in appstruct
         assert 'organization' not in appstruct
         assert 'joinable_by' not in appstruct
-
-    def test_it_raises_if_name_missing(self, schema):
-        with pytest.raises(ValidationError, match=".*is a required property.*"):
-            schema.validate({})
 
     def test_it_raises_if_name_too_short(self, schema):
         with pytest.raises(ValidationError, match="name:.*is too short"):
@@ -128,12 +128,39 @@ class TestCreateGroupSchema(object):
 
     @pytest.fixture
     def schema(self):
-        schema = CreateGroupAPISchema(group_authority='hypothes.is',
-                                      default_authority='hypothes.is')
+        schema = GroupAPISchema(group_authority='hypothes.is',
+                                default_authority='hypothes.is')
         return schema
 
     @pytest.fixture
     def third_party_schema(self):
-        schema = CreateGroupAPISchema(group_authority='thirdparty.com',
+        schema = GroupAPISchema(group_authority='thirdparty.com',
+                                default_authority='hypothes.is')
+        return schema
+
+
+class TestCreateGroupAPISchema(object):
+
+    def test_it_raises_if_name_missing(self, schema):
+        with pytest.raises(ValidationError, match=".*is a required property.*"):
+            schema.validate({})
+
+    @pytest.fixture
+    def schema(self):
+        schema = CreateGroupAPISchema(group_authority='hypothes.is',
+                                      default_authority='hypothes.is')
+        return schema
+
+
+class TestUpdateGroupAPISchema(object):
+
+    def test_it_allows_empty_payload(self, schema):
+        appstruct = schema.validate({})
+
+        assert appstruct == {}
+
+    @pytest.fixture
+    def schema(self):
+        schema = UpdateGroupAPISchema(group_authority='hypothes.is',
                                       default_authority='hypothes.is')
         return schema

--- a/tests/h/schemas/api/group_test.py
+++ b/tests/h/schemas/api/group_test.py
@@ -20,6 +20,17 @@ class TestCreateGroupSchema(object):
         assert third_party_schema.group_authority == 'thirdparty.com'
         assert third_party_schema.default_authority == 'hypothes.is'
 
+    def test_it_ignores_non_whitelisted_properties(self, schema):
+        appstruct = schema.validate({
+            'name': 'A proper name',
+            'organization': 'foobar',
+            'joinable_by': 'whoever',
+        })
+
+        assert 'name' in appstruct
+        assert 'organization' not in appstruct
+        assert 'joinable_by' not in appstruct
+
     def test_it_raises_if_name_missing(self, schema):
         with pytest.raises(ValidationError, match=".*is a required property.*"):
             schema.validate({})


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/287

Just about to implement some new update endpoints for groups, so need their schema(s) to be ready!

This PR refactors `h.schemas.api.group` to allow schema reuse between create and update operations. It sort of follows the pattern in `h.schemas.annotation`[1]. It also adds a private utility method for stripping out untrusted fields. Our views right now are doing that work implicitly (in that they only pass certain fields on to the services), but it seems wise to make like `h.api.annotation` and do it explicitly here on the appstruct/payload.

1: `h.schemas.annotation` uses composition instead of inheritance; inheritance felt like a better match here, but...shrug?