### PR TITLE
move all newrelic stuff to a single file under utils

### DIFF
--- a/h/util/metrics.py
+++ b/h/util/metrics.py
@@ -1,0 +1,85 @@
+from __future__ import unicode_literals
+
+import newrelic.agent
+
+
+def send_metric(name, metric):
+    """Send a metric to New Relic.
+
+    :arg name: The key name. Only the first 255 characters are retained
+    :type name: str
+    :arg metric: The string value to add to the current transaction
+        Only the first 255 characters are retained.
+    :type metric: str, int, float, bool
+    """
+    newrelic.agent.add_custom_parameter(name, metric)
+
+
+def record_search_query_param_usage(params, separate_replies):
+    """Send search request params to New Relic as metrics.
+
+    :arg params: the request params to record
+    :type params: webob.multidict.MultiDict
+    :arg separate_replies: Records usage of _separate_replies parameter in the search
+    :type separate_replies: bool
+    """
+    keys = [
+        # Record usage of inefficient offset and it's alternative search_after.
+        "offset",
+        "search_after",
+        "sort",
+        # Record usage of url/uri (url is an alias of uri).
+        "url",
+        "uri",
+        # Record usage of tags/tag (tags is an alias of tag).
+        "tags",
+        "tag",
+        # Record group and user-these help in identifying slow queries.
+        "group",
+        "user",
+        # Record usage of wildcard feature.
+        "wildcard_uri",
+    ]
+    # Record usage of _separate_replies which will help distinguish client calls
+    # for loading the sidebar annotations from other API calls.
+    send_metric("es__separate_replies", separate_replies)
+
+    for k in keys:
+        if k in params:
+            # The New Relic Query Language does not permit _ at the begining
+            # and offset is a reserved key word.
+            send_metric("es_{}".format(k), params[k])
+
+
+def record_search_api_usage_metrics(params):
+    """Send search API request params to New Relic as metrics.
+
+    :arg params: the request params to record
+    :type params: webob.multidict.MultiDict
+    """
+    keys = [
+        # Record usage of inefficient offset and it's alternative search_after.
+        "offset",
+        "search_after",
+        "sort",
+        # Record usage of url/uri (url is an alias of uri).
+        "url",
+        "uri",
+        # Record usage of tags/tag (tags is an alias of tag).
+        "tags",
+        "tag",
+        # Record usage of _separate_replies which will help distinguish client calls
+        # for loading the sidebar annotations from other api calls.
+        "_separate_replies",
+        # Record group and user-these help in identifying slow queries.
+        "group",
+        "user",
+        # Record usage of wildcard feature.
+        "wildcard_uri",
+    ]
+
+    for k in keys:
+        if k in params:
+            # The New Relic Query Language does not permit _ at the begining
+            # and offset is a reserved key word.
+            send_metric("es_{}".format(k), params[k])

--- a/tests/h/util/metrics_test.py
+++ b/tests/h/util/metrics_test.py
@@ -1,0 +1,47 @@
+from __future__ import unicode_literals
+
+import pytest
+from mock import call
+from webob.multidict import MultiDict
+
+from h.util import metrics
+
+
+class TestSendMetric(object):
+    def test_send_metric(self, newrelic):
+        metrics.send_metric("testkey", "testvalue")
+        newrelic.agent.add_custom_parameter.assert_called_once_with(
+            "testkey", "testvalue"
+        )
+
+    @pytest.fixture(autouse=True)
+    def newrelic(self, patch):
+        return patch("h.util.metrics.newrelic")
+
+
+@pytest.mark.usefixtures("send_metric")
+class TestRecordSearchApiUsageMetrics(object):
+    def test_records_parameters(self, send_metric):
+        params = MultiDict(tags="tagsvalue", url="urlvalue", bad="unwanted")
+        metrics.record_search_api_usage_metrics(params)
+        assert send_metric.call_args_list == [
+            call("es_url", "urlvalue"),
+            call("es_tags", "tagsvalue"),
+        ]
+
+
+@pytest.mark.usefixtures("send_metric")
+class TestRecordSearchQueryParamUsage(object):
+    def test_records_parameters(self, send_metric):
+        params = MultiDict(tags="tagsvalue", url="urlvalue", bad="unwanted")
+        metrics.record_search_query_param_usage(params, True)
+        assert send_metric.call_args_list == [
+            call("es__separate_replies", True),
+            call("es_url", "urlvalue"),
+            call("es_tags", "tagsvalue"),
+        ]
+
+
+@pytest.fixture
+def send_metric(patch):
+    return patch("h.util.metrics.send_metric")


### PR DESCRIPTION
Because we don't want to reference newrelic (and similar 3rd party services)
directly in our core app. This is simpler than making a new class to wrap
metrics, however this approach doesn't allow supporting metrics services
other than newrelic without code changes. It's an improvement because
all the logic will be in one place instead of scattered throughout.