### PR TITLE
Fix admin-group delete success messaging

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -42,7 +42,12 @@ def includeme(config):
     config.add_route("admin.cohorts_edit", "/admin/features/cohorts/{id}")
     config.add_route("admin.groups", "/admin/groups")
     config.add_route("admin.groups_create", "/admin/groups/new")
-    config.add_route("admin.groups_delete", "/admin/groups/delete/{pubid}")
+    config.add_route(
+        "admin.groups_delete",
+        "/admin/groups/delete/{id}",
+        factory="h.traversal.GroupRoot",
+        traverse="/{id}",
+    )
     config.add_route(
         "admin.groups_edit",
         "/admin/groups/{id}",

--- a/h/templates/admin/groups_edit.html.jinja2
+++ b/h/templates/admin/groups_edit.html.jinja2
@@ -7,7 +7,7 @@
   {{ form }}
   {% if pubid != '__world__' %}
     <form method="POST"
-          action="{{request.route_path('admin.groups_delete', pubid=pubid)}}">
+          action="{{request.route_path('admin.groups_delete', id=pubid)}}">
       <button class="btn btn--danger js-confirm-submit"
               data-confirm-message="Group &quot;{{ group_name }}&quot; has {{ annotation_count }} annotation(s) and {{ member_count }} member(s). Are you sure you want to delete it?">Delete</button>
     </form>

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -167,7 +167,8 @@ class GroupEditViews(object):
 
         svc.delete(group)
         self.request.session.flash(
-            _("Successfully deleted group %s" % (group.name), "success")
+            _("Successfully deleted group %s" % (group.name), "success"),
+            queue="success",
         )
 
         return HTTPFound(location=self.request.route_path("admin.groups"))

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -48,7 +48,12 @@ def test_includeme():
         call("admin.cohorts_edit", "/admin/features/cohorts/{id}"),
         call("admin.groups", "/admin/groups"),
         call("admin.groups_create", "/admin/groups/new"),
-        call("admin.groups_delete", "/admin/groups/delete/{pubid}"),
+        call(
+            "admin.groups_delete",
+            "/admin/groups/delete/{id}",
+            factory="h.traversal.GroupRoot",
+            traverse="/{id}",
+        ),
         call(
             "admin.groups_edit",
             "/admin/groups/{id}",


### PR DESCRIPTION
There was a double little bug here in which traversal was borked for the
delete view, as well as the flashed success message never showing up.