### PR TITLE
Use npm ci to install frontend dependencies during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV NODE_ENV production
 
 COPY . .
 
-RUN npm install --production && npm run build
+RUN npm ci --production && npm run build
 
 FROM alpine:3.7
 MAINTAINER Hypothes.is Project and contributors


### PR DESCRIPTION
`npm ci` is a faster and stricter alternative to `npm install` which
is the preferred way to install dependencies in CI-like environments.

Speeds up Docker image build by 10-20s on my MacBook.