### PR TITLE
Upgrade bleach to fix deprecated dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ SQLAlchemy >= 1.1.4
 alembic
 backports.functools_lru_cache
 bcrypt
-bleach >= 2.0
+bleach
 celery >= 4.2.1
 certifi  # Required to connect to Elasticsearch over SSL.
 cffi

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ amqp==2.2.2               # via kombu
 backports.functools-lru-cache==1.2.1
 bcrypt==3.1.3
 billiard==3.5.0.3         # via celery
-bleach==2.1.3
+bleach==3.0.2
 celery==4.2.1
 certifi==2018.8.24
 cffi==1.7.0
@@ -27,7 +27,6 @@ gevent==1.3.5
 greenlet==0.4.13
 gunicorn==19.9.0
 hkdf==0.0.3
-html5lib==0.999999999     # via bleach
 ipaddress==1.0.18         # via elasticsearch-dsl
 iso8601==0.1.11           # via colander
 itsdangerous==0.24
@@ -62,7 +61,7 @@ pytz==2016.6.1            # via celery
 raven==6.0.0
 repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.3      # via pyramid-mailer
-six==1.10.0               # via bcrypt, bleach, elasticsearch-dsl, html5lib, python-dateutil
+six==1.10.0               # via bcrypt, bleach, elasticsearch-dsl, python-dateutil
 sqlalchemy==1.1.4
 statsd==3.2.1
 transaction==2.1.2
@@ -71,7 +70,7 @@ unidecode==0.4.19         # via python-slugify
 urllib3==1.22             # via elasticsearch
 venusian==1.0
 vine==1.1.4               # via amqp
-webencodings==0.5.1       # via html5lib
+webencodings==0.5.1       # via bleach
 webob==1.6.1              # via pyramid
 ws4py==0.4.2
 wsaccel==0.6.2


### PR DESCRIPTION
`bleach` is used for markdown in our app.

The version we were using has a deprecated dependency that was making it impossible for me to run tests locally.