### PR TITLE
Cleanup metrics

### DIFF
--- a/h/util/metrics.py
+++ b/h/util/metrics.py
@@ -3,56 +3,18 @@ from __future__ import unicode_literals
 import newrelic.agent
 
 
-def send_metric(name, metric):
-    """Send a metric to New Relic.
-
-    :arg name: The key name. Only the first 255 characters are retained
-    :type name: str
-    :arg metric: The string value to add to the current transaction
-        Only the first 255 characters are retained.
-    :type metric: str, int, float, bool
+def record_search_query_params(params):
     """
-    newrelic.agent.add_custom_parameter(name, metric)
+    Send search params to New Relic as "attributes" on each transaction.
 
+    Only the first 255 characters of the value are retained and values must
+    be str, int, float, or bool types.
 
-def record_search_query_param_usage(params, separate_replies):
-    """Send search request params to New Relic as metrics.
+    Disclaimer: If there are multiple values for a single key, only
+    submit the first value to NewRelic as there is no way of submitting
+    multiple values for a single attribute and submitting a list of values
+    would not be condusive to data aggregation.
 
-    :arg params: the request params to record
-    :type params: webob.multidict.MultiDict
-    :arg separate_replies: Records usage of _separate_replies parameter in the search
-    :type separate_replies: bool
-    """
-    keys = [
-        # Record usage of inefficient offset and it's alternative search_after.
-        "offset",
-        "search_after",
-        "sort",
-        # Record usage of url/uri (url is an alias of uri).
-        "url",
-        "uri",
-        # Record usage of tags/tag (tags is an alias of tag).
-        "tags",
-        "tag",
-        # Record group and user-these help in identifying slow queries.
-        "group",
-        "user",
-        # Record usage of wildcard feature.
-        "wildcard_uri",
-    ]
-    # Record usage of _separate_replies which will help distinguish client calls
-    # for loading the sidebar annotations from other API calls.
-    send_metric("es__separate_replies", separate_replies)
-
-    for k in keys:
-        if k in params:
-            # The New Relic Query Language does not permit _ at the begining
-            # and offset is a reserved key word.
-            send_metric("es_{}".format(k), params[k])
-
-
-def record_search_api_usage_metrics(params):
-    """Send search API request params to New Relic as metrics.
 
     :arg params: the request params to record
     :type params: webob.multidict.MultiDict
@@ -77,9 +39,7 @@ def record_search_api_usage_metrics(params):
         # Record usage of wildcard feature.
         "wildcard_uri",
     ]
-
-    for k in keys:
-        if k in params:
-            # The New Relic Query Language does not permit _ at the begining
-            # and offset is a reserved key word.
-            send_metric("es_{}".format(k), params[k])
+    # The New Relic Query Language does not permit _ at the begining
+    # and offset is a reserved key word.
+    params = [("es_{}".format(k), params[k]) for k in keys if k in params]
+    newrelic.agent.current_transaction().add_custom_parameters(params)

--- a/h/util/metrics.py
+++ b/h/util/metrics.py
@@ -11,15 +11,13 @@ def record_search_query_params(params, separate_replies):
     be str, int, float, or bool types.
 
     Disclaimer: If there are multiple values for a single key, only
-    submit the first value to NewRelic as there is no way of submitting
-    multiple values for a single attribute and submitting a list of values
-    would not be condusive to data aggregation.
-
+    submit the first value to New Relic as there is no way of submitting
+    multiple values for a single attribute.
 
     :arg params: the request params to record
     :type params: webob.multidict.MultiDict
     :arg separate_replies: the value of the separate_replies search setting
-    :type params: bool
+    :type separate_replies: bool
     """
     keys = [
         # Record usage of inefficient offset and it's alternative search_after.
@@ -43,11 +41,11 @@ def record_search_query_params(params, separate_replies):
     params = [("es_{}".format(k), params[k]) for k in keys if k in params]
 
     # Record usage of _separate_replies which will help distinguish client calls
-    # for loading the sidebar annotations from other api calls.
+    # for loading the sidebar annotations from other API calls.
     if separate_replies:
         params.append(("es__separate_replies", separate_replies))
 
-    # On startup, there is a race condition in NewRelic where there may not be
+    # On startup, there is a race condition in New Relic where there may not be
     # a transaction. If there isn't, current_transaction will return None in which
     # case we can't record params.
     current_transaction = newrelic.agent.current_transaction()

--- a/h/util/metrics.py
+++ b/h/util/metrics.py
@@ -42,4 +42,9 @@ def record_search_query_params(params):
     # The New Relic Query Language does not permit _ at the begining
     # and offset is a reserved key word.
     params = [("es_{}".format(k), params[k]) for k in keys if k in params]
-    newrelic.agent.current_transaction().add_custom_parameters(params)
+    # On startup, there is a race condition in NewRelic where there may not be
+    # a transaction. If there isn't, current_transaction will return None in which
+    # case we can't record params.
+    current_transaction = newrelic.agent.current_transaction()
+    if current_transaction:
+        newrelic.agent.current_transaction().add_custom_parameters(params)

--- a/tests/h/util/metrics_test.py
+++ b/tests/h/util/metrics_test.py
@@ -9,32 +9,37 @@ from h.util import metrics
 
 class TestRecordSearchQueryParams(object):
     def test_records_parameters(self, newrelic_agent):
-        params = MultiDict(tag="tagsvalue",
-                           _separate_replies=True,
-                           url="urlvalue",
-                           bad="unwanted")
+        params = MultiDict(
+            tag="tagsvalue", _separate_replies=True, url="urlvalue", bad="unwanted"
+        )
         metrics.record_search_query_params(params, True)
         newrelic_agent.current_transaction().add_custom_parameters.assert_called_once_with(
-            [("es_url", "urlvalue"),
-             ("es_tag", "tagsvalue"),
-             ("es__separate_replies", True)])
+            [
+                ("es_url", "urlvalue"),
+                ("es_tag", "tagsvalue"),
+                ("es__separate_replies", True),
+            ]
+        )
 
     def test_does_not_record_separate_replies_if_false(self, newrelic_agent):
         params = MultiDict({})
         metrics.record_search_query_params(params, False)
-        newrelic_agent.current_transaction().add_custom_parameters.assert_called_once_with([])
+        newrelic_agent.current_transaction().add_custom_parameters.assert_called_once_with(
+            []
+        )
 
     def test_does_not_record_parameters_if_no_transaction(self, newrelic_agent):
         newrelic_agent.current_transaction.return_value = None
-        params = MultiDict(tag="tagsvalue",
-                           _separate_replies=True,
-                           url="urlvalue",
-                           bad="unwanted")
+        params = MultiDict(
+            tag="tagsvalue", _separate_replies=True, url="urlvalue", bad="unwanted"
+        )
         metrics.record_search_query_params(params, True)
 
     @pytest.fixture
     def newrelic_agent(self, newrelic_agent):
-        newrelic_agent.current_transaction.return_value.add_custom_parameters = mock.Mock()
+        newrelic_agent.current_transaction.return_value.add_custom_parameters = (
+            mock.Mock()
+        )
         return newrelic_agent
 
 

--- a/tests/h/util/metrics_test.py
+++ b/tests/h/util/metrics_test.py
@@ -19,6 +19,14 @@ class TestRecordSearchQueryParams(object):
              ("es_tag", "tagsvalue"),
              ("es__separate_replies", True)])
 
+    def test_does_not_record_parameters_if_no_transaction(self, newrelic_agent):
+        newrelic_agent.current_transaction.return_value = None
+        params = MultiDict(tag="tagsvalue",
+                           _separate_replies=True,
+                           url="urlvalue",
+                           bad="unwanted")
+        metrics.record_search_query_params(params)
+
     @pytest.fixture
     def newrelic_agent(self, newrelic_agent):
         newrelic_agent.current_transaction.return_value.add_custom_parameters = mock.Mock()

--- a/tests/h/util/metrics_test.py
+++ b/tests/h/util/metrics_test.py
@@ -8,10 +8,8 @@ from h.util import metrics
 
 
 class TestRecordSearchQueryParams(object):
-    def test_records_parameters(self, newrelic_agent):
-        params = MultiDict(
-            tag="tagsvalue", _separate_replies=True, url="urlvalue", bad="unwanted"
-        )
+    def test_it_passes_parameters_to_newrelic(self, newrelic_agent):
+        params = MultiDict(tag="tagsvalue", _separate_replies=True, url="urlvalue")
         metrics.record_search_query_params(params, True)
         newrelic_agent.current_transaction().add_custom_parameters.assert_called_once_with(
             [
@@ -21,18 +19,23 @@ class TestRecordSearchQueryParams(object):
             ]
         )
 
-    def test_does_not_record_separate_replies_if_false(self, newrelic_agent):
+    def test_it_does_not_pass_unrecognized_parameters_to_newrelic(self, newrelic_agent):
+        params = MultiDict(bad="unwanted")
+        metrics.record_search_query_params(params, True)
+        newrelic_agent.current_transaction().add_custom_parameters.assert_called_once_with(
+            [("es__separate_replies", True)]
+        )
+
+    def test_it_does_not_record_separate_replies_if_False(self, newrelic_agent):
         params = MultiDict({})
         metrics.record_search_query_params(params, False)
         newrelic_agent.current_transaction().add_custom_parameters.assert_called_once_with(
             []
         )
 
-    def test_does_not_record_parameters_if_no_transaction(self, newrelic_agent):
+    def test_it_does_not_record_parameters_if_no_transaction(self, newrelic_agent):
         newrelic_agent.current_transaction.return_value = None
-        params = MultiDict(
-            tag="tagsvalue", _separate_replies=True, url="urlvalue", bad="unwanted"
-        )
+        params = MultiDict(tag="tagsvalue")
         metrics.record_search_query_params(params, True)
 
     @pytest.fixture

--- a/tests/h/util/metrics_test.py
+++ b/tests/h/util/metrics_test.py
@@ -1,47 +1,30 @@
 from __future__ import unicode_literals
 
 import pytest
-from mock import call
+import mock
 from webob.multidict import MultiDict
 
 from h.util import metrics
 
 
-class TestSendMetric(object):
-    def test_send_metric(self, newrelic):
-        metrics.send_metric("testkey", "testvalue")
-        newrelic.agent.add_custom_parameter.assert_called_once_with(
-            "testkey", "testvalue"
-        )
+class TestRecordSearchQueryParams(object):
+    def test_records_parameters(self, newrelic_agent):
+        params = MultiDict(tag="tagsvalue",
+                           _separate_replies=True,
+                           url="urlvalue",
+                           bad="unwanted")
+        metrics.record_search_query_params(params)
+        newrelic_agent.current_transaction().add_custom_parameters.assert_called_once_with(
+            [("es_url", "urlvalue"),
+             ("es_tag", "tagsvalue"),
+             ("es__separate_replies", True)])
 
-    @pytest.fixture(autouse=True)
-    def newrelic(self, patch):
-        return patch("h.util.metrics.newrelic")
-
-
-@pytest.mark.usefixtures("send_metric")
-class TestRecordSearchApiUsageMetrics(object):
-    def test_records_parameters(self, send_metric):
-        params = MultiDict(tags="tagsvalue", url="urlvalue", bad="unwanted")
-        metrics.record_search_api_usage_metrics(params)
-        assert send_metric.call_args_list == [
-            call("es_url", "urlvalue"),
-            call("es_tags", "tagsvalue"),
-        ]
-
-
-@pytest.mark.usefixtures("send_metric")
-class TestRecordSearchQueryParamUsage(object):
-    def test_records_parameters(self, send_metric):
-        params = MultiDict(tags="tagsvalue", url="urlvalue", bad="unwanted")
-        metrics.record_search_query_param_usage(params, True)
-        assert send_metric.call_args_list == [
-            call("es__separate_replies", True),
-            call("es_url", "urlvalue"),
-            call("es_tags", "tagsvalue"),
-        ]
+    @pytest.fixture
+    def newrelic_agent(self, newrelic_agent):
+        newrelic_agent.current_transaction.return_value.add_custom_parameters = mock.Mock()
+        return newrelic_agent
 
 
 @pytest.fixture
-def send_metric(patch):
-    return patch("h.util.metrics.send_metric")
+def newrelic_agent(patch):
+    return patch("h.util.metrics.newrelic.agent")

--- a/tests/h/util/metrics_test.py
+++ b/tests/h/util/metrics_test.py
@@ -13,11 +13,16 @@ class TestRecordSearchQueryParams(object):
                            _separate_replies=True,
                            url="urlvalue",
                            bad="unwanted")
-        metrics.record_search_query_params(params)
+        metrics.record_search_query_params(params, True)
         newrelic_agent.current_transaction().add_custom_parameters.assert_called_once_with(
             [("es_url", "urlvalue"),
              ("es_tag", "tagsvalue"),
              ("es__separate_replies", True)])
+
+    def test_does_not_record_separate_replies_if_false(self, newrelic_agent):
+        params = MultiDict({})
+        metrics.record_search_query_params(params, False)
+        newrelic_agent.current_transaction().add_custom_parameters.assert_called_once_with([])
 
     def test_does_not_record_parameters_if_no_transaction(self, newrelic_agent):
         newrelic_agent.current_transaction.return_value = None
@@ -25,7 +30,7 @@ class TestRecordSearchQueryParams(object):
                            _separate_replies=True,
                            url="urlvalue",
                            bad="unwanted")
-        metrics.record_search_query_params(params)
+        metrics.record_search_query_params(params, True)
 
     @pytest.fixture
     def newrelic_agent(self, newrelic_agent):


### PR DESCRIPTION
Make one function for recording search query params that can be called inside h.search.core:Search.run.