### PR TITLE
Fix the functional tests in Python 3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,30 @@ skipsdist = true
 requires = tox-pip-extensions
 tox_pip_extensions_ext_venv_update = true
 
+[pytest]
+filterwarnings =
+    # Fail the tests if there are any warnings.
+    error
+
+    # Ignore certain specific warnings. One line per warning to ignore. The
+    # pattern is:
+    #
+    # ignore:<WARNING_MESSAGE>:<WARNING_CATEGORY>:<MODULE>
+    #
+    # <WARNING_MESSAGE> is a regex that must match the warning message that you
+    # want to ignore.
+    #
+    # <WARNING_CATEGORY> is the class of the warning that you want to ignore,
+    # e.g. DeprecationWarning. See:
+    # https://docs.python.org/2/library/warnings.html#warning-categories
+    #
+    # <MODULE> is the name of the module that the warning originates from.
+    #
+    # See https://docs.python.org/3/library/warnings.html and
+    # https://docs.pytest.org/en/latest/warnings.html
+    #
+    ignore:^Use of \.\. or absolute path in a resource path is not allowed and will raise exceptions in a future release\.$:DeprecationWarning:pkg_resources
+
 [testenv]
 skip_install = true
 sitepackages = {env:SITE_PACKAGES:false}
@@ -55,8 +79,8 @@ commands =
     lint: flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
     format: black h tests
     checkformatting: black --check h tests
-    tests: coverage run -m pytest -Werror {posargs:tests/h/}
-    functests: pytest -Werror {posargs:tests/functional/}
+    tests: coverage run -m pytest {posargs:tests/h/}
+    functests: pytest {posargs:tests/functional/}
     docs: sphinx-autobuild -BqT -b dirhtml -d {envdir}/doctrees . {envdir}/html
     checkdocs: sphinx-build -qTWn -b dirhtml -d {envdir}/doctrees . {envdir}/html
     {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envdir}/rst .


### PR DESCRIPTION
A new release of setuptools has introduced a deprecation warning that Jinja is triggering:

https://setuptools.readthedocs.io/en/latest/history.html#v40-8-0

The issue is currently unresolved in Jinja:

https://github.com/pallets/jinja/issues/942

This is causing our tests to fail since we fail the tests on warnings. Add an exception to ignore this particular warning.