### PR TITLE
Allow annotations from outside of scopes if `enforce_scope` is False

### DIFF
--- a/h/storage.py
+++ b/h/storage.py
@@ -261,7 +261,9 @@ def expand_uri(session, uri):
 
 
 def _validate_group_scope(group, target_uri):
-    if not group.scopes:
+    # If no scopes are present, or if the group is configured to allow
+    # annotations outside of its scope, there's nothing to do here
+    if not group.scopes or group.enforce_scope is False:
         return
     # The scope (origin) of the target URI must match at least one
     # of a group's defined scopes, if the group has any


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/865

This PR makes a small change to API service logic to allow the creation and updating of annotations outside of a scoped groups scopes if the group is configured with `enforce_scope` = `False`. This is needed for the Community Groups project.

A reminder of the logic here:

* `enforce_scope` defaults to True for all groups. The ability to change it is only exposed for open and restricted groups, via the admin interface.
* While the `enforce_scope` value is `True` for private groups, it has no effect on existing private groups as those groups have no scopes to enforce. Emphasis: no change to private group behavior.
* `enforce_scope` defaults to `True` for open and restricted groups as well. At present, all open and restricted groups have defined scopes. Thus the behavior of existing restricted and open groups will not change without intervention: annotations are only allowed if they match one or more of their defined scopes.
* Here's the change: If an open or restricted group is configured via the admin interface to set `enforce_scope` to `False` (e.g. uncheck the checkbox for this option), that group will now accept annotations web-wide—they don't have to match that group's scope.

As a reminder, the appearance of open and restricted groups in the groups drop-down vis-a-vis scope is unchanged for now. Open and restricted groups will continue to only appear in the client menu (i.e. get returned by the API) within their scopes.