### PR TITLE
Refactor Admin Groups index view

### DIFF
--- a/h/services/group.py
+++ b/h/services/group.py
@@ -58,6 +58,29 @@ class GroupService(object):
             .one_or_none()
         )
 
+    def filter_by_name(self, name=None):
+        """
+        Return a Query of all Groups, optionally filtered by name.
+
+        If ``name`` is present, groups will be filtered by name. Filtering
+        is case-insensitive and wildcarded. Otherwise, all groups will be
+        retrieved.
+
+        :rtype: sqlalchemy.orm.query.Query
+        """
+        filter_terms = []
+
+        if name:
+            filter_terms.append(
+                sa.func.lower(Group.name).like("%{}%".format(name.lower()))
+            )
+
+        return (
+            self.session.query(Group)
+            .filter(*filter_terms)
+            .order_by(Group.created.desc())
+        )
+
     def groupids_readable_by(self, user):
         """
         Return a list of pubids for which the user has read access.

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from jinja2 import Markup
 from pyramid.view import view_config, view_defaults
 from pyramid.httpexceptions import HTTPFound
-from sqlalchemy import func
+
 
 from h import form  # noqa F401
 from h import i18n
@@ -26,18 +26,12 @@ _ = i18n.TranslationString
 )
 @paginator.paginate_query
 def groups_index(context, request):
-    q = request.params.get("q")
+    """Retrieve a paginated list of all groups, filtered by optional group name parameter"""
 
-    filter_terms = []
-    if q:
-        name = models.Group.name
-        filter_terms.append(func.lower(name).like("%{}%".format(q.lower())))
+    group_svc = request.find_service(name="group")
+    name = request.params.get("q")
 
-    return (
-        request.db.query(models.Group)
-        .filter(*filter_terms)
-        .order_by(models.Group.created.desc())
-    )
+    return group_svc.filter_by_name(name)
 
 
 @view_defaults(


### PR DESCRIPTION
This PR does some refactoring of the index view for admin groups. It's part of a set of refactors I want to do to these view classes.

- Create the ability to filter groups via the `group` service. This is a rudimentary filtering method for now as I didn't want to prematurely generalize it. Note that it returns an SQLAlchemy `Query` object, which is necessary for pagination. I don't love that, but at least I've documented.
- View is thinned out and passes off query param to filter instead of doing its own querying.