### PR TITLE
Don't report API validation errors to Sentry

### DIFF
--- a/h/schemas/base.py
+++ b/h/schemas/base.py
@@ -10,6 +10,7 @@ import colander
 import deform
 import jsonschema
 from pyramid.session import check_csrf_token
+from pyramid import httpexceptions
 
 
 @colander.deferred
@@ -18,7 +19,7 @@ def deferred_csrf_token(node, kw):
     return request.session.get_csrf_token()
 
 
-class ValidationError(Exception):
+class ValidationError(httpexceptions.HTTPBadRequest):
     pass
 
 

--- a/h/views/api/errors.py
+++ b/h/views/api/errors.py
@@ -14,7 +14,6 @@ from pyramid.view import notfound_view_config
 from pyramid import httpexceptions
 
 from h.i18n import TranslationString as _  # noqa: N813
-from h.schemas import ValidationError
 from h.util.view import handle_exception, json_view
 from h.views.api.config import cors_policy
 
@@ -40,12 +39,6 @@ def api_notfound(request):
 def api_error(context, request):
     """Handle an expected/deliberately thrown API exception."""
     request.response.status_code = context.status_code
-    return {"status": "failure", "reason": str(context)}
-
-
-@json_view(context=ValidationError, path_info="/api/", decorator=cors_policy)
-def api_validation_error(context, request):
-    request.response.status_code = 400
     return {"status": "failure", "reason": str(context)}
 
 

--- a/tests/h/views/api/errors_test.py
+++ b/tests/h/views/api/errors_test.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 from mock import Mock
 from pyramid.httpexceptions import HTTPExpectationFailed
 
-from h.schemas import ValidationError
 from h.views.api import errors as views
 
 
@@ -25,16 +24,6 @@ def test_api_error_view(pyramid_request):
     assert pyramid_request.response.status_code == 417
     assert result["status"] == "failure"
     assert result["reason"] == "asplosions!"
-
-
-def test_api_validation_error(pyramid_request):
-    context = ValidationError("missing required userid")
-
-    result = views.api_validation_error(context, pyramid_request)
-
-    assert pyramid_request.response.status_code == 400
-    assert result["status"] == "failure"
-    assert result["reason"] == "missing required userid"
 
 
 def test_json_error_view(patch, pyramid_request):


### PR DESCRIPTION
Fixes https://github.com/hypothesis/h/issues/5492

These are deliberate error responses not crashes so we don't want to see them in Sentry. Make `ValidationError` inherit from `HTTPBadRequest` so that Sentry's Pyramid integration knows not to report it. The `api_validation_error()` error view that was setting the response status to 400 is no longer needed, since `HTTPBadRequest` is already 400 so delete it.

The API response should be exactly the same as before but just not reported to Sentry. For example:

Before:

    $ http GET "http://localhost:5000/api/search?limit=1000"
    HTTP/1.1 400 Bad Request
    Access-Control-Allow-Origin: *
    Cache-Control: no-cache
    Connection: close
    Content-Length: 80
    Content-Type: application/json; charset=UTF-8
    Date: Wed, 16 Jan 2019 11:57:33 GMT
    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
    Server: gunicorn/19.9.0
    X-XSS-Protection: 1; mode=block

    {
        "reason": "limit: 1000 is greater than maximum value 200",
        "status": "failure"
    }

After:

    $ http GET "http://localhost:5000/api/search?limit=1000"
    HTTP/1.1 400 Bad Request
    Access-Control-Allow-Origin: *
    Cache-Control: no-cache
    Connection: close
    Content-Length: 80
    Content-Type: application/json; charset=UTF-8
    Date: Wed, 16 Jan 2019 11:57:01 GMT
    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
    Server: gunicorn/19.9.0
    X-XSS-Protection: 1; mode=block

    {
        "reason": "limit: 1000 is greater than maximum value 200",
        "status": "failure"
    }