### PR TITLE
Remove deform-jinja2 package

### DIFF
--- a/h/form.py
+++ b/h/form.py
@@ -3,9 +3,7 @@
 Configure deform to use custom templates.
 
 Sets up the form handling and rendering library, deform, to use our own custom
-form templates in preference to the defaults. Uses `deform_jinja2` to provide
-the fallback templates in Jinja2 format, which we can then extend and modify as
-necessary.
+form templates in preference to the defaults.
 """
 from __future__ import unicode_literals
 import deform
@@ -19,7 +17,7 @@ from h import i18n
 
 ENVIRONMENT_KEY = "h.form.jinja2_environment"
 
-SEARCH_PATHS = ("h:templates/deform/", "deform_jinja2:bootstrap_templates/")
+SEARCH_PATHS = ["h:templates/deform/"]
 
 
 _ = i18n.TranslationString

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -52,10 +52,4 @@
       {% endfor -%}
     </div>
   </div>
-
-  {#
-    The default deform templates are ajax capable. I've removed that code here
-    for the sake of clarity. If we need to put it back it can be found in
-    deform_jinja2:bootstrap_templates/form.jinja2.
-  #}
 </form>

--- a/h/templates/deform/hidden.jinja2
+++ b/h/templates/deform/hidden.jinja2
@@ -1,0 +1,1 @@
+<input type="hidden" name="{{ field.name }}" value="{{ cstruct }}" id="{{ field.oid }}"/>

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,6 @@ certifi  # Required to connect to Elasticsearch over SSL.
 cffi
 click
 deform < 1.0
-deform-jinja2
 elasticsearch==6.3.1
 elasticsearch-dsl==6.3.1
 enum34

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ cffi==1.11.5
 chameleon==2.24           # via deform
 click==6.6
 colander==1.3.1           # via deform
-deform-jinja2==0.5
 deform==0.9.9
 elasticsearch-dsl==6.3.1
 elasticsearch==6.3.1
@@ -29,7 +28,7 @@ hkdf==0.0.3
 ipaddress==1.0.18         # via elasticsearch-dsl
 iso8601==0.1.11           # via colander
 itsdangerous==0.24
-jinja2==2.10              # via deform-jinja2, pyramid-jinja2
+jinja2==2.10              # via pyramid-jinja2
 jsonpointer==1.0
 jsonschema==2.5.1
 kombu==4.2.1

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -70,7 +70,6 @@ class TestCreateEnvironment(object):
         loader = kwargs["loader"]
 
         assert "templates/deform" in loader.searchpath[0]
-        assert "bootstrap_templates" in loader.searchpath[1]
 
 
 class TestCreateForm(object):


### PR DESCRIPTION
This originally provided the templates we used for form components. We
have since overridden all of the templates except for `hidden.jinja2`
with our own.

Removing this package unblocks a potential obstacle to the Python 3
upgrade and avoids the confusion of having to look at multiple places to
understand where form component markup comes from.

Fixes https://github.com/hypothesis/h/issues/5516