### PR TITLE
Replace uses of `map`

### DIFF
--- a/h/eventqueue.py
+++ b/h/eventqueue.py
@@ -16,7 +16,7 @@ def _get_subscribers(registry, event):
     # This code is adapted from the `subscribers` method in
     # `zope.interface.adapter` which is what Pyramid's `request.registry.notify`
     # is a very thin wrapper around.
-    return registry.adapters.subscriptions(map(providedBy, [event]), None)
+    return registry.adapters.subscriptions([providedBy(event)], None)
 
 
 class EventQueue(object):

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -714,7 +714,7 @@ class TestGroupSearchController(object):
     ):
 
         info = controller.search()["group_users_args"]
-        userids = list(map(lambda i: i["userid"], info[1]))
+        userids = [i["userid"] for i in info[1]]
         for member in test_group.members:
             assert member.userid in userids
 
@@ -726,7 +726,7 @@ class TestGroupSearchController(object):
     ):
 
         info = controller.search()["group_users_args"]
-        userids = list(map(lambda i: i["userid"], info[1]))
+        userids = [i["userid"] for i in info[1]]
 
         # At the moment, for an open group we return the group creator as the moderator
         assert userids == [test_group.creator.userid]


### PR DESCRIPTION
`map` has different behavior in Python 2/3. Avoid any surprises after we
migrate by rewriting a couple of unnecessary uses to avoid it.

Only the use in `h/eventqueue.py` could potentially have been a problem depending on the implementation of `registry.adapters.subscriptions`.

Part of https://github.com/hypothesis/h/issues/5515