### PR TITLE
Update nr use public func

### DIFF
--- a/h/util/metrics.py
+++ b/h/util/metrics.py
@@ -45,9 +45,4 @@ def record_search_query_params(params, separate_replies):
     if separate_replies:
         params.append(("es__separate_replies", separate_replies))
 
-    # On startup, there is a race condition in New Relic where there may not be
-    # a transaction. If there isn't, current_transaction will return None in which
-    # case we can't record params.
-    current_transaction = newrelic.agent.current_transaction()
-    if current_transaction:
-        newrelic.agent.current_transaction().add_custom_parameters(params)
+    newrelic.agent.add_custom_parameters(params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ kombu==4.2.1
 mako==1.0.4               # via alembic
 markupsafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.8.3
-newrelic==4.2.0.100
+newrelic==4.10.0.112
 oauthlib==2.0.2
 passlib==1.7.1
 pastedeploy==1.5.2        # via pyramid
@@ -66,7 +66,7 @@ statsd==3.2.1
 transaction==2.1.2
 translationstring==1.3    # via colander, deform, pyramid
 unidecode==0.4.19         # via python-slugify
-urllib3==1.24.1             # via elasticsearch
+urllib3==1.24.1           # via elasticsearch, sentry-sdk
 venusian==1.0
 vine==1.1.4               # via amqp
 webencodings==0.5.1       # via bleach

--- a/tests/h/util/metrics_test.py
+++ b/tests/h/util/metrics_test.py
@@ -11,7 +11,7 @@ class TestRecordSearchQueryParams(object):
     def test_it_passes_parameters_to_newrelic(self, newrelic_agent):
         params = MultiDict(tag="tagsvalue", _separate_replies=True, url="urlvalue")
         metrics.record_search_query_params(params, True)
-        newrelic_agent.current_transaction().add_custom_parameters.assert_called_once_with(
+        newrelic_agent.add_custom_parameters.assert_called_once_with(
             [
                 ("es_url", "urlvalue"),
                 ("es_tag", "tagsvalue"),
@@ -22,27 +22,18 @@ class TestRecordSearchQueryParams(object):
     def test_it_does_not_pass_unrecognized_parameters_to_newrelic(self, newrelic_agent):
         params = MultiDict(bad="unwanted")
         metrics.record_search_query_params(params, True)
-        newrelic_agent.current_transaction().add_custom_parameters.assert_called_once_with(
+        newrelic_agent.add_custom_parameters.assert_called_once_with(
             [("es__separate_replies", True)]
         )
 
     def test_it_does_not_record_separate_replies_if_False(self, newrelic_agent):
         params = MultiDict({})
         metrics.record_search_query_params(params, False)
-        newrelic_agent.current_transaction().add_custom_parameters.assert_called_once_with(
-            []
-        )
-
-    def test_it_does_not_record_parameters_if_no_transaction(self, newrelic_agent):
-        newrelic_agent.current_transaction.return_value = None
-        params = MultiDict(tag="tagsvalue")
-        metrics.record_search_query_params(params, True)
+        newrelic_agent.add_custom_parameters.assert_called_once_with([])
 
     @pytest.fixture
     def newrelic_agent(self, newrelic_agent):
-        newrelic_agent.current_transaction.return_value.add_custom_parameters = (
-            mock.Mock()
-        )
+        newrelic_agent.add_custom_parameters = mock.Mock()
         return newrelic_agent
 
 


### PR DESCRIPTION
In the [latest version of the newrelic python agent](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes) add_custom_parameters was made a public method. Previously we had to access it through the transaction ```newrelic.agent.current_transaction().add_custom_parameters``` which meant we had to handle the check for whether there was a current transaction but now we can use ```newrelic.agent.add_custom_parameters``` which handles the transaction check internally.