### PR TITLE
Remove "serviceUrl" key from client sidebar config

### DIFF
--- a/h/views/client.py
+++ b/h/views/client.py
@@ -53,7 +53,6 @@ def sidebar_app(request, extra=None):
         'authDomain': request.default_authority,
         'oauthClientId': settings.get('h.client_oauth_id'),
         'release': __version__,
-        'serviceUrl': request.route_url('index'),
 
         # The list of origins that the client will respond to cross-origin RPC
         # requests from.

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -19,7 +19,6 @@ class TestSidebarApp(object):
         expected_config = {
                 'apiUrl': 'http://example.com/api',
                 'websocketUrl': 'wss://example.com/ws',
-                'serviceUrl': 'http://example.com/',
                 'release': __version__,
                 'raven': {
                     'dsn': 'test-sentry-dsn',


### PR DESCRIPTION
This is no longer used by the Hypothesis client, which now gets all of the URLs
pointing to the h service from the API (mostly from `/api/` or `/api/links`),
with the exception of the WebSocket URL.