### PR TITLE
Upgrade elasticsearch to latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -10,8 +10,8 @@ cffi
 click
 deform < 1.0
 deform-jinja2
-elasticsearch==6.2.0
-elasticsearch-dsl==6.1.0
+elasticsearch==6.3.1
+elasticsearch-dsl==6.3.1
 enum34
 functools32; python_version < "3.0" # Required by jsonschema, listed here to add environment marker
 gevent >= 1.3.5  # TODO: Update to gevent 1.3.6 when released, then remove `greenlet`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,8 @@ colander==1.3.1           # via deform
 contextlib2==0.5.4        # via raven
 deform-jinja2==0.5
 deform==0.9.9
-elasticsearch-dsl==6.1.0
-elasticsearch==6.2.0
+elasticsearch-dsl==6.3.1
+elasticsearch==6.3.1
 enum34==1.1.6
 functools32==3.2.3.post2 ; python_version < "3.0"
 gevent==1.3.5

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -19,7 +19,7 @@ class TestClient(object):
     def test_it_sets_the_version_property(self):
         client = Client(host="http://localhost:9200", index="hypothesis")
 
-        assert client.version == (6, 2, 0)
+        assert client.version == (6, 3, 1)
 
     def test_it_sets_the_conn_property(self):
         client = Client(host="http://localhost:9200", index="hypothesis")


### PR DESCRIPTION
In order to upgrade urllib3 elasticsearch needs to be upgraded. This elasticsearch version is backwards compatible with all es6 versions which means the cluster does not need to be upgraded in order to upgrade the python library. 