### PR TITLE
Add migration to add `enforce_scope` column to `group` table

### DIFF
--- a/h/migrations/versions/2d0ad2b1bf07_add_enforce_scope_column_to_group_table.py
+++ b/h/migrations/versions/2d0ad2b1bf07_add_enforce_scope_column_to_group_table.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Add enforce_scope column to group table"""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "2d0ad2b1bf07"
+down_revision = "5ed9c8c105f6"
+
+
+def upgrade():
+    op.add_column(
+        "group",
+        sa.Column(
+            "enforce_scope",
+            sa.Boolean(),
+            server_default=sa.sql.expression.true(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("group", "enforce_scope")


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/865

This migration adds the `enforce_scope` column to the group table. It's a Boolean that defaults to `True` and is non-nullable.

The functionality of this column will documented more clearly in a subsequent PR when it is added as a property to the group model, but for quick reference: when this value is TRUE (default) _and_ the group in question has >= 1  scopes defined, annotations will only be allowed if their target document matches at least one scope for the group (none of this is enforced yet).
