### PR TITLE
Fix flakey test_it_limits_number_of_annotations

### DIFF
--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -18,7 +18,13 @@ OFFSET_MAX = query.OFFSET_MAX
 
 class TestLimiter(object):
     def test_it_limits_number_of_annotations(self, Annotation, search):
-        ann_ids = [Annotation().id, Annotation().id, Annotation().id, Annotation().id]
+        dt = datetime.datetime
+        ann_ids = [
+            Annotation(updated=dt(2017, 1, 1)).id,
+            Annotation(updated=dt(2017, 1, 2)).id,
+            Annotation(updated=dt(2017, 1, 3)).id,
+            Annotation(updated=dt(2017, 1, 4)).id,
+        ]
 
         params = webob.multidict.MultiDict([("offset", 1), ("limit", 2)])
         result = search.run(params)


### PR DESCRIPTION
The test_it_limits_number_of_annotations had a flakey failure due to
the minimal time between time.now() calls. The population of the 
updated field happens so fast that occasionally, the dates are the 
same and elasticsearch puts them in a different order. Since this 
test depends on the updated fields to be in a certain order (since 
updated is the default sort setting), it's safer to populate that field 
in the test such that no two annotations have the same updated
value. 
