### PR TITLE
Add rate limiting of /api/annotations

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -84,7 +84,6 @@ http {
       # to the server-this will allow other requests to take priority.
       location /api/badge {
         limit_req zone=user_1rps_limit burst=15;
-        limit_req_status 429;
 
         proxy_pass http://web;
       }
@@ -99,7 +98,6 @@ http {
       # a burst of 140 requests.
       location /assets {
         limit_req zone=user_1rps_limit burst=139 nodelay;
-        limit_req_status 429;
 
         proxy_pass http://web;
       }
@@ -115,9 +113,8 @@ http {
       # requests pass to the server, queue these requests and
       # only send 1 each second.
       # Allow a user to queue up 8 rps (8 times the expected rate).
-      location /api/annotations {
+      location =/api/annotations {
         limit_req zone=user_1rps_limit burst=8;
-        limit_req_status 429;
 
         proxy_pass http://web;
       }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -76,23 +76,50 @@ http {
       limit_req zone=user_1rps_limit burst=14 nodelay;
       limit_req_status 429;
 
-    # Each /api/annotations:create request has a 95 percentile 
-    # response time of .56s and there are 12 gunicorn
-    # workers per host. Create requests account for <1% of the 
-    # traffic on the host so assume .12 workers are allocated
-    # for /api/annotations:create requests.
-    #   .12 workers * 1 request / .56 s = .21 requests/s = ~1rps
-    # If too many of these requests happen back to back it can
-    # overwhelm the database so instead of letting a burst of
-    # requests pass to the server, queue these requests and 
-    # only send 1 each second.
-    # Allow a user to queue up 4 rps (4 times the expected rate). 
-    location /api/annotations {
-      limit_req zone=user_1rps_limit burst=3;
-      limit_req_status 429;
+      # The 95th percentile time for a badge request is .042s. 
+      # 7.6% of worker time is spent handling these requests.
+      # Typical usage per user is around 50 rpm.
+      # Queue up badge requests rather than sending them directly
+      # to the server-this will allow other requests to take priority.
+      location /api/badge {
+        limit_req zone=user_1rps_limit burst=15;
+        limit_req_status 429;
 
-      proxy_pass http://web;
-    }
+        proxy_pass http://web;
+      }
+
+      # The 95th percentile time for an asset is .013s. 
+      # The maximum burst of requests from a single page
+      # https://hypothes.is/docs/help is 20 requests.
+      # <1% of worker time is spent handling these requests.
+      # The maximum expected request rate is 25rpm. 
+      # Assume in frustration the user hammers on the refresh
+      # button 10 times in a row. Worst case the results in 
+      # a burst of 200 requests.
+      location /assets {
+        limit_req zone=user_1rps_limit burst=200 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://web;
+      }
+
+      # Each /api/annotations:create request has a 95 percentile 
+      # response time of .56s and there are 12 gunicorn
+      # workers per host. Create requests account for <1% of the 
+      # traffic on the host so assume .12 workers are allocated
+      # for /api/annotations:create requests.
+      #   .12 workers * 1 request / .56 s = .21 requests/s = ~1rps
+      # If too many of these requests happen back to back it can
+      # overwhelm the database so instead of letting a burst of
+      # requests pass to the server, queue these requests and 
+      # only send 1 each second.
+      # Allow a user to queue up 4 rps (4 times the expected rate). 
+      location /api/annotations {
+        limit_req zone=user_1rps_limit burst=3;
+        limit_req_status 429;
+
+        proxy_pass http://web;
+      }
 
       proxy_pass http://web;
       proxy_http_version 1.1;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -27,7 +27,11 @@ http {
   # 1m stands for 1 megabyte so the zone can store ~8k users.
   # User's typically don't go over 1rps including bots so set the
   # generic rate limit of all endpoints to 1rps.
+  limit_req_zone $limit_per_user zone=badge_user_1rps_limit:1m rate=1r/s;
+  limit_req_zone $limit_per_user zone=assets_user_1rps_limit:1m rate=1r/s;
+  limit_req_zone $limit_per_user zone=create_ann_user_1rps_limit:1m rate=1r/s;
   limit_req_zone $limit_per_user zone=user_1rps_limit:1m rate=1r/s;
+  limit_req_status 429;
 
   # We set fail_timeout=0 so that the upstream isn't marked as down if a single
   # request fails (e.g. if gunicorn kills a worker for taking too long to handle
@@ -67,15 +71,21 @@ http {
       return 302 "https://trello.com/b/2ajZ2dWe/public-roadmap";
     }
 
+    location @api_error_429 {
+        return 429 '{"status": "failure", "reason": "Request rate limit exceeded"}';
+    }
+
     location / {
-      # A bot may burst up to 50rpm and the client issues 5 requests upon
-      # loading the sidebar. Assume a max request rate of 15 rps in a burst.
-      # This means the queue size would be 14 requests.
-      # Allow a user to sustain the max bursty request rate for 3 seconds.
-	  # This would mean they can request up to 45 requests in one second but
-      # only 1 new request each second after that.
-      limit_req zone=user_1rps_limit burst=44 nodelay;
-      limit_req_status 429;
+      proxy_pass http://web;
+      proxy_http_version 1.1;
+      proxy_connect_timeout 10s;
+      proxy_send_timeout 10s;
+      proxy_read_timeout 10s;
+      proxy_redirect off;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Server $http_host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Request-Start "t=${msec}";
 
       # The 95th percentile time for a badge request is .042s.
       # 7.6% of worker time is spent handling these requests.
@@ -83,7 +93,8 @@ http {
       # Queue up badge requests rather than sending them directly
       # to the server-this will allow other requests to take priority.
       location /api/badge {
-        limit_req zone=user_1rps_limit burst=15;
+        limit_req zone=badge_user_1rps_limit burst=15;
+        error_page 429 @api_error_429;
 
         proxy_pass http://web;
       }
@@ -97,7 +108,7 @@ http {
       # button 7 times in a row. Worst case this results in
       # a burst of 140 requests.
       location /assets {
-        limit_req zone=user_1rps_limit burst=139 nodelay;
+        limit_req zone=assets_user_1rps_limit burst=139 nodelay;
 
         proxy_pass http://web;
       }
@@ -114,21 +125,26 @@ http {
       # only send 1 each second.
       # Allow a user to queue up 8 rps (8 times the expected rate).
       location =/api/annotations {
-        limit_req zone=user_1rps_limit burst=8;
+        limit_req zone=create_ann_user_1rps_limit burst=8;
+        error_page 429 @api_error_429;
 
         proxy_pass http://web;
       }
 
-      proxy_pass http://web;
-      proxy_http_version 1.1;
-      proxy_connect_timeout 10s;
-      proxy_send_timeout 10s;
-      proxy_read_timeout 10s;
-      proxy_redirect off;
-      proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-Server $http_host;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Request-Start "t=${msec}";
+      location /api {
+        limit_req zone=user_1rps_limit burst=44 nodelay;
+        error_page 429 @api_error_429;
+
+        proxy_pass http://web;
+      }
+
+      # A bot may burst up to 50rpm and the client issues 5 requests upon
+      # loading the sidebar. Assume a max request rate of 15 rps in a burst.
+      # This means the queue size would be 14 requests.
+      # Allow a user to sustain the max bursty request rate for 3 seconds.
+	  # This would mean they can request up to 45 requests in one second but
+      # only 1 new request each second after that.
+      limit_req zone=user_1rps_limit burst=44 nodelay;
     }
   }
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -87,11 +87,9 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Request-Start "t=${msec}";
 
-      # The 95th percentile time for a badge request is .042s.
-      # 7.6% of worker time is spent handling these requests.
-      # Typical usage per user is around 50 rpm.
-      # Queue up badge requests rather than sending them directly
-      # to the server-this will allow other requests to take priority.
+      # The /api/badge endpoint limit is chosen to limit the
+      # load from any single user, and take advantage of latency
+      # not being critical.
       location /api/badge {
         limit_req zone=badge_user_1rps_limit burst=15;
         error_page 429 @api_error_429;
@@ -99,31 +97,19 @@ http {
         proxy_pass http://web;
       }
 
-      # The 95th percentile time for an asset is .013s.
-      # The maximum burst of requests from a single page
-      # https://hypothes.is/docs/help is 20 requests.
-      # <1% of worker time is spent handling these requests.
-      # The maximum expected request rate is 25rpm.
-      # Assume in frustration the user hammers on the refresh
-      # button 7 times in a row. Worst case this results in
-      # a burst of 140 requests.
+      # The /assets rate limit is chosen so that the user
+      # can refresh the web page with the most asset links
+      # on it a few times in succession without hitting the
+      # limit.
       location /assets {
         limit_req zone=assets_user_1rps_limit burst=139 nodelay;
 
         proxy_pass http://web;
       }
 
-      # Each /api/annotations:create request has a 95 percentile
-      # response time of .56s and there are 12 gunicorn
-      # workers per host. Create requests account for <1% of the
-      # traffic on the host so assume .12 workers are allocated
-      # for /api/annotations:create requests.
-      #   .12 workers * 1 request / .56 s = .21 requests/s = ~1rps
-      # If too many of these requests happen back to back it can
-      # overwhelm the database so instead of letting a burst of
-      # requests pass to the server, queue these requests and
-      # only send 1 each second.
-      # Allow a user to queue up 8 rps (8 times the expected rate).
+      # The POST /api/annotations limit is chosen to allow
+      # reasonable usage while preventing a single user from
+      # causing service disruption.
       location =/api/annotations {
         limit_req zone=create_ann_user_1rps_limit burst=8;
         error_page 429 @api_error_429;
@@ -138,12 +124,8 @@ http {
         proxy_pass http://web;
       }
 
-      # A bot may burst up to 50rpm and the client issues 5 requests upon
-      # loading the sidebar. Assume a max request rate of 15 rps in a burst.
-      # This means the queue size would be 14 requests.
-      # Allow a user to sustain the max bursty request rate for 3 seconds.
-	  # This would mean they can request up to 45 requests in one second but
-      # only 1 new request each second after that.
+      # An overall rate limit was chosen to allow reasonable usage while
+      # preventing a single user from causing service disruption.
       limit_req zone=user_1rps_limit burst=44 nodelay;
     }
   }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -28,7 +28,7 @@ http {
   # User's typically don't go over 1rps including bots so set the
   # generic rate limit of all endpoints to 1rps.
   limit_req_zone $limit_per_user zone=user_1rps_limit:1m rate=1r/s;
-  
+
   # We set fail_timeout=0 so that the upstream isn't marked as down if a single
   # request fails (e.g. if gunicorn kills a worker for taking too long to handle
   # a single request).
@@ -42,7 +42,7 @@ http {
     server_tokens off;
 
     root /var/www;
-    
+
     location /ws {
       proxy_pass http://websocket;
       proxy_http_version 1.1;
@@ -68,15 +68,16 @@ http {
     }
 
     location / {
-      # A bot may burst up to 50rpm so and the client issues 5 requests upon
+      # A bot may burst up to 50rpm and the client issues 5 requests upon
       # loading the sidebar. Assume a max request rate of 15 rps in a burst.
       # This means the queue size would be 14 requests.
-      # Send up to 15 requests directly to the server but only allow
-      # 1 new request each second after that.
-      limit_req zone=user_1rps_limit burst=14 nodelay;
+      # Allow a user to sustain the max bursty request rate for 3 seconds.
+	  # This would mean they can request up to 45 requests in one second but
+      # only 1 new request each second after that.
+      limit_req zone=user_1rps_limit burst=44 nodelay;
       limit_req_status 429;
 
-      # The 95th percentile time for a badge request is .042s. 
+      # The 95th percentile time for a badge request is .042s.
       # 7.6% of worker time is spent handling these requests.
       # Typical usage per user is around 50 rpm.
       # Queue up badge requests rather than sending them directly
@@ -88,34 +89,34 @@ http {
         proxy_pass http://web;
       }
 
-      # The 95th percentile time for an asset is .013s. 
+      # The 95th percentile time for an asset is .013s.
       # The maximum burst of requests from a single page
       # https://hypothes.is/docs/help is 20 requests.
       # <1% of worker time is spent handling these requests.
-      # The maximum expected request rate is 25rpm. 
+      # The maximum expected request rate is 25rpm.
       # Assume in frustration the user hammers on the refresh
-      # button 10 times in a row. Worst case the results in 
-      # a burst of 200 requests.
+      # button 7 times in a row. Worst case this results in
+      # a burst of 140 requests.
       location /assets {
-        limit_req zone=user_1rps_limit burst=200 nodelay;
+        limit_req zone=user_1rps_limit burst=139 nodelay;
         limit_req_status 429;
 
         proxy_pass http://web;
       }
 
-      # Each /api/annotations:create request has a 95 percentile 
+      # Each /api/annotations:create request has a 95 percentile
       # response time of .56s and there are 12 gunicorn
-      # workers per host. Create requests account for <1% of the 
+      # workers per host. Create requests account for <1% of the
       # traffic on the host so assume .12 workers are allocated
       # for /api/annotations:create requests.
       #   .12 workers * 1 request / .56 s = .21 requests/s = ~1rps
       # If too many of these requests happen back to back it can
       # overwhelm the database so instead of letting a burst of
-      # requests pass to the server, queue these requests and 
+      # requests pass to the server, queue these requests and
       # only send 1 each second.
-      # Allow a user to queue up 4 rps (4 times the expected rate). 
+      # Allow a user to queue up 8 rps (8 times the expected rate).
       location /api/annotations {
-        limit_req zone=user_1rps_limit burst=3;
+        limit_req zone=user_1rps_limit burst=8;
         limit_req_status 429;
 
         proxy_pass http://web;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -17,6 +17,18 @@ http {
 
   access_log off;
 
+  # If there is an auth token, rate limit based on that,
+  # otherwise rate limit per ip.
+  map $http_authorization $limit_per_user {
+    "" $binary_remote_addr;
+    default $http_authorization;
+  }
+
+  # 1m stands for 1 megabyte so the zone can store ~8k users.
+  # User's typically don't go over 1rps including bots so set the
+  # generic rate limit of all endpoints to 1rps.
+  limit_req_zone $limit_per_user zone=user_1rps_limit:1m rate=1r/s;
+  
   # We set fail_timeout=0 so that the upstream isn't marked as down if a single
   # request fails (e.g. if gunicorn kills a worker for taking too long to handle
   # a single request).
@@ -30,7 +42,7 @@ http {
     server_tokens off;
 
     root /var/www;
-
+    
     location /ws {
       proxy_pass http://websocket;
       proxy_http_version 1.1;
@@ -56,6 +68,32 @@ http {
     }
 
     location / {
+      # A bot may burst up to 50rpm so and the client issues 5 requests upon
+      # loading the sidebar. Assume a max request rate of 15 rps in a burst.
+      # This means the queue size would be 14 requests.
+      # Send up to 15 requests directly to the server but only allow
+      # 1 new request each second after that.
+      limit_req zone=user_1rps_limit burst=14 nodelay;
+      limit_req_status 429;
+
+    # Each /api/annotations:create request has a 95 percentile 
+    # response time of .56s and there are 12 gunicorn
+    # workers per host. Create requests account for <1% of the 
+    # traffic on the host so assume .12 workers are allocated
+    # for /api/annotations:create requests.
+    #   .12 workers * 1 request / .56 s = .21 requests/s = ~1rps
+    # If too many of these requests happen back to back it can
+    # overwhelm the database so instead of letting a burst of
+    # requests pass to the server, queue these requests and 
+    # only send 1 each second.
+    # Allow a user to queue up 4 rps (4 times the expected rate). 
+    location /api/annotations {
+      limit_req zone=user_1rps_limit burst=3;
+      limit_req_status 429;
+
+      proxy_pass http://web;
+    }
+
       proxy_pass http://web;
       proxy_http_version 1.1;
       proxy_connect_timeout 10s;


### PR DESCRIPTION
Set an overall request rate limit per user. This will establish "fairness" between users and prevent one user from DDOSing other users and also issuing too many requests that the service simply can't handle. Note the difference between this and Cloudflare is the rate limiting is done per authtoken fallback to ip rather than per ip. 

Rate limit endpoints that are known to cause issues if over-requested
on a per user basis (use auth token to identify an individual user fallback
to using the ip address). Use the authorization token instead of ip address 
since users from a university may have the same ip address and the bulk 
of users in h day-to-day are students. 

Our current traffic allocation is as follows:
 - 60% badge
 - 22% search
 - <1% create

We currently have 12 gunicorn workers which means we have 2.7 workers for
handling search requests and .12 workers for handling create annotation requests.

/api/annotations are held in a request queue at the nginx level during bursty
traffic and forwarded to the server at a set rate. This prevents the server from
being overwhelmed with an influx of db intensive operations which will cause db
slowdowns and result in a larger than expected amount of gunicorn worker time 
spent processing create requests. See [incident report](https://docs.google.com/document/d/1AIbl0BMw9FP0cza1RAFNIvzo2ZbVpfIYAqlSxnAtJG8/edit#heading=h.3de8xgxrwmfo) for details. At peak load
this particular bot was running ~72rpm.

The large blue spikes in the graph below are from a bot that runs w/o crashing
our app today. The tricky part is this doesn't crash our app because it runs during
low traffic times, if this same traffic ran earlier in the day it would overwhelm the
server.
![image](https://user-images.githubusercontent.com/30059933/48432912-90df5c00-e72a-11e8-85db-db4f756552ce.png)


See https://www.nginx.com/blog/rate-limiting-nginx/ for details.
