### PR TITLE
Fix inconsistency in moderation status read/write permissions

### DIFF
--- a/h/formatters/annotation_moderation.py
+++ b/h/formatters/annotation_moderation.py
@@ -39,7 +39,7 @@ class AnnotationModerationFormatter(object):
         return flag_counts
 
     def format(self, annotation_resource):
-        if not self._has_permission("admin", annotation_resource.group):
+        if not self._has_permission("moderate", annotation_resource.group):
             return {}
 
         flag_count = self._load(annotation_resource.annotation)

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -30,7 +30,7 @@ class AnnotationJSONPresentationService(object):
         self.links_svc = links_svc
 
         def moderator_check(group):
-            return has_permission("admin", group)
+            return has_permission("moderate", group)
 
         self.formatters = [
             formatters.AnnotationFlagFormatter(flag_svc, user),

--- a/tests/h/formatters/annotation_moderation_test.py
+++ b/tests/h/formatters/annotation_moderation_test.py
@@ -78,13 +78,13 @@ class TestAnnotationModerationFormatter(object):
     @pytest.fixture
     def permission_granted(self, group):
         has_permission = FakePermissionCheck()
-        has_permission.add_permission("admin", group, True)
+        has_permission.add_permission("moderate", group, True)
         return has_permission
 
     @pytest.fixture
     def permission_denied(self, group):
         has_permission = FakePermissionCheck()
-        has_permission.add_permission("admin", group, False)
+        has_permission.add_permission("moderate", group, False)
         return has_permission
 
     @pytest.fixture

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -29,12 +29,22 @@ class TestAnnotationJSONPresentationService(object):
             mock.sentinel.user,
         )
 
+    def test_hidden_status_included_if_user_can_moderate_group(
+        self, formatters, has_permission, svc
+    ):
+        group = mock.Mock()
+        moderator_check = formatters.AnnotationHiddenFormatter.call_args[0][1]
+        moderator_check(group)
+        has_permission.assert_called_once_with("moderate", group)
+
     def test_it_configures_hidden_formatter(self, services, formatters, svc):
         assert formatters.AnnotationHiddenFormatter.return_value in svc.formatters
 
-    def test_initializes_moderation_formatter(self, services, formatters, svc):
+    def test_initializes_moderation_formatter(
+        self, services, formatters, has_permission, svc
+    ):
         formatters.AnnotationModerationFormatter.assert_called_once_with(
-            services["flag_count"], mock.sentinel.user, mock.sentinel.has_permission
+            services["flag_count"], mock.sentinel.user, has_permission
         )
 
     def test_it_configures_moderation_formatter(self, services, formatters, svc):
@@ -113,7 +123,7 @@ class TestAnnotationJSONPresentationService(object):
         assert result == [present.return_value]
 
     @pytest.fixture
-    def svc(self, services):
+    def svc(self, services, has_permission):
         return AnnotationJSONPresentationService(
             session=mock.sentinel.db_session,
             user=mock.sentinel.user,
@@ -123,8 +133,12 @@ class TestAnnotationJSONPresentationService(object):
             flag_count_svc=services["flag_count"],
             moderation_svc=services["annotation_moderation"],
             user_svc=services["user"],
-            has_permission=mock.sentinel.has_permission,
+            has_permission=has_permission,
         )
+
+    @pytest.fixture
+    def has_permission(self):
+        return mock.Mock()
 
     @pytest.fixture
     def annotation_resource(self):


### PR DESCRIPTION
When annotations are rendered to JSON for API responses, moderation
information such as the count of flags was included if the user had
"admin" permissions on the annotation's group.

However the API views for performing moderation-related actions tested
for the "moderate" permission on the annotation, which is inherited from
the "moderate" permission for the group.

User accounts assigned to the Staff or Admin roles have the "admin"
permission on all groups but not the "moderate" permission. As a result, staff
accounts on hypothes.is could see the flagged status for annotations in
groups they did not create, but attempting to click the "Hide" button in
the client to moderate the annotation would fail.

The fact that staff accounts have "admin" permissions on all groups but
not "moderate" permissions is an inconsistency in itself, but separate
to the inconsistency in which permission is used when reading/writing
moderation info for annotations.

----

**Steps to reproduce**

1. Log in to Hypothesis with a staff account and visit https://hypothes.is/a/7ivaom6eEeapHvtpEed6DA
2. Click the "Hide" button on the moderation banner

**Expected result**: No moderation banner is visible since the staff account does not have moderation permissions for the annotation.

**Actual result**: Moderation banner is visible but clicking the Hide button fails with a 404.