### PR TITLE
Fix admin-edit-group permissions

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -12,6 +12,7 @@ import slugify
 from h.db import Base
 from h.db import mixins
 from h import pubid
+from h.auth import role
 from h.util.group import split_groupid
 
 
@@ -251,6 +252,10 @@ class Group(Base, mixins.Timestamps):
         # auth_clients with matching authority should be able to read
         # the group
         terms.append((security.Allow, authority_principal, "read"))
+
+        # Those with the admin or staff role should be able to admin/edit any group
+        terms.append((security.Allow, role.Staff, "admin"))
+        terms.append((security.Allow, role.Admin, "admin"))
 
         terms.append(security.DENY_ALL)
 

--- a/h/routes.py
+++ b/h/routes.py
@@ -43,7 +43,12 @@ def includeme(config):
     config.add_route("admin.groups", "/admin/groups")
     config.add_route("admin.groups_create", "/admin/groups/new")
     config.add_route("admin.groups_delete", "/admin/groups/delete/{pubid}")
-    config.add_route("admin.groups_edit", "/admin/groups/{pubid}")
+    config.add_route(
+        "admin.groups_edit",
+        "/admin/groups/{id}",
+        factory="h.traversal.GroupRoot",
+        traverse="/{id}",
+    )
     config.add_route("admin.mailer", "/admin/mailer")
     config.add_route("admin.mailer_test", "/admin/mailer/test")
     config.add_route("admin.nipsa", "/admin/nipsa")

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -28,7 +28,7 @@
           <tr>
             <td>
               {% if group.type in ('open', 'restricted') %}
-              {% set edit_url = request.route_url('admin.groups_edit', pubid=group.pubid) %}
+              {% set edit_url = request.route_url('admin.groups_edit', id=group.pubid) %}
               <a href="{{ edit_url }}">{{ group.name }}</a>
               {% else %}
               {# The group edit view does not currently support editing private groups. #}

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from jinja2 import Markup
 from pyramid.view import view_config, view_defaults
-from pyramid.httpexceptions import HTTPFound, HTTPNotFound
+from pyramid.httpexceptions import HTTPFound
 from sqlalchemy import func
 
 from h import form  # noqa F401
@@ -11,7 +11,6 @@ from h import i18n
 from h import models
 from h import paginator
 from h.models.annotation import Annotation
-from h.traversal import GroupRoot
 from h.models.group_scope import GroupScope
 from h.models.organization import Organization
 from h.schemas.forms.admin.group import CreateAdminGroupSchema
@@ -138,19 +137,12 @@ class GroupCreateController(object):
 
 @view_defaults(
     route_name="admin.groups_edit",
-    permission="admin_groups",
+    permission="admin",
     renderer="h:templates/admin/groups_edit.html.jinja2",
 )
 class GroupEditController(object):
-    def __init__(self, request):
-        # Look up the group here rather than using traversal in the route
-        # definition as that would apply `Group.__acl__` which will not match if
-        # the current (admin) user is not the creator of the group.
-        try:
-            pubid = request.matchdict.get("pubid")
-            self.group = GroupRoot(request)[pubid]
-        except KeyError:
-            raise HTTPNotFound()
+    def __init__(self, context, request):
+        self.group = context
 
         list_org_svc = request.find_service(name="list_organizations")
         self.organizations = {

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -7,6 +7,7 @@ import pytest
 from pyramid import security
 from pyramid.authorization import ACLAuthorizationPolicy
 
+from h.auth import role
 from h import models
 from h.models.group import (
     JoinableBy,
@@ -384,6 +385,18 @@ class TestGroupACL(object):
 
         principals = authz_policy.principals_allowed_by_permission(group, "upsert")
         assert len(principals) == 0
+
+    def test_staff_user_has_admin_permission_on_any_group(self, group, authz_policy):
+        principals = authz_policy.principals_allowed_by_permission(group, "admin")
+
+        assert role.Staff in principals
+        assert authz_policy.permits(group, ["whatever", "group:__staff__"], "admin")
+
+    def test_admin_user_has_admin_permission_on_any_group(self, group, authz_policy):
+        principals = authz_policy.principals_allowed_by_permission(group, "admin")
+
+        assert role.Admin in principals
+        assert authz_policy.permits(group, ["whatever", "group:__admin__"], "admin")
 
     def test_fallback_is_deny_all(self, group, authz_policy):
         assert not authz_policy.permits(group, [security.Everyone], "foobar")

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -49,7 +49,12 @@ def test_includeme():
         call("admin.groups", "/admin/groups"),
         call("admin.groups_create", "/admin/groups/new"),
         call("admin.groups_delete", "/admin/groups/delete/{pubid}"),
-        call("admin.groups_edit", "/admin/groups/{pubid}"),
+        call(
+            "admin.groups_edit",
+            "/admin/groups/{id}",
+            factory="h.traversal.GroupRoot",
+            traverse="/{id}",
+        ),
         call("admin.mailer", "/admin/mailer"),
         call("admin.mailer_test", "/admin/mailer/test"),
         call("admin.nipsa", "/admin/nipsa"),


### PR DESCRIPTION
This PR updates `h.views.admin.groups` to use traversal for the edit-group view instead of having the view do lookup and use a root-level permission.

It updates the Group ACL to assign `admin` permissions to users with `role.Staff` or `role.Admin`. The route is updated to use traversal. That gets lookup logic out of the view and simplifies testing by a tick.

The overall downside is that there is yet more ACL logic in the Group model. But we know we want to move ACLs out of models and I think that centralizing as much as we can and making things adhere to traversal conventions is a good direction to go.