### PR TITLE
Pass NewRelic env variables to tox dev environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ passenv =
     dev: SENTRY_DSN
     dev: USE_HTTPS
     dev: WEBSOCKET_URL
+    dev: NEW_RELIC_LICENSE_KEY
+    dev: NEW_RELIC_APP_NAME
     {tests,functests}: TEST_DATABASE_URL
     {tests,functests}: ELASTICSEARCH_URL
     {tests,functests}: PYTEST_ADDOPTS


### PR DESCRIPTION
Fixes: NewRelic environment variables were not being pulled into tox.ini

