### PR TITLE
Upgrade to Sentry's newer Unified Python SDK

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -1,10 +1,6 @@
 [pipeline:main]
-# Most errors will be handled in exception views within the application. The
-# raven middleware is here primarily as a fail-safe, and to capture errors
-# thrown by framework code.
 pipeline:
   proxy-prefix
-  raven
   h
 
 [app:h]
@@ -13,26 +9,23 @@ use: call:h.app:create_app
 [filter:proxy-prefix]
 use: egg:PasteDeploy#prefix
 
-[filter:raven]
-use: egg:raven#raven
-
 [server:main]
 use: egg:gunicorn
 host: 0.0.0.0
 port: 5000
 
 [loggers]
-keys = root, alembic, gunicorn.error, h, sentry
+keys = root, alembic, gunicorn.error, h
 
 [handlers]
-keys = console, sentry
+keys = console
 
 [formatters]
 keys = generic
 
 [logger_root]
 level = WARNING
-handlers = console, sentry
+handlers = console
 
 [logger_alembic]
 level = INFO
@@ -49,21 +42,9 @@ level = INFO
 handlers =
 qualname = h
 
-[logger_sentry]
-level = WARNING
-handlers = console
-qualname = sentry.errors
-propagate = 0
-
 [handler_console]
 level = NOTSET
 class = StreamHandler
-args = ()
-formatter = generic
-
-[handler_sentry]
-level = WARNING
-class = raven.handlers.logging.SentryHandler
 args = ()
 formatter = generic
 

--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -31,7 +31,7 @@ errorlog: -
 reload: True
 
 [loggers]
-keys = root, gunicorn.error, h, raven
+keys = root, gunicorn.error, h
 
 [handlers]
 keys = console
@@ -52,12 +52,6 @@ qualname = gunicorn.error
 level = INFO
 handlers =
 qualname = h
-
-[logger_raven]
-level = WARNING
-handlers = console
-qualname = raven
-propagate = 0
 
 [handler_console]
 level = NOTSET

--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -5,9 +5,6 @@ use: call:h.websocket:create_app
 # it does use the same config loading code which checks for these settings.
 es.url: http://localhost:9200
 
-# Use gevent-compatible transport for the Sentry client
-raven.transport: gevent
-
 secret_key: notverysecretafterall
 
 # SQLAlchemy configuration -- See SQLAlchemy documentation
@@ -21,7 +18,7 @@ worker_class: h.websocket.Worker
 graceful_timeout: 0
 
 [loggers]
-keys = root, gunicorn.error, h, raven
+keys = root, gunicorn.error, h
 
 [handlers]
 keys = console
@@ -42,12 +39,6 @@ qualname = gunicorn.error
 level = INFO
 handlers =
 qualname = h
-
-[logger_raven]
-level = WARNING
-handlers = console
-qualname = raven
-propagate = 0
 
 [handler_console]
 level = NOTSET

--- a/conf/websocket.ini
+++ b/conf/websocket.ini
@@ -1,9 +1,6 @@
 [app:main]
 use: call:h.websocket:create_app
 
-# Use gevent-compatible transport for the Sentry client
-raven.transport: gevent
-
 [server:main]
 use: egg:gunicorn
 host: 0.0.0.0
@@ -12,28 +9,22 @@ worker_class: h.websocket.Worker
 graceful_timeout: 0
 
 [loggers]
-keys = root, gunicorn.error, sentry, ws4py
+keys = root, gunicorn.error, ws4py
 
 [handlers]
-keys = console, sentry
+keys = console
 
 [formatters]
 keys = generic
 
 [logger_root]
 level = WARNING
-handlers = console, sentry
+handlers = console
 
 [logger_gunicorn.error]
 level = INFO
 handlers =
 qualname = gunicorn.error
-
-[logger_sentry]
-level = WARNING
-handlers = console
-qualname = sentry.errors
-propagate = 0
 
 [logger_ws4py]
 level = WARNING
@@ -45,12 +36,6 @@ propagate = 0
 [handler_console]
 level = NOTSET
 class = StreamHandler
-args = ()
-formatter = generic
-
-[handler_sentry]
-level = WARNING
-class = raven.handlers.logging.SentryHandler
 args = ()
 formatter = generic
 

--- a/h/celery.py
+++ b/h/celery.py
@@ -19,7 +19,6 @@ from celery import Celery
 from celery import signals
 from celery.utils.log import get_task_logger
 from kombu import Exchange, Queue
-from raven.contrib.celery import register_signal, register_logger_signal
 
 __all__ = ("celery", "get_task_logger")
 
@@ -92,10 +91,6 @@ celery.conf.update(
 def bootstrap_worker(sender, **kwargs):
     request = sender.app.webapp_bootstrap()
     sender.app.request = request
-
-    # Configure Sentry reporting on task failure
-    register_signal(request.sentry)
-    register_logger_signal(request.sentry, loglevel=logging.ERROR)
 
 
 @signals.task_prerun.connect

--- a/h/config.py
+++ b/h/config.py
@@ -114,6 +114,7 @@ def configure(environ=None, settings=None):
     # password component in the DSN URI.
     settings_manager.set("h.sentry_dsn_client", "SENTRY_DSN_CLIENT")
     settings_manager.set("h.sentry_dsn_frontend", "SENTRY_DSN_FRONTEND")
+    settings_manager.set("h.sentry_environment", "SENTRY_ENVIRONMENT", default="dev")
     settings_manager.set("h.websocket_url", "WEBSOCKET_URL")
 
     # Debug/development settings

--- a/h/eventqueue.py
+++ b/h/eventqueue.py
@@ -6,6 +6,8 @@ import logging
 
 from zope.interface import providedBy
 
+from h.sentry import report_exception
+
 
 log = logging.getLogger(__name__)
 
@@ -59,14 +61,9 @@ class EventQueue(object):
                 try:
                     subscriber(event)
                 except Exception:
-                    sentry = getattr(event.request, "sentry", None)
-                    if sentry is not None:
-                        sentry.captureException()
-                    else:
-                        log.exception("Queued event subscriber failed")
-
                     if event.request.debug:
                         raise
+                    report_exception()
 
     def response_callback(self, request, response):
         if request.exception is not None:

--- a/h/sentry.py
+++ b/h/sentry.py
@@ -1,73 +1,32 @@
 # -*- coding: utf-8 -*-
-"""
-Provide a Sentry client at `request.sentry`.
-
-This module provides a Sentry client, preconfigured with appropriate request
-context, as a request property, `request.sentry`. This allows us to more easily
-log exceptions from within the application with a useful complement of
-diagnostic data.
-"""
+"""Error tracking service API and setup."""
 from __future__ import unicode_literals
 
-import raven
-from raven.transport import GeventedHTTPTransport
-from raven.utils.wsgi import get_environ
-
-from h import __version__
-
-PROCESSORS = (
-    "raven.processors.SanitizePasswordsProcessor",
-    "raven.processors.RemovePostDataProcessor",
-)
+import sentry_sdk
+import sentry_sdk.integrations.celery
+import sentry_sdk.integrations.pyramid
 
 
-def http_context_data(request):
-    return {
-        "url": request.url,
-        "method": request.method,
-        "data": request.body,
-        "query_string": request.query_string,
-        "cookies": dict(request.cookies),
-        "headers": dict(request.headers),
-        "env": dict(get_environ(request.environ)),
-    }
-
-
-def user_context_data(request):
-    return {"id": request.authenticated_userid, "ip_address": request.client_addr}
-
-
-def get_client(settings):
+def report_exception(exc=None):
     """
-    Get a Sentry client configured with context data for the current request.
+    Report an exception to the error tracking service.
+
+    If the given ``exc`` is :obj:`None` then the most recently raised exception
+    will be reported.
+
+    :arg exc: the exception to report
+    :type exc: :class:`Exception`, :obj:`None`, or a :func:`sys.exc_info` tuple
     """
-    # If the `raven.transport` setting is set to 'gevent', then we use the
-    # raven-supplied gevent compatible transport.
-    transport_name = settings.get("raven.transport")
-    transport = GeventedHTTPTransport if transport_name == "gevent" else None
-
-    # Application environment name
-    environment = settings.get("h.env", "dev")
-
-    return raven.Client(
-        environment=environment,
-        release=__version__,
-        transport=transport,
-        processors=PROCESSORS,
-    )
-
-
-def _get_request_client(request):
-    client = request.registry["sentry.client"]
-    client.http_context(http_context_data(request))
-    client.user_context(user_context_data(request))
-    request.add_finished_callback(lambda _: client.context.clear())
-    return client
+    sentry_sdk.capture_exception(exc)
 
 
 def includeme(config):
-    # Create a sentry client and store it in the registry
-    config.registry["sentry.client"] = get_client(config.registry.settings)
-
-    # Allow retrieval of the client within a request as `request.sentry`
-    config.add_request_method(_get_request_client, "sentry", reify=True)
+    """Set up the error tracking service."""
+    sentry_sdk.init(
+        integrations=[
+            sentry_sdk.integrations.celery.CeleryIntegration(),
+            sentry_sdk.integrations.pyramid.PyramidIntegration(),
+        ],
+        environment=config.registry.settings["h.sentry_environment"],
+        send_default_pii=True,
+    )

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -16,7 +16,6 @@ from h.services.links import LinksService
 from h.services.nipsa import NipsaService
 from h.services.groupfinder import GroupfinderService
 from h.streamer import websocket
-import h.sentry
 import h.stats
 
 from h._compat import text_type
@@ -49,13 +48,11 @@ def process_messages(settings, routing_key, work_queue, raise_error=True):
             )
 
     conn = realtime.get_connection(settings)
-    sentry_client = h.sentry.get_client(settings)
     statsd_client = h.stats.get_client(settings)
     consumer = Consumer(
         connection=conn,
         routing_key=routing_key,
         handler=_handler,
-        sentry_client=sentry_client,
         statsd_client=statsd_client,
     )
     consumer.run()

--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -67,7 +67,6 @@ def error_badhandshake(exc, request):
 @view_config(context=Exception, renderer="json")
 def error(context, request):
     request.response.status_code = 500
-    request.sentry.captureException()
     request.stats.incr("streamer.error.server_error")
     if request.debug:
         raise

--- a/h/util/view.py
+++ b/h/util/view.py
@@ -21,19 +21,6 @@ def handle_exception(request, exception):
     """
     request.response.status_int = 500
 
-    # There are two code paths here depending on whether this is the most recent
-    # exception in the current thread. If it is, we can let Raven capture
-    # the details under Python 2 + 3. If not, we need to construct the
-    # exc_info tuple manually and the stacktrace is only available in Python 3.
-    last_exc_info = _exc_info()
-    if exception is last_exc_info[1]:
-        request.sentry.captureException()
-    else:
-        # `__traceback__` is a Python 3-only property.
-        traceback = getattr(exception, "__traceback__", None)
-        exc_info = (type(exception), exception, traceback)
-        request.sentry.captureException(exc_info)
-
     # In debug mode we should just reraise, so that the exception is caught by
     # the debug toolbar.
     if request.debug:

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -61,7 +61,7 @@ class WebSocketWSGIHandler(PyWSGIHandler):
 
     def finalize_headers(self):
         if self.environ.get("HTTP_UPGRADE", "").lower() == "websocket":
-            # Middleware, like Raven, may yield from the empty upgrade
+            # Middleware may yield from the empty upgrade
             # response, confusing this method into sending "Transfer-Encoding:
             # chunked" and, in turn, this confuses some strict WebSocket
             # clients.

--- a/requirements.in
+++ b/requirements.in
@@ -38,7 +38,7 @@ pyramid_mailer
 pyramid_tm
 python-dateutil
 python-slugify < 1.2.0
-raven
+sentry-sdk
 statsd
 transaction
 venusian

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ cffi==1.11.5
 chameleon==2.24           # via deform
 click==6.6
 colander==1.3.1           # via deform
-contextlib2==0.5.4        # via raven
 deform-jinja2==0.5
 deform==0.9.9
 elasticsearch-dsl==6.3.1
@@ -58,9 +57,9 @@ python-dateutil==2.5.3
 python-editor==1.0.1      # via alembic
 python-slugify==1.1.4
 pytz==2016.6.1            # via celery
-raven==6.0.0
 repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.3      # via pyramid-mailer
+sentry-sdk==0.6.2
 six==1.10.0               # via bcrypt, bleach, elasticsearch-dsl, python-dateutil
 sqlalchemy==1.1.4
 statsd==3.2.1

--- a/tests/h/celery_test.py
+++ b/tests/h/celery_test.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import logging
 
 import mock
-import pytest
 
 from billiard.einfo import ExceptionInfo
 
@@ -12,14 +10,6 @@ from h import celery
 
 
 class TestCelery(object):
-    @pytest.fixture(autouse=True)
-    def register_signal(self, request):
-        return _patch("h.celery.register_signal", request)
-
-    @pytest.fixture(autouse=True)
-    def register_logger_signal(self, request):
-        return _patch("h.celery.register_logger_signal", request)
-
     def test_bootstrap_worker_bootstraps_application(self):
         sender = mock.Mock(spec=["app"])
 
@@ -34,20 +24,6 @@ class TestCelery(object):
         celery.bootstrap_worker(sender)
 
         assert sender.app.request == request
-
-    def test_bootstrap_worker_configures_sentry_reporting(
-        self, register_signal, register_logger_signal
-    ):
-        sender = mock.Mock(spec=["app"])
-        request = sender.app.webapp_bootstrap.return_value
-        request.sentry = mock.sentinel.sentry
-
-        celery.bootstrap_worker(sender)
-
-        register_signal.assert_called_once_with(mock.sentinel.sentry)
-        register_logger_signal.assert_called_once_with(
-            mock.sentinel.sentry, loglevel=logging.ERROR
-        )
 
     def test_nipsa_cache(self, pyramid_config, pyramid_request):
         sender = mock.Mock(app=mock.Mock(request=pyramid_request))

--- a/tests/h/eventqueue_test.py
+++ b/tests/h/eventqueue_test.py
@@ -82,29 +82,6 @@ class TestEventQueue(object):
             queue.publish_all()
         assert str(excinfo.value) == "boom!"
 
-    def test_publish_all_sends_exception_to_sentry(self, subscriber, pyramid_request):
-        pyramid_request.sentry = mock.Mock()
-        subscriber.side_effect = ValueError("exploded!")
-        queue = eventqueue.EventQueue(pyramid_request)
-        event = DummyEvent(pyramid_request)
-        queue(event)
-
-        queue.publish_all()
-
-        assert pyramid_request.sentry.captureException.called
-
-    def test_publish_all_logs_exception_when_sentry_is_not_available(
-        self, log, subscriber, pyramid_request
-    ):
-        subscriber.side_effect = ValueError("exploded!")
-        queue = eventqueue.EventQueue(pyramid_request)
-        event = DummyEvent(pyramid_request)
-        queue(event)
-
-        queue.publish_all()
-
-        assert log.exception.called
-
     def test_response_callback_skips_publishing_events_on_exception(
         self, publish_all, pyramid_request
     ):

--- a/tests/h/sentry_test.py
+++ b/tests/h/sentry_test.py
@@ -1,18 +1,44 @@
 # -*- coding: utf-8 -*-
-
 from __future__ import unicode_literals
 
 import pytest
 
-from h.sentry import get_client
+from h.sentry import includeme, report_exception
 
 
-class TestGetClient(object):
-    @pytest.mark.parametrize(
-        "settings,env",
-        [({}, "dev"), ({"h.env": "qa"}, "qa"), ({"h.env": "prod"}, "prod")],
-    )
-    def test_set_environment(self, settings, env):
-        client = get_client(settings)
+class TestReportException(object):
+    def test_it_reports_the_exception_to_Sentry(self, sentry_sdk):
+        exc = ValueError("Test exception")
 
-        assert client.environment == env
+        report_exception(exc)
+
+        sentry_sdk.capture_exception.assert_called_once_with(exc)
+
+    def test_exc_defaults_to_None(self, sentry_sdk):
+        report_exception()
+
+        sentry_sdk.capture_exception.assert_called_once_with(None)
+
+
+class TestIncludeMe(object):
+    def test_it_initializes_sentry_sdk(self, pyramid_config, sentry_sdk):
+        includeme(pyramid_config)
+
+        sentry_sdk.init.assert_called_once_with(
+            integrations=[
+                sentry_sdk.integrations.celery.CeleryIntegration.return_value,
+                sentry_sdk.integrations.pyramid.PyramidIntegration.return_value,
+            ],
+            environment="test",
+            send_default_pii=True,
+        )
+
+    @pytest.fixture(autouse=True)
+    def pyramid_config(self, pyramid_config):
+        pyramid_config.registry.settings["h.sentry_environment"] = "test"
+        return pyramid_config
+
+
+@pytest.fixture(autouse=True)
+def sentry_sdk(patch):
+    return patch("h.sentry.sentry_sdk")

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -32,26 +32,8 @@ class FakeSocket(object):
         self.send_json_payloads.append(payload)
 
 
-@pytest.mark.usefixtures("fake_sentry", "fake_stats")
+@pytest.mark.usefixtures("fake_stats")
 class TestProcessMessages(object):
-    def test_creates_sentry_client(self, fake_sentry, fake_consumer, queue):
-        settings = {}
-
-        messages.process_messages(settings, "foobar", queue, raise_error=False)
-
-        fake_sentry.get_client.assert_called_once_with(settings)
-
-    def test_passes_sentry_client_to_consumer(self, fake_sentry, fake_consumer, queue):
-        messages.process_messages({}, "foobar", queue, raise_error=False)
-
-        fake_consumer.assert_called_once_with(
-            connection=mock.ANY,
-            routing_key=mock.ANY,
-            handler=mock.ANY,
-            sentry_client=fake_sentry.get_client.return_value,
-            statsd_client=mock.ANY,
-        )
-
     def test_creates_statsd_client(self, fake_stats, fake_consumer, queue):
         settings = {}
 
@@ -66,7 +48,6 @@ class TestProcessMessages(object):
             connection=mock.ANY,
             routing_key=mock.ANY,
             handler=mock.ANY,
-            sentry_client=mock.ANY,
             statsd_client=fake_stats.get_client.return_value,
         )
 
@@ -77,7 +58,6 @@ class TestProcessMessages(object):
             connection=mock.ANY,
             routing_key="foobar",
             handler=mock.ANY,
-            sentry_client=mock.ANY,
             statsd_client=mock.ANY,
         )
 
@@ -94,7 +74,6 @@ class TestProcessMessages(object):
             connection=fake_realtime.get_connection.return_value,
             routing_key=mock.ANY,
             handler=mock.ANY,
-            sentry_client=mock.ANY,
             statsd_client=mock.ANY,
         )
 
@@ -112,10 +91,6 @@ class TestProcessMessages(object):
 
         assert result.topic == "foobar"
         assert result.payload == {"foo": "bar"}
-
-    @pytest.fixture
-    def fake_sentry(self, patch):
-        return patch("h.sentry")
 
     @pytest.fixture
     def fake_stats(self, patch):

--- a/tests/h/util/view_test.py
+++ b/tests/h/util/view_test.py
@@ -15,21 +15,6 @@ class TestHandleException(object):
 
         assert pyramid_request.response.status_int == 500
 
-    def test_triggers_sentry_capture_with_latest_exception(
-        self, pyramid_request, latest_exception
-    ):
-        handle_exception(pyramid_request, latest_exception)
-        pyramid_request.sentry.captureException.assert_called_once_with()
-
-    def test_triggers_sentry_capture_with_old_exception(
-        self, pyramid_request, old_exception
-    ):
-        handle_exception(pyramid_request, old_exception)
-        traceback = getattr(old_exception, "__traceback__", None)
-        pyramid_request.sentry.captureException.assert_called_once_with(
-            (type(old_exception), old_exception, traceback)
-        )
-
     def test_reraises_in_debug_mode(self, pyramid_request):
         pyramid_request.debug = True
         dummy_exc = ValueError("dummy")
@@ -43,8 +28,6 @@ class TestHandleException(object):
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        sentry = Mock(spec_set=["captureException"])
-        pyramid_request.sentry = sentry
         pyramid_request.debug = False
         return pyramid_request
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ passenv =
     dev: CLIENT_RPC_ALLOWED_ORIGINS
     dev: CLIENT_URL
     dev: SENTRY_DSN
+    dev: SENTRY_ENVIRONMENT
     dev: USE_HTTPS
     dev: WEBSOCKET_URL
     dev: NEW_RELIC_LICENSE_KEY


### PR DESCRIPTION
<del>Depends on https://github.com/hypothesis/h/pull/5464 and contains the commits from #5464. After #5464 is merged this'll need to be rebased, which should be a clean rebase (no conflicts). Only the last commit (Upgrade to Sentry's newer Unified Python SDK) is actually part of this PR.</del>

Upgrade to Sentry's newer Unified Python SDK instead of the legacy client (Raven) that we were using previously.

Unified Python SDK docs:

https://docs.sentry.io/error-reporting/quickstart/?platform=python

We're using the builtin Pyramid and Celery integrations:

https://docs.sentry.io/platforms/python/pyramid/
https://docs.sentry.io/platforms/python/celery/

The logging integration (sending standard `logging.debug()` messages to Sentry as breadcrumbs, and `logging.error()` messages as errors) is also enabled by default:

https://docs.sentry.io/platforms/python/logging/

A few other integrations are also enabled by default:

https://docs.sentry.io/platforms/python/default-integrations/

Sentry's Unified Python SDK is much more "just works" so this commit largely just removes Sentry-related code that's no longer needed. In fact, **all** code related to reporting Python errors to Sentry is now in `h/sentry.py`. There's no usage of Sentry left outside of this one file.  If you grep for "sentry" you will find it in several files but this has to do with the `SENTRY_DSN_CLIENT` setting that h passes to the
client and the `SENTRY_DSN_FRONTEND` setting that h passes to its own frontend code so they can report their errors to Sentry.

Testing
-------

To test this you'll need to set up a Sentry account and project and configure your dev environment to use it:

1. Go to <https://sentry.io/signup/> and create a free account.
2. In your Sentry account create an `h` project.
3. Copy the project's DSN (a URL like `https://*@sentry.io/*`) from the
   Settings > Client Keys (DSN) page and set it as the value of the
   `SENTRY_DSN` environment variable in your environment.
4. Restart h.

Changes
-------

* The `raven` Python dependency has been removed and `sentry-sdk` added instead.

* A new config setting `SENTRY_ENVIRONMENT` / `"h.sentry_environment"` has been added. h reads it in from the environment variable and passes it to Sentry.

  In the `h` project in Sentry you'll see a dropdown menu in the top-right for filtering the errors by what environment they came from -- Dev, Prod or QA. This setting is what adds that to the errors sent to Sentry. It defaults to `"dev"` so that developers won't have to set it in their dev envs. It'll need to be set on QA and prod.

* `h/sentry.py` has changed completely. It now just configures Sentry's Unified Python SDK which is much simpler, just a single function call. See the docs above.

  `h/sentry.py` gets included (by `h/app.py`) early in the boot process and configures Sentry. From then on Sentry just works automatically. (Or if anything does import `sentry_sdk` and call it directly the config will be present.)

  Some Sentry processors and context data that were being set up in `sentry.py` have simply been removed -- the builtin Pyramid integration's defaults are much better.

  There's no `request.sentry` anymore. The Unified Python SDK doesn't have a client object. The only thing we were using `request.sentry` for was to manually report errors in various places. With the Unified SDK you just do this without a client object:

  ```python
  import sentry_sdk

  sentry_sdk.capture_exception()
  ```

  But it turns out we don't need to manually report anything anymore, so we don't need this anyway.

* All Sentry and Raven logger configuration is removed from all `conf/*.ini` files.  None of this is needed anymore.

* `util/view.py::handle_exception()` is a helper function called by web and API error views to report exceptions to Sentry among other things. These now get reported automatically so the Sentry stuff has been removed from this file.

  You can test this by creating crashes in web and API requests. For example lets make activity pages crash:

  ```diff
  diff --git a/h/views/activity.py b/h/views/activity.py
  index 37ed340e4..bac33b8d6 100644
  --- a/h/views/activity.py
  +++ b/h/views/activity.py
  @@ -41,6 +41,8 @@ class SearchController(object):

      @view_config(request_method="GET")
      def search(self):
  +        raise RuntimeError("Failed")
  +
          # Make a copy of the query params to be consumed by search.
          q = self.parsed_query_params.copy()

  ```

  Now visit <http://localhost:5000/search> and it should crash. Visit
  Sentry and you should see the crash reported there.

  To test the API crash reporting lets create a crash in an API view:

  ```diff
  diff --git a/h/views/api/groups.py b/h/views/api/groups.py
  index 8c1b541b9..5971ac433 100644
  --- a/h/views/api/groups.py
  +++ b/h/views/api/groups.py
  @@ -22,6 +22,7 @@ from h.views.api.config import api_config
  )
  def groups(request):
      """Retrieve the groups for this request's user."""
  +    raise RuntimeError("Failed")

      authority = request.params.get("authority")
      document_uri = request.params.get("document_uri")
  ```

  Now visit <http://localhost:5000/api/groups> and it should crash.
  Visit Sentry and you should see the crash reported there.

* The Celery integration using `raven.contrib.celery` in `h/celery.py`
  is removed. This is no longer needed because Sentry's builtin
  `CeleryIntegration` (activated in `h/sentry.py`) just works.

  You can test this by creating an error in a Celery worker. For
  example lets break the rename user task:

  ```diff
  diff --git a/h/tasks/admin.py b/h/tasks/admin.py
  index 451d66892..247ad3616 100644
  --- a/h/tasks/admin.py
  +++ b/h/tasks/admin.py
  @@ -12,6 +12,7 @@ log = get_task_logger(__name__)

  @celery.task
  def rename_user(user_id, new_username):
  +    raise RuntimeError("Failed")
      user = celery.request.db.query(models.User).get(user_id)
      if user is None:
          raise ValueError("Could not find user with id %d" % user_id)
  ```

  Now go to <http://localhost:5000/admin/users> as an admin and try to
  rename a user. You should see a worker crash in your terminal, and if
  you visit Sentry you should see the error there.

* `h/eventqueue.py` contains code that iterates over a list of Pyramid
  event subscribers calling each one and silencing any exceptions
  presumably so that one subscriber crashing doesn't cause others to
  crash. There was an additional call to `sentry.captureException()` to
  make sure that the silenced exceptions still get reported to Sentry.
  This has been removed as it's no longer needed -- they get reported
  automatically.

  You can test this by creating an error in a subscriber. For example
  lets break the `publish_annotation_event()` subscriber:

  ```diff
  diff --git a/h/subscribers.py b/h/subscribers.py
  index 97c13332d..c446e79b7 100644
  --- a/h/subscribers.py
  +++ b/h/subscribers.py
  @@ -32,6 +32,7 @@ def add_renderer_globals(event):

  def publish_annotation_event(event):
      """Publish an annotation event to the message queue."""
  +    raise RuntimeError("Failed")
      data = {
          "action": event.action,
          "annotation_id": event.annotation_id,
  ```

  Now go to <http://localhost:5000/docs/help> and try to create an
  annotation. You should see a crash in your terminal and if you visit
  Sentry you should see the error there.

* `h/realtime.py` contained a couple of `captureException()` calls for
  reporting problems with the Kombu connection. For example if the
  connection to RabbitMQ is lost then an exception is reported. This has
  been removed because it's no longer necessary -- these get reported
  automatically now.

  You can test this by breaking Kombu's connection. For example while
  `make dev` is running stop the RabbitMQ server by doing:

  ```shellsession
  $ docker-compose stop rabbit
  ```

  You should see a crash in your terminal and if you visit Sentry you
  should see the error there.

  You can run `docker-compose start rabbit` to restart RabbitMQ.

* `streamer/messages.py` was passing the Sentry client into the
  `Consumer` class (`realtime.py`) but `Consumer` no longer needs Sentry
  (see above) so this has been removed.

* `streamer/views.py` contained an error view that was calling
  `captureException()`. This now happens automatically so its been
  removed.

  You can test this by creating a crash in the websocket code. For
  example:

  ```diff
  diff --git a/h/streamer/views.py b/h/streamer/views.py
  index d904ab4c2..a8dc919b3 100644
  --- a/h/streamer/views.py
  +++ b/h/streamer/views.py
  @@ -12,6 +12,7 @@ from h.streamer import streamer, websocket

  @view_config(route_name="ws")
  def websocket_view(request):
  +    raise RuntimeError("Failed")
      # Provide environment which the WebSocket handler can use...
      request.environ.update(
          {
  ```

  Now visit <http://localhost:5000/docs/help> and you should see a
  websocket crash in your terminal. Visit Sentry and you should see the
  error reported there.