### PR TITLE
Add `profile_groups` API endpoint

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -297,6 +297,38 @@ paths:
           description: Profile information
           schema:
             $ref: '#/definitions/Profile'
+
+  /profile/groups:
+    get:
+      tags:
+        - users
+      summary: Get the user's groups
+      operationId: profileGroups
+      description: >
+        When used with an API key, will return the list of groups for which
+        the corresponding authenticated user is a member.
+
+        If no authenticated user is present on the request, an empty list will
+        be returned.
+
+        Returned groups are sorted by name.
+
+      parameters:
+        - name: expand
+          description: >
+            Array of fields to expand in the response
+          in: query
+          type: array
+          items:
+            type: string
+            enum:
+              - organization
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/GroupResults'
+
   /groups:
     get:
       tags:

--- a/h/routes.py
+++ b/h/routes.py
@@ -150,6 +150,7 @@ def includeme(config):
         traverse="/{id}",
     )
     config.add_route("api.profile", "/api/profile", factory="h.traversal.ProfileRoot")
+    config.add_route("api.profile_groups", "/api/profile/groups")
     config.add_route("api.debug_token", "/api/debug-token")
     config.add_route(
         "api.group_member",

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -145,6 +145,7 @@ def test_includeme():
             traverse="/{id}",
         ),
         call("api.profile", "/api/profile", factory="h.traversal.ProfileRoot"),
+        call("api.profile_groups", "/api/profile/groups"),
         call("api.debug_token", "/api/debug-token"),
         call(
             "api.group_member",


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/865

This PR adds a new endpoint! Hooray! This new endpoint at `GET /api/profile/groups` will return a list of the groups the currently-auth'd user is a member of, regardless of group type. We'll need this for community-groups work.

It's a simple endpoint. It takes an `expand` parameter similar to `GET /api/groups` to allow `organization` to be expanded (and soon, likely, `scopes`). A partial screenshot of the added docs is below:

<img width="1656" alt="screen shot 2019-01-17 at 12 17 36 pm" src="https://user-images.githubusercontent.com/439947/51336209-f8c76100-1a51-11e9-9ecc-449d3b148fe9.png">

The use of `profile` nomenclature is mostly to do with following established precedent in this "version" of our API.

At present, this endpoint does not return the `__world__` group; it is literally only a list of groups for which the current user has an extant user-group relation. We can debate that! I'm not wedded to it.
