### PR TITLE
Render search result buckets lazily

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -16,6 +16,8 @@ FEATURES = {
     'filter_highlights': ("Filter highlights in document based on visible"
                           " annotations in sidebar?"),
     'overlay_highlighter': "Use the new overlay highlighter?",
+    'render_buckets_lazily': ("Render annotation cards only when buckets are expanded "
+                              "in activity pages search results?"),
     'client_display_names': "Render display names instead of user names in the client",
 }
 

--- a/h/routes.py
+++ b/h/routes.py
@@ -26,6 +26,7 @@ def includeme(config):
 
     # Activity
     config.add_route('activity.search', '/search')
+    config.add_route('activity.bucket', '/search/bucket')
     config.add_route('activity.user_search',
                      '/users/{username}',
                      factory='h.traversal:UserRoot',

--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -5,12 +5,20 @@ const scrollIntoView = require('scroll-into-view');
 const Controller = require('../base/controller');
 const setElementState = require('../util/dom').setElementState;
 
+function delay(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 /**
  * @typedef Options
  * @property {EnvironmentFlags} [envFlags] - Environment flags. Provided as a
  *           test seam.
  * @property {Function} [scrollTo] - A function that scrolls a given element
  *           into view. Provided as a test seam.
+ * @property {Function} [fetch] - Fetch API. Test seam.
+ * @property {Function} [delay] - Test seam.
  */
 
 /**
@@ -24,6 +32,20 @@ class SearchBucketController extends Controller {
   constructor(element, options) {
     super(element, options);
 
+    this.options.fetch = this.options.fetch || window.fetch;
+    this.options.delay = this.options.delay || delay;
+
+    /**
+     * Promise which resolves when the content for this bucket has been fetched,
+     * or `null` if fetching has not been triggered.
+     */
+    this.fetched = null;
+
+    if (!this.refs.annotationCards) {
+      // Lazy rendering is disabled and this bucket has already been populated.
+      this.fetched = Promise.resolve();
+    }
+
     this.scrollTo = this.options.scrollTo || scrollIntoView;
 
     this.refs.header.addEventListener('click', (event) => {
@@ -34,24 +56,30 @@ class SearchBucketController extends Controller {
       event.stopPropagation();
       event.preventDefault();
 
-      this.setState({expanded: !this.state.expanded});
+      this.toggle();
     });
 
     this.refs.title.addEventListener('click', (event) => {
       event.stopPropagation();
       event.preventDefault();
 
-      this.setState({expanded: !this.state.expanded});
+      this.toggle();
     });
 
     this.refs.collapseView.addEventListener('click', () => {
-      this.setState({expanded: !this.state.expanded});
+      this.toggle();
     });
 
     const envFlags = this.options.envFlags || window.envFlags;
 
     this.setState({
       expanded: !!envFlags.get('js-timeout'),
+    });
+
+    // Trigger a pre-emptive fetch when the user begins to click/tap a bucket.
+    // This makes the bucket content appear to load faster.
+    this.element.addEventListener('mousedown', () => {
+      this.fetchContent();
     });
   }
 
@@ -65,6 +93,68 @@ class SearchBucketController extends Controller {
     if (typeof prevState.expanded !== 'undefined' && state.expanded) {
       this.scrollTo(this.element);
     }
+
+    // Fetch content on initial expand.
+    if (state.expanded && this.fetched === null) {
+      this.fetchContent();
+    }
+  }
+
+  /**
+   * Toggle the expanded state of the bucket, fetching content beforehand if
+   * necessary.
+   */
+  toggle() {
+    if (this.state.expanded) {
+      this.setState({ expanded: false });
+      return Promise.resolve();
+    }
+
+    // Fetch the bucket content and then expand it. If the fetch is quick
+    // then delay showing the bucket until it is ready to avoid a flash of
+    // missing content. Otherwise the bucket will be expanded with a loading
+    // indicator visible.
+    const delay = this.options.delay;
+    return Promise.race([delay(300), this.fetchContent()]).then(() => {
+      this.setState({ expanded: true });
+    });
+  }
+
+  /**
+   * Fetch and populate the HTML content of the bucket.
+   */
+  fetchContent() {
+    if (this.fetched) {
+      return this.fetched;
+    }
+
+    const container = this.refs.annotationCards;
+    const annotationIds = container.dataset.ids.split(',');
+    const fetchOpts = {
+      method: 'POST',
+      body: JSON.stringify({ annotation_ids: annotationIds }),
+    };
+    const fetch = this.options.fetch;
+
+    // Display a loading indicator. If the user has a reasonably fast connection,
+    // they should not usually see this.
+    //
+    // TODO - Make the loading indicator look prettier in case the user does
+    // see it.
+    container.innerHTML = '...';
+
+    this.fetched = fetch('/search/bucket', fetchOpts).then((rsp) => {
+      return rsp.text();
+    }).then((html) => {
+      container.innerHTML = html;
+    }).catch((err) => {
+      container.textContent = `Unable to fetch annotations: ${err.message}`;
+
+      // Try again the next time the bucket is expanded.
+      this.fetched = null;
+    });
+
+    return this.fetched;
   }
 }
 

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -99,4 +99,34 @@ describe('SearchBucketController', () => {
       assert.isTrue(ctrl.state.expanded);
     });
   });
+
+  context('when lazy rendering is enabled', () => {
+    it('fetches rendered annotations when bucket is expanded', () => {
+      // TODO
+    });
+
+    it('expands bucket once content is fetched', () => {
+      // TODO
+    });
+
+    it('expands bucket if content is not fetched after a timeout', () => {
+      // TODO
+    });
+
+    it('populates bucket with fetched HTML', () => {
+      // TODO
+    });
+
+    it('does not fetch rendered annotations if already fetched', () => {
+      // TODO
+    });
+
+    it('renders an error message if fetch fails', () => {
+      // TODO
+    });
+
+    it('pre-fetches rendered annotations on mousedown', () => {
+      // TODO
+    });
+  });
 });

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -3,15 +3,27 @@
 const SearchBucketController = require('../../controllers/search-bucket-controller');
 const util = require('./util');
 
-const TEMPLATE = `<div class="js-search-bucket">
-  <div data-ref="header">
-    <a data-ref="domainLink">foo.com</a>
+function template({ lazyRendering }) {
+  const contentMarkup = lazyRendering ?
+    '<div data-ref="annotationCards"></div>' : '';
+
+  return `<div class="js-search-bucket">
+    <div data-ref="header">
+      <a data-ref="domainLink">foo.com</a>
+    </div>
+    <div data-ref="content">
+      ${contentMarkup}
+    </div>
+    <a data-ref="title"></a>
+    <button data-ref="collapseView"></button>
   </div>
-  <div data-ref="content"></div>
-  <a data-ref="title"></a>
-  <button data-ref="collapseView"></button>
-</div>
-`;
+  `;
+}
+
+const templates = {
+  lazyRender: template({ lazyRendering: true }),
+  noLazyRender: template({ lazyRendering: false }),
+};
 
 class FakeEnvFlags {
   constructor (flags = []) {
@@ -27,7 +39,7 @@ describe('SearchBucketController', () => {
   let ctrl;
 
   beforeEach(() => {
-    ctrl = util.setupComponent(document, TEMPLATE, SearchBucketController, {
+    ctrl = util.setupComponent(document, templates.noLazyRender, SearchBucketController, {
       envFlags: new FakeEnvFlags(),
     });
   });
@@ -85,7 +97,7 @@ describe('SearchBucketController', () => {
 
     beforeEach(() => {
       scrollTo = sinon.stub();
-      ctrl = util.setupComponent(document, TEMPLATE, SearchBucketController, {
+      ctrl = util.setupComponent(document, templates.noLazyRender, SearchBucketController, {
         scrollTo: scrollTo,
         envFlags: new FakeEnvFlags(['js-timeout']),
       });
@@ -101,6 +113,10 @@ describe('SearchBucketController', () => {
   });
 
   context('when lazy rendering is enabled', () => {
+    beforeEach(() => {
+      // TODO
+    });
+
     it('fetches rendered annotations when bucket is expanded', () => {
       // TODO
     });

--- a/h/templates/activity/bucket.html.jinja2
+++ b/h/templates/activity/bucket.html.jinja2
@@ -1,0 +1,5 @@
+{% from '../includes/annotation_card.html.jinja2' import annotation_card %}
+
+{% for ann in annotations %}
+  {{ annotation_card(ann, request, tag_link) }}
+{% endfor %}

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -129,11 +129,18 @@
   {# The content is the area that appears / disappears on expand / collapse. #}
   <div class="search-result-bucket__content">
     <div class="search-result-bucket__annotation-cards-container" data-ref="content">
-      <ol class="search-result-bucket__annotation-cards">
-        {% for result in bucket.presented_annotations %}
-          {{ annotation_card(result, request, tag_link) }}
-        {% endfor %}
+      {% if request.feature('render_buckets_lazily') %}
+      <ol class="search-result-bucket__annotation-cards"
+          data-ref="annotationCards"
+          data-ids="{{ ','.join(bucket.annotation_ids) }}">
       </ol>
+      {% else %}
+      <ol class="search-result-bucket__annotation-cards">
+          {% for ann in bucket.presented_annotations %}
+             {{ annotation_card(ann, request, tag_link) }}
+          {% endfor %}
+      </ol>
+      {% endif %}
       {{ search_bucket_stats(bucket) }}
     </div>
   </div>
@@ -220,12 +227,12 @@
     <input type="hidden" name="q" value="{{ q }}">
     {% if organization %}
       <div class="search-result-sidebar__organization">
-        <span class="search-result-sidebar__org-logo"> 
+        <span class="search-result-sidebar__org-logo">
           {% if organization.logo %}
             <img src="{{ organization.logo }}" alt="Organization logo" class='search-result-sidebar__logo'></img>
           {% endif %}
         </span>
-        <span class="search-result-sidebar__org-name"> 
+        <span class="search-result-sidebar__org-name">
           {{ organization.name }}
         </span>
       </div>
@@ -315,7 +322,7 @@
           <p>{{ paragraph }}</p>
         {% endfor %}
       {% endif %}
-    
+
       <div class="search-result-sidebar__subsection">
       {% if stats.annotation_count %}
         <p class="search-result-sidebar__subsection-p">

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -405,6 +405,10 @@ class TestExecute(object):
         _fetch_groups.assert_called_once_with(
             pyramid_request.db, matchers.UnorderedList(group_pubids))
 
+    def test_it_does_not_fetch_groups_when_lazy_rendering(self):
+        # TODO
+        pass
+
     def test_it_returns_each_annotation_presented(self,
                                                   annotations,
                                                   pyramid_request):
@@ -421,6 +425,10 @@ class TestExecute(object):
                     break
             else:
                 assert False
+
+    def test_it_does_not_present_annotations_when_lazy_rendering(self):
+        # TODO
+        pass
 
     def test_it_returns_each_annotations_group(self,
                                                _fetch_groups,
@@ -635,8 +643,14 @@ class TestExecute(object):
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
+        pyramid_request.feature.flags['render_buckets_lazily'] = False
         pyramid_request.stats = None
         return pyramid_request
+
+
+class TestPresentAnnotations(object):
+    # TODO - Test for presentation.
+    pass
 
 
 class TestFetchAnnotations(object):

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -34,6 +34,7 @@ def test_includeme():
         call('claim_account_legacy', '/claim_account/{token}'),
         call('dismiss_sidebar_tutorial', '/app/dismiss_sidebar_tutorial'),
         call('activity.search', '/search'),
+        call('activity.bucket', '/search/bucket'),
         call('activity.user_search', '/users/{username}', factory='h.traversal:UserRoot', traverse='/{username}'),
         call('admin.index', '/admin/'),
         call('admin.admins', '/admin/admins'),

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -1206,6 +1206,18 @@ class TestGroupAndUserSearchController(object):
         return activity.UserSearchController(user, pyramid_request)
 
 
+class TestBucket(object):
+    # TODO - Tests
+    def test_it_presents_annotations(self):
+        pass
+
+    def test_it_returns_tag_links(self):
+        pass
+
+    def test_it_returns_400_for_invalid_json(self):
+        pass
+
+
 @pytest.fixture
 def group(factories):
     group = factories.Group()


### PR DESCRIPTION
_This is some work in progress code I made a start on locally which addresses https://github.com/hypothesis/product-backlog/issues/830._

**Problem:**

Rendering of activity pages search results which return many annotations is slow in production (typically 1500ms+). New Relic profiling shows that the bulk of the time is spent in Jinja template rendering.

**Approach:**

This PR adds a feature-flagged optimization which speeds up activity pages by rendering the annotation cards lazily when the user expands the bucket, instead of always rendering all (up to 200) cards in the initial HTML document. This is implemented as follows:

1. The initial results page HTML does not contain rendered annotation buckets but just an empty content element for each bucket which has a data attribute that lists the IDs of annotations in the bucket.
2. Clicking on a bucket triggers a `POST /search/bucket` request with an array of annotation IDs in the payload.
3. The backend responds with the rendered HTML for all annotations in the bucket, which the client-side code then uses to populate the content element.

To try and avoid any noticeable visual changes when interacting with buckets, a few tricks are used:

1. When the user presses the mouse/finger down on a bucket, a pre-emptive request is made to fetch the content. The bucket only expands on mouse up, so this buys 200ms or so.
2. When the mouse up event occurs, the client-side code will wait for up to 300ms before expanding the bucket until the content is available. This avoids a "flash of empty bucket"
3. Finally if fetching takes longer than 300ms after mouse up, the bucket expands and displays a loading indicator so that the user can see something happened.

**Caveats:**

The content of annotation cards is no longer available to consumers of search result pages which don't run JavaScript. I have a strong Opinion™ that we should change our overall approach to how much of the site works without JS. This needs discussion though. There is a way that we could provide a fallback if necessary which might be useful for eg. bots.

**Alternatives:**

An alternative approach would be to move the rendering client-side, and possibly share some of the rendering code with the client. This would allow us to support videos, maths etc. on activity pages. That however requires more substantial work and this approach solves the performance problem and I suggest is an easier first step in the right direction.