### PR TITLE
WIP: Approach for API Versioning via config, headers

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -143,6 +143,11 @@ def configure(environ=None, settings=None):
     es_logger = logging.getLogger("elasticsearch")
     es_logger.addFilter(ExceptionFilter((("ReadTimeoutError", "WARNING"),)))
 
+    # Add API version settings
+    # These cannot be overridden by env
+    settings["api.versions"] = ["v1", "v2"]
+    settings["api.version.current"] = "v1"
+
     return Configurator(settings=settings)
 
 

--- a/h/views/api/__init__.py
+++ b/h/views/api/__init__.py
@@ -3,4 +3,13 @@ from __future__ import unicode_literals
 
 
 def includeme(config):
+    config.add_accept_view_order("application/json")
+    # If request Accept header is missing or doesn't match any registered API views,
+    # by default we want to use the view that is configured for "application/json".
+    # This will be the current-version API view for the route.
+    for version in config.registry.settings["api.versions"]:
+        config.add_accept_view_order(
+            "application/vnd.hypothesis." + version + "+json",
+            weighs_less_than="application/json",
+        )
     config.scan(__name__)

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -24,6 +24,7 @@ from h.views.api.config import api_config
     request_method="GET",
     link_name="groups.read",
     description="Fetch the user's groups",
+    versions=["v1"],
 )
 def groups(request):
     """Retrieve the groups for this request's user."""
@@ -39,6 +40,17 @@ def groups(request):
     all_groups = [GroupContext(group, request) for group in all_groups]
     all_groups = GroupsJSONPresenter(all_groups).asdicts(expand=expand)
     return all_groups
+
+
+@api_config(
+    route_name="api.groups",
+    request_method="GET",
+    link_name="groups.read",
+    description="Search groups",
+    versions=["v2"],
+)
+def groups_v2(request):
+    return {"status": "OK"}
 
 
 @api_config(

--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from h.views.api.config import api_config, AngularRouteTemplater
 
 
-@api_config(route_name="api.index")
+@api_config(route_name="api.index", versions=["v1"])
 def index(context, request):
     """Return the API descriptor document.
 
@@ -32,6 +32,17 @@ def index(context, request):
         _set_at_path(links, link["name"].split("."), method_info)
 
     return {"links": links}
+
+
+@api_config(route_name="api.index", versions=["v2"])
+def index_v2(context, request):
+    """Return the API descriptor document.
+
+    Clients may use this to discover endpoints for the API.
+    """
+
+    api_links = request.registry.api_links["v2"]
+    return api_links
 
 
 def _set_at_path(dict_, path, value):

--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -12,7 +12,7 @@ def index(context, request):
     Clients may use this to discover endpoints for the API.
     """
 
-    api_links = request.registry.api_links
+    api_links = request.registry.api_links["v1"]
 
     # We currently need to keep a list of the parameter names we use in our API
     # paths and pass these explicitly into the templater. As and when new

--- a/tests/h/config_test.py
+++ b/tests/h/config_test.py
@@ -18,17 +18,30 @@ from h.config import configure
     ],
 )
 def test_configure_updates_settings_from_env_vars(
-    env_var, env_val, setting_name, setting_val
+    env_var, env_val, setting_name, setting_val, required_settings
 ):
     environ = {env_var: env_val} if env_var else {}
-    settings_from_conf = {
-        "h.db_session_checks": True,
-        # Required settings
-        "es.url": "https://es6-search-cluster",
-        "secret_key": "notasecret",
-        "sqlalchemy.url": "postgres://user@dbhost/dbname",
-    }
+    settings_from_conf = required_settings
+    settings_from_conf["h.db_session_checks"] = True
 
     config = configure(environ=environ, settings=settings_from_conf)
 
     assert config.registry.settings[setting_name] == setting_val
+
+
+def test_configure_sets_api_settings(required_settings):
+    environ = {}
+
+    config = configure(environ=environ, settings=required_settings)
+
+    assert config.registry.settings["api.versions"] == ["v1", "v2"]
+    assert config.registry.settings["api.version.current"] == "v1"
+
+
+@pytest.fixture
+def required_settings():
+    return {
+        "es.url": "https://es6-search-cluster",
+        "secret_key": "notasecret",
+        "sqlalchemy.url": "postgres://user@dbhost/dbname",
+    }

--- a/tests/h/views/api/config_test.py
+++ b/tests/h/views/api/config_test.py
@@ -120,7 +120,7 @@ class TestAddApiView(object):
             **kwargs
         )
 
-        assert pyramid_config.registry.api_links == [
+        assert pyramid_config.registry.api_links["v1"] == [
             {
                 "name": link_name,
                 "description": description,

--- a/tests/h/views/api/index_test.py
+++ b/tests/h/views/api/index_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+import pytest
+
 from pyramid import testing
 from pyramid.config import Configurator
 
@@ -10,12 +12,11 @@ from h.views.api import index as views
 
 class TestIndex(object):
     def test_it_returns_the_right_links_for_annotation_endpoints(
-        self, pyramid_config, pyramid_request
+        self, pyramid_config, pyramid_request, config
     ):
 
         # Scan `h.views.api_annotations` for API link metadata specified in @api_config
         # declarations.
-        config = Configurator()
         config.scan("h.views.api.annotations")
         pyramid_request.registry.api_links = config.registry.api_links
 
@@ -46,10 +47,9 @@ class TestIndex(object):
         assert set(links.keys()) == set(["annotation", "search"])
 
     def test_it_returns_the_right_links_for_flag_endpoints(
-        self, pyramid_config, pyramid_request
+        self, pyramid_config, pyramid_request, config
     ):
 
-        config = Configurator()
         config.scan("h.views.api.flags")
         pyramid_request.registry.api_links = config.registry.api_links
         host = "http://example.com"  # Pyramid's default host URL'
@@ -66,10 +66,9 @@ class TestIndex(object):
         )
 
     def test_it_returns_the_right_links_for_group_endpoints(
-        self, pyramid_config, pyramid_request
+        self, pyramid_config, pyramid_request, config
     ):
 
-        config = Configurator()
         config.scan("h.views.api.groups")
         pyramid_request.registry.api_links = config.registry.api_links
         host = "http://example.com"  # Pyramid's default host URL'
@@ -117,10 +116,9 @@ class TestIndex(object):
         assert set(links["group"]["member"].keys()) == set(["add", "delete"])
 
     def test_it_returns_the_right_links_for_links_endpoints(
-        self, pyramid_config, pyramid_request
+        self, pyramid_config, pyramid_request, config
     ):
 
-        config = Configurator()
         config.scan("h.views.api.links")
         pyramid_request.registry.api_links = config.registry.api_links
         host = "http://example.com"  # Pyramid's default host URL'
@@ -135,10 +133,9 @@ class TestIndex(object):
         assert links["links"]["url"] == (host + "/dummy/links")
 
     def test_it_returns_the_right_links_for_moderation_endpoints(
-        self, pyramid_config, pyramid_request
+        self, pyramid_config, pyramid_request, config
     ):
 
-        config = Configurator()
         config.scan("h.views.api.moderation")
         pyramid_request.registry.api_links = config.registry.api_links
         host = "http://example.com"  # Pyramid's default host URL'
@@ -161,10 +158,9 @@ class TestIndex(object):
         assert set(links["annotation"].keys()) == set(["hide", "unhide"])
 
     def test_it_returns_the_right_links_for_profile_endpoints(
-        self, pyramid_config, pyramid_request
+        self, pyramid_config, pyramid_request, config
     ):
 
-        config = Configurator()
         config.scan("h.views.api.profile")
         pyramid_request.registry.api_links = config.registry.api_links
         host = "http://example.com"  # Pyramid's default host URL'
@@ -190,10 +186,9 @@ class TestIndex(object):
         assert set(links["profile"]["groups"].keys()) == set(["read"])
 
     def test_it_returns_the_right_links_for_user_endpoints(
-        self, pyramid_config, pyramid_request
+        self, pyramid_config, pyramid_request, config
     ):
 
-        config = Configurator()
         config.scan("h.views.api.users")
         pyramid_request.registry.api_links = config.registry.api_links
         host = "http://example.com"  # Pyramid's default host URL'
@@ -211,3 +206,11 @@ class TestIndex(object):
         assert links["user"]["update"]["url"] == (host + "/dummy/users/:username")
 
         assert set(links["user"].keys()) == set(["create", "update"])
+
+
+@pytest.fixture
+def config():
+    config = Configurator()
+    config.registry.settings["api.versions"] = ["v1", "v2"]
+    config.registry.settings["api.version.current"] = "v1"
+    return config


### PR DESCRIPTION
This PR is a prototype of adding Content Header negotiation to our Pyramid app to support API versioning. It allows views to declare what versions they are available for.  As such, it:

* **Defines a list of known/published API versions as well as the current API version.**

    Right now, these are defined as non-override-able settings (`config.registry.settings[“api.versions”]`, `config.registry.settings[“api.version.current”]`. This is not a pattern we’ve followed before—having a setting that cannot be altered by env—so I’m more than open to putting this somewhere else. Basically these are constants that I’d like available during the app’s lifecycle.

   My goals are to make this easy to find for a future dev, and clear, not buried somewhere in a submodule that may make it confusing. That said, as long as this information—a list of all versions the app is aware of plus the current version—is available during bootstrap (i.e. `config`) and view execution (i.e.  `request)`, I’m cool.

* **Extends API view configuration such that views may declare which API versions they support**

    The `@api_config` decorator accepts a `versions`  (List) param. This param, for the moment, is optional and defaults to the current version of the API, but I’m leaning toward making it required so that we don’t end up with unexpected configurations. I waffled over this for a while this morning. Initially, I thought I only wanted us to have to set `versions` config on views that were not for the default version—to make this config more implicit than explicit. However, as I mused over how longer-term maintenance would go, it seems like just taking a few minutes to add this param to all the existing API views and be done with it and have really clear config going on. Anyway.

* **Assigns the right `accepts` config to a view during config, based on its versions**

   If a view supports the current version of the API, it will be configured with `accept=“application/json` as well as the Accept header for the current API version (e.g. `accept=“application/vnd.hypothesis.v1+json”`). If a declared version is unknown, the config will raise at present.
* **Weights `Accept` headers such that views for the current version of the API will be preferred if a request’s Accept header is missing, invalid or generic**

    This allows us to use the current API version’s view when a request lacks a versioned Accept header (for example, a missing Accept or an `Accept:application/json`)

    Note: If a request has an *invalid* Accept header, it’ll raise a 404. This surprised me because [Pyramid's documentation](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html#accept-content-negotiation) on this makes it sound like the heaviest-weighted accepts-view will get used if the header is invalid. In any case, this is not a regression: if you send an invalid Accept at our API endpoints today, you’ll get a 404 (a missing Accept is OK and works, but not an invalid one). Shrug?
* **Does a light/naive refactoring of the way that API services are registered as “links”** (i.e. what gets returned by the API’s index route). 

    This was mostly done to “make things work” for the purposes of a speedy prototype.
* **Adds a couple example “v2” views for the purpose of illustration**

    If you’re interested, you can run this branch and try hitting either `GET /api/groups` or `GET /api` locally with different Accept headers and see what response you get. I guess leaving this as an exercise for the reader is rude, so I’ll spill the beans:

    * Send `Accept:application/json`, `Accept:application/vnd.hypothesis.v1+json` or no Accept header and you’ll get the default/v1 response
    * Send `Accept:application/vnd.hypothesis.v2+json` and you’ll get the “new”, fake v2 response on those endpoints

### So…

I’m looking for feedback on the general approach, things like where to stick settings and whether the config stuff seems generally OK. Don’t get too caught up on the lack of tight factoring on the config functions themselves as I will be refactoring when I do the actual implementation. I just wanted to get a prototype out quickly. More notes in code comments to come…
