### PR TITLE
Fix stage 2's incremental docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,14 +59,14 @@ RUN apk add --no-cache --virtual build-deps \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del build-deps
 
+# Copy frontend assets.
+COPY --from=build /build build
+
 # Copy the rest of the application files.
 COPY . .
 
 # If we're building from a git clone, ensure that .git is writeable
 RUN [ -d .git ] && chown -R hypothesis:hypothesis .git || :
-
-# Copy frontend assets.
-COPY --from=build /build build
 
 # Expose the default port.
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,14 @@ WORKDIR /var/lib/hypothesis
 # Ensure nginx state and log directories writeable by unprivileged user.
 RUN chown -R hypothesis:hypothesis /var/log/nginx /var/lib/nginx /var/tmp/nginx
 
+# Copy nginx config
+COPY conf/nginx.conf /etc/nginx/nginx.conf
+
+# Copy collectd config
+COPY conf/collectd.conf /etc/collectd/collectd.conf
+RUN mkdir /etc/collectd/collectd.conf.d \
+ && chown hypothesis:hypothesis /etc/collectd/collectd.conf.d
+
 # Copy minimal data to allow installation of dependencies.
 COPY requirements.txt ./
 
@@ -50,14 +58,6 @@ RUN apk add --no-cache --virtual build-deps \
   && pip install --no-cache-dir -U pip supervisor \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del build-deps
-
-# Copy nginx config
-COPY conf/nginx.conf /etc/nginx/nginx.conf
-
-# Copy collectd config
-COPY conf/collectd.conf /etc/collectd/collectd.conf
-RUN mkdir /etc/collectd/collectd.conf.d \
- && chown hypothesis:hypothesis /etc/collectd/collectd.conf.d
 
 # Copy the rest of the application files.
 COPY . .


### PR DESCRIPTION
Re-order stage 2 such that steps that are more likely to change occur farther down in the file to decrease build times.

Overall this reduces build time for build events containing changes to either the front end or the python code by ~2.5 seconds.