### PR TITLE
Only copy necessary files for node build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM node:alpine as build
 
 ENV NODE_ENV production
 
-COPY . .
+COPY package-lock.json ./
+COPY package.json ./
+COPY gulpfile.js ./ 
+COPY scripts/gulp ./scripts/gulp
+COPY h/static ./h/static
 
 RUN npm ci --production && npm run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,16 @@ FROM node:alpine as build
 
 ENV NODE_ENV production
 
+# Install node dependencies.
 COPY package-lock.json ./
 COPY package.json ./
+RUN npm ci --production
+
+# Build h js/css.
 COPY gulpfile.js ./ 
 COPY scripts/gulp ./scripts/gulp
 COPY h/static ./h/static
-
-RUN npm ci --production && npm run build
+RUN npm run build
 
 FROM alpine:3.7
 LABEL maintainer="Hypothes.is Project and contributors"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY h/static ./h/static
 RUN npm ci --production && npm run build
 
 FROM alpine:3.7
-MAINTAINER Hypothes.is Project and contributors
+LABEL maintainer="Hypothes.is Project and contributors"
 
 # Install system build and runtime dependencies.
 RUN apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
+# Stage 1: Build node portion of the H app.
 FROM node:alpine as build
 
 ENV NODE_ENV production
 
-# Install node dependencies.
+# Build node dependencies.
 COPY package-lock.json ./
 COPY package.json ./
 RUN npm ci --production
@@ -13,6 +14,7 @@ COPY scripts/gulp ./scripts/gulp
 COPY h/static ./h/static
 RUN npm run build
 
+# Stage 2: Build the rest of the app using the build output from Stage 1.
 FROM alpine:3.7
 LABEL maintainer="Hypothes.is Project and contributors"
 


### PR DESCRIPTION
Previously the node build stage was copying all files. This means any time any of the files change, even ones irrelevant to this stage, this stage is re-run thus not allowing docker to take advantage of incremental build caching. Only copy the files needed for the node build into the node build stage.

MAINTAINER has been deprecated in favor of LABEL. See [docs](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated).

This is a partial fix for https://github.com/hypothesis/product-backlog/issues/889.