### PR TITLE
Don't send streamer message exceptions to Sentry

### DIFF
--- a/h/streamer/streamer.py
+++ b/h/streamer/streamer.py
@@ -97,8 +97,8 @@ def process_work_queue(settings, queue, session_factory=None):
         except (KeyboardInterrupt, SystemExit):
             session.rollback()
             raise
-        except:  # noqa: E722
-            log.exception("Caught exception handling streamer message:")
+        except Exception as exc:  # noqa: E722
+            log.warning("Caught exception handling streamer message:", exc_info=exc)
             session.rollback()
         else:
             session.commit()

--- a/h/streamer/streamer.py
+++ b/h/streamer/streamer.py
@@ -97,7 +97,7 @@ def process_work_queue(settings, queue, session_factory=None):
         except (KeyboardInterrupt, SystemExit):
             session.rollback()
             raise
-        except Exception as exc:  # noqa: E722
+        except Exception as exc:
             log.warning("Caught exception handling streamer message:", exc_info=exc)
             session.rollback()
         else:


### PR DESCRIPTION
Log streamer message handling exceptions with log level warning rather than error. The log message and exception (including traceback) will still appear in the logs, but since sentry_sdk's logger integration only reports error-level log messages to Sentry, by changing them from errors to warnings they'll no longer be sent.

Exceptions from streamer message handling happen often and seem to be a lot of unactionable noise. See eaa84288394a6bb50649c9007c6655469311afd4

Fixes https://github.com/hypothesis/h/issues/5499