### PR TITLE
Add `enforce_scope` property to model

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -64,6 +64,20 @@ class Group(Base, mixins.Timestamps):
 
     description = sa.Column(sa.UnicodeText())
 
+    #: Enforce scope match for annotations in this group.
+    #: For groups with 1-n scopes, only allow annotations for target
+    #: documents whose URIs match one of the group's scopes.
+    #: When disabled, annotations should be allowed web-wide.
+    #: This setting has no effect if the group does not have any scopes.
+    #: Enforcement is the responsibility of services (i.e. the model
+    #: layer does not enforce scope compliance).
+    enforce_scope = sa.Column(
+        sa.Boolean,
+        nullable=False,
+        default=True,
+        server_default=sa.sql.expression.true(),
+    )
+
     #: Allow authorities to define their own unique identifier for a group
     #: (versus the pubid). This identifier is owned by the authority/client
     #: versus ``pubid``, which is owned and controlled by the service.

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -17,10 +17,11 @@ from h.models.group import (
 
 
 def test_init_sets_given_attributes():
-    group = models.Group(name="My group", authority="example.com")
+    group = models.Group(name="My group", authority="example.com", enforce_scope=False)
 
     assert group.name == "My group"
     assert group.authority == "example.com"
+    assert group.enforce_scope is False
 
 
 def test_with_short_name():
@@ -33,6 +34,28 @@ def test_with_long_name():
     """Should raise ValueError if name longer than 25 characters."""
     with pytest.raises(ValueError):
         models.Group(name="abcdefghijklmnopqrstuvwxyz")
+
+
+def test_enforce_scope_is_True_by_default(db_session, factories):
+    user = factories.User()
+    group = models.Group(name="Foobar", authority="foobar.com", creator=user)
+
+    db_session.add(group)
+    db_session.flush()
+
+    assert group.enforce_scope is True
+
+
+def test_enforce_scope_can_be_set_False(db_session, factories):
+    user = factories.User()
+    group = models.Group(
+        name="Foobar", authority="foobar.com", creator=user, enforce_scope=False
+    )
+
+    db_session.add(group)
+    db_session.flush()
+
+    assert group.enforce_scope is False
 
 
 def test_slug(db_session, factories, default_organization):


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h/pull/5455

Marking WIP because of dependency.

This PR adds the `enforce_scope` property to the group model.