### PR TITLE
Use custom params to record search params

### DIFF
--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -190,18 +190,31 @@ def _annotation_resource(request, annotation):
 
 def _record_search_api_usage_metrics(
     params,
-    record_metrics=newrelic.agent.record_custom_metrics,
+    record_param=newrelic.agent.add_custom_parameter,
 ):
-    metrics = [
-        # Record usage of deprecated offset.
-        ('Custom/SearchApi/offset', int("offset" in params)),
-
+    # Record usage of search params and associate them with a transaction.
+    keys = [
+        # Record usage of inefficient offset and it's alternative search_after.
+        "offset",
+        "search_after",
+        "sort",
         # Record usage of url/uri (url is an alias of uri).
-        ('Custom/SearchApi/url', int("url" in params)),
-        ('Custom/SearchApi/uri', int("uri" in params)),
-
+        "url",
+        "uri",
         # Record usage of tags/tag (tags is an alias of tag).
-        ('Custom/SearchApi/tags', int("tags" in params)),
-        ('Custom/SearchApi/tag', int("tag" in params)),
+        "tags",
+        "tag",
+        # Record usage of _separate_replies which will help distinguish client calls
+        # for loading the sidebar annotations from other api calls.
+        "_separate_replies",
+        # Record group and user-these help in identifying slow queries.
+        "group",
+        "user",
+        # Record usage of wildcard feature.
+        "wildcard_uri",
     ]
-    record_metrics(metrics)
+
+    for k in keys:
+        if k in params:
+            # The NewRelic query language does not permit _ at the begining.
+            record_param(k.lstrip('_'), str(params[k]))

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -216,5 +216,6 @@ def _record_search_api_usage_metrics(
 
     for k in keys:
         if k in params:
-            # The NewRelic query language does not permit _ at the begining.
-            record_param(k.lstrip('_'), str(params[k]))
+            # The New Relic Query Language does not permit _ at the begining
+            # and offset is a reserved key word.
+            record_param("es_{}".format(k), str(params[k]))


### PR DESCRIPTION
Previously, custom metrics was used. There are a couple reasons
why using custom parameters is better in this instance:
1) The parameters will be linked to a particular transaction which
    helps during debug.
2) The parameters allow recording of the actual value as opposed to
    simply whether it was used or not and in cases like offset that
    is an important distinction.
3) Since the params are linked to a particular transaction and we have
    info on who was logged in, we can get a better sense of which
    market segment is using which search features.

A new dashboard has been made for these params [here](https://insights.newrelic.com/accounts/1385283/dashboards/783077). Note currently this is pulling data from h (dev) but will be switched to h (qa) and h (prod) during and after release.