### PR TITLE
Convert unicode to utf-8 for NewRelic reporting

### DIFF
--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -218,4 +218,4 @@ def _record_search_api_usage_metrics(
         if k in params:
             # The New Relic Query Language does not permit _ at the begining
             # and offset is a reserved key word.
-            record_param("es_{}".format(k), str(params[k]))
+            record_param("es_{}".format(k), params[k])


### PR DESCRIPTION
Occasionally urls contain unicode characters outside of the 255 set so we can't simply cast them as str. Luckily the newrelic cutom_paramter function handles this for us and it accepts ints and bools so just pass the value directly and let new relic convert from unicode to str.

This is a fix for https://sentry.io/hypothesis/h/issues/786983659/.