### PR TITLE
Fix API "links"

### DIFF
--- a/h/views/api/flags.py
+++ b/h/views/api/flags.py
@@ -15,7 +15,7 @@ from h.tasks import mailer
     route_name="api.annotation_flag",
     request_method="PUT",
     link_name="annotation.flag",
-    description="Flag an annotation for review.",
+    description="Flag an annotation for review",
     permission="flag",
 )
 def create(context, request):

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -50,6 +50,7 @@ def groups(request):
     route_name="api.groups",
     request_method="POST",
     permission="create",
+    link_name="group.create",
     description="Create a new group",
 )
 def create(request):
@@ -86,6 +87,7 @@ def create(request):
     route_name="api.group",
     request_method="GET",
     permission="read",
+    link_name="group.read",
     description="Fetch a group",
 )
 def read(group, request):
@@ -100,6 +102,7 @@ def read(group, request):
     route_name="api.group",
     request_method="PATCH",
     permission="admin",
+    link_name="group.update",
     description="Update a group",
 )
 def update(group, request):
@@ -132,6 +135,7 @@ def update(group, request):
     route_name="api.group_upsert",
     request_method="PUT",
     permission="upsert",
+    link_name="group.create_or_update",
     description="Create or update a group",
 )
 def upsert(context, request):
@@ -193,7 +197,7 @@ def upsert(context, request):
     route_name="api.group_member",
     request_method="DELETE",
     link_name="group.member.delete",
-    description="Remove the current user from a group.",
+    description="Remove the current user from a group",
     effective_principals=security.Authenticated,
 )
 def remove_member(group, request):

--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -19,7 +19,7 @@ def index(context, request):
     # parameter names are added, we'll need to add them here, or this view will
     # break (and get caught by the `test_api_index` functional test).
     templater = AngularRouteTemplater(
-        request.route_url, params=["id", "pubid", "user", "userid"]
+        request.route_url, params=["id", "pubid", "user", "userid", "username"]
     )
 
     links = {}

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -12,7 +12,7 @@ from h.views.api.config import api_config
     route_name="api.annotation_hide",
     request_method="PUT",
     link_name="annotation.hide",
-    description="Hide an annotation as a group moderator.",
+    description="Hide an annotation as a group moderator",
     permission="moderate",
 )
 def create(context, request):
@@ -30,7 +30,7 @@ def create(context, request):
     route_name="api.annotation_hide",
     request_method="DELETE",
     link_name="annotation.unhide",
-    description="Unhide an annotation as a group moderator.",
+    description="Unhide an annotation as a group moderator",
     permission="moderate",
 )
 def delete(context, request):

--- a/h/views/api/profile.py
+++ b/h/views/api/profile.py
@@ -24,6 +24,7 @@ def profile(request):
 @api_config(
     route_name="api.profile_groups",
     request_method="GET",
+    link_name="profile.groups.read",
     description="Fetch the current user's groups",
 )
 def profile_groups(request):

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -6,14 +6,20 @@ from pyramid.httpexceptions import HTTPConflict
 
 from h.auth.util import client_authority
 from h.views.api.exceptions import PayloadError
+from h.views.api.config import api_config
 from h.presenters import UserJSONPresenter
 from h.schemas.api.user import CreateUserAPISchema, UpdateUserAPISchema
 from h.schemas import ValidationError
 from h.services.user_unique import DuplicateUserError
-from h.util.view import json_view
 
 
-@json_view(route_name="api.users", request_method="POST", permission="create")
+@api_config(
+    route_name="api.users",
+    request_method="POST",
+    link_name="user.create",
+    description="Create a new user",
+    permission="create",
+)
 def create(request):
     """
     Create a user.
@@ -57,7 +63,13 @@ def create(request):
     return presenter.asdict()
 
 
-@json_view(route_name="api.user", request_method="PATCH", permission="update")
+@api_config(
+    route_name="api.user",
+    request_method="PATCH",
+    link_name="user.update",
+    description="Update a user",
+    permission="update",
+)
 def update(user, request):
     """
     Update a user.

--- a/tests/h/views/api/index_test.py
+++ b/tests/h/views/api/index_test.py
@@ -9,7 +9,9 @@ from h.views.api import index as views
 
 
 class TestIndex(object):
-    def test_it_returns_the_right_links(self, pyramid_config, pyramid_request):
+    def test_it_returns_the_right_links_for_annotation_endpoints(
+        self, pyramid_config, pyramid_request
+    ):
 
         # Scan `h.views.api_annotations` for API link metadata specified in @api_config
         # declarations.
@@ -36,3 +38,153 @@ class TestIndex(object):
         assert links["annotation"]["update"]["url"] == (host + "/dummy/annotations/:id")
         assert links["search"]["method"] == "GET"
         assert links["search"]["url"] == host + "/dummy/search"
+
+        # Make sure no extra links we didn't test for
+        assert set(links["annotation"].keys()) == set(
+            ["create", "read", "delete", "update"]
+        )
+        assert set(links.keys()) == set(["annotation", "search"])
+
+    def test_it_returns_the_right_links_for_flag_endpoints(
+        self, pyramid_config, pyramid_request
+    ):
+
+        config = Configurator()
+        config.scan("h.views.api.flags")
+        pyramid_request.registry.api_links = config.registry.api_links
+        host = "http://example.com"  # Pyramid's default host URL'
+
+        pyramid_config.add_route("api.annotation_flag", "/dummy/annotations/:id/flag")
+
+        result = views.index(testing.DummyResource(), pyramid_request)
+
+        links = result["links"]
+
+        assert links["annotation"]["flag"]["method"] == "PUT"
+        assert links["annotation"]["flag"]["url"] == (
+            host + "/dummy/annotations/:id/flag"
+        )
+
+    def test_it_returns_the_right_links_for_group_endpoints(
+        self, pyramid_config, pyramid_request
+    ):
+
+        config = Configurator()
+        config.scan("h.views.api.groups")
+        pyramid_request.registry.api_links = config.registry.api_links
+        host = "http://example.com"  # Pyramid's default host URL'
+
+        pyramid_config.add_route("api.groups", "/dummy/groups")
+        pyramid_config.add_route("api.group", "/dummy/groups/:id")
+        pyramid_config.add_route(
+            "api.group_upsert", "/dummy/groups/:id", request_method="PUT"
+        )
+        pyramid_config.add_route(
+            "api.group_member", "/dummy/groups/:pubid/members/:userid"
+        )
+
+        result = views.index(testing.DummyResource(), pyramid_request)
+
+        links = result["links"]
+        # Groups collections
+        assert links["groups"]["read"]["method"] == "GET"
+        assert links["groups"]["read"]["url"] == (host + "/dummy/groups")
+
+        # Group resources
+        assert links["group"]["create"]["method"] == "POST"
+        assert links["group"]["create"]["url"] == (host + "/dummy/groups")
+        assert links["group"]["read"]["method"] == "GET"
+        assert links["group"]["read"]["url"] == (host + "/dummy/groups/:id")
+        assert links["group"]["update"]["method"] == "PATCH"
+        assert links["group"]["update"]["url"] == (host + "/dummy/groups/:id")
+        assert links["group"]["create_or_update"]["method"] == "PUT"
+        assert links["group"]["create_or_update"]["url"] == (host + "/dummy/groups/:id")
+
+        # Group membership
+        assert links["group"]["member"]["add"]["method"] == "POST"
+        assert links["group"]["member"]["add"]["url"] == (
+            host + "/dummy/groups/:pubid/members/:userid"
+        )
+        assert links["group"]["member"]["delete"]["method"] == "DELETE"
+        assert links["group"]["member"]["delete"]["url"] == (
+            host + "/dummy/groups/:pubid/members/:userid"
+        )
+
+        # Make sure no extra links we didn't test for
+        assert set(links["group"].keys()) == set(
+            ["member", "create", "read", "create_or_update", "update"]
+        )
+        assert set(links["group"]["member"].keys()) == set(["add", "delete"])
+
+    def test_it_returns_the_right_links_for_links_endpoints(
+        self, pyramid_config, pyramid_request
+    ):
+
+        config = Configurator()
+        config.scan("h.views.api.links")
+        pyramid_request.registry.api_links = config.registry.api_links
+        host = "http://example.com"  # Pyramid's default host URL'
+
+        pyramid_config.add_route("api.links", "/dummy/links")
+
+        result = views.index(testing.DummyResource(), pyramid_request)
+
+        links = result["links"]
+
+        assert links["links"]["method"] == "GET"
+        assert links["links"]["url"] == (host + "/dummy/links")
+
+    def test_it_returns_the_right_links_for_moderation_endpoints(
+        self, pyramid_config, pyramid_request
+    ):
+
+        config = Configurator()
+        config.scan("h.views.api.moderation")
+        pyramid_request.registry.api_links = config.registry.api_links
+        host = "http://example.com"  # Pyramid's default host URL'
+
+        pyramid_config.add_route("api.annotation_hide", "/dummy/annotations/:id/hide")
+
+        result = views.index(testing.DummyResource(), pyramid_request)
+
+        links = result["links"]
+
+        assert links["annotation"]["hide"]["method"] == "PUT"
+        assert links["annotation"]["hide"]["url"] == (
+            host + "/dummy/annotations/:id/hide"
+        )
+        assert links["annotation"]["unhide"]["method"] == "DELETE"
+        assert links["annotation"]["unhide"]["url"] == (
+            host + "/dummy/annotations/:id/hide"
+        )
+
+        assert set(links["annotation"].keys()) == set(["hide", "unhide"])
+
+    def test_it_returns_the_right_links_for_profile_endpoints(
+        self, pyramid_config, pyramid_request
+    ):
+
+        config = Configurator()
+        config.scan("h.views.api.profile")
+        pyramid_request.registry.api_links = config.registry.api_links
+        host = "http://example.com"  # Pyramid's default host URL'
+
+        pyramid_config.add_route("api.profile", "/dummy/profile")
+        pyramid_config.add_route("api.profile_groups", "/dummy/profile/groups")
+
+        result = views.index(testing.DummyResource(), pyramid_request)
+
+        links = result["links"]
+
+        assert links["profile"]["read"]["method"] == "GET"
+        assert links["profile"]["read"]["url"] == (host + "/dummy/profile")
+        assert links["profile"]["update"]["method"] == "PATCH"
+        assert links["profile"]["update"]["url"] == (host + "/dummy/profile")
+
+        assert links["profile"]["groups"]["read"]["method"] == "GET"
+        assert links["profile"]["groups"]["read"]["url"] == (
+            host + "/dummy/profile/groups"
+        )
+
+        assert set(links["profile"].keys()) == set(["read", "update", "groups"])
+        assert set(links["profile"]["groups"].keys()) == set(["read"])

--- a/tests/h/views/api/index_test.py
+++ b/tests/h/views/api/index_test.py
@@ -188,3 +188,26 @@ class TestIndex(object):
 
         assert set(links["profile"].keys()) == set(["read", "update", "groups"])
         assert set(links["profile"]["groups"].keys()) == set(["read"])
+
+    def test_it_returns_the_right_links_for_user_endpoints(
+        self, pyramid_config, pyramid_request
+    ):
+
+        config = Configurator()
+        config.scan("h.views.api.users")
+        pyramid_request.registry.api_links = config.registry.api_links
+        host = "http://example.com"  # Pyramid's default host URL'
+
+        pyramid_config.add_route("api.users", "/dummy/users")
+        pyramid_config.add_route("api.user", "/dummy/users/:username")
+
+        result = views.index(testing.DummyResource(), pyramid_request)
+
+        links = result["links"]
+
+        assert links["user"]["create"]["method"] == "POST"
+        assert links["user"]["create"]["url"] == (host + "/dummy/users")
+        assert links["user"]["update"]["method"] == "PATCH"
+        assert links["user"]["update"]["url"] == (host + "/dummy/users/:username")
+
+        assert set(links["user"].keys()) == set(["create", "update"])


### PR DESCRIPTION
Required for https://github.com/hypothesis/product-backlog/issues/865

This PR started out as a one-liner/5-minute job and turned into what you see here, but it is not doing anything terribly complex. It remediates a long-standing bit of tech debt we've had where our `api.index` list of links was gravely out of date. The client needs these links to be able to resolve where to send API requests, and the immediate need was to add the new `profile_groups` endpoint to the set of links output by the `index` endpoint.

Thus, this PR ensures that all of the published API endpoints have a `link_name` config value, which is used by the `@api_config` decorator to inform the `index` endpoint what to output. This was mostly straightforward, but did require the conversion of the views in `h.views.api.users` from using the `@json_view` decorator to the `@api_config` decorator.

Figuring out what the heck links "mean" vis-a-vis our API was on my long list of things to fix in the API in general, so this leaves me with a good feeling. The tests are verbose and not isolated well, but they build on an existing pattern, are explicit, and I don't want perfect to be the enemy of the good here.

For the record, the term _links_ is overloaded by our application. Depending on where you are in the app, _links_ can mean one of several things, including: 

* A set of "links" defining available API endpoints, [returned by the `index` API endpoint](https://api.hypothes.is/api/). These are the kind of "links" addressed in this PR.
* Linked Data-type links generated for annotations and, to some extent, group resources. These are URLs attached to resource objects returned by the API. They're complex (and the code that generates them extra so), but necessary to meet spec in our annotation representations.
* There is also, somewhat inelegantly perhaps?, [a `links` API endpoint](https://api.hypothes.is/api/links). Whereas the `index` endpoint returns links to API endpoints, the `links` endpoint returns URLs to feature pages served by our `h` app (e.g. accounts, password reset). I'd wager to guess this is for the benefit of our client to generate links from the client to our web services, but am not certain on that. I should point out that this endpoint appears to be undocumented. I hadn't understood how it was distinguished from the `index` endpoint until today. Amazing how much there is to learn.