### PR TITLE
Use stable node version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,17 +38,14 @@ matrix:
     # Test web application frontend
     - env: ACTION=gulp
       language: node_js
-      # We currently build production against Alpine v3.4:
-      #
-      #   https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.4
-      node_js: '6.7'
+      node_js: 'node'
       before_install: npm install gulp-cli
       script: gulp test
 
     # Lint frontend code
     - env: ACTION=frontend-lint
       language: node_js
-      node_js: '6.7'
+      node_js: 'node'
       script:
         gulp lint
 


### PR DESCRIPTION
Node was pinned at v6.7 on Travis to match the Alpine 3.4 environment
used in the Docker build at the time.

However we now build the frontend parts of h in a separate build stage
which uses the current stable version of Node.