### PR TITLE
Use `metrics` util to record search API parameter usage

### DIFF
--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -18,7 +18,6 @@ objects and Pyramid ACLs in :mod:`h.traversal`.
 """
 from __future__ import unicode_literals
 from pyramid import i18n
-import newrelic.agent
 
 from h import search as search_lib
 from h import storage
@@ -28,6 +27,7 @@ from h.interfaces import IGroupService
 from h.presenters import AnnotationJSONLDPresenter
 from h.traversal import AnnotationContext
 from h.schemas.util import validate_query_params
+from h.util import metrics
 from h.schemas.annotation import (
     CreateAnnotationSchema,
     SearchParamsSchema,
@@ -46,7 +46,7 @@ def search(request):
     schema = SearchParamsSchema()
     params = validate_query_params(schema, request.params)
 
-    _record_search_api_usage_metrics(params)
+    metrics.record_search_api_usage_metrics(params)
 
     separate_replies = params.pop("_separate_replies", False)
 
@@ -183,35 +183,3 @@ def _annotation_resource(request, annotation):
     group_service = request.find_service(IGroupService)
     links_service = request.find_service(name="links")
     return AnnotationContext(annotation, group_service, links_service)
-
-
-def _record_search_api_usage_metrics(
-    params, record_param=newrelic.agent.add_custom_parameter
-):
-    # Record usage of search params and associate them with a transaction.
-    keys = [
-        # Record usage of inefficient offset and it's alternative search_after.
-        "offset",
-        "search_after",
-        "sort",
-        # Record usage of url/uri (url is an alias of uri).
-        "url",
-        "uri",
-        # Record usage of tags/tag (tags is an alias of tag).
-        "tags",
-        "tag",
-        # Record usage of _separate_replies which will help distinguish client calls
-        # for loading the sidebar annotations from other api calls.
-        "_separate_replies",
-        # Record group and user-these help in identifying slow queries.
-        "group",
-        "user",
-        # Record usage of wildcard feature.
-        "wildcard_uri",
-    ]
-
-    for k in keys:
-        if k in params:
-            # The New Relic Query Language does not permit _ at the begining
-            # and offset is a reserved key word.
-            record_param("es_{}".format(k), params[k])


### PR DESCRIPTION
This PR removes New Relic metrics code from `h.views.api.annotations` and uses `h.util.metric` instead.

There are a couple of other places in the app to update...