### PR TITLE
Remove usage of api_render_user_info feature flag

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -16,7 +16,6 @@ FEATURES = {
     'filter_highlights': ("Filter highlights in document based on visible"
                           " annotations in sidebar?"),
     'overlay_highlighter': "Use the new overlay highlighter?",
-    'api_render_user_info': "Return users' extended info in API responses?",
     'client_display_names': "Render display names instead of user names in the client",
 }
 
@@ -39,6 +38,7 @@ FEATURES = {
 # 4. Finally, remove the feature from FEATURES_PENDING_REMOVAL.
 #
 FEATURES_PENDING_REMOVAL = {
+    'api_render_user_info': "Return users' extended info in API responses?",
 }
 
 

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -14,7 +14,7 @@ from h.interfaces import IGroupService
 
 class AnnotationJSONPresentationService(object):
     def __init__(self, session, user, group_svc, links_svc, flag_svc, flag_count_svc,
-                 moderation_svc, user_svc, has_permission, render_user_info):
+                 moderation_svc, user_svc, has_permission):
         self.session = session
         self.group_svc = group_svc
         self.links_svc = links_svc
@@ -26,10 +26,8 @@ class AnnotationJSONPresentationService(object):
             formatters.AnnotationFlagFormatter(flag_svc, user),
             formatters.AnnotationHiddenFormatter(moderation_svc, moderator_check, user),
             formatters.AnnotationModerationFormatter(flag_count_svc, user, has_permission),
+            formatters.AnnotationUserInfoFormatter(self.session, user_svc),
         ]
-
-        if render_user_info:
-            self.formatters.append(formatters.AnnotationUserInfoFormatter(self.session, user_svc))
 
     def present(self, annotation_resource):
         presenter = self._get_presenter(annotation_resource)
@@ -63,7 +61,6 @@ def annotation_json_presentation_service_factory(context, request):
     flag_count_svc = request.find_service(name='flag_count')
     moderation_svc = request.find_service(name='annotation_moderation')
     user_svc = request.find_service(name='user')
-    render_user_info = request.feature('api_render_user_info')
     return AnnotationJSONPresentationService(session=request.db,
                                              user=request.user,
                                              group_svc=group_svc,
@@ -72,5 +69,4 @@ def annotation_json_presentation_service_factory(context, request):
                                              flag_count_svc=flag_count_svc,
                                              moderation_svc=moderation_svc,
                                              user_svc=user_svc,
-                                             has_permission=request.has_permission,
-                                             render_user_info=render_user_info)
+                                             has_permission=request.has_permission)

--- a/h/session.py
+++ b/h/session.py
@@ -40,8 +40,7 @@ def profile(request, authority=None):
     profile['features'] = request.feature.all()
     profile['preferences'] = _user_preferences(user)
 
-    if request.feature('api_render_user_info'):
-        profile.update(user_info(user))
+    profile.update(user_info(user))
 
     return profile
 

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -42,20 +42,6 @@ class TestAnnotationJSONPresentationService(object):
     def test_it_configures_user_info_formatter(self, services, formatters, svc):
         assert formatters.AnnotationUserInfoFormatter.return_value in svc.formatters
 
-    def test_it_skips_configuring_user_info_formatter_when_told_to(self, services, formatters):
-        svc = AnnotationJSONPresentationService(session=mock.sentinel.db_session,
-                                                user=mock.sentinel.user,
-                                                group_svc=services['group'],
-                                                links_svc=services['links'],
-                                                flag_svc=services['flag'],
-                                                flag_count_svc=services['flag_count'],
-                                                moderation_svc=services['annotation_moderation'],
-                                                user_svc=services['user'],
-                                                has_permission=mock.sentinel.has_permission,
-                                                render_user_info=False)
-
-        assert formatters.AnnotationUserInfoFormatter.return_value not in svc.formatters
-
     def test_present_inits_presenter(self, svc, presenters, annotation_resource):
         svc.present(annotation_resource)
 
@@ -121,8 +107,7 @@ class TestAnnotationJSONPresentationService(object):
                                                  flag_count_svc=services['flag_count'],
                                                  moderation_svc=services['annotation_moderation'],
                                                  user_svc=services['user'],
-                                                 has_permission=mock.sentinel.has_permission,
-                                                 render_user_info=True)
+                                                 has_permission=mock.sentinel.has_permission)
 
     @pytest.fixture
     def annotation_resource(self):

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -195,11 +195,6 @@ class TestProfile(object):
         user_info = profile['user_info']
         assert user_info['display_name'] == authenticated_request.user.display_name
 
-    def test_user_info_authenticated_when_flag_off(self, authenticated_request):
-        authenticated_request.feature.flags['api_render_user_info'] = False
-        profile = session.profile(authenticated_request)
-        assert 'user_info' not in profile
-
     def test_user_info_unauthenticated(self, unauthenticated_request):
         profile = session.profile(unauthenticated_request)
         assert 'user_info' not in profile


### PR DESCRIPTION
This flag has been turned on in production for many months. Remove usage
of it in the code and mark it as pending removal.

Fixes #5447