### PR TITLE
Avoid generating service mocks for every search test

### DIFF
--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -9,7 +9,7 @@ from h.services.group import GroupService
 from h.services.annotation_moderation import AnnotationModerationService
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def group_service(pyramid_config):
     group_service = mock.create_autospec(GroupService, instance=True, spec_set=True)
     group_service.groupids_readable_by.return_value = ["__world__"]
@@ -17,7 +17,7 @@ def group_service(pyramid_config):
     return group_service
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def moderation_service(pyramid_config):
     svc = mock.create_autospec(
         AnnotationModerationService, spec_set=True, instance=True
@@ -45,7 +45,7 @@ def Annotation(factories, index):
 
 
 @pytest.fixture
-def index(es_client, pyramid_request):
+def index(es_client, pyramid_request, group_service, moderation_service):
     def _index(*annotations):
         """Index the given annotation(s) into Elasticsearch."""
         for annotation in annotations:

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -16,6 +16,7 @@ from webob.multidict import MultiDict
 from h import search
 
 
+@pytest.mark.usefixtures("group_service", "moderation_service")
 class TestSearch(object):
     """Unit tests for search.Search when no separate_replies argument is given."""
 
@@ -163,6 +164,7 @@ class TestSearch(object):
         return patch("h.search.core.query.UriCombinedWildcardFilter")
 
 
+@pytest.mark.usefixtures("group_service", "moderation_service")
 class TestSearchWithSeparateReplies(object):
     """Unit tests for search.Search when separate_replies=True is given."""
 

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -564,7 +564,9 @@ class SearchResponseWithIDs(Matcher):
 
 
 @pytest.fixture
-def batch_indexer(db_session, es_client, pyramid_request):
+def batch_indexer(
+    db_session, es_client, pyramid_request, group_service, moderation_service
+):
     return h.search.index.BatchIndexer(
         db_session, es_client, pyramid_request, es_client.index
     )

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -1048,7 +1048,7 @@ class TestUsersAggregation(object):
 
 
 @pytest.fixture
-def search(pyramid_request):
+def search(pyramid_request, group_service, moderation_service):
     search = Search(pyramid_request)
     # Remove all default modifiers and aggregators except Sorter.
     search.clear()


### PR DESCRIPTION
The h.search.parser tests were sometimes failing in CI due to a 200ms default
timeout in the Hypothesis library being exceeded.

These tests _should_ be very quick, but are slowed down by the execution of
expensive mock fixtures (`group_service` and `moderation_service`) which were
autouse'd by every test in tests/h/search.

This commit resolves the issue by disabling autouse for these fixtures and only
using these fixtures either via `pytest.mark.usefixture` for tests that need
them, or via fixture dependencies for fixtures which need them.

These services are mocked in the first place because
`AnnotationSearchIndexPresenter` needs them. Some tests could be more aggressive
and mock the presenter itself so they don't have to mock each of its
dependencies.

With this change the h.search.parser tests are about ~4x faster on my system
(~4s => ~1s).