### PR TITLE
Allow AuthClients to `PATCH groups/{id}` without Forwarded User

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -379,7 +379,7 @@ paths:
       summary: Update a  group
       operationId: patchGroup
       description: >
-        Update an existing group. The authenticated user must be the group's original creator to have permission to update it.
+        Update an existing group. If `developerAPIKey` authentication is used, the authenticated user must be the group's creator. If `authClientCredentials` or `authClientForwardedUser` are used, the group's authority must match the client's authority.
       parameters:
         - name: id
           in: path
@@ -407,6 +407,7 @@ paths:
             $ref: '#/definitions/ConflictError'
       security:
         - authClientForwardedUser: []
+        - authClientCredentials: []
         - developerAPIKey: []
 
     put:

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -212,7 +212,7 @@ class Group(Base, mixins.Timestamps):
             terms.append((security.Allow, write_principal, 'write'))
 
         if self.creator:
-            # The creator of the grouop shoulld be able to update it
+            # The creator of the group should be able to update it
             terms.append((security.Allow, self.creator.userid, 'admin'))
             # auth_clients that have the same authority as this group
             # should be allowed to update it

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -277,8 +277,18 @@ class TestGroupACL(object):
     def test_creator_has_moderate_permission(self, group, authz_policy):
         assert authz_policy.permits(group, 'acct:luke@example.com', 'moderate')
 
-    def test_creator_has_admin_permissions(self, group, authz_policy):
+    def test_creator_has_admin_permission(self, group, authz_policy):
         assert authz_policy.permits(group, 'acct:luke@example.com', 'admin')
+
+    def test_auth_client_with_matching_authority_has_admin_permission(self, group, authz_policy):
+        group.authority = 'weewhack.com'
+
+        assert authz_policy.permits(group, ['flip', 'client_authority:weewhack.com'], 'admin')
+
+    def test_auth_client_without_matching_authority_does_not_have_admin_permission(self, group, authz_policy):
+        group.authority = 'weewhack.com'
+
+        assert not authz_policy.permits(group, ['flip', 'client_authority:2weewhack.com'], 'admin')
 
     def test_creator_has_upsert_permissions(self, group, authz_policy):
         assert authz_policy.permits(group, 'acct:luke@example.com', 'upsert')


### PR DESCRIPTION
This PR opens up permissions somewhat on the recently-added `PATCH /groups/{id}` endpoint. Previously, an authenticated user (via API key or AuthClient ForwardedUser) was required on the request. This was somewhat of a carryover from `POST groups` in which you _need_ a user to assign as the group's creator.

This PR allows an AuthClient without a ForwardedUser to update groups within its own authority. This brings this endpoint more into alignment with `PATCH users/{username}`(i.e. allowing an AuthClient to manipulate all users and groups within its authority).

Docs have been updated, too.

(This is needed by LMS).