### PR TITLE
Add enforce_scope checkbox to admin-group forms

### DIFF
--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -3,7 +3,13 @@
 from __future__ import unicode_literals
 
 import colander
-from deform.widget import SelectWidget, SequenceWidget, TextAreaWidget, TextInputWidget
+from deform.widget import (
+    CheckboxWidget,
+    SelectWidget,
+    SequenceWidget,
+    TextAreaWidget,
+    TextInputWidget,
+)
 
 from h import i18n
 from h.schemas import validators
@@ -146,6 +152,18 @@ class CreateAdminGroupSchema(CSRFSchema):
         validator=colander.Length(max=GROUP_DESCRIPTION_MAX_LENGTH),
         widget=TextAreaWidget(rows=3, max_length=GROUP_DESCRIPTION_MAX_LENGTH),
         missing=None,
+    )
+
+    # Although the default value of the enforce_scope property is True,
+    # we need to allow the unchecking of the checkbox that represents it,
+    # which means that empty values should be treated as False.
+    enforce_scope = colander.SchemaNode(
+        colander.Boolean(),
+        hint=_(
+            "Only allow annotations for documents within this group's defined scopes"
+        ),
+        widget=CheckboxWidget(css_class="form-checkbox--inline"),
+        missing=False,
     )
 
     origins = colander.SequenceSchema(

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -59,10 +59,12 @@ class GroupCreateController(object):
 
     @view_config(request_method="GET")
     def get(self):
+
         self.form.set_appstruct(
             {
                 "creator": self.request.user.username,
                 "organization": Organization.default(self.request.db).pubid,
+                "enforce_scope": True,
             }
         )
         return self._template_context()
@@ -70,39 +72,35 @@ class GroupCreateController(object):
     @view_config(request_method="POST")
     def post(self):
         def on_success(appstruct):
+            """Create a group on successful validation of POSTed form data"""
+
             group_create_svc = self.request.find_service(name="group_create")
             group_members_svc = self.request.find_service(name="group_members")
 
-            # Create the new group.
-            creator = appstruct["creator"]
-            description = appstruct["description"]
-            name = appstruct["name"]
             organization = self.organizations[appstruct["organization"]]
-            origins = appstruct["origins"]
+            # We know this user exists because it is checked during schema validation
+            creator_userid = _userid(appstruct["creator"], organization.authority)
+
             type_ = appstruct["group_type"]
-
-            userid = _userid(creator, organization.authority)
-
-            if type_ == "open":
-                group = group_create_svc.create_open_group(
-                    name=name,
-                    userid=userid,
-                    origins=origins,
-                    description=description,
-                    organization=organization,
-                )
-            elif type_ == "restricted":
-                group = group_create_svc.create_restricted_group(
-                    name=name,
-                    userid=userid,
-                    origins=origins,
-                    description=description,
-                    organization=organization,
-                )
-            else:
+            if type_ not in ["open", "restricted"]:
                 raise Exception("Unsupported group type {}".format(type_))
 
-            # Add members to the group
+            create_fns = {
+                "open": group_create_svc.create_open_group,
+                "restricted": group_create_svc.create_restricted_group,
+            }
+
+            group = create_fns[type_](
+                name=appstruct["name"],
+                userid=creator_userid,
+                origins=appstruct["origins"],
+                description=appstruct["description"],
+                organization=organization,
+                enforce_scope=appstruct["enforce_scope"],
+            )
+
+            # Add members to the group. We know that these users exist
+            # because that check is part of form schema validation.
             member_userids = [
                 _userid(username, organization.authority)
                 for username in appstruct["members"]
@@ -118,7 +116,7 @@ class GroupCreateController(object):
             self.request.session.flash(
                 Markup(
                     'Created new group <a href="{url}">{name}</a>'.format(
-                        name=name, url=group_url
+                        name=group.name, url=group_url
                     )
                 ),
                 queue="success",
@@ -162,7 +160,7 @@ class GroupEditController(object):
         user_svc = request.find_service(name="user")
         self.request = request
         self.schema = CreateAdminGroupSchema().bind(
-            request=request,
+            request=self.request,
             group=self.group,
             organizations=self.organizations,
             user_svc=user_svc,

--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -24,6 +24,7 @@ class Group(ModelFactory):
     readable_by = ReadableBy.members
     writeable_by = WriteableBy.members
     members = factory.LazyAttribute(lambda obj: [obj.creator])
+    enforce_scope = True
 
     @factory.post_generation
     def scopes(self, create, scopes=0, **kwargs):

--- a/tests/common/factories/group_scope.py
+++ b/tests/common/factories/group_scope.py
@@ -12,6 +12,7 @@ from .base import ModelFactory
 class GroupScope(ModelFactory):
     class Meta:
         model = models.GroupScope
+        sqlalchemy_session_persistence = "flush"
 
     origin = factory.Faker("url")
     group = factory.SubFactory("tests.common.factories.OpenGroup")

--- a/tests/h/schemas/forms/admin/group_test.py
+++ b/tests/h/schemas/forms/admin/group_test.py
@@ -167,6 +167,7 @@ def group_data(factories):
         "description": "Lorem ipsum dolor sit amet consectetuer",
         "organization": "__default__",
         "origins": ["http://www.foo.com", "https://www.foo.com"],
+        "enforce_scope": True,
     }
 
 

--- a/tests/h/services/group_create_test.py
+++ b/tests/h/services/group_create_test.py
@@ -90,6 +90,18 @@ class TestCreatePrivateGroup(object):
 
         assert group.organization == org
 
+    def test_it_creates_group_with_enforce_scope_True_by_default(self, creator, svc):
+        group = svc.create_private_group("Anteater fans", creator.userid)
+
+        assert group.enforce_scope is True
+
+    def test_it_sets_group_with_specified_enforce_scope(self, creator, svc):
+        group = svc.create_private_group(
+            "Anteater fans", creator.userid, enforce_scope=False
+        )
+
+        assert group.enforce_scope is False
+
     def test_it_adds_group_to_session(self, db_session, creator, svc):
         group = svc.create_private_group("Anteater fans", creator.userid)
 
@@ -182,6 +194,26 @@ class TestCreateOpenGroup(object):
         )
 
         assert group.organization == org
+
+    def test_it_creates_group_with_enforce_scope_True_by_default(
+        self, creator, svc, origins, db_session
+    ):
+        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+
+        db_session.flush()
+
+        assert group.enforce_scope is True
+
+    def test_it_creates_group_with_specified_enforce_scope(
+        self, creator, svc, origins, db_session
+    ):
+        group = svc.create_open_group(
+            "Anteater fans", creator.userid, origins=origins, enforce_scope=False
+        )
+
+        db_session.flush()
+
+        assert group.enforce_scope is False
 
     def test_it_adds_group_to_session(self, db_session, creator, svc, origins):
         group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
@@ -309,6 +341,28 @@ class TestCreateRestrictedGroup(object):
         )
 
         assert group.organization == org
+
+    def test_it_creates_group_with_enforce_scope_True_by_default(
+        self, creator, svc, origins, db_session
+    ):
+        group = svc.create_restricted_group(
+            "Anteater fans", creator.userid, origins=origins
+        )
+
+        db_session.flush()
+
+        assert group.enforce_scope is True
+
+    def test_it_creates_group_with_specified_enforce_scope(
+        self, creator, svc, origins, db_session
+    ):
+        group = svc.create_restricted_group(
+            "Anteater fans", creator.userid, origins=origins, enforce_scope=False
+        )
+
+        db_session.flush()
+
+        assert group.enforce_scope is False
 
     def test_it_adds_group_to_session(self, db_session, creator, svc, origins):
         group = svc.create_restricted_group(

--- a/tests/h/services/group_update_test.py
+++ b/tests/h/services/group_update_test.py
@@ -30,6 +30,24 @@ class TestGroupUpdate(object):
 
         assert updated_group == group
 
+    def test_it_accepts_scope_relations(self, factories, svc, db_session):
+        group = factories.Group()
+        scopes = [factories.GroupScope(), factories.GroupScope()]
+        data = {"name": "whatnot", "scopes": scopes}
+
+        updated_group = svc.update(group, **data)
+
+        assert updated_group.scopes == scopes
+
+    def test_it_replaces_scope_relations(self, factories, svc, db_session):
+        group = factories.Group(scopes=[factories.GroupScope()])
+        updated_scopes = [factories.GroupScope(), factories.GroupScope()]
+        data = {"name": "whatnot", "scopes": updated_scopes}
+
+        updated_group = svc.update(group, **data)
+
+        assert updated_group.scopes == updated_scopes
+
     def test_it_does_not_protect_against_undefined_properties(self, factories, svc):
         group = factories.Group()
         data = {"some_random_field": "whatever"}

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -104,7 +104,7 @@ class TestGroupCreateController(object):
         (_, call_kwargs) = schema.bind.call_args
         assert call_kwargs["organizations"] == {default_org.pubid: default_org}
 
-    def test_it_handles_form_submission(
+    def test_post_handles_form_submission(
         self, pyramid_request, handle_form_submission, matchers
     ):
         ctrl = GroupCreateController(pyramid_request)
@@ -134,6 +134,7 @@ class TestGroupCreateController(object):
                     "members": [],
                     "organization": default_org.pubid,
                     "origins": [],
+                    "enforce_scope": True,
                 }
             )
 
@@ -156,10 +157,8 @@ class TestGroupCreateController(object):
         type_,
         default_org,
     ):
-        name = "My new group"
         creator = pyramid_request.user.username
         member_to_add = factories.User()
-        description = "Purpose of new group"
         origins = ["https://example.com"]
 
         def call_on_success(request, form, on_success, on_failure):
@@ -167,11 +166,12 @@ class TestGroupCreateController(object):
                 {
                     "organization": default_org.pubid,
                     "creator": creator,
-                    "description": description,
+                    "description": "Whatnot",
                     "group_type": type_,
-                    "name": name,
+                    "name": "My New Group",
                     "origins": origins,
                     "members": [member_to_add.username],
+                    "enforce_scope": True,
                 }
             )
 
@@ -191,11 +191,12 @@ class TestGroupCreateController(object):
         ).userid
 
         create_method.assert_called_with(
-            name=name,
+            name="My New Group",
             userid=expected_userid,
-            description=description,
+            description="Whatnot",
             origins=origins,
             organization=default_org,
+            enforce_scope=True,
         )
         group_members_svc.add_members.assert_called_once_with(
             create_method.return_value, [member_to_add.userid]


### PR DESCRIPTION
This PR adds the ability to set (or unset) the "enforce scope" option for a group through the group admin pages (create and edit). Work for this entailed some refactor of the view (to use services and be less verbose) and its tests (which are fairly convoluted, even after a first pass at refactor).

~~I believe this PR still needs a bit more finesse, so I'm marking it WIP until I make another refactor pass. But I wanted to get it up to show my general direction here.~~

Some needed refactor will come as a followup PR.