### PR TITLE
Fix `member_add` call in admin-group updating

### DIFF
--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -194,7 +194,7 @@ class GroupEditViews(object):
 
             memberids = []
             for username in appstruct["members"]:
-                memberids.append(self.user_svc.fetch(username, group.authority))
+                memberids.append(self.user_svc.fetch(username, group.authority).userid)
 
             self.group_members_svc.update_members(group, memberids)
 

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -330,7 +330,7 @@ class TestGroupEditViews(object):
         view.update()
 
         group_members_svc.update_members.assert_any_call(
-            group, [fetched_user, fetched_user]
+            group, [fetched_user.userid, fetched_user.userid]
         )
 
     def test_delete_deletes_group(


### PR DESCRIPTION
A recently-deployed PR that refactored admin-group editing broke the form submission.

The view was incorrectly calling the `member_add` service method with User model objects instead of userids. And testing for that (so both the logic and the tests were wrong). A functional or integration test would have caught this a little faster.