### PR TITLE
Add basic concept of API "v1" to `h` codebase

### DIFF
--- a/h/views/api/__init__.py
+++ b/h/views/api/__init__.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+API_VERSIONS = ["v1"]
+API_VERSION_DEFAULT = "v1"
+
+__all__ = ("API_VERSIONS", "API_VERSION_DEFAULT")
+
 
 def includeme(config):
     config.scan(__name__)

--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -3,6 +3,8 @@ import venusian
 
 from h.util import cors
 
+from h.views.api import API_VERSION_DEFAULT
+
 
 #: Decorator that adds CORS headers to API responses.
 #:
@@ -22,26 +24,42 @@ cors_policy = cors.policy(
 
 
 def add_api_view(
-    config, view, link_name=None, description=None, enable_preflight=True, **settings
+    config,
+    view,
+    versions=None,
+    link_name=None,
+    description=None,
+    enable_preflight=True,
+    **settings
 ):
 
     """
     Add a view configuration for an API view.
 
-    This adds a new view using `config.add_view` with appropriate defaults for
-    API methods (JSON in & out, CORS support). Additionally if `link_name` is
-    specified it adds the view to the list of views returned by the `api.index`
-    route.
+    This configuration takes care of some common tasks for configuring
+    API views:
 
-    :param config: The Pyramid `Configurator`
+    * It registers the view with Pyramid using some appropriate defaults for
+      API method views, e.g. JSON and CORs support. As part of this, it also
+      configures views to respond to requests for different versions of
+      the API, via Accept header negotiation.
+    * If ``link_name`` is present, the view will be registered as one of the
+      available "links" that are returned by the ``api.index`` route for its
+      version(s).
+
+    :param config:
+    :type config: :class:`Pyramid.config.Configurator`
     :param view: The view callable
-    :param link_name: Dotted path of the metadata for this route in the output
-                      of the `api.index` view
-    :param description: Description of the view to use in the `api.index` view
-    :param enable_preflight: If `True` add support for CORS preflight requests
-                             for this view. If `True`, a `route_name` must be
-                             specified.
-    :param settings: Arguments to pass on to `config.add_view`
+    :param versions: API versions this view supports. Each entry must be one of
+                     the versions defined in :py:const:`h.views.api.API_VERSIONS`
+    :type versions: list[string] or None
+    :param str link_name: Dotted path of the metadata for this route in the output
+                          of the `api.index` view
+    :param str description: Description of the view to use in `api.index`
+    :param bool enable_preflight: If ```True``, add support for CORS preflight
+                                  requests for this view. If ``True``, a
+                                  `route_name` must be specified.
+    :param dict settings: Arguments to pass on to ``config.add_view``
     """
 
     # Get the HTTP method for use in the API links metadata
@@ -54,6 +72,8 @@ def add_api_view(
     settings.setdefault("accept", "application/json")
     settings.setdefault("renderer", "json")
     settings.setdefault("decorator", cors_policy)
+
+    versions = versions or [API_VERSION_DEFAULT]
 
     if link_name:
         link = {
@@ -69,6 +89,13 @@ def add_api_view(
         registry.api_links.append(link)
 
     config.add_view(view=view, **settings)
+
+    for version in versions:
+        # config.add_view only allows one, string value for `accept`, so we
+        # have to re-invoke it to add additional accept headers
+        settings["accept"] = "application/vnd.hypothesis." + version + "+json"
+        config.add_view(view=view, **settings)
+
     if enable_preflight:
         cors.add_preflight_view(config, settings["route_name"], cors_policy)
 

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""
+Test the versioning of our API using Accept headers
+"""
+
+from __future__ import unicode_literals
+
+import pytest
+
+# String type for request/response headers and metadata in WSGI.
+#
+# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
+# though it has different meanings.
+#
+# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
+native_str = str
+
+
+@pytest.mark.functional
+class TestIndexEndpointVersions(object):
+    def test_api_index_default(self, app):
+        """
+        Don't send any Accept headers and we should get a 200 response.
+        """
+        res = app.get("/api/")
+
+        assert res.status_code == 200
+        assert "links" in res.json
+
+    def test_api_index_application_json(self, app):
+        """
+        Send ``application/json`` and we should get a 200 response from the
+        default version.
+        """
+        headers = {"Accept": str("application/json")}
+
+        res = app.get("/api/", headers=headers)
+
+        assert res.status_code == 200
+        assert "links" in res.json
+
+    def test_api_index_v1(self, app):
+        """
+        Set a v1 Accept header and we should get a 200 response.
+        """
+        headers = {"Accept": str("application/vnd.hypothesis.v1+json")}
+
+        res = app.get("/api/", headers=headers)
+
+        assert res.status_code == 200
+        assert "links" in res.json
+
+    def test_api_index_v2(self, app):
+        """
+        Set a v2 Accept header and we should get a 404 response.
+        (For now because the version doesn't exist quite yet)
+        """
+        headers = {"Accept": str("application/vnd.hypothesis.v2+json")}
+
+        res = app.get("/api/", headers=headers, expect_errors=True)
+
+        assert res.status_code == 404
+
+    def test_api_index_invalid_accept(self, app):
+        """
+        Set a generally-invalid Accept header and we should always get a 404.
+        """
+        headers = {"Accept": str("nonsensical")}
+
+        res = app.get("/api/", headers=headers, expect_errors=True)
+
+        assert res.status_code == 404

--- a/tests/h/views/api/config_test.py
+++ b/tests/h/views/api/config_test.py
@@ -11,31 +11,31 @@ from h.views.api import config as api_config
 class TestAddApiView(object):
     def test_it_sets_accept_setting(self, pyramid_config, view):
         api_config.add_api_view(pyramid_config, view, route_name="thing.read")
-        (_, kwargs) = pyramid_config.add_view.call_args
+        (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["accept"] == "application/json"
 
     def test_it_allows_accept_setting_override(self, pyramid_config, view):
         api_config.add_api_view(
             pyramid_config, view, accept="application/xml", route_name="thing.read"
         )
-        (_, kwargs) = pyramid_config.add_view.call_args
+        (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["accept"] == "application/xml"
 
     def test_it_sets_renderer_setting(self, pyramid_config, view):
         api_config.add_api_view(pyramid_config, view, route_name="thing.read")
-        (_, kwargs) = pyramid_config.add_view.call_args
+        (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["renderer"] == "json"
 
     def test_it_allows_renderer_setting_override(self, pyramid_config, view):
         api_config.add_api_view(
             pyramid_config, view, route_name="thing.read", renderer="xml"
         )
-        (_, kwargs) = pyramid_config.add_view.call_args
+        (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["renderer"] == "xml"
 
     def test_it_sets_cors_decorator(self, pyramid_config, view):
         api_config.add_api_view(pyramid_config, view, route_name="thing.read")
-        (_, kwargs) = pyramid_config.add_view.call_args
+        (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["decorator"] == api_config.cors_policy
 
     def test_it_adds_cors_preflight_view(self, pyramid_config, view, cors):
@@ -59,6 +59,11 @@ class TestAddApiView(object):
         )
         (_, kwargs) = pyramid_config.add_view.call_args
         assert kwargs["decorator"] == decorator
+
+    def test_it_adds_default_version_accept(self, pyramid_config, view):
+        api_config.add_api_view(pyramid_config, view, route_name="thing.read")
+        (_, kwargs) = pyramid_config.add_view.call_args_list[1]
+        assert kwargs["accept"] == "application/vnd.hypothesis.v1+json"
 
     @pytest.mark.parametrize(
         "link_name,route_name,description,request_method,expected_method",


### PR DESCRIPTION
This PR bites off a chunk of what was in #5538 and is part of https://github.com/hypothesis/product-backlog/issues/941

This PR adds a very basic notion of API versions to the `h` codebase. The only "known" version in this iteration is "v1". Known versions and default version are set as constants, for now, in the `h.api.views` module.

`@api_config` will, for now, assign an additional v1 `accept` (header) to all registering API views. This is an interim step and will become more nuanced shortly. The net effect is that as of this PR, **clients may optionally send a versioned Accept header** e.g. `Accept: application/vnd.hypothesis.v1+json`, and get responses (that are identical to requests with no Accept header or `Accept: application/json`).

I added a few functional tests that send requests with those Accept headers.

Really, this is a no-op, but gets the groundwork in place... 

Oh, and I fixed the docstring for `add_api_view`