### PR TITLE
Separate Python package build into a separate build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,6 @@ RUN apk add --no-cache \
     collectd \
     collectd-disk \
     collectd-nginx \
-    git \
     libffi \
     libpq \
     nginx \
@@ -76,9 +75,6 @@ COPY --from=python-build /python/ /usr/
 
 # Copy the rest of the application files.
 COPY . .
-
-# If we're building from a git clone, ensure that .git is writeable
-RUN [ -d .git ] && chown -R hypothesis:hypothesis .git || :
 
 # Expose the default port.
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ FROM alpine:3.7
 LABEL maintainer="Hypothes.is Project and contributors"
 
 # Install runtime dependencies.
-# (nb. `git` is indeed required at runtime).
 RUN apk add --no-cache \
     ca-certificates \
     collectd \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node {
                                          "-e SITE_PACKAGES=true"
                                          ) {
                 // Test dependencies
-                sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev'
+                sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev py2-pip'
                 sh 'apk add --no-cache python3 python3-dev'
                 sh 'pip install -q tox tox-pip-extensions'
 

--- a/h/_version.py
+++ b/h/_version.py
@@ -70,7 +70,7 @@ def get_version():
     # First we try to retrieve the current application version from git.
     try:
         return git_version()
-    except subprocess.CalledProcessError:
+    except (OSError, subprocess.CalledProcessError):
         pass
 
     # We are not in a git checkout or extracting the version from git failed,


### PR DESCRIPTION
This PR is a follow-up to https://github.com/hypothesis/h/pull/5474 which does what the original version of that PR tried to do by avoiding unnecessary reinstalls of apk packages required to build Python dependencies. It does this by introducing a separate build stage for building and installing the Python dependencies. Only the final artefacts are then copied to the main Docker image. This is similar to what we were already doing with node.

The second commit resolves an issue I noticed along the way where git is installed in the Docker image even though it isn't really needed - the version is baked into `h/_version.py` in the Docker build context by `git archive`. The only reason the container failed to run without git installed is because the exception was not handled.

As a result the Docker image size drops from 158MB to 128MB and builds where Python dependencies have changed but build dependencies have not will be a little bit faster (maybe 30 seconds or so).

Frankly the benefits are a bit marginal, but curiosity got the better of me.