### PR TITLE
fix flakey elasticsearch tests

### DIFF
--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -20,10 +20,10 @@ class TestLimiter(object):
     def test_it_limits_number_of_annotations(self, Annotation, search):
         dt = datetime.datetime
         ann_ids = [
-            Annotation(updated=dt(2017, 1, 1)).id,
-            Annotation(updated=dt(2017, 1, 2)).id,
-            Annotation(updated=dt(2017, 1, 3)).id,
             Annotation(updated=dt(2017, 1, 4)).id,
+            Annotation(updated=dt(2017, 1, 3)).id,
+            Annotation(updated=dt(2017, 1, 2)).id,
+            Annotation(updated=dt(2017, 1, 1)).id,
         ]
 
         params = webob.multidict.MultiDict([("offset", 1), ("limit", 2)])


### PR DESCRIPTION
There were a couple problems here:
1. The annotations made for the test_it_limits_number_of_annotations were in reverse order in the list. The default search order is descending not ascending. 
1. Because of the default behavior of synchronizing changes between shards and pushing changes from the translog to the segment every second instead of when a change is made (this feature is known as refresh), an annotation may get marked as deleted during cleanup of a previous test, but a search may happen before that in the current test, resulting in a deleted annotation appearing as not deleted.