### PR TITLE
Enable sitepackages on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,9 @@ node {
             testApp(image: img, runArgs: "-u root " +
                                          "-e BROKER_URL=${brokerUrl} " +
                                          "-e ELASTICSEARCH_URL=${elasticsearchHost} " +
-                                         "-e TEST_DATABASE_URL=${databaseUrl}") {
+                                         "-e TEST_DATABASE_URL=${databaseUrl} " +
+                                         "-e SITE_PACKAGES=true"
+                                         ) {
                 // Test dependencies
                 sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev'
                 sh 'apk add --no-cache python3 python3-dev'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ billiard==3.5.0.3         # via celery
 bleach==3.0.2
 celery==4.2.1
 certifi==2018.8.24
-cffi==1.7.0
+cffi==1.11.5
 chameleon==2.24           # via deform
 click==6.6
 colander==1.3.1           # via deform

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ tox_pip_extensions_ext_venv_update = true
 
 [testenv]
 skip_install = true
+sitepackages = {env:SITE_PACKAGES:false}
 passenv =
     dev: AUTHORITY
     dev: BOUNCER_URL


### PR DESCRIPTION
Enable Python sitepackages in the Tox testenvs on Jenkins. This should avoid Tox reinstalling Python packages in the virtualenv that're already installed in the Docker container, so it should speed up running
the tests on Jenkins.

Typical times to run the tests on master on Jenkins are [9min 38s-10min 38s](https://jenkins.hypothes.is/job/h/job/master/). On this branch they ran in [7min 31s-7min 32s](https://jenkins.hypothes.is/job/h/job/dont-build-python-deps-twice-on-jenkins/).

[We actually run three Tox testenvs on Jenkins](https://github.com/hypothesis/h/blob/68d82e20b116b94f6b7d54718a25f9f4118a80db/Jenkinsfile#L35-L39) (the unit tests in Python 2, the functional tests in Python 2, and the functional tests in Python 3) so Tox has to create three separate virtualenvs and install all the dependencies into each of them. That's a lot of building. So reducing the virtualenv build time can help a lot.

In a follow-up PR we may be able to speed this up further by having the three testenvs all share a single virtualenv, instead of creating three separate virtualenvs, by using the [`envdir` setting](https://tox.readthedocs.io/en/latest/config.html#conf-envdir).

As you can see from the second commit that I had to make, by not isolating the testenv from the Docker container's site packages there is some risk of problems being introduced that will occur on Jenkins but not locally or on Travis. Hopefully this'll be rare.

The `cffi` package that I had to upgrade is the [C Foreign Function Interface](https://cffi.readthedocs.io/en/latest/). Here's the [changelog](https://cffi.readthedocs.io/en/latest/whatsnew.html). I don't see any obvious problems with this upgrade.