### PR TITLE
Refactor `users` API view to use service for update

### DIFF
--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -69,17 +69,11 @@ def update(user, request):
     schema = UpdateUserAPISchema()
     appstruct = schema.validate(_json_payload(request))
 
-    _update_user(user, appstruct)
+    user_update_service = request.find_service(name='user_update')
+    user = user_update_service.update(user, **appstruct)
 
     presenter = UserJSONPresenter(user)
     return presenter.asdict()
-
-
-def _update_user(user, appstruct):
-    if 'email' in appstruct:
-        user.email = appstruct['email']
-    if 'display_name' in appstruct:
-        user.display_name = appstruct['display_name']
 
 
 def _json_payload(request):

--- a/tests/functional/api/test_users.py
+++ b/tests/functional/api/test_users.py
@@ -76,6 +76,19 @@ class TestUpdateUser(object):
 
         assert res.status_code == 200
 
+    def test_it_ignores_unrecognized_parameters(self, app, auth_client_header, user):
+        url = "/api/users/{username}".format(username=user.username)
+        payload = {
+            'email': 'fingers@bonzo.com',
+            'authority': 'nicetry.com'
+        }
+
+        res = app.patch_json(url, payload, headers=auth_client_header)
+
+        assert res.status_code == 200
+        assert res.json_body['email'] == 'fingers@bonzo.com'
+        assert res.json_body['authority'] == 'example.com'
+
     def test_it_returns_updated_user_when_successful(self, app, auth_client_header, user, patch_user_payload):
         url = "/api/users/{username}".format(username=user.username)
 


### PR DESCRIPTION
This PR switches the user API view over to use the newly-minted `user_update` service. It also rewrites some tests for the view to update for this change and update them in general to meet our testing practices better.