### PR TITLE
Don't send ws4py error logging to Sentry

### DIFF
--- a/conf/websocket.ini
+++ b/conf/websocket.ini
@@ -9,7 +9,7 @@ worker_class: h.websocket.Worker
 graceful_timeout: 0
 
 [loggers]
-keys = root, gunicorn.error, ws4py
+keys = root, gunicorn.error
 
 [handlers]
 keys = console
@@ -25,13 +25,6 @@ handlers = console
 level = INFO
 handlers =
 qualname = gunicorn.error
-
-[logger_ws4py]
-level = WARNING
-qualname = ws4py
-handlers = console
-# Prevent these messages filtering through to Sentry
-propagate = 0
 
 [handler_console]
 level = NOTSET

--- a/h/sentry/helpers/before_send.py
+++ b/h/sentry/helpers/before_send.py
@@ -29,7 +29,7 @@ def before_send(event_dict, hint_dict):
     # If you add a new filter function you should add it to this list to enable
     # it.
     filter_functions = [
-        filters.filter_ws4py_error_terminating_connection,
+        filters.filter_ws4py_error_logging,
         filters.filter_ws4py_handshake_error,
     ]
 

--- a/h/sentry/helpers/filters.py
+++ b/h/sentry/helpers/filters.py
@@ -12,18 +12,9 @@ from __future__ import unicode_literals
 import ws4py.exc
 
 
-def filter_ws4py_error_terminating_connection(event):
-    """
-    Filter out ws4py's "Error when terminating connection" message.
-
-    Thousands of these get logged every day in production and I don't think
-    they're actually a problem.
-
-    See: https://github.com/hypothesis/h/issues/5496
-    """
-    if event.logger == "ws4py" and event.message.startswith(
-        "Error when terminating the connection"
-    ):
+def filter_ws4py_error_logging(event):
+    """Filter out all error messages logged by ws4py."""
+    if event.logger == "ws4py":
         return False
     return True
 

--- a/tests/h/sentry/helpers/before_send_test.py
+++ b/tests/h/sentry/helpers/before_send_test.py
@@ -21,7 +21,7 @@ class TestBeforeSend(object):
 
         # If you've added a new filter function you should add it to this list.
         filters = [
-            filters.filter_ws4py_error_terminating_connection,
+            filters.filter_ws4py_error_logging,
             filters.filter_ws4py_handshake_error,
         ]
 
@@ -29,7 +29,7 @@ class TestBeforeSend(object):
             filter.assert_called_once_with(Event.return_value)
 
     def test_it_filters_out_the_event_if_a_filter_fails(self, filters):
-        filters.filter_ws4py_error_terminating_connection.return_value = False
+        filters.filter_ws4py_error_logging.return_value = False
 
         result = before_send(mock.sentinel.event_dict, mock.sentinel.hint_dict)
 
@@ -37,7 +37,7 @@ class TestBeforeSend(object):
 
     def test_it_logs_when_it_filters_out_an_event(self, caplog, filters):
         caplog.set_level(logging.INFO)
-        filters.filter_ws4py_error_terminating_connection.return_value = False
+        filters.filter_ws4py_error_logging.return_value = False
 
         before_send(mock.sentinel.event_dict, mock.sentinel.hint_dict)
 

--- a/tests/h/sentry/helpers/filters_test.py
+++ b/tests/h/sentry/helpers/filters_test.py
@@ -10,28 +10,16 @@ from h.sentry.helpers import filters
 from h.sentry.helpers.event import Event
 
 
-class TestFilterWS4PYErrorTerminatingConnection(object):
-    def test_it_filters_terminating_connection_events(self):
+class TestFilterWS4PYErrorLogging(object):
+    def test_it_filters_ws4py_logger_events(self):
         event = logger_event("ws4py", "Error when terminating the connection")
-        assert filters.filter_ws4py_error_terminating_connection(event) is False
-
-    def test_it_doesnt_filter_other_ws4py_logger_events(self):
-        event = logger_event("ws4py", "Other message")
-        assert filters.filter_ws4py_error_terminating_connection(event) is True
+        assert filters.filter_ws4py_error_logging(event) is False
 
     def test_it_doesnt_filter_other_logger_events(self, unexpected_logger_event):
-        assert (
-            filters.filter_ws4py_error_terminating_connection(unexpected_logger_event)
-            is True
-        )
+        assert filters.filter_ws4py_error_logging(unexpected_logger_event) is True
 
     def test_it_doesnt_filter_exception_events(self, unexpected_exception_event):
-        assert (
-            filters.filter_ws4py_error_terminating_connection(
-                unexpected_exception_event
-            )
-            is True
-        )
+        assert filters.filter_ws4py_error_logging(unexpected_exception_event) is True
 
 
 class TestFilterWS4PYHandshakeError(object):


### PR DESCRIPTION
The recent move to the new sentry_sdk broke some logging config that had been added in commit [6e09c2a4c4b4f91673429c7a6b768ee4c6cd2a79](https://github.com/hypothesis/h/commit/6e09c2a4c4b4f91673429c7a6b768ee4c6cd2a79) in order to filter out error messages logged by ws4py from being sent to Sentry.

Remove this logging config as its no longer functioning, and add code to once again filter out all ws4py error messages from Sentry.

Note that this filters out error messages _logged_, it doesn't prevent exceptions raised by ws4py from going to Sentry.

The reason for filtering out these error messages is that they're not useful. They're not actionable by us to fix any actual problems as far as we can see. They can overflow our Sentry quotas. They're all messages like:

* Error when terminating the connection
* Broken pipe
* Connection reset by peer

Fixes https://github.com/hypothesis/h/issues/5499.
Fixes https://github.com/hypothesis/h/issues/5500.

This should clear up Sentry issues like:

* https://sentry.io/organizations/hypothesis/issues/900196167/
* https://sentry.io/organizations/hypothesis/issues/812461144/
* https://sentry.io/organizations/hypothesis/issues/628538396/
* https://sentry.io/organizations/hypothesis/issues/846984673/
* https://sentry.io/organizations/hypothesis/issues/846783712/