### PR TITLE
Fix Celery worker logging on QA and production

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -28,7 +28,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:worker]
-command=newrelic-admin run-program hypothesis celery worker
+command=newrelic-admin run-program hypothesis celery worker -l INFO
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true

--- a/h/tasks/mailer.py
+++ b/h/tasks/mailer.py
@@ -41,7 +41,7 @@ def send(self, recipients, subject, body, html=None):
             log.info("emailing in debug mode: check the `mail/' directory")
         mailer.send_immediately(email)
     except smtplib.SMTPRecipientsRefused as exc:
-        log.warning(
+        log.info(
             "Recipient was refused when trying to send an email. Does the user have an invalid email address?",
             exc_info=exc,
         )


### PR DESCRIPTION
Fix sending log messages from Celery tasks to the logs in QA and
production. These weren't being logged at all.

You have to pass a log level to the `hypothesis celery worker` command,
as we already do in dev:

https://github.com/hypothesis/h/blob/4e45a8f18f8a1a002ae7d28458f89dc793880a2e/h/cli/commands/devserver.py#L100

otherwise it doesn't log anything.

Also move the log message when sending an email fails due to an invalid
email address back down to INFO level, where it belongs. (I had moved it
up to WARNING in an attempt to get the message to show up in the logs.)