### PR TITLE
Don't send invalid email errors to Sentry

### DIFF
--- a/h/tasks/mailer.py
+++ b/h/tasks/mailer.py
@@ -40,6 +40,11 @@ def send(self, recipients, subject, body, html=None):
         if celery.request.debug:
             log.info("emailing in debug mode: check the `mail/' directory")
         mailer.send_immediately(email)
+    except smtplib.SMTPRecipientsRefused as exc:
+        log.debug(
+            "Recipient was refused when trying to send an email. Does the user have an invalid email address?",
+            exc_info=exc,
+        )
     except (smtplib.socket.error, smtplib.SMTPException) as exc:
         # Exponential backoff in case the SMTP service is having problems.
         countdown = self.default_retry_delay * 2 ** self.request.retries


### PR DESCRIPTION
When a user registers or changes their email address we can't 100%
validate that the email address they entered is a valid email address*.
This means that we can't be sure that invalid email addresses won't get
into our DB, and that we won't get "recipient refused" errors from the
SMTP server when we try to send an email to them.

Given that we can't prevent these errors from happening, send the
exceptions to the logs instead of to Sentry.

Fixes https://github.com/hypothesis/product-backlog/issues/967

`*` Except by trying to send an email to it and requiring them to click on
a link in the email to "activate" or "validate" their email address, but
implementing proper email address verification would be a big change
that we don't have time for right now.

For why you can't pre-validate email addresses see:

https://archive.fosdem.org/2018/schedule/event/email_address_quiz/
https://hackernoon.com/the-100-correct-way-to-validate-email-addresses-7c4818f24643
https://slack-redir.net/link?url=https%3A%2F%2Fhaacked.com%2Farchive%2F2007%2F08%2F21%2Fi-knew-how-to-validate-an-email-address-until-i.aspx%2F)