### PR TITLE
Explicitly add userid principal for AuthClient forwarded users

### DIFF
--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -160,11 +160,20 @@ def principals_for_auth_client_user(user, client):
     :type client: :py:class:`h.models.auth_client.AuthClient`
     :rtype: list
     """
+
+    # Other auth policies that extend Pyramid auth policies, e.g.
+    # ``Pyramid.authentication.CallbackAuthenticationPolicy``, automatically
+    # get a ``userid`` principal via its ``effective_principals`` method.
+    # But :py:class:`h.auth.policy.AuthClientPolicy` overrides ``effective_principals``
+    # with its own method, so the ``userid`` principal needs to be added explicitly here
+    # for forwarded users
+    userid_principals = [user.userid]
+
     user_principals = principals_for_user(user)
     client_principals = principals_for_auth_client(client)
     auth_client_principals = [role.AuthClientUser]
 
-    all_principals = user_principals + client_principals + auth_client_principals
+    all_principals = userid_principals + user_principals + client_principals + auth_client_principals
     distinct_principals = list(set(all_principals))
 
     return distinct_principals

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -183,6 +183,13 @@ class TestPrincipalsForAuthClientUser(object):
 
         principals_for_auth_client.assert_called_once_with(auth_client)
 
+    def test_it_adds_the_userid_principal(self, factories, auth_client):
+        user = factories.User(authority=auth_client.authority)
+
+        principals = util.principals_for_auth_client_user(user, auth_client)
+
+        assert user.userid in principals
+
     def test_it_adds_the_authclientuser_role(self, factories, auth_client):
         user = factories.User(authority=auth_client.authority)
 


### PR DESCRIPTION
This PR amends the list of principals built for authentication using our AuthClientPolicy with a forwarded user by adding a `userid` principal representing the authenticated forwarded user.

We haven't needed this before, because that authentication path was already setting some roles and also `request.user` that sufficed up until this point. Now we need to be able to use more granular resource permissions that get assigned via `userid` principals.

Specifically this is needed for both the PATCH and PUT group endpoints such that appropriate forwarded users pick up the `admin` permission for the group in question via traversal + the Group model's ACL. This small change should make this "just work" without the need for any extra machinery.

Backstory:

`h.auth.policy.AuthClientPolicy` defines its own `effective_principals` method, whereas `h.auth.policy.TokenAuthPolicy` does not, thus falling back to its inherited `pyramid.authentication.CallbackAuthenticationPolicy`'s `effective_principals`. 

`pyramid.authentication.CallbackAuthenticationPolicy.effective_principals` explicitly adds a principal for the authenticated user, which in our world is the `userid` principal (formatted `acct:username@authority`). We get the `userid` principal magically/for free with that auth policy, in other words.

However, since we've rolled our own `h.auth.policy.AuthClientPolicy.effective_principals`, we need to explicitly add this principal if we want it.