### PR TITLE
Make API versions required by `@api_config`

### DIFF
--- a/h/views/api/__init__.py
+++ b/h/views/api/__init__.py
@@ -2,7 +2,15 @@
 from __future__ import unicode_literals
 
 API_VERSIONS = ["v1"]
+"""All of the app's known API versions"""
+
 API_VERSION_DEFAULT = "v1"
+"""
+The current API version.
+
+API requests will match to views supporting this version unless the request
+specifies a different version with a properly-formatted Accept header
+"""
 
 __all__ = ("API_VERSIONS", "API_VERSION_DEFAULT")
 

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -38,7 +38,10 @@ _ = i18n.TranslationStringFactory(__package__)
 
 
 @api_config(
-    route_name="api.search", link_name="search", description="Search for annotations"
+    versions=["v1"],
+    route_name="api.search",
+    link_name="search",
+    description="Search for annotations",
 )
 def search(request):
     """Search the database for annotations matching with the given query."""
@@ -63,6 +66,7 @@ def search(request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.annotations",
     request_method="POST",
     permission="create",
@@ -84,6 +88,7 @@ def create(request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.annotation",
     request_method="GET",
     permission="read",
@@ -96,7 +101,12 @@ def read(context, request):
     return svc.present(context)
 
 
-@api_config(route_name="api.annotation.jsonld", request_method="GET", permission="read")
+@api_config(
+    versions=["v1"],
+    route_name="api.annotation.jsonld",
+    request_method="GET",
+    permission="read",
+)
 def read_jsonld(context, request):
     request.response.content_type = "application/ld+json"
     request.response.content_type_params = {
@@ -108,6 +118,7 @@ def read_jsonld(context, request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.annotation",
     request_method=("PATCH", "PUT"),
     permission="update",
@@ -137,6 +148,7 @@ def update(context, request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.annotation",
     request_method="DELETE",
     permission="delete",

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -184,7 +184,7 @@ class OAuthAccessTokenController(object):
 
         self.oauth = self.request.find_service(name="oauth_provider")
 
-    @api_config(route_name="token", request_method="POST")
+    @api_config(versions=["v1"], route_name="token", request_method="POST")
     def post(self):
         headers, body, status = self.oauth.create_token_response(
             self.request.url,
@@ -204,7 +204,7 @@ class OAuthRevocationController(object):
 
         self.oauth = self.request.find_service(name="oauth_provider")
 
-    @api_config(route_name="oauth_revoke", request_method="POST")
+    @api_config(versions=["v1"], route_name="oauth_revoke", request_method="POST")
     def post(self):
         headers, body, status = self.oauth.create_revocation_response(
             self.request.url,
@@ -218,7 +218,7 @@ class OAuthRevocationController(object):
             raise exception_response(status, body=body)
 
 
-@api_config(route_name="api.debug_token", request_method="GET")
+@api_config(versions=["v1"], route_name="api.debug_token", request_method="GET")
 def debug_token(request):
     if not request.auth_token:
         raise OAuthTokenError(
@@ -237,6 +237,7 @@ def debug_token(request):
 
 
 @api_config(
+    versions=["v1"],
     context=OAuthTokenError,
     # This is a handler called only if a request fails, so the CORS
     # preflight request will have been handled by the original view.

--- a/h/views/api/flags.py
+++ b/h/views/api/flags.py
@@ -12,6 +12,7 @@ from h.tasks import mailer
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.annotation_flag",
     request_method="PUT",
     link_name="annotation.flag",

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -20,6 +20,7 @@ from h.views.api.config import api_config
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.groups",
     request_method="GET",
     link_name="groups.read",
@@ -42,6 +43,7 @@ def groups(request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.groups",
     request_method="POST",
     permission="create",
@@ -79,6 +81,7 @@ def create(request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.group",
     request_method="GET",
     permission="read",
@@ -94,6 +97,7 @@ def read(group, request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.group",
     request_method="PATCH",
     permission="admin",
@@ -127,6 +131,7 @@ def update(group, request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.group_upsert",
     request_method="PUT",
     permission="upsert",
@@ -189,6 +194,7 @@ def upsert(context, request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.group_member",
     request_method="DELETE",
     link_name="group.member.delete",
@@ -210,6 +216,7 @@ def remove_member(group, request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.group_member",
     request_method="POST",
     link_name="group.member.add",

--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -6,7 +6,7 @@ from h.views.api.config import api_config
 from h.views.api.helpers.angular import AngularRouteTemplater
 
 
-@api_config(route_name="api.index")
+@api_config(versions=["v1"], route_name="api.index")
 def index(context, request):
     """Return the API descriptor document.
 

--- a/h/views/api/links.py
+++ b/h/views/api/links.py
@@ -7,6 +7,7 @@ from h.views.api.helpers.angular import AngularRouteTemplater
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.links",
     link_name="links",
     renderer="json_sorted",

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -9,6 +9,7 @@ from h.views.api.config import api_config
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.annotation_hide",
     request_method="PUT",
     link_name="annotation.hide",
@@ -27,6 +28,7 @@ def create(context, request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.annotation_hide",
     request_method="DELETE",
     link_name="annotation.unhide",

--- a/h/views/api/profile.py
+++ b/h/views/api/profile.py
@@ -11,6 +11,7 @@ from h.views.api.config import api_config
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.profile",
     request_method="GET",
     link_name="profile.read",
@@ -22,6 +23,7 @@ def profile(request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.profile_groups",
     request_method="GET",
     link_name="profile.groups.read",
@@ -45,6 +47,7 @@ def profile_groups(request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.profile",
     request_method="PATCH",
     permission="update",

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -14,6 +14,7 @@ from h.services.user_unique import DuplicateUserError
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.users",
     request_method="POST",
     link_name="user.create",
@@ -64,6 +65,7 @@ def create(request):
 
 
 @api_config(
+    versions=["v1"],
     route_name="api.user",
     request_method="PATCH",
     link_name="user.update",

--- a/tests/h/views/api/config_test.py
+++ b/tests/h/views/api/config_test.py
@@ -10,36 +10,52 @@ from h.views.api import config as api_config
 @pytest.mark.usefixtures("cors")
 class TestAddApiView(object):
     def test_it_sets_accept_setting(self, pyramid_config, view):
-        api_config.add_api_view(pyramid_config, view, route_name="thing.read")
+        api_config.add_api_view(
+            pyramid_config, view, versions=["v1"], route_name="thing.read"
+        )
         (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["accept"] == "application/json"
 
     def test_it_allows_accept_setting_override(self, pyramid_config, view):
         api_config.add_api_view(
-            pyramid_config, view, accept="application/xml", route_name="thing.read"
+            pyramid_config,
+            view,
+            versions=["v1"],
+            accept="application/xml",
+            route_name="thing.read",
         )
         (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["accept"] == "application/xml"
 
     def test_it_sets_renderer_setting(self, pyramid_config, view):
-        api_config.add_api_view(pyramid_config, view, route_name="thing.read")
+        api_config.add_api_view(
+            pyramid_config, view, versions=["v1"], route_name="thing.read"
+        )
         (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["renderer"] == "json"
 
     def test_it_allows_renderer_setting_override(self, pyramid_config, view):
         api_config.add_api_view(
-            pyramid_config, view, route_name="thing.read", renderer="xml"
+            pyramid_config,
+            view,
+            versions=["v1"],
+            route_name="thing.read",
+            renderer="xml",
         )
         (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["renderer"] == "xml"
 
     def test_it_sets_cors_decorator(self, pyramid_config, view):
-        api_config.add_api_view(pyramid_config, view, route_name="thing.read")
+        api_config.add_api_view(
+            pyramid_config, view, versions=["v1"], route_name="thing.read"
+        )
         (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["decorator"] == api_config.cors_policy
 
     def test_it_adds_cors_preflight_view(self, pyramid_config, view, cors):
-        api_config.add_api_view(pyramid_config, view, route_name="thing.read")
+        api_config.add_api_view(
+            pyramid_config, view, versions=["v1"], route_name="thing.read"
+        )
         ([_, route_name, policy], _) = cors.add_preflight_view.call_args
         assert route_name == "thing.read"
         assert policy == api_config.cors_policy
@@ -48,22 +64,38 @@ class TestAddApiView(object):
         self, pyramid_config, view, cors
     ):
         api_config.add_api_view(
-            pyramid_config, view, route_name="thing.read", enable_preflight=False
+            pyramid_config,
+            view,
+            versions=["v1"],
+            route_name="thing.read",
+            enable_preflight=False,
         )
         assert cors.add_preflight_view.call_count == 0
 
     def test_it_allows_decorator_override(self, pyramid_config, view):
         decorator = mock.Mock()
         api_config.add_api_view(
-            pyramid_config, view, route_name="thing.read", decorator=decorator
+            pyramid_config,
+            view,
+            versions=["v1"],
+            route_name="thing.read",
+            decorator=decorator,
         )
         (_, kwargs) = pyramid_config.add_view.call_args
         assert kwargs["decorator"] == decorator
 
     def test_it_adds_default_version_accept(self, pyramid_config, view):
-        api_config.add_api_view(pyramid_config, view, route_name="thing.read")
+        api_config.add_api_view(
+            pyramid_config, view, versions=["v1"], route_name="thing.read"
+        )
         (_, kwargs) = pyramid_config.add_view.call_args_list[1]
         assert kwargs["accept"] == "application/vnd.hypothesis.v1+json"
+
+    def test_it_raises_ValueError_on_unrecognized_version(self, pyramid_config, view):
+        with pytest.raises(ValueError, match="Unrecognized API version"):
+            api_config.add_api_view(
+                pyramid_config, view, versions=["v2"], route_name="thing.read"
+            )
 
     @pytest.mark.parametrize(
         "link_name,route_name,description,request_method,expected_method",
@@ -90,6 +122,7 @@ class TestAddApiView(object):
         api_config.add_api_view(
             pyramid_config,
             view=view,
+            versions=["v1"],
             link_name=link_name,
             description=description,
             route_name=route_name,


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/941

This PR makes `versions` a required param for the `@api_config` decorator. This makes our configs explicit; all API views are required to declare what versions of the API they support. The only valid version is "v1" for the short term.

The app will crash on bootstrap if versions are missing or invalid (intentionally). To see this in action, try removing the "versions" arg from any use of `@api_config` and then try starting the app (or running functional tests).

The reasoning for this is to be explicit rather than implicit in our version support.

We're almost ready to make the app aware of a "v2"...