### PR TITLE
Move authority-determining logic out of view

### DIFF
--- a/h/services/group_list.py
+++ b/h/services/group_list.py
@@ -84,7 +84,7 @@ class GroupListService(object):
 
         return world_readable_groups + private_groups
 
-    def request_groups(self, authority, user=None, document_uri=None):
+    def request_groups(self, authority=None, user=None, document_uri=None):
         """
         Return a list of groups relevant to this request context.
 
@@ -104,6 +104,7 @@ class GroupListService(object):
           This should return a list of groups appropriate to the client
           via the API.
         """
+        authority = self._authority(user, authority)
         scoped_groups = self.scoped_groups(authority, document_uri)
 
         world_group = self.world_group(authority)

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -28,18 +28,13 @@ from h.views.api.config import api_config
 def groups(request):
     """Retrieve the groups for this request's user."""
 
-    authority = request.params.get("authority")
-    document_uri = request.params.get("document_uri")
     expand = request.GET.getall("expand") or []
-
     list_svc = request.find_service(name="group_list")
 
-    if request.user is not None:
-        authority = request.user.authority
-    else:
-        authority = authority or request.default_authority
     all_groups = list_svc.request_groups(
-        user=request.user, authority=authority, document_uri=document_uri
+        user=request.user,
+        authority=request.params.get("authority"),
+        document_uri=request.params.get("document_uri"),
     )
     all_groups = [GroupContext(group, request) for group in all_groups]
     all_groups = GroupsJSONPresenter(all_groups).asdicts(expand=expand)

--- a/tests/functional/api/groups/test_read.py
+++ b/tests/functional/api/groups/test_read.py
@@ -38,6 +38,20 @@ class TestReadGroups(object):
         assert group1.pubid in groupids
         assert group2.pubid in groupids
 
+    def test_it_overrides_authority_param_with_user_authority(
+        self, app, factories, db_session, user_with_token, token_auth_header
+    ):
+        user, _ = user_with_token
+        # This group will be created with the user's authority
+        group1 = factories.Group(creator=user)
+        db_session.commit()
+
+        res = app.get("/api/groups?authority=whatever.com", headers=token_auth_header)
+
+        groupids = [group["id"] for group in res.json]
+        # It still returns the groups from the user's authority
+        assert group1.pubid in groupids
+
     def test_it_expands_scope_if_requested(self, app):
         res = app.get("/api/groups?expand=scopes")
 

--- a/tests/h/services/group_list_test.py
+++ b/tests/h/services/group_list_test.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import pytest
+import mock
 
 from h.services.group_list import GroupListService
 from h.services.group_list import group_list_factory
@@ -91,6 +92,26 @@ class TestListGroupsRequestGroups(object):
         results = svc.request_groups(authority=default_authority)
 
         assert results[0].pubid == "__world__"
+
+    def test_it_overrides_authority_with_user_authority(self, svc, user):
+        svc.scoped_groups = mock.Mock()
+        svc.scoped_groups.return_value = []
+        svc.world_group = mock.Mock()
+
+        svc.request_groups(authority="foople.com", user=user)
+
+        svc.scoped_groups.assert_called_once_with(user.authority, None)
+        svc.world_group.assert_called_once_with(user.authority)
+
+    def test_it_defaults_to_default_authority(self, svc, default_authority):
+        svc.scoped_groups = mock.Mock()
+        svc.scoped_groups.return_value = []
+        svc.world_group = mock.Mock()
+
+        svc.request_groups()
+
+        svc.scoped_groups.assert_called_once_with(default_authority, None)
+        svc.world_group.assert_called_once_with(default_authority)
 
     def test_it_returns_matching_scoped_open_groups(
         self, svc, authority, document_uri, scoped_open_groups

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -31,7 +31,7 @@ class TestGetGroups(object):
         views.groups(anonymous_request)
 
         group_list_service.request_groups.assert_called_once_with(
-            user=None, authority=anonymous_request.default_authority, document_uri=None
+            user=None, authority=None, document_uri=None
         )
 
     def test_proxies_request_params(self, anonymous_request, group_list_service):
@@ -43,19 +43,6 @@ class TestGetGroups(object):
             user=None,
             authority="foo.com",
             document_uri="http://example.com/thisthing.html",
-        )
-
-    def test_overrides_authority_with_user_authority(
-        self, authenticated_request, group_list_service
-    ):
-        authenticated_request.params["authority"] = "foo.com"
-
-        views.groups(authenticated_request)
-
-        group_list_service.request_groups.assert_called_once_with(
-            user=authenticated_request.user,
-            authority=authenticated_request.user.authority,
-            document_uri=None,
         )
 
     def test_converts_groups_to_resources(


### PR DESCRIPTION
Thin out the view for `GET /api/groups` by moving authority logic into the service, where it already existed as a private method, anyway.

Tackled this view because I think this endpoint may be the first to get messed with in API v2.

~~Marking WIP for now because I'd like to piggyback a couple of functional tests onto the new functional test class introduced in #5526~~

No longer WIP.