### PR TITLE
Add a Prospector (linter) "ratchet" script

### DIFF
--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -141,8 +141,8 @@ def _maybe_create_default_organization(engine, authority):
 
 
 def _maybe_create_world_group(engine, authority, default_org):
-    from h import models
-    from h.models.group import ReadableBy, WriteableBy
+    from h import models  # pylint:disable=cyclic-import
+    from h.models.group import ReadableBy, WriteableBy  # pylint:disable=cyclic-import
 
     session = Session(bind=engine)
     world_group = session.query(models.Group).filter_by(pubid="__world__").one_or_none()

--- a/scripts/lint.json
+++ b/scripts/lint.json
@@ -1,0 +1,22581 @@
+{
+    "summary": {
+        "started": "2019-02-28 18:55:49.662122",
+        "libraries": [],
+        "strictness": "from profile",
+        "profiles": ".prospector.yaml, doc_warnings, strictness_veryhigh, no_member_warnings, no_test_warnings",
+        "tools": [
+            "dodgy",
+            "pep257",
+            "profile-validator",
+            "pylint",
+            "pyroma"
+        ],
+        "message_count": 1880,
+        "completed": "2019-02-28 18:56:52.268189",
+        "time_taken": "62.61",
+        "formatter": "json"
+    },
+    "messages": [
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/viewderivers.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/viewderivers.py",
+                "module": null,
+                "function": null,
+                "line": 7,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/viewderivers.py",
+                "module": null,
+                "function": null,
+                "line": 45,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/cli/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/cli/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 67,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/cli/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 71,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "no-value-for-parameter",
+            "location": {
+                "path": "h/cli/__init__.py",
+                "module": "h.cli",
+                "function": "main",
+                "line": 75,
+                "character": 4
+            },
+            "message": "No value for argument 'ctx' in function call"
+        },
+        {
+            "source": "pylint",
+            "code": "no-value-for-parameter",
+            "location": {
+                "path": "h/cli/__init__.py",
+                "module": "h.cli",
+                "function": "main",
+                "line": 75,
+                "character": 4
+            },
+            "message": "No value for argument 'app_url' in function call"
+        },
+        {
+            "source": "pylint",
+            "code": "no-value-for-parameter",
+            "location": {
+                "path": "h/cli/__init__.py",
+                "module": "h.cli",
+                "function": "main",
+                "line": 75,
+                "character": 4
+            },
+            "message": "No value for argument 'dev' in function call"
+        },
+        {
+            "source": "pylint",
+            "code": "unexpected-keyword-arg",
+            "location": {
+                "path": "h/cli/__init__.py",
+                "module": "h.cli",
+                "function": "main",
+                "line": 75,
+                "character": 4
+            },
+            "message": "Unexpected keyword argument 'prog_name' in function call"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/cli/commands/authclient.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/cli/commands/authclient.py",
+                "module": null,
+                "function": null,
+                "line": 30,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/cli/commands/authclient.py",
+                "module": "h.cli.commands.authclient",
+                "function": "add",
+                "line": 35,
+                "character": 4
+            },
+            "message": "Redefining name 'authclient' from outer scope (line 10)"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/cli/commands/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/cli/commands/init.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/cli/commands/init.py",
+                "module": null,
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/cli/commands/initdb.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/cli/commands/initdb.py",
+                "module": null,
+                "function": null,
+                "line": 7,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/cli/commands/devserver.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/cli/commands/devserver.py",
+                "module": "h.cli.commands.devserver",
+                "function": "devserver",
+                "line": 36,
+                "character": 0
+            },
+            "message": "Too many arguments (6/5)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/cli/commands/devserver.py",
+                "module": "h.cli.commands.devserver",
+                "function": "devserver",
+                "line": 36,
+                "character": 0
+            },
+            "message": "Too many arguments (6/5)"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/cli/commands/devserver.py",
+                "module": "h.cli.commands.devserver",
+                "function": "devserver",
+                "line": 36,
+                "character": 0
+            },
+            "message": "Argument name \"ws\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-branches",
+            "location": {
+                "path": "h/cli/commands/devserver.py",
+                "module": "h.cli.commands.devserver",
+                "function": "devserver",
+                "line": 36,
+                "character": 0
+            },
+            "message": "Too many branches (16/12)"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/cli/commands/devserver.py",
+                "module": "h.cli.commands.devserver",
+                "function": "devserver",
+                "line": 84,
+                "character": 4
+            },
+            "message": "Variable name \"m\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/cli/commands/celery.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": null,
+                "function": null,
+                "line": 21,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": null,
+                "function": null,
+                "line": 21,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": null,
+                "function": null,
+                "line": 32,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": null,
+                "function": null,
+                "line": 42,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": null,
+                "function": null,
+                "line": 52,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": null,
+                "line": 4,
+                "character": 0
+            },
+            "message": "standard import \"from collections import namedtuple\" should be placed before \"from h._compat import xrange\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": null,
+                "line": 4,
+                "character": 0
+            },
+            "message": "standard import \"from collections import namedtuple\" should be placed before \"from h._compat import xrange\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": null,
+                "line": 6,
+                "character": 0
+            },
+            "message": "third party import \"import click\" should be placed before \"from h._compat import xrange\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": null,
+                "line": 6,
+                "character": 0
+            },
+            "message": "third party import \"import click\" should be placed before \"from h._compat import xrange\""
+        },
+        {
+            "source": "pylint",
+            "code": "ungrouped-imports",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Imports from package h are not grouped"
+        },
+        {
+            "source": "pylint",
+            "code": "ungrouped-imports",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Imports from package h are not grouped"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": "_normalize_document_uris_window",
+                "line": 90,
+                "character": 12
+            },
+            "message": "Access to a protected member _claimant_normalized of a client class"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": "_normalize_document_uris_window",
+                "line": 90,
+                "character": 12
+            },
+            "message": "Access to a protected member _claimant_normalized of a client class"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": "_normalize_document_uris_window",
+                "line": 91,
+                "character": 12
+            },
+            "message": "Access to a protected member _uri_normalized of a client class"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": "_normalize_document_uris_window",
+                "line": 91,
+                "character": 12
+            },
+            "message": "Access to a protected member _uri_normalized of a client class"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": "_normalize_document_meta_window",
+                "line": 113,
+                "character": 12
+            },
+            "message": "Access to a protected member _claimant_normalized of a client class"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": "_normalize_document_meta_window",
+                "line": 113,
+                "character": 12
+            },
+            "message": "Access to a protected member _claimant_normalized of a client class"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": "_normalize_annotations_window",
+                "line": 126,
+                "character": 8
+            },
+            "message": "Variable name \"a\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": "_normalize_annotations_window",
+                "line": 129,
+                "character": 12
+            },
+            "message": "Access to a protected member _target_uri_normalized of a client class"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "h/cli/commands/normalize_uris.py",
+                "module": "h.cli.commands.normalize_uris",
+                "function": "_normalize_annotations_window",
+                "line": 129,
+                "character": 12
+            },
+            "message": "Access to a protected member _target_uri_normalized of a client class"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/cli/commands/search.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/cli/commands/user.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/cli/commands/user.py",
+                "module": null,
+                "function": null,
+                "line": 120,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Delete', not 'Deletes')"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/cli/commands/user.py",
+                "module": "h.cli.commands.user",
+                "function": "add",
+                "line": 20,
+                "character": 30
+            },
+            "message": "Redefining name 'password' from outer scope (line 89)"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/cli/commands/user.py",
+                "module": "h.cli.commands.user",
+                "function": "admin",
+                "line": 54,
+                "character": 0
+            },
+            "message": "Argument name \"on\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/cli/commands/user.py",
+                "module": "h.cli.commands.user",
+                "function": "admin",
+                "line": 66,
+                "character": 4
+            },
+            "message": "Redefining name 'user' from outer scope (line 10)"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/cli/commands/user.py",
+                "module": "h.cli.commands.user",
+                "function": "password",
+                "line": 89,
+                "character": 39
+            },
+            "message": "Redefining name 'password' from outer scope (line 89)"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/cli/commands/user.py",
+                "module": "h.cli.commands.user",
+                "function": "password",
+                "line": 102,
+                "character": 4
+            },
+            "message": "Redefining name 'user' from outer scope (line 10)"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/cli/commands/user.py",
+                "module": "h.cli.commands.user",
+                "function": "delete",
+                "line": 130,
+                "character": 4
+            },
+            "message": "Redefining name 'user' from outer scope (line 10)"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/cli/commands/move_uri.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/cli/commands/move_uri.py",
+                "module": null,
+                "function": null,
+                "line": 21,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/cli/commands/move_uri.py",
+                "module": "h.cli.commands.move_uri",
+                "function": "move_uri",
+                "line": 49,
+                "character": 4
+            },
+            "message": "Variable name \"c\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/cli/commands/shell.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/cli/commands/shell.py",
+                "module": null,
+                "function": null,
+                "line": 30,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/cli/commands/shell.py",
+                "module": null,
+                "function": null,
+                "line": 36,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/cli/commands/shell.py",
+                "module": null,
+                "function": null,
+                "line": 45,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "import-error",
+            "location": {
+                "path": "h/cli/commands/shell.py",
+                "module": "h.cli.commands.shell",
+                "function": "bpython",
+                "line": 31,
+                "character": 4
+            },
+            "message": "Unable to import 'bpython'"
+        },
+        {
+            "source": "pylint",
+            "code": "import-error",
+            "location": {
+                "path": "h/cli/commands/shell.py",
+                "module": "h.cli.commands.shell",
+                "function": "bpython",
+                "line": 31,
+                "character": 4
+            },
+            "message": "Unable to import 'bpython'"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/cli/commands/shell.py",
+                "module": "h.cli.commands.shell",
+                "function": "bpython",
+                "line": 31,
+                "character": 4
+            },
+            "message": "Redefining name 'bpython' from outer scope (line 30)"
+        },
+        {
+            "source": "pylint",
+            "code": "import-error",
+            "location": {
+                "path": "h/cli/commands/shell.py",
+                "module": "h.cli.commands.shell",
+                "function": "ipython",
+                "line": 37,
+                "character": 4
+            },
+            "message": "Unable to import 'IPython'"
+        },
+        {
+            "source": "pylint",
+            "code": "import-error",
+            "location": {
+                "path": "h/cli/commands/shell.py",
+                "module": "h.cli.commands.shell",
+                "function": "ipython",
+                "line": 37,
+                "character": 4
+            },
+            "message": "Unable to import 'IPython'"
+        },
+        {
+            "source": "pylint",
+            "code": "import-error",
+            "location": {
+                "path": "h/cli/commands/shell.py",
+                "module": "h.cli.commands.shell",
+                "function": "ipython",
+                "line": 38,
+                "character": 4
+            },
+            "message": "Unable to import 'traitlets.config'"
+        },
+        {
+            "source": "pylint",
+            "code": "import-error",
+            "location": {
+                "path": "h/cli/commands/shell.py",
+                "module": "h.cli.commands.shell",
+                "function": "ipython",
+                "line": 38,
+                "character": 4
+            },
+            "message": "Unable to import 'traitlets.config'"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/cli/commands/shell.py",
+                "module": "h.cli.commands.shell",
+                "function": "ipython",
+                "line": 40,
+                "character": 4
+            },
+            "message": "Variable name \"c\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/cli/commands/migrate.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/cli/commands/migrate.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/cli/commands/migrate.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/cli/commands/migrate.py",
+                "module": null,
+                "function": null,
+                "line": 33,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "h/cli/commands/migrate.py",
+                "module": "h.cli.commands.migrate",
+                "function": "CommandLine.__init__",
+                "line": 26,
+                "character": 17
+            },
+            "message": "Access to a protected member _actions of a client class"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "h/cli/commands/migrate.py",
+                "module": "h.cli.commands.migrate",
+                "function": "CommandLine.__init__",
+                "line": 26,
+                "character": 17
+            },
+            "message": "Access to a protected member _actions of a client class"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/cli/commands/migrate.py",
+                "module": "h.cli.commands.migrate",
+                "function": "CommandLine.__init__",
+                "line": 26,
+                "character": 12
+            },
+            "message": "Variable name \"a\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/cli/commands/annotation_id.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/cli/commands/annotation_id.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'Utility')"
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/cli/commands/annotation_id.py",
+                "module": "h.cli.commands.annotation_id",
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "standard import \"from uuid import UUID\" should be placed before \"import click\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/cli/commands/annotation_id.py",
+                "module": "h.cli.commands.annotation_id",
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "standard import \"from uuid import UUID\" should be placed before \"import click\""
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/cli/commands/annotation_id.py",
+                "module": "h.cli.commands.annotation_id",
+                "function": "to_urlsafe",
+                "line": 24,
+                "character": 15
+            },
+            "message": "Redefining name 'annotation_id' from outer scope (line 11)"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/notification/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/notification/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/notification/reply.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/notification/reply.py",
+                "module": null,
+                "function": null,
+                "line": 115,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "inconsistent-return-statements",
+            "location": {
+                "path": "h/notification/reply.py",
+                "module": "h.notification.reply",
+                "function": "get_notification",
+                "line": 34,
+                "character": 0
+            },
+            "message": "Either all return statements in a function should return an expression, or none of them should."
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-return-statements",
+            "location": {
+                "path": "h/notification/reply.py",
+                "module": "h.notification.reply",
+                "function": "get_notification",
+                "line": 34,
+                "character": 0
+            },
+            "message": "Too many return statements (11/6)"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/flag.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/flag.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/blocklist.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/models/blocklist.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/models/blocklist.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/blocklist.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/organization.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/models/organization.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/models/organization.py",
+                "module": "h.models.organization",
+                "function": "Organization.validate_name",
+                "line": 31,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/models/organization.py",
+                "module": "h.models.organization",
+                "function": "Organization.validate_name",
+                "line": 31,
+                "character": 28
+            },
+            "message": "Unused argument 'key'"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/organization.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/organization.py",
+                "module": null,
+                "function": null,
+                "line": 42,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/organization.py",
+                "module": null,
+                "function": null,
+                "line": 46,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/user_identity.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/models/user_identity.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/user_identity.py",
+                "module": null,
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/models/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 137,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 146,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 150,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 164,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 168,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 172,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 219,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pylint",
+            "code": "inconsistent-return-statements",
+            "location": {
+                "path": "h/models/annotation.py",
+                "module": "h.models.annotation",
+                "function": "Annotation.parent_id",
+                "line": 176,
+                "character": 4
+            },
+            "message": "Either all return statements in a function should return an expression, or none of them should."
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/models/annotation.py",
+                "module": "h.models.annotation",
+                "function": "Annotation.thread_root_id",
+                "line": 196,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 25,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 47,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 51,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 103,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 135,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 165,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 174,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 178,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 187,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 190,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 194,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 215,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 224,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 227,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 400,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 400,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'w')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/models/document.py",
+                "module": null,
+                "function": null,
+                "line": 400,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Take', not 'Takes')"
+        },
+        {
+            "source": "pylint",
+            "code": "ungrouped-imports",
+            "location": {
+                "path": "h/models/document.py",
+                "module": "h.models.document",
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "Imports from package sqlalchemy are not grouped"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/models/document.py",
+                "module": "h.models.document",
+                "function": "Document.find_or_create_by_uris",
+                "line": 100,
+                "character": 4
+            },
+            "message": "Too many arguments (6/5)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/models/document.py",
+                "module": "h.models.document",
+                "function": "create_or_update_document_uri",
+                "line": 231,
+                "character": 0
+            },
+            "message": "Too many arguments (8/5)"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-builtin",
+            "location": {
+                "path": "h/models/document.py",
+                "module": "h.models.document",
+                "function": "create_or_update_document_uri",
+                "line": 232,
+                "character": 28
+            },
+            "message": "Redefining built-in 'type'"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/models/document.py",
+                "module": "h.models.document",
+                "function": "create_or_update_document_meta",
+                "line": 315,
+                "character": 0
+            },
+            "message": "Too many arguments (7/5)"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-builtin",
+            "location": {
+                "path": "h/models/document.py",
+                "module": "h.models.document",
+                "function": "create_or_update_document_meta",
+                "line": 316,
+                "character": 23
+            },
+            "message": "Redefining built-in 'type'"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/models/document.py",
+                "module": "h.models.document",
+                "function": "merge_documents",
+                "line": 416,
+                "character": 12
+            },
+            "message": "Variable name \"u\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/models/document.py",
+                "module": "h.models.document",
+                "function": "merge_documents",
+                "line": 421,
+                "character": 12
+            },
+            "message": "Variable name \"m\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/models/document.py",
+                "module": "h.models.document",
+                "function": "update_document_metadata",
+                "line": 439,
+                "character": 0
+            },
+            "message": "Too many arguments (6/5)"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/feature_cohort.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/models/feature_cohort.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/models/feature_cohort.py",
+                "module": null,
+                "function": null,
+                "line": 26,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/feature.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/models/feature.py",
+                "module": null,
+                "function": null,
+                "line": 51,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/feature.py",
+                "module": null,
+                "function": null,
+                "line": 83,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/feature.py",
+                "module": null,
+                "function": null,
+                "line": 117,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/authz_code.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/activation.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/models/activation.py",
+                "module": null,
+                "function": null,
+                "line": 26,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/token.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/models/token.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D301",
+            "location": {
+                "path": "h/models/token.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "Use r\"\"\" if any backslashes in a docstring"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/models/token.py",
+                "module": null,
+                "function": null,
+                "line": 64,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'True')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/models/token.py",
+                "module": null,
+                "function": null,
+                "line": 72,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'True')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/models/token.py",
+                "module": null,
+                "function": null,
+                "line": 80,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'The')"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/subscriptions.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/models/subscriptions.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/subscriptions.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/subscriptions.py",
+                "module": null,
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 26,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 30,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 35,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 40,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 106,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 115,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 115,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 148,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-super-delegation",
+            "location": {
+                "path": "h/models/group.py",
+                "module": "h.models.group",
+                "function": "Group.__init__",
+                "line": 148,
+                "character": 4
+            },
+            "message": "Useless super delegation in method '__init__'"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/models/group.py",
+                "module": "h.models.group",
+                "function": "Group.validate_name",
+                "line": 152,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/models/group.py",
+                "module": "h.models.group",
+                "function": "Group.validate_name",
+                "line": 152,
+                "character": 28
+            },
+            "message": "Unused argument 'key'"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 152,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/models/group.py",
+                "module": "h.models.group",
+                "function": "Group.validate_authority_provided_id",
+                "line": 161,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/models/group.py",
+                "module": "h.models.group",
+                "function": "Group.validate_authority_provided_id",
+                "line": 161,
+                "character": 45
+            },
+            "message": "Unused argument 'key'"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 161,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 181,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 186,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'The')"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 213,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 216,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/group.py",
+                "module": null,
+                "function": null,
+                "line": 264,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/group_scope.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/group_scope.py",
+                "module": null,
+                "function": null,
+                "line": 36,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/setting.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/models/setting.py",
+                "module": null,
+                "function": null,
+                "line": 13,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/models/user.py",
+                "module": "h.models.user",
+                "function": "UsernameComparator.operate",
+                "line": 42,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'operate' method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 42,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 76,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "super-init-not-called",
+            "location": {
+                "path": "h/models/user.py",
+                "module": "h.models.user",
+                "function": "UserIDComparator.__init__",
+                "line": 76,
+                "character": 4
+            },
+            "message": "__init__ method from base class 'Comparator' is not called"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 80,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/models/user.py",
+                "module": "h.models.user",
+                "function": "UserIDComparator.in_",
+                "line": 110,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'in_' method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 110,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 127,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 214,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 226,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 255,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/models/user.py",
+                "module": "h.models.user",
+                "function": "User.validate_email",
+                "line": 281,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/models/user.py",
+                "module": "h.models.user",
+                "function": "User.validate_email",
+                "line": 281,
+                "character": 29
+            },
+            "message": "Unused argument 'key'"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 281,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/models/user.py",
+                "module": "h.models.user",
+                "function": "User.validate_username",
+                "line": 293,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/models/user.py",
+                "module": "h.models.user",
+                "function": "User.validate_username",
+                "line": 293,
+                "character": 32
+            },
+            "message": "Unused argument 'key'"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 293,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 339,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/user.py",
+                "module": null,
+                "function": null,
+                "line": 351,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/models/user.py",
+                "module": "h.models.user",
+                "function": "UsernameComparator",
+                "line": 29,
+                "character": 0
+            },
+            "message": "Method 'reverse_operate' is abstract in class 'Operators' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/models/user.py",
+                "module": "h.models.user",
+                "function": "UserIDComparator",
+                "line": 50,
+                "character": 0
+            },
+            "message": "Method 'operate' is abstract in class 'Operators' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/models/user.py",
+                "module": "h.models.user",
+                "function": "UserIDComparator",
+                "line": 50,
+                "character": 0
+            },
+            "message": "Method 'reverse_operate' is abstract in class 'Operators' but is not overridden"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/auth_client.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/auth_client.py",
+                "module": null,
+                "function": null,
+                "line": 121,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/models/annotation_moderation.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/models/annotation_moderation.py",
+                "module": null,
+                "function": null,
+                "line": 41,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/paginator.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/paginator.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "chained-comparison",
+            "location": {
+                "path": "h/paginator.py",
+                "module": "h.paginator",
+                "function": "paginate",
+                "line": 49,
+                "character": 10
+            },
+            "message": "Simplify chained comparison between the operands"
+        },
+        {
+            "source": "pylint",
+            "code": "chained-comparison",
+            "location": {
+                "path": "h/paginator.py",
+                "module": "h.paginator",
+                "function": "paginate",
+                "line": 61,
+                "character": 10
+            },
+            "message": "Simplify chained comparison between the operands"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/nipsa/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/nipsa/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/nipsa/subscribers.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/traversal/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D404",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 80,
+                "character": 0
+            },
+            "message": "First word of the docstring should not be `This`"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 92,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 101,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 104,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-builtin",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": "h.traversal.roots",
+                "function": "AnnotationRoot.__getitem__",
+                "line": 104,
+                "character": 26
+            },
+            "message": "Redefining built-in 'id'"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 123,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 126,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 155,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 158,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 179,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 183,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 203,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 207,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 215,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'I')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 227,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 231,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 241,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 241,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 247,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 261,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": null,
+                "function": null,
+                "line": 265,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": "h.traversal.roots",
+                "function": "Root",
+                "line": 79,
+                "character": 0
+            },
+            "message": "Class 'Root' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": "h.traversal.roots",
+                "function": "AnnotationRoot",
+                "line": 96,
+                "character": 0
+            },
+            "message": "Class 'AnnotationRoot' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": "h.traversal.roots",
+                "function": "AuthClientRoot",
+                "line": 114,
+                "character": 0
+            },
+            "message": "Class 'AuthClientRoot' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": "h.traversal.roots",
+                "function": "OrganizationRoot",
+                "line": 146,
+                "character": 0
+            },
+            "message": "Class 'OrganizationRoot' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": "h.traversal.roots",
+                "function": "OrganizationLogoRoot",
+                "line": 170,
+                "character": 0
+            },
+            "message": "Class 'OrganizationLogoRoot' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": "h.traversal.roots",
+                "function": "GroupRoot",
+                "line": 193,
+                "character": 0
+            },
+            "message": "Class 'GroupRoot' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": "h.traversal.roots",
+                "function": "GroupUpsertRoot",
+                "line": 214,
+                "character": 0
+            },
+            "message": "Class 'GroupUpsertRoot' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": "h.traversal.roots",
+                "function": "ProfileRoot",
+                "line": 240,
+                "character": 0
+            },
+            "message": "Class 'ProfileRoot' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/roots.py",
+                "module": "h.traversal.roots",
+                "function": "UserRoot",
+                "line": 251,
+                "character": 0
+            },
+            "message": "Class 'UserRoot' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 35,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 41,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 45,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 48,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 100,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 106,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 110,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 114,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 119,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 130,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 136,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 140,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 144,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 151,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'T')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 153,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 158,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": null,
+                "function": null,
+                "line": 158,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'l')"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": "h.traversal.contexts",
+                "function": "AnnotationContext",
+                "line": 32,
+                "character": 0
+            },
+            "message": "Class 'AnnotationContext' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": "h.traversal.contexts",
+                "function": "OrganizationContext",
+                "line": 97,
+                "character": 0
+            },
+            "message": "Class 'OrganizationContext' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": "h.traversal.contexts",
+                "function": "GroupContext",
+                "line": 127,
+                "character": 0
+            },
+            "message": "Class 'GroupContext' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/traversal/contexts.py",
+                "module": "h.traversal.contexts",
+                "function": "GroupUpsertContext",
+                "line": 150,
+                "character": 0
+            },
+            "message": "Class 'GroupUpsertContext' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/subscribers.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/subscribers.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/activity/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": "h.activity.bucketing",
+                "function": "DocumentBucket",
+                "line": 20,
+                "character": 0
+            },
+            "message": "Class 'DocumentBucket' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": null,
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": null,
+                "function": null,
+                "line": 21,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": null,
+                "function": null,
+                "line": 42,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": null,
+                "function": null,
+                "line": 58,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": null,
+                "function": null,
+                "line": 63,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": null,
+                "function": null,
+                "line": 67,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": null,
+                "function": null,
+                "line": 87,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": null,
+                "function": null,
+                "line": 129,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": "h.activity.bucketing",
+                "function": "TimeframeGenerator",
+                "line": 135,
+                "character": 0
+            },
+            "message": "Class 'TimeframeGenerator' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": null,
+                "function": null,
+                "line": 135,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": null,
+                "function": null,
+                "line": 136,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": null,
+                "function": null,
+                "line": 188,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "len-as-condition",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": "h.activity.bucketing",
+                "function": "DocumentBucket.incontext_link",
+                "line": 54,
+                "character": 11
+            },
+            "message": "Do not use `len(SEQUENCE)` to determine if a sequence is empty"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": "h.activity.bucketing",
+                "function": "Timeframe",
+                "line": 78,
+                "character": 0
+            },
+            "message": "Class 'Timeframe' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "no-value-for-parameter",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": "h.activity.bucketing",
+                "function": "Timeframe.append",
+                "line": 92,
+                "character": 4
+            },
+            "message": "No value for argument 'wrapped' in function call"
+        },
+        {
+            "source": "pylint",
+            "code": "no-value-for-parameter",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": "h.activity.bucketing",
+                "function": "TimeframeGenerator.next",
+                "line": 141,
+                "character": 4
+            },
+            "message": "No value for argument 'wrapped' in function call"
+        },
+        {
+            "source": "pylint",
+            "code": "no-value-for-parameter",
+            "location": {
+                "path": "h/activity/bucketing.py",
+                "module": "h.activity.bucketing",
+                "function": "bucket",
+                "line": 163,
+                "character": 0
+            },
+            "message": "No value for argument 'wrapped' in function call"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": null,
+                "function": null,
+                "line": 26,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": null,
+                "function": null,
+                "line": 34,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": null,
+                "function": null,
+                "line": 62,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Check', not 'Checks')"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": null,
+                "function": null,
+                "line": 110,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": null,
+                "function": null,
+                "line": 155,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": null,
+                "function": null,
+                "line": 166,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "no-value-for-parameter",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": "h.activity.query",
+                "function": "extract",
+                "line": 32,
+                "character": 0
+            },
+            "message": "No value for argument 'wrapped' in function call"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": "h.activity.query",
+                "function": "extract",
+                "line": 45,
+                "character": 4
+            },
+            "message": "Variable name \"q\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "no-value-for-parameter",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": "h.activity.query",
+                "function": "execute",
+                "line": 109,
+                "character": 0
+            },
+            "message": "No value for argument 'wrapped' in function call"
+        },
+        {
+            "source": "pylint",
+            "code": "consider-using-set-comprehension",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": "h.activity.query",
+                "function": "execute",
+                "line": 128,
+                "character": 19
+            },
+            "message": "Consider using a set comprehension"
+        },
+        {
+            "source": "pylint",
+            "code": "no-value-for-parameter",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": "h.activity.query",
+                "function": "fetch_annotations",
+                "line": 165,
+                "character": 0
+            },
+            "message": "No value for argument 'wrapped' in function call"
+        },
+        {
+            "source": "pylint",
+            "code": "no-value-for-parameter",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": "h.activity.query",
+                "function": "_execute_search",
+                "line": 177,
+                "character": 0
+            },
+            "message": "No value for argument 'wrapped' in function call"
+        },
+        {
+            "source": "pylint",
+            "code": "no-value-for-parameter",
+            "location": {
+                "path": "h/activity/query.py",
+                "module": "h.activity.query",
+                "function": "_fetch_groups",
+                "line": 206,
+                "character": 0
+            },
+            "message": "No value for argument 'wrapped' in function call"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/auth/interfaces.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/auth/interfaces.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Check', not 'Checks')"
+        },
+        {
+            "source": "pylint",
+            "code": "inherit-non-class",
+            "location": {
+                "path": "h/auth/interfaces.py",
+                "module": "h.auth.interfaces",
+                "function": "IAuthenticationToken",
+                "line": 8,
+                "character": 0
+            },
+            "message": "Inheriting 'Interface', which is not a class."
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/auth/tokens.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/auth/tokens.py",
+                "module": null,
+                "function": null,
+                "line": 27,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/auth/tokens.py",
+                "module": "h.auth.tokens",
+                "function": "Token",
+                "line": 13,
+                "character": 0
+            },
+            "message": "Class 'Token' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 28,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 33,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 39,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 44,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 49,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 54,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 62,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 78,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 82,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 88,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 95,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 114,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 120,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 130,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 130,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 162,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 168,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'd')"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 186,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 221,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 't')"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 248,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 248,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 296,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 309,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 324,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": null,
+                "function": null,
+                "line": 371,
+                "character": 0
+            },
+            "message": "First line should end with a period (not '?')"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "AuthenticationPolicy",
+                "line": 27,
+                "character": 0
+            },
+            "message": "Class 'AuthenticationPolicy' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "APIAuthenticationPolicy",
+                "line": 60,
+                "character": 0
+            },
+            "message": "Class 'APIAuthenticationPolicy' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "AuthClientPolicy",
+                "line": 127,
+                "character": 0
+            },
+            "message": "Class 'AuthClientPolicy' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "inconsistent-return-statements",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "AuthClientPolicy.authenticated_userid",
+                "line": 185,
+                "character": 4
+            },
+            "message": "Either all return statements in a function should return an expression, or none of them should."
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "AuthClientPolicy.remember",
+                "line": 238,
+                "character": 0
+            },
+            "message": "Unused argument 'kw'"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "AuthClientPolicy.remember",
+                "line": 238,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "AuthClientPolicy.remember",
+                "line": 238,
+                "character": 23
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "AuthClientPolicy.remember",
+                "line": 238,
+                "character": 32
+            },
+            "message": "Unused argument 'userid'"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "AuthClientPolicy.forget",
+                "line": 242,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "AuthClientPolicy.forget",
+                "line": 242,
+                "character": 21
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "TokenAuthenticationPolicy.remember",
+                "line": 328,
+                "character": 0
+            },
+            "message": "Unused argument 'kw'"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "TokenAuthenticationPolicy.remember",
+                "line": 328,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "TokenAuthenticationPolicy.remember",
+                "line": 328,
+                "character": 23
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "TokenAuthenticationPolicy.remember",
+                "line": 328,
+                "character": 32
+            },
+            "message": "Unused argument 'userid'"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "TokenAuthenticationPolicy.forget",
+                "line": 332,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "TokenAuthenticationPolicy.forget",
+                "line": 332,
+                "character": 21
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/auth/policy.py",
+                "module": "h.auth.policy",
+                "function": "TokenAuthenticationPolicy.unauthenticated_userid",
+                "line": 336,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/auth/role.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/auth/role.py",
+                "module": "h.auth.role",
+                "function": null,
+                "line": 6,
+                "character": 0
+            },
+            "message": "Constant name \"Admin\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/auth/role.py",
+                "module": "h.auth.role",
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Constant name \"Staff\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/auth/role.py",
+                "module": "h.auth.role",
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Constant name \"AuthClient\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/auth/role.py",
+                "module": "h.auth.role",
+                "function": null,
+                "line": 17,
+                "character": 0
+            },
+            "message": "Constant name \"User\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/auth/role.py",
+                "module": "h.auth.role",
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "Constant name \"AuthClientUser\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/auth/util.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/auth/util.py",
+                "module": null,
+                "function": null,
+                "line": 59,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/util.py",
+                "module": null,
+                "function": null,
+                "line": 84,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/auth/util.py",
+                "module": null,
+                "function": null,
+                "line": 104,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/util.py",
+                "module": null,
+                "function": null,
+                "line": 104,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/auth/util.py",
+                "module": null,
+                "function": null,
+                "line": 139,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/util.py",
+                "module": null,
+                "function": null,
+                "line": 139,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 't')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/auth/util.py",
+                "module": null,
+                "function": null,
+                "line": 160,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/auth/util.py",
+                "module": null,
+                "function": null,
+                "line": 160,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'r')"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/routes.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-statements",
+            "location": {
+                "path": "h/routes.py",
+                "module": "h.routes",
+                "function": "includeme",
+                "line": 6,
+                "character": 0
+            },
+            "message": "Too many statements (103/50)"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/routes.py",
+                "module": null,
+                "function": null,
+                "line": 6,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 54,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 54,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/tweens.py",
+                "module": "h.tweens",
+                "function": "invalid_path_tween_factory",
+                "line": 76,
+                "character": 40
+            },
+            "message": "Unused argument 'registry'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 76,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/tweens.py",
+                "module": "h.tweens",
+                "function": "redirect_tween_factory",
+                "line": 98,
+                "character": 36
+            },
+            "message": "Unused argument 'registry'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 98,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 116,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 137,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 137,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 137,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Set', not 'Sets')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 154,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D301",
+            "location": {
+                "path": "h/tweens.py",
+                "module": null,
+                "function": null,
+                "line": 154,
+                "character": 0
+            },
+            "message": "Use r\"\"\" if any backslashes in a docstring"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-builtin",
+            "location": {
+                "path": "h/tweens.py",
+                "module": "h.tweens",
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "Redefining built-in 'open'"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/tweens.py",
+                "module": "h.tweens",
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Constant name \"resolver\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/tweens.py",
+                "module": "h.tweens",
+                "function": "conditional_http_tween_factory",
+                "line": 18,
+                "character": 44
+            },
+            "message": "Unused argument 'registry'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/tweens.py",
+                "module": "h.tweens",
+                "function": "csrf_tween_factory",
+                "line": 53,
+                "character": 32
+            },
+            "message": "Unused argument 'registry'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/tweens.py",
+                "module": "h.tweens",
+                "function": "security_header_tween_factory",
+                "line": 115,
+                "character": 43
+            },
+            "message": "Unused argument 'registry'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/tweens.py",
+                "module": "h.tweens",
+                "function": "cache_header_tween_factory",
+                "line": 136,
+                "character": 40
+            },
+            "message": "Unused argument 'registry'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/tweens.py",
+                "module": "h.tweens",
+                "function": "encode_headers_tween_factory",
+                "line": 153,
+                "character": 42
+            },
+            "message": "Unused argument 'registry'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/interfaces.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "inherit-non-class",
+            "location": {
+                "path": "h/interfaces.py",
+                "module": "h.interfaces",
+                "function": "IGroupService",
+                "line": 8,
+                "character": 0
+            },
+            "message": "Inheriting 'Interface', which is not a class."
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/interfaces.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/interfaces.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Find', not 'Finds')"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/groups/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/groups/__init__.py",
+                "module": "h.groups",
+                "function": "includeme",
+                "line": 6,
+                "character": 14
+            },
+            "message": "Unused argument 'config'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/groups/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 6,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/groups/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D201",
+            "location": {
+                "path": "h/groups/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 33,
+                "character": 0
+            },
+            "message": "No blank lines allowed before function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/groups/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 33,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/app.py",
+                "module": null,
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/app.py",
+                "module": null,
+                "function": null,
+                "line": 26,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-statements",
+            "location": {
+                "path": "h/app.py",
+                "module": "h.app",
+                "function": "includeme",
+                "line": 41,
+                "character": 0
+            },
+            "message": "Too many statements (58/50)"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/app.py",
+                "module": null,
+                "function": null,
+                "line": 41,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/app.py",
+                "module": "h.app",
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "standard import \"import logging\" should be placed before \"from h._compat import urlparse\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/app.py",
+                "module": "h.app",
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "third party import \"import transaction\" should be placed before \"from h._compat import urlparse\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/app.py",
+                "module": "h.app",
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "third party import \"from pyramid.settings import asbool\" should be placed before \"from h._compat import urlparse\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/app.py",
+                "module": "h.app",
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "third party import \"from pyramid.tweens import EXCVIEW\" should be placed before \"from h._compat import urlparse\""
+        },
+        {
+            "source": "pylint",
+            "code": "ungrouped-imports",
+            "location": {
+                "path": "h/app.py",
+                "module": "h.app",
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "Imports from package h are not grouped"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/app.py",
+                "module": "h.app",
+                "function": "create_app",
+                "line": 30,
+                "character": 15
+            },
+            "message": "Unused argument 'global_config'"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/db/mixins.py",
+                "module": "h.db.mixins",
+                "function": "Timestamps",
+                "line": 12,
+                "character": 0
+            },
+            "message": "Class 'Timestamps' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/db/mixins.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/db/types.py",
+                "module": null,
+                "function": null,
+                "line": 37,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/db/types.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/db/types.py",
+                "module": null,
+                "function": null,
+                "line": 58,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/db/types.py",
+                "module": null,
+                "function": null,
+                "line": 63,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/db/types.py",
+                "module": null,
+                "function": null,
+                "line": 72,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D301",
+            "location": {
+                "path": "h/db/types.py",
+                "module": null,
+                "function": null,
+                "line": 72,
+                "character": 0
+            },
+            "message": "Use r\"\"\" if any backslashes in a docstring"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/db/types.py",
+                "module": null,
+                "function": null,
+                "line": 82,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/db/types.py",
+                "module": null,
+                "function": null,
+                "line": 85,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/db/types.py",
+                "module": null,
+                "function": null,
+                "line": 90,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/db/types.py",
+                "module": null,
+                "function": null,
+                "line": 141,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/db/types.py",
+                "module": "h.db.types",
+                "function": null,
+                "line": 7,
+                "character": 0
+            },
+            "message": "standard import \"import binascii\" should be placed before \"from h._compat import string_types\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/db/types.py",
+                "module": "h.db.types",
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "standard import \"import base64\" should be placed before \"from h._compat import string_types\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/db/types.py",
+                "module": "h.db.types",
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "standard import \"import uuid\" should be placed before \"from h._compat import string_types\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/db/types.py",
+                "module": "h.db.types",
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "third party import \"from sqlalchemy import types\" should be placed before \"from h._compat import string_types\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/db/types.py",
+                "module": "h.db.types",
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "third party import \"from sqlalchemy.dialects import postgresql\" should be placed before \"from h._compat import string_types\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/db/types.py",
+                "module": "h.db.types",
+                "function": null,
+                "line": 13,
+                "character": 0
+            },
+            "message": "third party import \"from sqlalchemy.exc import DontWrapMixin\" should be placed before \"from h._compat import string_types\""
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/db/types.py",
+                "module": "h.db.types",
+                "function": "URLSafeUUID",
+                "line": 41,
+                "character": 0
+            },
+            "message": "Method 'process_literal_param' is abstract in class 'TypeDecorator' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/db/types.py",
+                "module": "h.db.types",
+                "function": "URLSafeUUID",
+                "line": 41,
+                "character": 0
+            },
+            "message": "Method 'python_type' is abstract in class 'TypeEngine' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/db/types.py",
+                "module": "h.db.types",
+                "function": "AnnotationSelectorJSONB",
+                "line": 70,
+                "character": 0
+            },
+            "message": "Method 'process_literal_param' is abstract in class 'TypeDecorator' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/db/types.py",
+                "module": "h.db.types",
+                "function": "AnnotationSelectorJSONB",
+                "line": 70,
+                "character": 0
+            },
+            "message": "Method 'python_type' is abstract in class 'TypeEngine' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/db/types.py",
+                "module": "h.db.types",
+                "function": "_escape_null_byte",
+                "line": 198,
+                "character": 0
+            },
+            "message": "Argument name \"s\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/db/types.py",
+                "module": "h.db.types",
+                "function": "_unescape_null_byte",
+                "line": 205,
+                "character": 0
+            },
+            "message": "Argument name \"s\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/form.py",
+                "module": null,
+                "function": null,
+                "line": 165,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "ungrouped-imports",
+            "location": {
+                "path": "h/form.py",
+                "module": "h.form",
+                "function": null,
+                "line": 13,
+                "character": 0
+            },
+            "message": "Imports from package pyramid are not grouped"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/form.py",
+                "module": "h.form",
+                "function": "Jinja2Renderer",
+                "line": 26,
+                "character": 0
+            },
+            "message": "Class 'Jinja2Renderer' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/util/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/util/redirects.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/util/redirects.py",
+                "module": null,
+                "function": null,
+                "line": 45,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/util/redirects.py",
+                "module": null,
+                "function": null,
+                "line": 50,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/redirects.py",
+                "module": "h.util.redirects",
+                "function": "lookup",
+                "line": 61,
+                "character": 8
+            },
+            "message": "Variable name \"r\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/util/redirects.py",
+                "module": "h.util.redirects",
+                "function": "lookup",
+                "line": 62,
+                "character": 8
+            },
+            "message": "Unnecessary \"elif\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/redirects.py",
+                "module": "h.util.redirects",
+                "function": "parse",
+                "line": 83,
+                "character": 12
+            },
+            "message": "Variable name \"r\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/redirects.py",
+                "module": "h.util.redirects",
+                "function": "parse",
+                "line": 85,
+                "character": 12
+            },
+            "message": "Variable name \"r\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/redirects.py",
+                "module": "h.util.redirects",
+                "function": "parse",
+                "line": 87,
+                "character": 12
+            },
+            "message": "Variable name \"r\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/redirects.py",
+                "module": "h.util.redirects",
+                "function": "parse",
+                "line": 89,
+                "character": 12
+            },
+            "message": "Variable name \"r\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/util/redirects.py",
+                "module": "h.util.redirects",
+                "function": "_dst_root",
+                "line": 97,
+                "character": 4
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/util/logging_filters.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/util/metrics.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/util/uri.py",
+                "module": null,
+                "function": null,
+                "line": 139,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/util/uri.py",
+                "module": "h.util.uri",
+                "function": "normalize.decode_result",
+                "line": 156,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/uri.py",
+                "module": "h.util.uri",
+                "function": "_blacklisted_query_param",
+                "line": 293,
+                "character": 0
+            },
+            "message": "Argument name \"s\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/util/session_tracker.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/util/session_tracker.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/util/session_tracker.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/util/session_tracker.py",
+                "module": null,
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/util/session_tracker.py",
+                "module": null,
+                "function": null,
+                "line": 33,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/util/session_tracker.py",
+                "module": null,
+                "function": null,
+                "line": 33,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'n')"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/util/session_tracker.py",
+                "module": "h.util.session_tracker",
+                "function": "Tracker",
+                "line": 15,
+                "character": 0
+            },
+            "message": "Class 'Tracker' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/util/session_tracker.py",
+                "module": "h.util.session_tracker",
+                "function": "Tracker._after_rollback",
+                "line": 68,
+                "character": 0
+            },
+            "message": "Unused argument 'args'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/util/session_tracker.py",
+                "module": "h.util.session_tracker",
+                "function": "Tracker._after_commit",
+                "line": 71,
+                "character": 0
+            },
+            "message": "Unused argument 'args'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/util/session_tracker.py",
+                "module": "h.util.session_tracker",
+                "function": "Tracker._after_flush",
+                "line": 74,
+                "character": 0
+            },
+            "message": "Unused argument 'args'"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/util/query.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/util/query.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/util/query.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'o')"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/util/query.py",
+                "module": "h.util.query",
+                "function": "column_windows.interval_for_range",
+                "line": 36,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/query.py",
+                "module": "h.util.query",
+                "function": "column_windows",
+                "line": 41,
+                "character": 4
+            },
+            "message": "Variable name \"q\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/query.py",
+                "module": "h.util.query",
+                "function": "column_windows",
+                "line": 46,
+                "character": 8
+            },
+            "message": "Variable name \"q\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/query.py",
+                "module": "h.util.query",
+                "function": "column_windows",
+                "line": 48,
+                "character": 4
+            },
+            "message": "Variable name \"q\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/query.py",
+                "module": "h.util.query",
+                "function": "column_windows",
+                "line": 52,
+                "character": 8
+            },
+            "message": "Variable name \"q\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/util/document_claims.py",
+                "module": null,
+                "function": null,
+                "line": 82,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/document_claims.py",
+                "module": "h.util.document_claims",
+                "function": "doi_uri_from_string",
+                "line": 273,
+                "character": 0
+            },
+            "message": "Argument name \"s\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/util/view.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/util/view.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/util/view.py",
+                "module": "h.util.view",
+                "function": "handle_exception",
+                "line": 15,
+                "character": 30
+            },
+            "message": "Unused argument 'exception'"
+        },
+        {
+            "source": "pylint",
+            "code": "misplaced-bare-raise",
+            "location": {
+                "path": "h/util/view.py",
+                "module": "h.util.view",
+                "function": "handle_exception",
+                "line": 27,
+                "character": 8
+            },
+            "message": "The raise statement is not inside an except clause"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/util/group.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/util/group.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "First line should end with a period (not '`')"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/util/db.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/util/db.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/util/db.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'o')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/util/db.py",
+                "module": null,
+                "function": null,
+                "line": 40,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/util/db.py",
+                "module": null,
+                "function": null,
+                "line": 45,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/util/db.py",
+                "module": null,
+                "function": null,
+                "line": 53,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/util/db.py",
+                "module": null,
+                "function": null,
+                "line": 53,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Decorate', not 'Decorator')"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/util/group_scope.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/util/group_scope.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "First line should end with a period (not '?')"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/util/group_scope.py",
+                "module": null,
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'I')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/util/group_scope.py",
+                "module": null,
+                "function": null,
+                "line": 32,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/util/user.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/util/datetime.py",
+                "module": null,
+                "function": null,
+                "line": 13,
+                "character": 0
+            },
+            "message": "First line should end with a period (not ')')"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 61,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 62,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 66,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 67,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "MathInlineLexer.output_inline_math",
+                "line": 72,
+                "character": 4
+            },
+            "message": "Argument name \"m\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 72,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 76,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 77,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "MathBlockLexer.parse_block_math",
+                "line": 82,
+                "character": 4
+            },
+            "message": "Argument name \"m\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 82,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 86,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 87,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-super-delegation",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "MathRenderer.__init__",
+                "line": 87,
+                "character": 4
+            },
+            "message": "Useless super delegation in method '__init__'"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "MathRenderer.block_math",
+                "line": 90,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 90,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "MathRenderer.inline_math",
+                "line": 93,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 93,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 97,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": null,
+                "function": null,
+                "line": 104,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "ungrouped-imports",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "Imports from package bleach are not grouped"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "_filter_link_attributes",
+                "line": 37,
+                "character": 28
+            },
+            "message": "Unused argument 'tag'"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": null,
+                "line": 56,
+                "character": 0
+            },
+            "message": "Constant name \"cleaner\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": null,
+                "line": 58,
+                "character": 0
+            },
+            "message": "Constant name \"markdown\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "render",
+                "line": 99,
+                "character": 8
+            },
+            "message": "Redefining name 'render' from outer scope (line 97)"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "sanitize",
+                "line": 105,
+                "character": 4
+            },
+            "message": "Redefining name 'cleaner' from outer scope (line 56)"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "_linkify_target_blank",
+                "line": 109,
+                "character": 33
+            },
+            "message": "Unused argument 'new'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "_linkify_rel",
+                "line": 128,
+                "character": 24
+            },
+            "message": "Unused argument 'new'"
+        },
+        {
+            "source": "pylint",
+            "code": "global-statement",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "_get_cleaner",
+                "line": 142,
+                "character": 4
+            },
+            "message": "Using the global statement"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "_get_cleaner",
+                "line": 142,
+                "character": 4
+            },
+            "message": "Constant name \"cleaner\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "global-statement",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "_get_markdown",
+                "line": 154,
+                "character": 4
+            },
+            "message": "Using the global statement"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/util/markdown.py",
+                "module": "h.util.markdown",
+                "function": "_get_markdown",
+                "line": 154,
+                "character": 4
+            },
+            "message": "Constant name \"markdown\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/api/moderation.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/api/moderation.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/api/moderation.py",
+                "module": null,
+                "function": null,
+                "line": 36,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/views/api/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/api/profile.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/api/profile.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/api/profile.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/api/profile.py",
+                "module": null,
+                "function": null,
+                "line": 54,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/api/flags.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/api/flags.py",
+                "module": null,
+                "function": null,
+                "line": 21,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/api/exceptions.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/api/exceptions.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-ancestors",
+            "location": {
+                "path": "h/views/api/exceptions.py",
+                "module": "h.views.api.exceptions",
+                "function": "OAuthAuthorizeError",
+                "line": 11,
+                "character": 0
+            },
+            "message": "Too many ancestors (9/7)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-ancestors",
+            "location": {
+                "path": "h/views/api/exceptions.py",
+                "module": "h.views.api.exceptions",
+                "function": "OAuthAuthorizeError",
+                "line": 11,
+                "character": 0
+            },
+            "message": "Too many ancestors (9/7)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-ancestors",
+            "location": {
+                "path": "h/views/api/exceptions.py",
+                "module": "h.views.api.exceptions",
+                "function": "OAuthTokenError",
+                "line": 15,
+                "character": 0
+            },
+            "message": "Too many ancestors (9/7)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-ancestors",
+            "location": {
+                "path": "h/views/api/exceptions.py",
+                "module": "h.views.api.exceptions",
+                "function": "OAuthTokenError",
+                "line": 15,
+                "character": 0
+            },
+            "message": "Too many ancestors (9/7)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-ancestors",
+            "location": {
+                "path": "h/views/api/exceptions.py",
+                "module": "h.views.api.exceptions",
+                "function": "PayloadError",
+                "line": 28,
+                "character": 0
+            },
+            "message": "Too many ancestors (9/7)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-ancestors",
+            "location": {
+                "path": "h/views/api/exceptions.py",
+                "module": "h.views.api.exceptions",
+                "function": "PayloadError",
+                "line": 28,
+                "character": 0
+            },
+            "message": "Too many ancestors (9/7)"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/api/groups.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/api/groups.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/api/groups.py",
+                "module": null,
+                "function": null,
+                "line": 89,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/views/api/groups.py",
+                "module": null,
+                "function": null,
+                "line": 220,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/views/api/groups.py",
+                "module": null,
+                "function": null,
+                "line": 246,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/api/index.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/api/index.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/views/api/index.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/api/index.py",
+                "module": "h.views.api.index",
+                "function": "index",
+                "line": 10,
+                "character": 10
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/api/index.py",
+                "module": "h.views.api.index",
+                "function": "index",
+                "line": 10,
+                "character": 10
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/api/links.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/api/links.py",
+                "module": "h.views.api.links",
+                "function": "links",
+                "line": 15,
+                "character": 10
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/api/links.py",
+                "module": "h.views.api.links",
+                "function": "links",
+                "line": 15,
+                "character": 10
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/api/links.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/api/config.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D201",
+            "location": {
+                "path": "h/views/api/config.py",
+                "module": null,
+                "function": null,
+                "line": 36,
+                "character": 0
+            },
+            "message": "No blank lines allowed before function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/api/config.py",
+                "module": null,
+                "function": null,
+                "line": 36,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/api/config.py",
+                "module": null,
+                "function": null,
+                "line": 104,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/views/api/config.py",
+                "module": null,
+                "function": null,
+                "line": 104,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/views/api/config.py",
+                "module": "h.views.api.config",
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "Constant name \"cors_policy\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/views/api/config.py",
+                "module": "h.views.api.config",
+                "function": "add_api_view",
+                "line": 26,
+                "character": 0
+            },
+            "message": "Too many arguments (6/5)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/views/api/config.py",
+                "module": "h.views.api.config",
+                "function": "add_api_view",
+                "line": 26,
+                "character": 0
+            },
+            "message": "Too many arguments (6/5)"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/api/config.py",
+                "module": "h.views.api.config",
+                "function": "api_config.callback",
+                "line": 111,
+                "character": 26
+            },
+            "message": "Unused argument 'name'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/api/config.py",
+                "module": "h.views.api.config",
+                "function": "api_config.callback",
+                "line": 111,
+                "character": 26
+            },
+            "message": "Unused argument 'name'"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/views/api/config.py",
+                "module": "h.views.api.config",
+                "function": "api_config.callback",
+                "line": 111,
+                "character": 4
+            },
+            "message": "Argument name \"ob\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/api/annotations.py",
+                "module": null,
+                "function": null,
+                "line": 100,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/views/api/annotations.py",
+                "module": "h.views.api.annotations",
+                "function": "search",
+                "line": 52,
+                "character": 4
+            },
+            "message": "Redefining name 'search' from outer scope (line 42)"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": null,
+                "function": null,
+                "line": 24,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": null,
+                "function": null,
+                "line": 25,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthAccessTokenController",
+                "line": 181,
+                "character": 0
+            },
+            "message": "Class 'OAuthAccessTokenController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthAccessTokenController",
+                "line": 181,
+                "character": 0
+            },
+            "message": "Class 'OAuthAccessTokenController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": null,
+                "function": null,
+                "line": 181,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": null,
+                "function": null,
+                "line": 182,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": null,
+                "function": null,
+                "line": 188,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthRevocationController",
+                "line": 201,
+                "character": 0
+            },
+            "message": "Class 'OAuthRevocationController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthRevocationController",
+                "line": 201,
+                "character": 0
+            },
+            "message": "Class 'OAuthRevocationController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": null,
+                "function": null,
+                "line": 201,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": null,
+                "function": null,
+                "line": 202,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": null,
+                "function": null,
+                "line": 208,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": null,
+                "function": null,
+                "line": 222,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthAuthorizeController",
+                "line": 23,
+                "character": 0
+            },
+            "message": "Class 'OAuthAuthorizeController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthAuthorizeController",
+                "line": 23,
+                "character": 0
+            },
+            "message": "Class 'OAuthAuthorizeController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-variable",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthAuthorizeController._authorize",
+                "line": 109,
+                "character": 12
+            },
+            "message": "Unused variable 'scopes'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-variable",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthAuthorizeController._authorized_response",
+                "line": 154,
+                "character": 20
+            },
+            "message": "Unused variable 'status'"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthAuthorizeController._render_web_message_response",
+                "line": 168,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthAuthorizeController._render_web_message_response",
+                "line": 168,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-variable",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthAccessTokenController.post",
+                "line": 189,
+                "character": 8
+            },
+            "message": "Unused variable 'headers'"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthAccessTokenController.post",
+                "line": 195,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthAccessTokenController.post",
+                "line": 195,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "unused-variable",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthRevocationController.post",
+                "line": 209,
+                "character": 8
+            },
+            "message": "Unused variable 'headers'"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthRevocationController.post",
+                "line": 215,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/views/api/auth.py",
+                "module": "h.views.api.auth",
+                "function": "OAuthRevocationController.post",
+                "line": 215,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/api/users.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/views/api/helpers/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/api/helpers/cors.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/api/helpers/cors.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/views/api/helpers/cors.py",
+                "module": "h.views.api.helpers.cors",
+                "function": "set_cors_headers",
+                "line": 49,
+                "character": 0
+            },
+            "message": "Too many arguments (7/5)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/views/api/helpers/cors.py",
+                "module": "h.views.api.helpers.cors",
+                "function": "set_cors_headers",
+                "line": 49,
+                "character": 0
+            },
+            "message": "Too many arguments (7/5)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-branches",
+            "location": {
+                "path": "h/views/api/helpers/cors.py",
+                "module": "h.views.api.helpers.cors",
+                "function": "set_cors_headers",
+                "line": 49,
+                "character": 0
+            },
+            "message": "Too many branches (14/12)"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/api/helpers/cors.py",
+                "module": null,
+                "function": null,
+                "line": 49,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/api/helpers/cors.py",
+                "module": "h.views.api.helpers.cors",
+                "function": "add_preflight_view.preflight_view",
+                "line": 125,
+                "character": 23
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/api/helpers/cors.py",
+                "module": "h.views.api.helpers.cors",
+                "function": "add_preflight_view.preflight_view",
+                "line": 125,
+                "character": 23
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/api/helpers/cors.py",
+                "module": "h.views.api.helpers.cors",
+                "function": "add_preflight_view.preflight_view",
+                "line": 125,
+                "character": 32
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/api/helpers/cors.py",
+                "module": "h.views.api.helpers.cors",
+                "function": "add_preflight_view.preflight_view",
+                "line": 125,
+                "character": 32
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/views/api/helpers/angular.py",
+                "module": null,
+                "function": null,
+                "line": 2,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D106",
+            "location": {
+                "path": "h/views/api/helpers/angular.py",
+                "module": null,
+                "function": null,
+                "line": 24,
+                "character": 0
+            },
+            "message": "Missing docstring in public nested class"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/api/helpers/angular.py",
+                "module": "h.views.api.helpers.angular",
+                "function": "AngularRouteTemplater.URLParameter",
+                "line": 24,
+                "character": 4
+            },
+            "message": "Class 'URLParameter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/api/helpers/angular.py",
+                "module": "h.views.api.helpers.angular",
+                "function": "AngularRouteTemplater.URLParameter",
+                "line": 24,
+                "character": 4
+            },
+            "message": "Class 'URLParameter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/api/helpers/angular.py",
+                "module": null,
+                "function": null,
+                "line": 25,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/api/helpers/angular.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/api/helpers/angular.py",
+                "module": null,
+                "function": null,
+                "line": 33,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/views/api/helpers/angular.py",
+                "module": null,
+                "function": null,
+                "line": 37,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/api/helpers/angular.py",
+                "module": null,
+                "function": null,
+                "line": 52,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/api/helpers/angular.py",
+                "module": "h.views.api.helpers.angular",
+                "function": "AngularRouteTemplater",
+                "line": 9,
+                "character": 0
+            },
+            "message": "Class 'AngularRouteTemplater' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/api/helpers/angular.py",
+                "module": "h.views.api.helpers.angular",
+                "function": "AngularRouteTemplater",
+                "line": 9,
+                "character": 0
+            },
+            "message": "Class 'AngularRouteTemplater' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/views/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/feeds.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/views/feeds.py",
+                "module": null,
+                "function": null,
+                "line": 26,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'An')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/views/feeds.py",
+                "module": null,
+                "function": null,
+                "line": 39,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'An')"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/views/feeds.py",
+                "module": "h.views.feeds",
+                "function": "_annotations",
+                "line": 19,
+                "character": 4
+            },
+            "message": "Variable name \"s\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/main.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/main.py",
+                "module": "h.views.main",
+                "function": "robots",
+                "line": 61,
+                "character": 11
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/main.py",
+                "module": null,
+                "function": null,
+                "line": 61,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/main.py",
+                "module": "h.views.main",
+                "function": "stream",
+                "line": 72,
+                "character": 11
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/main.py",
+                "module": null,
+                "function": null,
+                "line": 72,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/main.py",
+                "module": null,
+                "function": null,
+                "line": 95,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/views/main.py",
+                "module": null,
+                "function": null,
+                "line": 103,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/main.py",
+                "module": null,
+                "function": null,
+                "line": 103,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/views/main.py",
+                "module": "h.views.main",
+                "function": "stream",
+                "line": 73,
+                "character": 4
+            },
+            "message": "Variable name \"q\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/badge.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/badge.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/views/badge.py",
+                "module": null,
+                "function": null,
+                "line": 27,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/views/badge.py",
+                "module": "h.views.badge",
+                "function": "badge",
+                "line": 52,
+                "character": 8
+            },
+            "message": "Variable name \"s\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/notification.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/notification.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/views/notification.py",
+                "module": "h.views.notification",
+                "function": "unsubscribe",
+                "line": 22,
+                "character": 8
+            },
+            "message": "Variable name \"s\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/views/admin/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": null,
+                "function": null,
+                "line": 34,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": "h.views.admin.features",
+                "function": "cohorts_index",
+                "line": 62,
+                "character": 18
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": "h.views.admin.features",
+                "function": "cohorts_index",
+                "line": 62,
+                "character": 18
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": null,
+                "function": null,
+                "line": 62,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": "h.views.admin.features",
+                "function": "cohorts_edit",
+                "line": 91,
+                "character": 17
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": "h.views.admin.features",
+                "function": "cohorts_edit",
+                "line": 91,
+                "character": 17
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": null,
+                "function": null,
+                "line": 91,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": null,
+                "function": null,
+                "line": 109,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": null,
+                "function": null,
+                "line": 140,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-branches",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": "h.views.admin.features",
+                "function": "features_save",
+                "line": 33,
+                "character": 0
+            },
+            "message": "Too many branches (16/12)"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-builtin",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": "h.views.admin.features",
+                "function": "cohorts_edit",
+                "line": 92,
+                "character": 4
+            },
+            "message": "Redefining built-in 'id'"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-builtin",
+            "location": {
+                "path": "h/views/admin/features.py",
+                "module": "h.views.admin.features",
+                "function": "cohorts_edit",
+                "line": 92,
+                "character": 4
+            },
+            "message": "Redefining built-in 'id'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/admin/badge.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/badge.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/badge.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/badge.py",
+                "module": null,
+                "function": null,
+                "line": 54,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/admin/mailer.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/admin/staff.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/views/admin/staff.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/admin/nipsa.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/admin/nipsa.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/nipsa.py",
+                "module": null,
+                "function": null,
+                "line": 21,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/nipsa.py",
+                "module": null,
+                "function": null,
+                "line": 36,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/nipsa.py",
+                "module": null,
+                "function": null,
+                "line": 63,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/nipsa.py",
+                "module": null,
+                "function": null,
+                "line": 77,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": null,
+                "function": null,
+                "line": 39,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": null,
+                "function": null,
+                "line": 40,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": null,
+                "function": null,
+                "line": 47,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": null,
+                "function": null,
+                "line": 60,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": null,
+                "function": null,
+                "line": 101,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": null,
+                "function": null,
+                "line": 102,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": null,
+                "function": null,
+                "line": 109,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": null,
+                "function": null,
+                "line": 114,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": null,
+                "function": null,
+                "line": 157,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": "h.views.admin.oauthclients",
+                "function": "_response_type_for_grant_type",
+                "line": 18,
+                "character": 4
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": "h.views.admin.oauthclients",
+                "function": "_response_type_for_grant_type",
+                "line": 18,
+                "character": 4
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": "h.views.admin.oauthclients",
+                "function": "AuthClientCreateController",
+                "line": 34,
+                "character": 0
+            },
+            "message": "Class 'AuthClientCreateController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": "h.views.admin.oauthclients",
+                "function": "AuthClientCreateController",
+                "line": 34,
+                "character": 0
+            },
+            "message": "Class 'AuthClientCreateController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": "h.views.admin.oauthclients",
+                "function": "AuthClientEditController",
+                "line": 96,
+                "character": 0
+            },
+            "message": "Class 'AuthClientEditController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/admin/oauthclients.py",
+                "module": "h.views.admin.oauthclients",
+                "function": "AuthClientEditController",
+                "line": 96,
+                "character": 0
+            },
+            "message": "Class 'AuthClientEditController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'r')"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 45,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 63,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'm')"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 74,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 76,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 76,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'a')"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 136,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 137,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 159,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 164,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 177,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 181,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": null,
+                "function": null,
+                "line": 181,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'n')"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": "h.views.admin.groups",
+                "function": "groups_index",
+                "line": 28,
+                "character": 17
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": "h.views.admin.groups",
+                "function": "groups_index",
+                "line": 28,
+                "character": 17
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-instance-attributes",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": "h.views.admin.groups",
+                "function": "GroupCreateViews",
+                "line": 37,
+                "character": 0
+            },
+            "message": "Too many instance attributes (9/7)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-instance-attributes",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": "h.views.admin.groups",
+                "function": "GroupCreateViews",
+                "line": 37,
+                "character": 0
+            },
+            "message": "Too many instance attributes (9/7)"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": "h.views.admin.groups",
+                "function": "GroupCreateViews",
+                "line": 37,
+                "character": 0
+            },
+            "message": "Class 'GroupCreateViews' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": "h.views.admin.groups",
+                "function": "GroupCreateViews",
+                "line": 37,
+                "character": 0
+            },
+            "message": "Class 'GroupCreateViews' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-instance-attributes",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": "h.views.admin.groups",
+                "function": "GroupEditViews",
+                "line": 131,
+                "character": 0
+            },
+            "message": "Too many instance attributes (9/7)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-instance-attributes",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": "h.views.admin.groups",
+                "function": "GroupEditViews",
+                "line": 131,
+                "character": 0
+            },
+            "message": "Too many instance attributes (9/7)"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": "h.views.admin.groups",
+                "function": "GroupEditViews",
+                "line": 131,
+                "character": 0
+            },
+            "message": "Class 'GroupEditViews' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/admin/groups.py",
+                "module": "h.views.admin.groups",
+                "function": "GroupEditViews",
+                "line": 131,
+                "character": 0
+            },
+            "message": "Class 'GroupEditViews' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/admin/admins.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/views/admin/admins.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/admin/index.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/index.py",
+                "module": null,
+                "function": null,
+                "line": 17,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": "h.views.admin.organizations",
+                "function": "index",
+                "line": 26,
+                "character": 10
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": "h.views.admin.organizations",
+                "function": "index",
+                "line": 26,
+                "character": 10
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 26,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 47,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 48,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 56,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 61,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 91,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 92,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 100,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 104,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 131,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": "h.views.admin.organizations",
+                "function": "index",
+                "line": 27,
+                "character": 4
+            },
+            "message": "Variable name \"q\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": "h.views.admin.organizations",
+                "function": "OrganizationCreateController",
+                "line": 42,
+                "character": 0
+            },
+            "message": "Class 'OrganizationCreateController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": "h.views.admin.organizations",
+                "function": "OrganizationCreateController",
+                "line": 42,
+                "character": 0
+            },
+            "message": "Class 'OrganizationCreateController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": "h.views.admin.organizations",
+                "function": "OrganizationEditController",
+                "line": 86,
+                "character": 0
+            },
+            "message": "Class 'OrganizationEditController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/admin/organizations.py",
+                "module": "h.views.admin.organizations",
+                "function": "OrganizationEditController",
+                "line": 86,
+                "character": 0
+            },
+            "message": "Class 'OrganizationEditController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/admin/users.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/admin/users.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/users.py",
+                "module": null,
+                "function": null,
+                "line": 26,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/users.py",
+                "module": null,
+                "function": null,
+                "line": 59,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/users.py",
+                "module": null,
+                "function": null,
+                "line": 85,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/users.py",
+                "module": null,
+                "function": null,
+                "line": 126,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/admin/users.py",
+                "module": null,
+                "function": null,
+                "line": 141,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/help.py",
+                "module": "h.views.help",
+                "function": "custom_onboarding_page",
+                "line": 15,
+                "character": 27
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/help.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/help.py",
+                "module": "h.views.help",
+                "function": "onboarding_page",
+                "line": 24,
+                "character": 20
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/help.py",
+                "module": null,
+                "function": null,
+                "line": 24,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/help.py",
+                "module": "h.views.help",
+                "function": "help_page",
+                "line": 29,
+                "character": 14
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/help.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/status.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/status.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/account_signup.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/account_signup.py",
+                "module": null,
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/account_signup.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/account_signup.py",
+                "module": "h.views.account_signup",
+                "function": "SignupController",
+                "line": 21,
+                "character": 0
+            },
+            "message": "Class 'SignupController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 40,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": "h.views.accounts",
+                "function": "bad_csrf_token_html",
+                "line": 55,
+                "character": 24
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 55,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": "h.views.accounts",
+                "function": "bad_csrf_token_json",
+                "line": 68,
+                "character": 24
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 68,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 75,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 81,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 87,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 88,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 172,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 174,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 222,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 224,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 300,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 301,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 396,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 397,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 431,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Call', not 'Called')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 441,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Call', not 'Called')"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 449,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 452,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 474,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 475,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 484,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'm')"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 498,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 523,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 524,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 578,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 579,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": null,
+                "function": null,
+                "line": 627,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": "h.views.accounts",
+                "function": "AuthController",
+                "line": 86,
+                "character": 0
+            },
+            "message": "Class 'AuthController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": "h.views.accounts",
+                "function": "ForgotPasswordController",
+                "line": 166,
+                "character": 0
+            },
+            "message": "Class 'ForgotPasswordController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": "h.views.accounts",
+                "function": "ResetController",
+                "line": 217,
+                "character": 0
+            },
+            "message": "Class 'ResetController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": "h.views.accounts",
+                "function": "ActivateController",
+                "line": 299,
+                "character": 0
+            },
+            "message": "Class 'ActivateController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": "h.views.accounts",
+                "function": "AccountController",
+                "line": 391,
+                "character": 0
+            },
+            "message": "Class 'AccountController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": "h.views.accounts",
+                "function": "EditProfileController",
+                "line": 469,
+                "character": 0
+            },
+            "message": "Class 'EditProfileController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": "h.views.accounts",
+                "function": "NotificationsController",
+                "line": 518,
+                "character": 0
+            },
+            "message": "Class 'NotificationsController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": "h.views.accounts",
+                "function": "NotificationsController._update_notifications",
+                "line": 554,
+                "character": 12
+            },
+            "message": "Variable name \"n\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": "h.views.accounts",
+                "function": "DeveloperController",
+                "line": 573,
+                "character": 0
+            },
+            "message": "Class 'DeveloperController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/accounts.py",
+                "module": "h.views.accounts",
+                "function": "claim_account_legacy",
+                "line": 619,
+                "character": 25
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/home.py",
+                "module": "h.views.home",
+                "function": "via_redirect",
+                "line": 12,
+                "character": 17
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/home.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/home.py",
+                "module": "h.views.home",
+                "function": "index_redirect",
+                "line": 23,
+                "character": 19
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/home.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/groups.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/groups.py",
+                "module": null,
+                "function": null,
+                "line": 21,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/groups.py",
+                "module": null,
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/groups.py",
+                "module": null,
+                "function": null,
+                "line": 46,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/views/groups.py",
+                "module": null,
+                "function": null,
+                "line": 78,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/groups.py",
+                "module": null,
+                "function": null,
+                "line": 79,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/groups.py",
+                "module": null,
+                "function": null,
+                "line": 88,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/groups.py",
+                "module": null,
+                "function": null,
+                "line": 96,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/groups.py",
+                "module": null,
+                "function": null,
+                "line": 118,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/groups.py",
+                "module": "h.views.groups",
+                "function": "GroupCreateController",
+                "line": 16,
+                "character": 0
+            },
+            "message": "Class 'GroupCreateController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/groups.py",
+                "module": "h.views.groups",
+                "function": "GroupEditController",
+                "line": 73,
+                "character": 0
+            },
+            "message": "Class 'GroupEditController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": null,
+                "function": null,
+                "line": 37,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": null,
+                "function": null,
+                "line": 99,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": null,
+                "function": null,
+                "line": 110,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": null,
+                "function": null,
+                "line": 327,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": null,
+                "function": null,
+                "line": 331,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": null,
+                "function": null,
+                "line": 335,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": null,
+                "function": null,
+                "line": 359,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": null,
+                "function": null,
+                "line": 364,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": null,
+                "function": null,
+                "line": 418,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": null,
+                "function": null,
+                "line": 422,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": null,
+                "function": null,
+                "line": 426,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "third party import \"from jinja2 import Markup\" should be placed before \"from h._compat import urlparse\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "third party import \"from pyramid import httpexceptions\" should be placed before \"from h._compat import urlparse\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "third party import \"from pyramid import security\" should be placed before \"from h._compat import urlparse\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "third party import \"from pyramid.view import view_config\" should be placed before \"from h._compat import urlparse\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": null,
+                "line": 13,
+                "character": 0
+            },
+            "message": "third party import \"from pyramid.view import view_defaults\" should be placed before \"from h._compat import urlparse\""
+        },
+        {
+            "source": "pylint",
+            "code": "ungrouped-imports",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Imports from package h are not grouped"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": "SearchController",
+                "line": 31,
+                "character": 0
+            },
+            "message": "Class 'SearchController' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": "SearchController.search",
+                "line": 45,
+                "character": 8
+            },
+            "message": "Variable name \"q\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": "SearchController.search.tag_link",
+                "line": 66,
+                "character": 12
+            },
+            "message": "Variable name \"q\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": "GroupSearchController._get_total_annotations_in_group",
+                "line": 224,
+                "character": 54
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pylint",
+            "code": "inconsistent-return-statements",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": "GroupSearchController._check_access_permissions",
+                "line": 338,
+                "character": 4
+            },
+            "message": "Either all return statements in a function should return an expression, or none of them should."
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": "UserSearchController._get_total_user_annotations",
+                "line": 404,
+                "character": 50
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/views/activity.py",
+                "module": "h.views.activity",
+                "function": "_update_q",
+                "line": 576,
+                "character": 4
+            },
+            "message": "Variable name \"q\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/views/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/views/organizations.py",
+                "module": "h.views.organizations",
+                "function": "organization_logo",
+                "line": 11,
+                "character": 28
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/views/organizations.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/views/client.py",
+                "module": null,
+                "function": null,
+                "line": 25,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/views/client.py",
+                "module": null,
+                "function": null,
+                "line": 41,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/emails/signup.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-builtin",
+            "location": {
+                "path": "h/emails/signup.py",
+                "module": "h.emails.signup",
+                "function": "generate",
+                "line": 10,
+                "character": 22
+            },
+            "message": "Redefining built-in 'id'"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/emails/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/emails/reply_notification.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/emails/reply_notification.py",
+                "module": "h.emails.reply_notification",
+                "function": null,
+                "line": 7,
+                "character": 0
+            },
+            "message": "third party import \"from pyramid.renderers import render\" should be placed before \"from h import links\""
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-locals",
+            "location": {
+                "path": "h/emails/reply_notification.py",
+                "module": "h.emails.reply_notification",
+                "function": "generate",
+                "line": 10,
+                "character": 0
+            },
+            "message": "Too many local variables (16/15)"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/emails/flag_notification.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/emails/reset_password.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/events.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/events.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/events.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/events.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/events.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/events.py",
+                "module": null,
+                "function": null,
+                "line": 24,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/events.py",
+                "module": "h.events",
+                "function": "AnnotationEvent",
+                "line": 5,
+                "character": 0
+            },
+            "message": "Class 'AnnotationEvent' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/events.py",
+                "module": "h.events",
+                "function": "AnnotationTransformEvent",
+                "line": 14,
+                "character": 0
+            },
+            "message": "Class 'AnnotationTransformEvent' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/pubid.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "pointless-string-statement",
+            "location": {
+                "path": "h/pubid.py",
+                "module": "h.pubid",
+                "function": null,
+                "line": 31,
+                "character": null
+            },
+            "message": "String statement has no effect"
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-position",
+            "location": {
+                "path": "h/pubid.py",
+                "module": "h.pubid",
+                "function": null,
+                "line": 33,
+                "character": 0
+            },
+            "message": "Import \"import random\" should be placed at the top of the module"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/tasks/indexer.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/tasks/indexer.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/tasks/indexer.py",
+                "module": null,
+                "function": null,
+                "line": 30,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/tasks/indexer.py",
+                "module": null,
+                "function": null,
+                "line": 41,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/tasks/indexer.py",
+                "module": "h.tasks.indexer",
+                "function": "_current_reindex_new_name",
+                "line": 53,
+                "character": 30
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/tasks/admin.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/tasks/admin.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/tasks/cleanup.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/tasks/cleanup.py",
+                "module": null,
+                "function": null,
+                "line": 32,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/tasks/cleanup.py",
+                "module": null,
+                "function": null,
+                "line": 39,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/tasks/cleanup.py",
+                "module": null,
+                "function": null,
+                "line": 46,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/oauth/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/oauth/tokens.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/oauth/tokens.py",
+                "module": "h.oauth.tokens",
+                "function": "BearerToken",
+                "line": 8,
+                "character": 0
+            },
+            "message": "Method '__call__' is abstract in class 'TokenBase' but is not overridden"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/oauth/tokens.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/oauth/tokens.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/oauth/tokens.py",
+                "module": "h.oauth.tokens",
+                "function": "BearerToken.__init__",
+                "line": 9,
+                "character": 4
+            },
+            "message": "Too many arguments (6/5)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/oauth/tokens.py",
+                "module": null,
+                "function": null,
+                "line": 26,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/oauth/errors.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/oauth/errors.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/oauth/errors.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/oauth/errors.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/oauth/errors.py",
+                "module": null,
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/oauth/errors.py",
+                "module": null,
+                "function": null,
+                "line": 30,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/oauth/jwt_grant.py",
+                "module": "h.oauth.jwt_grant",
+                "function": "JWTAuthorizationGrant",
+                "line": 48,
+                "character": 0
+            },
+            "message": "Method 'create_authorization_response' is abstract in class 'GrantTypeBase' but is not overridden"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/oauth/jwt_grant.py",
+                "module": null,
+                "function": null,
+                "line": 48,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/oauth/jwt_grant.py",
+                "module": null,
+                "function": null,
+                "line": 49,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "super-init-not-called",
+            "location": {
+                "path": "h/oauth/jwt_grant.py",
+                "module": "h.oauth.jwt_grant",
+                "function": "JWTAuthorizationGrant.__init__",
+                "line": 49,
+                "character": 4
+            },
+            "message": "__init__ method from base class 'GrantTypeBase' is not called"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/oauth/jwt_grant.py",
+                "module": null,
+                "function": null,
+                "line": 55,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/oauth/jwt_grant.py",
+                "module": null,
+                "function": null,
+                "line": 89,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/oauth/jwt_grant.py",
+                "module": null,
+                "function": null,
+                "line": 89,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Validate', not 'Validates')"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/oauth/jwt_grant_token.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/oauth/jwt_grant_token.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/oauth/jwt_grant_token.py",
+                "module": null,
+                "function": null,
+                "line": 38,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/oauth/jwt_grant_token.py",
+                "module": null,
+                "function": null,
+                "line": 44,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/oauth/jwt_grant_token.py",
+                "module": null,
+                "function": null,
+                "line": 60,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/oauth/jwt_grant_token.py",
+                "module": null,
+                "function": null,
+                "line": 96,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/oauth/jwt_grant_token.py",
+                "module": null,
+                "function": null,
+                "line": 100,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/oauth/jwt_grant_token.py",
+                "module": null,
+                "function": null,
+                "line": 113,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/oauth/jwt_grant_token.py",
+                "module": "h.oauth.jwt_grant_token",
+                "function": "JWTGrantToken",
+                "line": 17,
+                "character": 0
+            },
+            "message": "Class 'JWTGrantToken' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/feeds/rss.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/feeds/rss.py",
+                "module": null,
+                "function": null,
+                "line": 30,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/feeds/rss.py",
+                "module": null,
+                "function": null,
+                "line": 55,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/feeds/rss.py",
+                "module": "h.feeds.rss",
+                "function": "feed_from_annotations",
+                "line": 52,
+                "character": 0
+            },
+            "message": "Too many arguments (6/5)"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/feeds/render.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/feeds/render.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/feeds/render.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/feeds/render.py",
+                "module": null,
+                "function": null,
+                "line": 56,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/feeds/render.py",
+                "module": null,
+                "function": null,
+                "line": 56,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/feeds/render.py",
+                "module": "h.feeds.render",
+                "function": "render_atom",
+                "line": 8,
+                "character": 0
+            },
+            "message": "Too many arguments (6/5)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/feeds/render.py",
+                "module": "h.feeds.render",
+                "function": "render_rss",
+                "line": 55,
+                "character": 0
+            },
+            "message": "Too many arguments (6/5)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/feeds/atom.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/feeds/atom.py",
+                "module": null,
+                "function": null,
+                "line": 69,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/feeds/atom.py",
+                "module": "h.feeds.atom",
+                "function": "feed_from_annotations",
+                "line": 60,
+                "character": 0
+            },
+            "message": "Too many arguments (7/5)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/feeds/util.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/schemas/api/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/schemas/api/group.py",
+                "module": null,
+                "function": null,
+                "line": 2,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/schemas/api/group.py",
+                "module": null,
+                "function": null,
+                "line": 27,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'a')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/schemas/api/group.py",
+                "module": null,
+                "function": null,
+                "line": 103,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/schemas/api/group.py",
+                "module": null,
+                "function": null,
+                "line": 103,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/schemas/api/group.py",
+                "module": null,
+                "function": null,
+                "line": 115,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'a')"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/schemas/api/group.py",
+                "module": null,
+                "function": null,
+                "line": 125,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'a')"
+        },
+        {
+            "source": "pylint",
+            "code": "inconsistent-return-statements",
+            "location": {
+                "path": "h/schemas/api/group.py",
+                "module": "h.schemas.api.group",
+                "function": "GroupAPISchema._validate_groupid",
+                "line": 62,
+                "character": 4
+            },
+            "message": "Either all return statements in a function should return an expression, or none of them should."
+        },
+        {
+            "source": "pylint",
+            "code": "inconsistent-return-statements",
+            "location": {
+                "path": "h/schemas/api/group.py",
+                "module": "h.schemas.api.group",
+                "function": "GroupAPISchema._validate_groupid",
+                "line": 62,
+                "character": 4
+            },
+            "message": "Either all return statements in a function should return an expression, or none of them should."
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/schemas/api/group.py",
+                "module": "h.schemas.api.group",
+                "function": "GroupAPISchema._whitelisted_fields_only",
+                "line": 102,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/schemas/api/group.py",
+                "module": "h.schemas.api.group",
+                "function": "GroupAPISchema._whitelisted_fields_only",
+                "line": 102,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "consider-iterating-dictionary",
+            "location": {
+                "path": "h/schemas/api/group.py",
+                "module": "h.schemas.api.group",
+                "function": "GroupAPISchema._whitelisted_fields_only",
+                "line": 107,
+                "character": 29
+            },
+            "message": "Consider iterating the dictionary directly instead of calling .keys()"
+        },
+        {
+            "source": "pylint",
+            "code": "consider-iterating-dictionary",
+            "location": {
+                "path": "h/schemas/api/group.py",
+                "module": "h.schemas.api.group",
+                "function": "GroupAPISchema._whitelisted_fields_only",
+                "line": 107,
+                "character": 29
+            },
+            "message": "Consider iterating the dictionary directly instead of calling .keys()"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/schemas/api/user.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/schemas/api/user.py",
+                "module": null,
+                "function": null,
+                "line": 52,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/schemas/api/user.py",
+                "module": null,
+                "function": null,
+                "line": 72,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/schemas/api/user.py",
+                "module": null,
+                "function": null,
+                "line": 78,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/schemas/api/user.py",
+                "module": null,
+                "function": null,
+                "line": 78,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/schemas/api/user.py",
+                "module": "h.schemas.api.user",
+                "function": "UpdateUserAPISchema._whitelisted_properties_only",
+                "line": 77,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/schemas/api/user.py",
+                "module": "h.schemas.api.user",
+                "function": "UpdateUserAPISchema._whitelisted_properties_only",
+                "line": 77,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "consider-iterating-dictionary",
+            "location": {
+                "path": "h/schemas/api/user.py",
+                "module": "h.schemas.api.user",
+                "function": "UpdateUserAPISchema._whitelisted_properties_only",
+                "line": 82,
+                "character": 29
+            },
+            "message": "Consider iterating the dictionary directly instead of calling .keys()"
+        },
+        {
+            "source": "pylint",
+            "code": "consider-iterating-dictionary",
+            "location": {
+                "path": "h/schemas/api/user.py",
+                "module": "h.schemas.api.user",
+                "function": "UpdateUserAPISchema._whitelisted_properties_only",
+                "line": 82,
+                "character": 29
+            },
+            "message": "Consider iterating the dictionary directly instead of calling .keys()"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 104,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 106,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 110,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 158,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 160,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 166,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 293,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 428,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": null,
+                "function": null,
+                "line": 447,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": "h.schemas.annotation",
+                "function": null,
+                "line": 6,
+                "character": 0
+            },
+            "message": "standard import \"import copy\" should be placed before \"import colander\""
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": "h.schemas.annotation",
+                "function": "CreateAnnotationSchema",
+                "line": 102,
+                "character": 0
+            },
+            "message": "Class 'CreateAnnotationSchema' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": "h.schemas.annotation",
+                "function": "UpdateAnnotationSchema",
+                "line": 156,
+                "character": 0
+            },
+            "message": "Class 'UpdateAnnotationSchema' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": "h.schemas.annotation",
+                "function": "_target_selectors",
+                "line": 287,
+                "character": 4
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/schemas/annotation.py",
+                "module": "h.schemas.annotation",
+                "function": "SearchParamsSchema._date_is_parsable",
+                "line": 446,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/schemas/validators.py",
+                "module": null,
+                "function": null,
+                "line": 30,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/schemas/validators.py",
+                "module": null,
+                "function": null,
+                "line": 34,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/schemas/validators.py",
+                "module": null,
+                "function": null,
+                "line": 35,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/schemas/auth_client.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/schemas/auth_client.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/schemas/auth_client.py",
+                "module": null,
+                "function": null,
+                "line": 64,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": "h.schemas.base",
+                "function": "deferred_csrf_token",
+                "line": 17,
+                "character": 24
+            },
+            "message": "Unused argument 'node'"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": "h.schemas.base",
+                "function": "deferred_csrf_token",
+                "line": 17,
+                "character": 0
+            },
+            "message": "Argument name \"kw\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": null,
+                "function": null,
+                "line": 17,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-ancestors",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": "h.schemas.base",
+                "function": "ValidationError",
+                "line": 22,
+                "character": 0
+            },
+            "message": "Too many ancestors (9/7)"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": null,
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": "h.schemas.base",
+                "function": "CSRFSchema.validator",
+                "line": 41,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": "h.schemas.base",
+                "function": "CSRFSchema.validator",
+                "line": 41,
+                "character": 30
+            },
+            "message": "Unused argument 'value'"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": null,
+                "function": null,
+                "line": 41,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": null,
+                "function": null,
+                "line": 56,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": null,
+                "function": null,
+                "line": 81,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": "h.schemas.base",
+                "function": "JSONSchema",
+                "line": 46,
+                "character": 0
+            },
+            "message": "Class 'JSONSchema' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": "h.schemas.base",
+                "function": "enum_type.EnumType.deserialize",
+                "line": 89,
+                "character": 8
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": "h.schemas.base",
+                "function": "enum_type.EnumType.serialize",
+                "line": 99,
+                "character": 8
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/schemas/base.py",
+                "module": "h.schemas.base",
+                "function": "enum_type.EnumType.serialize",
+                "line": 99,
+                "character": 28
+            },
+            "message": "Unused argument 'node'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/schemas/util.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/schemas/forms/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/schemas/forms/admin/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/schemas/forms/admin/organization.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/schemas/forms/admin/organization.py",
+                "module": null,
+                "function": null,
+                "line": 27,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/schemas/forms/admin/organization.py",
+                "module": null,
+                "function": null,
+                "line": 46,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/schemas/forms/admin/organization.py",
+                "module": "h.schemas.forms.admin.organization",
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "standard import \"from xml.etree import ElementTree\" should be placed before \"import colander\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/schemas/forms/admin/organization.py",
+                "module": "h.schemas.forms.admin.organization",
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "standard import \"from xml.etree import ElementTree\" should be placed before \"import colander\""
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": "h.schemas.forms.admin.group",
+                "function": "group_creator_validator",
+                "line": 29,
+                "character": 28
+            },
+            "message": "Unused argument 'node'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": "h.schemas.forms.admin.group",
+                "function": "group_creator_validator",
+                "line": 29,
+                "character": 28
+            },
+            "message": "Unused argument 'node'"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": "h.schemas.forms.admin.group",
+                "function": "group_creator_validator",
+                "line": 29,
+                "character": 0
+            },
+            "message": "Argument name \"kw\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": null,
+                "function": null,
+                "line": 73,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": "h.schemas.forms.admin.group",
+                "function": "group_type_validator",
+                "line": 81,
+                "character": 25
+            },
+            "message": "Unused argument 'node'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": "h.schemas.forms.admin.group",
+                "function": "group_type_validator",
+                "line": 81,
+                "character": 25
+            },
+            "message": "Unused argument 'node'"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": "h.schemas.forms.admin.group",
+                "function": "group_type_validator",
+                "line": 81,
+                "character": 0
+            },
+            "message": "Argument name \"kw\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": null,
+                "function": null,
+                "line": 81,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": "h.schemas.forms.admin.group",
+                "function": "group_organization_select_widget",
+                "line": 96,
+                "character": 37
+            },
+            "message": "Unused argument 'node'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": "h.schemas.forms.admin.group",
+                "function": "group_organization_select_widget",
+                "line": 96,
+                "character": 37
+            },
+            "message": "Unused argument 'node'"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": "h.schemas.forms.admin.group",
+                "function": "group_organization_select_widget",
+                "line": 96,
+                "character": 0
+            },
+            "message": "Argument name \"kw\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": null,
+                "function": null,
+                "line": 96,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": null,
+                "function": null,
+                "line": 109,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/schemas/forms/admin/group.py",
+                "module": null,
+                "function": null,
+                "line": 110,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/schemas/forms/accounts/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/schemas/forms/accounts/reset_password.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/schemas/forms/accounts/reset_password.py",
+                "module": null,
+                "function": null,
+                "line": 17,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/schemas/forms/accounts/reset_password.py",
+                "module": "h.schemas.forms.accounts.reset_password",
+                "function": "ResetCode.serialize",
+                "line": 19,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/schemas/forms/accounts/reset_password.py",
+                "module": "h.schemas.forms.accounts.reset_password",
+                "function": "ResetCode.serialize",
+                "line": 19,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/schemas/forms/accounts/reset_password.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/schemas/forms/accounts/reset_password.py",
+                "module": "h.schemas.forms.accounts.reset_password",
+                "function": "ResetCode.deserialize",
+                "line": 28,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/schemas/forms/accounts/reset_password.py",
+                "module": "h.schemas.forms.accounts.reset_password",
+                "function": "ResetCode.deserialize",
+                "line": 28,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/schemas/forms/accounts/reset_password.py",
+                "module": null,
+                "function": null,
+                "line": 28,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/schemas/forms/accounts/reset_password.py",
+                "module": null,
+                "function": null,
+                "line": 56,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/schemas/forms/accounts/forgot_password.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/schemas/forms/accounts/forgot_password.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/schemas/forms/accounts/forgot_password.py",
+                "module": "h.schemas.forms.accounts.forgot_password",
+                "function": "ForgotPasswordSchema.validator",
+                "line": 22,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'validator' method"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/schemas/forms/accounts/forgot_password.py",
+                "module": "h.schemas.forms.accounts.forgot_password",
+                "function": "ForgotPasswordSchema.validator",
+                "line": 22,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'validator' method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/schemas/forms/accounts/forgot_password.py",
+                "module": null,
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/schemas/forms/accounts/login.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/schemas/forms/accounts/login.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/schemas/forms/accounts/login.py",
+                "module": "h.schemas.forms.accounts.login",
+                "function": "LoginSchema.validator",
+                "line": 24,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'validator' method"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/schemas/forms/accounts/login.py",
+                "module": "h.schemas.forms.accounts.login",
+                "function": "LoginSchema.validator",
+                "line": 24,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'validator' method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/schemas/forms/accounts/login.py",
+                "module": null,
+                "function": null,
+                "line": 24,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/schemas/forms/accounts/util.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/schemas/forms/accounts/edit_profile.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/schemas/forms/accounts/edit_profile.py",
+                "module": null,
+                "function": null,
+                "line": 17,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/schemas/forms/accounts/edit_profile.py",
+                "module": null,
+                "function": null,
+                "line": 24,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/schemas/forms/accounts/edit_profile.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/storage.py",
+                "module": null,
+                "function": null,
+                "line": 53,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/storage.py",
+                "module": null,
+                "function": null,
+                "line": 53,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 't')"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/formatters/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/formatters/annotation_flag.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/formatters/annotation_flag.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "inconsistent-return-statements",
+            "location": {
+                "path": "h/formatters/annotation_flag.py",
+                "module": "h.formatters.annotation_flag",
+                "function": "AnnotationFlagFormatter.preload",
+                "line": 27,
+                "character": 4
+            },
+            "message": "Either all return statements in a function should return an expression, or none of them should."
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/formatters/annotation_flag.py",
+                "module": null,
+                "function": null,
+                "line": 27,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/formatters/annotation_flag.py",
+                "module": null,
+                "function": null,
+                "line": 37,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/formatters/annotation_flag.py",
+                "module": "h.formatters.annotation_flag",
+                "function": "AnnotationFlagFormatter",
+                "line": 10,
+                "character": 0
+            },
+            "message": "Class 'AnnotationFlagFormatter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/formatters/interfaces.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "inherit-non-class",
+            "location": {
+                "path": "h/formatters/interfaces.py",
+                "module": "h.formatters.interfaces",
+                "function": "IAnnotationFormatter",
+                "line": 8,
+                "character": 0
+            },
+            "message": "Inheriting 'Interface', which is not a class."
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/formatters/annotation_user_info.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/formatters/annotation_user_info.py",
+                "module": null,
+                "function": null,
+                "line": 13,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/formatters/annotation_user_info.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/formatters/annotation_user_info.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/formatters/annotation_user_info.py",
+                "module": null,
+                "function": null,
+                "line": 30,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/formatters/annotation_user_info.py",
+                "module": "h.formatters.annotation_user_info",
+                "function": "AnnotationUserInfoFormatter",
+                "line": 12,
+                "character": 0
+            },
+            "message": "Class 'AnnotationUserInfoFormatter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/formatters/annotation_hidden.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/formatters/annotation_hidden.py",
+                "module": null,
+                "function": null,
+                "line": 27,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/formatters/annotation_hidden.py",
+                "module": null,
+                "function": null,
+                "line": 36,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/formatters/annotation_hidden.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/formatters/annotation_hidden.py",
+                "module": "h.formatters.annotation_hidden",
+                "function": "AnnotationHiddenFormatter",
+                "line": 10,
+                "character": 0
+            },
+            "message": "Class 'AnnotationHiddenFormatter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/formatters/annotation_hidden.py",
+                "module": "h.formatters.annotation_hidden",
+                "function": "AnnotationHiddenFormatter.format",
+                "line": 53,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/formatters/annotation_moderation.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/formatters/annotation_moderation.py",
+                "module": null,
+                "function": null,
+                "line": 21,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "inconsistent-return-statements",
+            "location": {
+                "path": "h/formatters/annotation_moderation.py",
+                "module": "h.formatters.annotation_moderation",
+                "function": "AnnotationModerationFormatter.preload",
+                "line": 30,
+                "character": 4
+            },
+            "message": "Either all return statements in a function should return an expression, or none of them should."
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/formatters/annotation_moderation.py",
+                "module": null,
+                "function": null,
+                "line": 30,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/formatters/annotation_moderation.py",
+                "module": null,
+                "function": null,
+                "line": 41,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/formatters/annotation_moderation.py",
+                "module": "h.formatters.annotation_moderation",
+                "function": "AnnotationModerationFormatter",
+                "line": 10,
+                "character": 0
+            },
+            "message": "Class 'AnnotationModerationFormatter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/eventqueue.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/eventqueue.py",
+                "module": null,
+                "function": null,
+                "line": 36,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/eventqueue.py",
+                "module": null,
+                "function": null,
+                "line": 42,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/eventqueue.py",
+                "module": null,
+                "function": null,
+                "line": 45,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/eventqueue.py",
+                "module": "h.eventqueue",
+                "function": "EventQueue.response_callback",
+                "line": 68,
+                "character": 41
+            },
+            "message": "Unused argument 'response'"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/eventqueue.py",
+                "module": null,
+                "function": null,
+                "line": 68,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/eventqueue.py",
+                "module": null,
+                "function": null,
+                "line": 75,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/eventqueue.py",
+                "module": "h.eventqueue",
+                "function": "EventQueue",
+                "line": 22,
+                "character": 0
+            },
+            "message": "Class 'EventQueue' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "broad-except",
+            "location": {
+                "path": "h/eventqueue.py",
+                "module": "h.eventqueue",
+                "function": "EventQueue.publish_all",
+                "line": 63,
+                "character": 23
+            },
+            "message": "Catching too general exception Exception"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/accounts/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/accounts/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/accounts/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 17,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/accounts/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 17,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/accounts/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 28,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/accounts/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/accounts/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/accounts/subscribers.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/accounts/subscribers.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/accounts/subscribers.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/accounts/subscribers.py",
+                "module": null,
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/accounts/subscribers.py",
+                "module": null,
+                "function": null,
+                "line": 25,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/accounts/subscribers.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": "h.accounts.events",
+                "function": "ActivationEvent",
+                "line": 5,
+                "character": 0
+            },
+            "message": "Class 'ActivationEvent' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": null,
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": null,
+                "function": null,
+                "line": 6,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": "h.accounts.events",
+                "function": "LoginEvent",
+                "line": 11,
+                "character": 0
+            },
+            "message": "Class 'LoginEvent' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": "h.accounts.events",
+                "function": "LogoutEvent",
+                "line": 17,
+                "character": 0
+            },
+            "message": "Class 'LogoutEvent' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": null,
+                "function": null,
+                "line": 17,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": "h.accounts.events",
+                "function": "PasswordResetEvent",
+                "line": 22,
+                "character": 0
+            },
+            "message": "Class 'PasswordResetEvent' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": null,
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/accounts/events.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 27,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 88,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'd')"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 135,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 167,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": "h.accounts.schemas",
+                "function": "EmailChangeSchema.validator",
+                "line": 172,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'validator' method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 172,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 186,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": "h.accounts.schemas",
+                "function": "PasswordChangeSchema.validator",
+                "line": 198,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'validator' method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 198,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 215,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": "h.accounts.schemas",
+                "function": "includeme",
+                "line": 224,
+                "character": 14
+            },
+            "message": "Unused argument 'config'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": null,
+                "function": null,
+                "line": 224,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-builtin",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": "h.accounts.schemas",
+                "function": null,
+                "line": 3,
+                "character": 0
+            },
+            "message": "Redefining built-in 'open'"
+        },
+        {
+            "source": "pylint",
+            "code": "global-statement",
+            "location": {
+                "path": "h/accounts/schemas.py",
+                "module": "h.accounts.schemas",
+                "function": "get_blacklist",
+                "line": 28,
+                "character": 4
+            },
+            "message": "Using the global statement"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/accounts/util.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/accounts/util.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/accounts/util.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-format-args",
+            "location": {
+                "path": "h/accounts/util.py",
+                "module": "h.accounts.util",
+                "function": "validate_orcid",
+                "line": 51,
+                "character": 25
+            },
+            "message": "Too many arguments for format string"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/accounts/util.py",
+                "module": "h.accounts.util",
+                "function": "_orcid_checksum_digit",
+                "line": 76,
+                "character": 4
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/security.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/security.py",
+                "module": "h.security",
+                "function": null,
+                "line": 25,
+                "character": 0
+            },
+            "message": "Constant name \"password_context\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/jinja_extensions.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/jinja_extensions.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/jinja_extensions.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/jinja_extensions.py",
+                "module": null,
+                "function": null,
+                "line": 27,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/jinja_extensions.py",
+                "module": null,
+                "function": null,
+                "line": 44,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/jinja_extensions.py",
+                "module": null,
+                "function": null,
+                "line": 49,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/jinja_extensions.py",
+                "module": null,
+                "function": null,
+                "line": 74,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/jinja_extensions.py",
+                "module": null,
+                "function": null,
+                "line": 74,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/jinja_extensions.py",
+                "module": null,
+                "function": null,
+                "line": 78,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/jinja_extensions.py",
+                "module": null,
+                "function": null,
+                "line": 88,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/jinja_extensions.py",
+                "module": "h.jinja_extensions",
+                "function": "Filters",
+                "line": 21,
+                "character": 0
+            },
+            "message": "Method 'parse' is abstract in class 'Extension' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/jinja_extensions.py",
+                "module": "h.jinja_extensions",
+                "function": "SvgIcon",
+                "line": 72,
+                "character": 0
+            },
+            "message": "Method 'parse' is abstract in class 'Extension' but is not overridden"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/search/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/search/parser.py",
+                "module": null,
+                "function": null,
+                "line": 3,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/search/parser.py",
+                "module": null,
+                "function": null,
+                "line": 3,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'd')"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/search/parser.py",
+                "module": null,
+                "function": null,
+                "line": 56,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/search/parser.py",
+                "module": "h.search.parser",
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "Constant name \"named_fields\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/search/parser.py",
+                "module": "h.search.parser",
+                "function": null,
+                "line": 21,
+                "character": 0
+            },
+            "message": "Constant name \"whitespace\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/search/parser.py",
+                "module": "h.search.parser",
+                "function": "parse",
+                "line": 55,
+                "character": 0
+            },
+            "message": "Argument name \"q\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/search/parser.py",
+                "module": "h.search.parser",
+                "function": "parse",
+                "line": 71,
+                "character": 4
+            },
+            "message": "Redefining name 'parser' from outer scope (line 51)"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/search/parser.py",
+                "module": "h.search.parser",
+                "function": "unparse",
+                "line": 80,
+                "character": 0
+            },
+            "message": "Argument name \"q\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "global-statement",
+            "location": {
+                "path": "h/search/parser.py",
+                "module": "h.search.parser",
+                "function": "_get_parser",
+                "line": 100,
+                "character": 4
+            },
+            "message": "Using the global statement"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/search/parser.py",
+                "module": "h.search.parser",
+                "function": "_decorate_match.parse_action_impl",
+                "line": 133,
+                "character": 4
+            },
+            "message": "Argument name \"t\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/search/parser.py",
+                "module": "h.search.parser",
+                "function": "_escape_term",
+                "line": 143,
+                "character": 8
+            },
+            "message": "Unnecessary \"elif\" after \"return\""
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D210",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "No whitespaces allowed surrounding docstring text"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 't')"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 37,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 50,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 91,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 124,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Convert', not 'Converts')"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 152,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 154,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 160,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 160,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 164,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 167,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 173,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 188,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 200,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 200,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 204,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 216,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 220,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 227,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 243,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 254,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D301",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 300,
+                "character": 0
+            },
+            "message": "Use r\"\"\" if any backslashes in a docstring"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 300,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'Same')"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 324,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 324,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 328,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 339,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 346,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 353,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 379,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 379,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 383,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 398,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 400,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 410,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 412,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 415,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "TagsAggregation",
+                "line": 421,
+                "character": 0
+            },
+            "message": "Class 'TagsAggregation' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 421,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 422,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 426,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 429,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "UsersAggregation",
+                "line": 436,
+                "character": 0
+            },
+            "message": "Class 'UsersAggregation' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 436,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 437,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 441,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/query.py",
+                "module": null,
+                "function": null,
+                "line": 444,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": null,
+                "line": 6,
+                "character": 0
+            },
+            "message": "standard import \"from datetime import datetime as dt\" should be placed before \"from dateutil.parser import parse\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "third party import \"from elasticsearch_dsl import Q\" should be placed before \"from h import storage\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "third party import \"from elasticsearch_dsl.query import SimpleQueryString\" should be placed before \"from h import storage\""
+        },
+        {
+            "source": "pylint",
+            "code": "ungrouped-imports",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Imports from package h are not grouped"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "KeyValueMatcher",
+                "line": 29,
+                "character": 0
+            },
+            "message": "Class 'KeyValueMatcher' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "Limiter",
+                "line": 43,
+                "character": 0
+            },
+            "message": "Class 'Limiter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "Limiter._extract_offset",
+                "line": 55,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "Limiter._extract_limit",
+                "line": 66,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "Sorter",
+                "line": 80,
+                "character": 0
+            },
+            "message": "Class 'Sorter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "Sorter._parse_date",
+                "line": 123,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "TopLevelAnnotationsFilter",
+                "line": 150,
+                "character": 0
+            },
+            "message": "Class 'TopLevelAnnotationsFilter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "AuthorityFilter",
+                "line": 158,
+                "character": 0
+            },
+            "message": "Class 'AuthorityFilter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "AuthFilter",
+                "line": 171,
+                "character": 0
+            },
+            "message": "Class 'AuthFilter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "GroupFilter",
+                "line": 198,
+                "character": 0
+            },
+            "message": "Class 'GroupFilter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "GroupAuthFilter",
+                "line": 213,
+                "character": 0
+            },
+            "message": "Class 'GroupAuthFilter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "UriCombinedWildcardFilter",
+                "line": 225,
+                "character": 0
+            },
+            "message": "Class 'UriCombinedWildcardFilter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "UriCombinedWildcardFilter._normalize_uris",
+                "line": 295,
+                "character": 12
+            },
+            "message": "Variable name \"us\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "UriCombinedWildcardFilter._wildcard_uri_normalized",
+                "line": 299,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "UserFilter",
+                "line": 322,
+                "character": 0
+            },
+            "message": "Class 'UserFilter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "DeletedFilter",
+                "line": 337,
+                "character": 0
+            },
+            "message": "Class 'DeletedFilter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "HiddenFilter",
+                "line": 350,
+                "character": 0
+            },
+            "message": "Class 'HiddenFilter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "AnyMatcher",
+                "line": 377,
+                "character": 0
+            },
+            "message": "Class 'AnyMatcher' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "AnyMatcher.__call__",
+                "line": 386,
+                "character": 8
+            },
+            "message": "Variable name \"qs\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "TagsMatcher",
+                "line": 396,
+                "character": 0
+            },
+            "message": "Class 'TagsMatcher' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/query.py",
+                "module": "h.search.query",
+                "function": "RepliesMatcher",
+                "line": 408,
+                "character": 0
+            },
+            "message": "Class 'RepliesMatcher' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/search/core.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/search/core.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/search/core.py",
+                "module": null,
+                "function": null,
+                "line": 76,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'y')"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/search/core.py",
+                "module": null,
+                "function": null,
+                "line": 108,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/search/core.py",
+                "module": null,
+                "function": null,
+                "line": 108,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Apply', not 'Applies')"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/core.py",
+                "module": "h.search.core",
+                "function": "Search",
+                "line": 20,
+                "character": 0
+            },
+            "message": "Class 'Search' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/search/core.py",
+                "module": "h.search.core",
+                "function": "Search._instrument",
+                "line": 178,
+                "character": 8
+            },
+            "message": "Variable name \"s\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/search/index.py",
+                "module": null,
+                "function": null,
+                "line": 25,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/search/index.py",
+                "module": null,
+                "function": null,
+                "line": 64,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/search/index.py",
+                "module": null,
+                "function": null,
+                "line": 99,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/search/index.py",
+                "module": null,
+                "function": null,
+                "line": 99,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'o')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/search/index.py",
+                "module": null,
+                "function": null,
+                "line": 104,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/search/index.py",
+                "module": "h.search.index",
+                "function": "BatchIndexer.__init__",
+                "line": 104,
+                "character": 4
+            },
+            "message": "Too many arguments (6/5)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/search/index.py",
+                "module": null,
+                "function": null,
+                "line": 210,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'Default')"
+        },
+        {
+            "source": "pylint",
+            "code": "ungrouped-imports",
+            "location": {
+                "path": "h/search/index.py",
+                "module": "h.search.index",
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Imports from package sqlalchemy are not grouped"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/index.py",
+                "module": "h.search.index",
+                "function": "BatchIndexer",
+                "line": 98,
+                "character": 0
+            },
+            "message": "Class 'BatchIndexer' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/search/index.py",
+                "module": "h.search.index",
+                "function": "BatchIndexer.index",
+                "line": 150,
+                "character": 12
+            },
+            "message": "Variable name \"ok\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/search/index.py",
+                "module": "h.search.index",
+                "function": "_all_annotations",
+                "line": 193,
+                "character": 12
+            },
+            "message": "Variable name \"a\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/search/index.py",
+                "module": "h.search.index",
+                "function": "_filtered_annotations",
+                "line": 205,
+                "character": 8
+            },
+            "message": "Variable name \"a\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/search/config.py",
+                "module": null,
+                "function": null,
+                "line": 184,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/search/config.py",
+                "module": "h.search.config",
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "standard import \"import logging\" should be placed before \"import elasticsearch\""
+        },
+        {
+            "source": "pylint",
+            "code": "wrong-import-order",
+            "location": {
+                "path": "h/search/config.py",
+                "module": "h.search.config",
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "standard import \"import os\" should be placed before \"import elasticsearch\""
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/search/util.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/search/util.py",
+                "module": null,
+                "function": null,
+                "line": 38,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/search/util.py",
+                "module": null,
+                "function": null,
+                "line": 38,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/search/client.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/search/client.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/search/client.py",
+                "module": null,
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/search/client.py",
+                "module": "h.search.client",
+                "function": "Client.__init__",
+                "line": 20,
+                "character": 36
+            },
+            "message": "Redefining name 'elasticsearch' from outer scope (line 4)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/client.py",
+                "module": null,
+                "function": null,
+                "line": 32,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/search/client.py",
+                "module": null,
+                "function": null,
+                "line": 36,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/search/client.py",
+                "module": null,
+                "function": null,
+                "line": 53,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'The')"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/search/client.py",
+                "module": "h.search.client",
+                "function": "Client",
+                "line": 7,
+                "character": 0
+            },
+            "message": "Class 'Client' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/renderers.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/renderers.py",
+                "module": null,
+                "function": null,
+                "line": 28,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/renderers.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/renderers.py",
+                "module": null,
+                "function": null,
+                "line": 47,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/renderers.py",
+                "module": "h.renderers",
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Constant name \"json_sorted_factory\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/renderers.py",
+                "module": "h.renderers",
+                "function": "SVGRenderer",
+                "line": 11,
+                "character": 0
+            },
+            "message": "Class 'SVGRenderer' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/links.py",
+                "module": null,
+                "function": null,
+                "line": 3,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/links.py",
+                "module": null,
+                "function": null,
+                "line": 60,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/links.py",
+                "module": null,
+                "function": null,
+                "line": 64,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/links.py",
+                "module": null,
+                "function": null,
+                "line": 68,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/streamer/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/streamer/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/streamer/views.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/streamer/views.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/views.py",
+                "module": "h.streamer.views",
+                "function": "notfound",
+                "line": 34,
+                "character": 13
+            },
+            "message": "Unused argument 'exc'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/streamer/views.py",
+                "module": null,
+                "function": null,
+                "line": 34,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/views.py",
+                "module": "h.streamer.views",
+                "function": "forbidden",
+                "line": 45,
+                "character": 14
+            },
+            "message": "Unused argument 'exc'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/streamer/views.py",
+                "module": null,
+                "function": null,
+                "line": 45,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/views.py",
+                "module": "h.streamer.views",
+                "function": "error_badhandshake",
+                "line": 57,
+                "character": 23
+            },
+            "message": "Unused argument 'exc'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/streamer/views.py",
+                "module": null,
+                "function": null,
+                "line": 57,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/views.py",
+                "module": "h.streamer.views",
+                "function": "error",
+                "line": 68,
+                "character": 10
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/streamer/views.py",
+                "module": null,
+                "function": null,
+                "line": 68,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/streamer/views.py",
+                "module": null,
+                "function": null,
+                "line": 80,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "misplaced-bare-raise",
+            "location": {
+                "path": "h/streamer/views.py",
+                "module": "h.streamer.views",
+                "function": "error",
+                "line": 72,
+                "character": 8
+            },
+            "message": "The raise statement is not inside an except clause"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": "h.streamer.filter",
+                "function": "FilterHandler",
+                "line": 35,
+                "character": 0
+            },
+            "message": "Class 'FilterHandler' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": null,
+                "function": null,
+                "line": 35,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": null,
+                "function": null,
+                "line": 36,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": "h.streamer.filter",
+                "function": "FilterHandler.evaluate_clause",
+                "line": 39,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": null,
+                "function": null,
+                "line": 39,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": null,
+                "function": null,
+                "line": 78,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": "h.streamer.filter",
+                "function": "FilterHandler.match",
+                "line": 84,
+                "character": 28
+            },
+            "message": "Unused argument 'action'"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": null,
+                "function": null,
+                "line": 84,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": "h.streamer.filter",
+                "function": "FilterHandler.evaluate_clause",
+                "line": 66,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": "h.streamer.filter",
+                "function": "FilterHandler.evaluate_clause",
+                "line": 71,
+                "character": 12
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": "h.streamer.filter",
+                "function": "FilterHandler.match",
+                "line": 85,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "len-as-condition",
+            "location": {
+                "path": "h/streamer/filter.py",
+                "module": "h.streamer.filter",
+                "function": "FilterHandler.match",
+                "line": 85,
+                "character": 11
+            },
+            "message": "Do not use `len(SEQUENCE)` to determine if a sequence is empty"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/streamer/messages.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/streamer/messages.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/streamer/messages.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/streamer/messages.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'd')"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/streamer/messages.py",
+                "module": null,
+                "function": null,
+                "line": 89,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/messages.py",
+                "module": "h.streamer.messages",
+                "function": "handle_user_event",
+                "line": 112,
+                "character": 40
+            },
+            "message": "Unused argument 'settings'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/messages.py",
+                "module": "h.streamer.messages",
+                "function": "handle_user_event",
+                "line": 112,
+                "character": 50
+            },
+            "message": "Unused argument 'session'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/streamer/messages.py",
+                "module": null,
+                "function": null,
+                "line": 112,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/streamer/messages.py",
+                "module": null,
+                "function": null,
+                "line": 191,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-return-statements",
+            "location": {
+                "path": "h/streamer/messages.py",
+                "module": "h.streamer.messages",
+                "function": "_generate_annotation_event",
+                "line": 120,
+                "character": 0
+            },
+            "message": "Too many return statements (7/6)"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 25,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 52,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": "h.streamer.websocket",
+                "function": "WebSocket.__new__",
+                "line": 67,
+                "character": 0
+            },
+            "message": "Unused argument 'args'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": "h.streamer.websocket",
+                "function": "WebSocket.__new__",
+                "line": 67,
+                "character": 0
+            },
+            "message": "Unused argument 'kwargs'"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 67,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": "h.streamer.websocket",
+                "function": "WebSocket.received_message",
+                "line": 72,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'received_message' method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 72,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 86,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 92,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 128,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 145,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 180,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 188,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-builtin",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": "h.streamer.websocket",
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Redefining built-in 'filter'"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": "h.streamer.websocket",
+                "function": "Message.reply",
+                "line": 26,
+                "character": 4
+            },
+            "message": "Argument name \"ok\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": "h.streamer.websocket",
+                "function": "handle_client_id_message",
+                "line": 127,
+                "character": 38
+            },
+            "message": "Unused argument 'session'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": "h.streamer.websocket",
+                "function": "handle_ping_message",
+                "line": 179,
+                "character": 33
+            },
+            "message": "Unused argument 'session'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": "h.streamer.websocket",
+                "function": "handle_whoami_message",
+                "line": 187,
+                "character": 35
+            },
+            "message": "Unused argument 'session'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/streamer/websocket.py",
+                "module": "h.streamer.websocket",
+                "function": "handle_unknown_message",
+                "line": 195,
+                "character": 36
+            },
+            "message": "Unused argument 'session'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/streamer/streamer.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/streamer/streamer.py",
+                "module": null,
+                "function": null,
+                "line": 111,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/streamer/streamer.py",
+                "module": null,
+                "function": null,
+                "line": 119,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/streamer/streamer.py",
+                "module": "h.streamer.streamer",
+                "function": "process_work_queue",
+                "line": 68,
+                "character": 4
+            },
+            "message": "Variable name \"s\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "broad-except",
+            "location": {
+                "path": "h/streamer/streamer.py",
+                "module": "h.streamer.streamer",
+                "function": "process_work_queue",
+                "line": 100,
+                "character": 15
+            },
+            "message": "Catching too general exception Exception"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/stats.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/stats.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-statements",
+            "location": {
+                "path": "h/config.py",
+                "module": "h.config",
+                "function": "configure",
+                "line": 30,
+                "character": 0
+            },
+            "message": "Too many statements (58/50)"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/config.py",
+                "module": null,
+                "function": null,
+                "line": 30,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "trailing-comma-tuple",
+            "location": {
+                "path": "h/config.py",
+                "module": "h.config",
+                "function": null,
+                "line": 52,
+                "character": 0
+            },
+            "message": "Disallow trailing comma tuple"
+        },
+        {
+            "source": "pylint",
+            "code": "expression-not-assigned",
+            "location": {
+                "path": "h/config.py",
+                "module": "h.config",
+                "function": "configure",
+                "line": 52,
+                "character": 4
+            },
+            "message": "Expression \"(settings_manager.set('es.url', 'ELASTICSEARCH_URL', required=True), )\" is assigned to nothing"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/panels/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/panels/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/panels/back_link.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/panels/back_link.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/panels/back_link.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/panels/back_link.py",
+                "module": null,
+                "function": null,
+                "line": 35,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/panels/back_link.py",
+                "module": null,
+                "function": null,
+                "line": 35,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/panels/back_link.py",
+                "module": "h.panels.back_link",
+                "function": "back_link",
+                "line": 14,
+                "character": 14
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/panels/navbar.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/panels/navbar.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'The')"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/panels/navbar.py",
+                "module": "h.panels.navbar",
+                "function": "navbar",
+                "line": 13,
+                "character": 11
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 26,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/realtime.py",
+                "module": "h.realtime",
+                "function": "Consumer.get_consumers",
+                "line": 33,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'get_consumers' method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 33,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 44,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 48,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 48,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 48,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Handle', not 'Handles')"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 58,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'g')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 89,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 118,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 118,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Return', not 'Returns')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 126,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 126,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Return', not 'Returns')"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/realtime.py",
+                "module": null,
+                "function": null,
+                "line": 132,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/realtime.py",
+                "module": "h.realtime",
+                "function": "Consumer._random_id",
+                "line": 57,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/realtime.py",
+                "module": "h.realtime",
+                "function": "Publisher",
+                "line": 79,
+                "character": 0
+            },
+            "message": "Class 'Publisher' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/sentry/helpers/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/sentry/helpers/event.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/sentry/helpers/event.py",
+                "module": null,
+                "function": null,
+                "line": 24,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'The')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/sentry/helpers/event.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'The')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/sentry/helpers/event.py",
+                "module": null,
+                "function": null,
+                "line": 34,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'The')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/sentry/helpers/event.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'The')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/sentry/helpers/event.py",
+                "module": null,
+                "function": null,
+                "line": 52,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'The')"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/sentry/helpers/event.py",
+                "module": "h.sentry.helpers.event",
+                "function": "Event",
+                "line": 15,
+                "character": 0
+            },
+            "message": "Class 'Event' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/sentry/helpers/event.py",
+                "module": "h.sentry.helpers.event",
+                "function": "Event",
+                "line": 15,
+                "character": 0
+            },
+            "message": "Class 'Event' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/sentry/helpers/before_send.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/viewpredicates.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/viewpredicates.py",
+                "module": "h.viewpredicates",
+                "function": "FeaturePredicate.__init__",
+                "line": 10,
+                "character": 32
+            },
+            "message": "Unused argument 'config'"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/viewpredicates.py",
+                "module": null,
+                "function": null,
+                "line": 13,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/viewpredicates.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/viewpredicates.py",
+                "module": null,
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/viewpredicates.py",
+                "module": "h.viewpredicates",
+                "function": "FeaturePredicate",
+                "line": 7,
+                "character": 0
+            },
+            "message": "Class 'FeaturePredicate' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/i18n.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/i18n.py",
+                "module": "h.i18n",
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "Constant name \"TranslationString\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/session.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/session.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/session.py",
+                "module": null,
+                "function": null,
+                "line": 49,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Return', not 'Returns')"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/session.py",
+                "module": null,
+                "function": null,
+                "line": 61,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/session.py",
+                "module": null,
+                "function": null,
+                "line": 68,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/session.py",
+                "module": null,
+                "function": null,
+                "line": 68,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/session.py",
+                "module": null,
+                "function": null,
+                "line": 100,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/session.py",
+                "module": "h.session",
+                "function": "profile",
+                "line": 36,
+                "character": 4
+            },
+            "message": "Redefining name 'profile' from outer scope (line 19)"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/session.py",
+                "module": "h.session",
+                "function": "_group_model",
+                "line": 82,
+                "character": 4
+            },
+            "message": "Redefining name 'model' from outer scope (line 9)"
+        },
+        {
+            "source": "pep257",
+            "code": "D104",
+            "location": {
+                "path": "h/indexer/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public package"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/indexer/subscribers.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/indexer/subscribers.py",
+                "module": null,
+                "function": null,
+                "line": 7,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/indexer/reindexer.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/indexer/reindexer.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "logging-format-interpolation",
+            "location": {
+                "path": "h/indexer/reindexer.py",
+                "module": "h.indexer.reindexer",
+                "function": "reindex",
+                "line": 31,
+                "character": 13
+            },
+            "message": "Use % formatting in logging functions and pass the % parameters as arguments"
+        },
+        {
+            "source": "pylint",
+            "code": "logging-format-interpolation",
+            "location": {
+                "path": "h/indexer/reindexer.py",
+                "module": "h.indexer.reindexer",
+                "function": "reindex",
+                "line": 38,
+                "character": 17
+            },
+            "message": "Use % formatting in logging functions and pass the % parameters as arguments"
+        },
+        {
+            "source": "pylint",
+            "code": "logging-format-interpolation",
+            "location": {
+                "path": "h/indexer/reindexer.py",
+                "module": "h.indexer.reindexer",
+                "function": "reindex",
+                "line": 46,
+                "character": 16
+            },
+            "message": "Use % formatting in logging functions and pass the % parameters as arguments"
+        },
+        {
+            "source": "pylint",
+            "code": "logging-format-interpolation",
+            "location": {
+                "path": "h/indexer/reindexer.py",
+                "module": "h.indexer.reindexer",
+                "function": "reindex",
+                "line": 51,
+                "character": 20
+            },
+            "message": "Use % formatting in logging functions and pass the % parameters as arguments"
+        },
+        {
+            "source": "pylint",
+            "code": "logging-format-interpolation",
+            "location": {
+                "path": "h/indexer/reindexer.py",
+                "module": "h.indexer.reindexer",
+                "function": "reindex",
+                "line": 54,
+                "character": 17
+            },
+            "message": "Use % formatting in logging functions and pass the % parameters as arguments"
+        },
+        {
+            "source": "pylint",
+            "code": "logging-format-interpolation",
+            "location": {
+                "path": "h/indexer/reindexer.py",
+                "module": "h.indexer.reindexer",
+                "function": "reindex",
+                "line": 57,
+                "character": 17
+            },
+            "message": "Use % formatting in logging functions and pass the % parameters as arguments"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/flag.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/flag.py",
+                "module": "h.services.flag",
+                "function": "FlagService",
+                "line": 8,
+                "character": 0
+            },
+            "message": "Class 'FlagService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/flag.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/flag.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/flag.py",
+                "module": "h.services.flag",
+                "function": "flag_service_factory",
+                "line": 79,
+                "character": 25
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/flag.py",
+                "module": null,
+                "function": null,
+                "line": 79,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "consider-using-set-comprehension",
+            "location": {
+                "path": "h/services/flag.py",
+                "module": "h.services.flag",
+                "function": "FlagService.all_flagged",
+                "line": 52,
+                "character": 15
+            },
+            "message": "Consider using a set comprehension"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/annotation_json_presentation.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/annotation_json_presentation.py",
+                "module": "h.services.annotation_json_presentation",
+                "function": "AnnotationJSONPresentationService",
+                "line": 15,
+                "character": 0
+            },
+            "message": "Class 'AnnotationJSONPresentationService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/annotation_json_presentation.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/annotation_json_presentation.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/services/annotation_json_presentation.py",
+                "module": "h.services.annotation_json_presentation",
+                "function": "AnnotationJSONPresentationService.__init__",
+                "line": 16,
+                "character": 4
+            },
+            "message": "Too many arguments (10/5)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/annotation_json_presentation.py",
+                "module": null,
+                "function": null,
+                "line": 44,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/annotation_json_presentation.py",
+                "module": null,
+                "function": null,
+                "line": 48,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/annotation_json_presentation.py",
+                "module": "h.services.annotation_json_presentation",
+                "function": "annotation_json_presentation_service_factory",
+                "line": 71,
+                "character": 49
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/annotation_json_presentation.py",
+                "module": null,
+                "function": null,
+                "line": 71,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D208",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "Docstring is over-indented"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 43,
+                "character": 0
+            },
+            "message": "First line should end with a period (not ',')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 118,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 136,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 150,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'y')"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 209,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 209,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D210",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 222,
+                "character": 0
+            },
+            "message": "No whitespaces allowed surrounding docstring text"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 222,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D403",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": null,
+                "function": null,
+                "line": 222,
+                "character": 0
+            },
+            "message": "First word of the first line should be properly capitalized ('Sort', not 'sort')"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": "h.services.group_list",
+                "function": "GroupListService",
+                "line": 10,
+                "character": 0
+            },
+            "message": "Class 'GroupListService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": "h.services.group_list",
+                "function": "GroupListService._sort",
+                "line": 221,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/group_list.py",
+                "module": "h.services.group_list",
+                "function": "group_list_factory",
+                "line": 226,
+                "character": 23
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/organization.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/services/organization.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/organization.py",
+                "module": "h.services.organization",
+                "function": "OrganizationService",
+                "line": 7,
+                "character": 0
+            },
+            "message": "Class 'OrganizationService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/organization.py",
+                "module": "h.services.organization",
+                "function": "organization_factory",
+                "line": 36,
+                "character": 25
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/rename_user.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/rename_user.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/rename_user.py",
+                "module": null,
+                "function": null,
+                "line": 31,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/rename_user.py",
+                "module": null,
+                "function": null,
+                "line": 35,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/rename_user.py",
+                "module": null,
+                "function": null,
+                "line": 46,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/rename_user.py",
+                "module": null,
+                "function": null,
+                "line": 95,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/rename_user.py",
+                "module": "h.services.rename_user",
+                "function": "RenameUserService",
+                "line": 13,
+                "character": 0
+            },
+            "message": "Class 'RenameUserService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/rename_user.py",
+                "module": "h.services.rename_user",
+                "function": "rename_user_factory",
+                "line": 107,
+                "character": 24
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 27,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 28,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 35,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 48,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 48,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Return', not 'Returns')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 57,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 57,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 57,
+                "character": 0
+            },
+            "message": "First line should end with a period (not ')')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 57,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Verify', not 'Verifies')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 92,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 110,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": null,
+                "function": null,
+                "line": 123,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": "h.services.auth_ticket",
+                "function": "AuthTicketService",
+                "line": 26,
+                "character": 0
+            },
+            "message": "Class 'AuthTicketService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/auth_ticket.py",
+                "module": "h.services.auth_ticket",
+                "function": "auth_ticket_service_factory",
+                "line": 117,
+                "character": 32
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/auth_token.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/auth_token.py",
+                "module": "h.services.auth_token",
+                "function": "AuthTokenService",
+                "line": 9,
+                "character": 0
+            },
+            "message": "Class 'AuthTokenService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/auth_token.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/auth_token.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/auth_token.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/auth_token.py",
+                "module": "h.services.auth_token",
+                "function": "auth_token_service_factory",
+                "line": 66,
+                "character": 31
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/auth_token.py",
+                "module": null,
+                "function": null,
+                "line": 66,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/developer_token.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/developer_token.py",
+                "module": null,
+                "function": null,
+                "line": 38,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Create', not 'Creates')"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/developer_token.py",
+                "module": "h.services.developer_token",
+                "function": "developer_token_service_factory",
+                "line": 83,
+                "character": 36
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/developer_token.py",
+                "module": null,
+                "function": null,
+                "line": 83,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/developer_token.py",
+                "module": "h.services.developer_token",
+                "function": "DeveloperTokenService",
+                "line": 12,
+                "character": 0
+            },
+            "message": "Class 'DeveloperTokenService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/services/developer_token.py",
+                "module": "h.services.developer_token",
+                "function": "DeveloperTokenService._generate_token",
+                "line": 79,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/user_update.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/user_update.py",
+                "module": "h.services.user_update",
+                "function": "UserUpdateService",
+                "line": 10,
+                "character": 0
+            },
+            "message": "Class 'UserUpdateService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/user_update.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/user_update.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/user_update.py",
+                "module": null,
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/user_update.py",
+                "module": "h.services.user_update",
+                "function": "user_update_factory",
+                "line": 68,
+                "character": 24
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 35,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 50,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Authenticate', not 'Authenticates')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 68,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Authenticate', not 'Authenticates')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 78,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 121,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 124,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 127,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 131,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 131,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Return', not 'Returns')"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 188,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 202,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Save', not 'Saves')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 229,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 229,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Check', not 'Checks')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 266,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Validate', not 'Validates')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 276,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 310,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 321,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": null,
+                "function": null,
+                "line": 360,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "Client",
+                "line": 20,
+                "character": 0
+            },
+            "message": "Class 'Client' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService",
+                "line": 28,
+                "character": 0
+            },
+            "message": "Method 'get_id_token' is abstract in class 'RequestValidator' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService",
+                "line": 28,
+                "character": 0
+            },
+            "message": "Method 'validate_bearer_token' is abstract in class 'RequestValidator' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService",
+                "line": 28,
+                "character": 0
+            },
+            "message": "Method 'validate_silent_authorization' is abstract in class 'RequestValidator' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService",
+                "line": 28,
+                "character": 0
+            },
+            "message": "Method 'validate_silent_login' is abstract in class 'RequestValidator' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService",
+                "line": 28,
+                "character": 0
+            },
+            "message": "Method 'validate_user' is abstract in class 'RequestValidator' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "abstract-method",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService",
+                "line": 28,
+                "character": 0
+            },
+            "message": "Method 'validate_user_match' is abstract in class 'RequestValidator' but is not overridden"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-public-methods",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService",
+                "line": 28,
+                "character": 0
+            },
+            "message": "Too many public methods (22/20)"
+        },
+        {
+            "source": "pylint",
+            "code": "inconsistent-return-statements",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService.get_default_redirect_uri",
+                "line": 130,
+                "character": 4
+            },
+            "message": "Either all return statements in a function should return an expression, or none of them should."
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService.invalidate_refresh_token",
+                "line": 151,
+                "character": 0
+            },
+            "message": "Unused argument 'args'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService.invalidate_refresh_token",
+                "line": 151,
+                "character": 0
+            },
+            "message": "Unused argument 'kwargs'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService.invalidate_refresh_token",
+                "line": 151,
+                "character": 54
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService.validate_response_type",
+                "line": 307,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'validate_response_type' method"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "OAuthValidatorService.validate_scopes",
+                "line": 320,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'validate_scopes' method"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/oauth_validator.py",
+                "module": "h.services.oauth_validator",
+                "function": "oauth_validator_service_factory",
+                "line": 354,
+                "character": 36
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/delete_user.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/delete_user.py",
+                "module": "h.services.delete_user",
+                "function": "DeleteUserService",
+                "line": 10,
+                "character": 0
+            },
+            "message": "Class 'DeleteUserService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/delete_user.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/delete_user.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/delete_user.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/delete_user.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Delete', not 'Deletes')"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/services/delete_user.py",
+                "module": null,
+                "function": null,
+                "line": 35,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/delete_user.py",
+                "module": "h.services.delete_user",
+                "function": "delete_user_service_factory",
+                "line": 78,
+                "character": 32
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/delete_user.py",
+                "module": null,
+                "function": null,
+                "line": 78,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "len-as-condition",
+            "location": {
+                "path": "h/services/delete_user.py",
+                "module": "h.services.delete_user",
+                "function": "DeleteUserService._groups_that_have_collaborators",
+                "line": 50,
+                "character": 11
+            },
+            "message": "Do not use `len(SEQUENCE)` to determine if a sequence is empty"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/services/delete_user.py",
+                "module": "h.services.delete_user",
+                "function": "DeleteUserService._unassign_groups_creator",
+                "line": 73,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/group_members.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/services/group_members.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/group_members.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/services/group_members.py",
+                "module": null,
+                "function": null,
+                "line": 38,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/group_members.py",
+                "module": null,
+                "function": null,
+                "line": 38,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'y')"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/group_members.py",
+                "module": "h.services.group_members",
+                "function": "GroupMembersService",
+                "line": 9,
+                "character": 0
+            },
+            "message": "Class 'GroupMembersService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/services/group_members.py",
+                "module": "h.services.group_members",
+                "function": "GroupMembersService.__init__",
+                "line": 13,
+                "character": 23
+            },
+            "message": "Redefining name 'session' from outer scope (line 6)"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/group_members.py",
+                "module": "h.services.group_members",
+                "function": "group_members_factory",
+                "line": 84,
+                "character": 26
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/group_create.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/group_create.py",
+                "module": "h.services.group_create",
+                "function": "GroupCreateService",
+                "line": 16,
+                "character": 0
+            },
+            "message": "Class 'GroupCreateService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/group_create.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/services/group_create.py",
+                "module": "h.services.group_create",
+                "function": "GroupCreateService.__init__",
+                "line": 17,
+                "character": 23
+            },
+            "message": "Redefining name 'session' from outer scope (line 7)"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/services/group_create.py",
+                "module": "h.services.group_create",
+                "function": "GroupCreateService._create",
+                "line": 98,
+                "character": 4
+            },
+            "message": "Too many arguments (6/5)"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/services/group_create.py",
+                "module": "h.services.group_create",
+                "function": "GroupCreateService._validate_authorities_match",
+                "line": 146,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/group_create.py",
+                "module": "h.services.group_create",
+                "function": "group_create_factory",
+                "line": 155,
+                "character": 25
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/feature.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/feature.py",
+                "module": null,
+                "function": null,
+                "line": 13,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/feature.py",
+                "module": null,
+                "function": null,
+                "line": 25,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/feature.py",
+                "module": null,
+                "function": null,
+                "line": 52,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/services/feature.py",
+                "module": null,
+                "function": null,
+                "line": 74,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/feature.py",
+                "module": null,
+                "function": null,
+                "line": 74,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/feature.py",
+                "module": null,
+                "function": null,
+                "line": 74,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Return', not 'Returns')"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/feature.py",
+                "module": "h.services.feature",
+                "function": "feature_service_factory",
+                "line": 105,
+                "character": 28
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/feature.py",
+                "module": null,
+                "function": null,
+                "line": 105,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/feature.py",
+                "module": "h.services.feature",
+                "function": "FeatureRequestProperty",
+                "line": 17,
+                "character": 0
+            },
+            "message": "Class 'FeatureRequestProperty' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/feature.py",
+                "module": "h.services.feature",
+                "function": "FeatureService",
+                "line": 38,
+                "character": 0
+            },
+            "message": "Class 'FeatureService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/services/feature.py",
+                "module": "h.services.feature",
+                "function": "_feature_overrides",
+                "line": 119,
+                "character": 8
+            },
+            "message": "Variable name \"m\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/user_unique.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/user_unique.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 's')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/user_unique.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-super-delegation",
+            "location": {
+                "path": "h/services/user_unique.py",
+                "module": "h.services.user_unique",
+                "function": "DuplicateUserError.__init__",
+                "line": 12,
+                "character": 4
+            },
+            "message": "Useless super delegation in method '__init__'"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/services/user_unique.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/services/user_unique.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/user_unique.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'l')"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/services/user_unique.py",
+                "module": null,
+                "function": null,
+                "line": 33,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/user_unique.py",
+                "module": null,
+                "function": null,
+                "line": 33,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/user_unique.py",
+                "module": "h.services.user_unique",
+                "function": "user_unique_factory",
+                "line": 82,
+                "character": 24
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/user_unique.py",
+                "module": null,
+                "function": null,
+                "line": 82,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/user_unique.py",
+                "module": "h.services.user_unique",
+                "function": "UserUniqueService",
+                "line": 16,
+                "character": 0
+            },
+            "message": "Class 'UserUniqueService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/nipsa.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/services/nipsa.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/services/nipsa.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/nipsa.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "First line should end with a period (not '\"')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/nipsa.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/nipsa.py",
+                "module": null,
+                "function": null,
+                "line": 40,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/nipsa.py",
+                "module": "h.services.nipsa",
+                "function": "NipsaService",
+                "line": 8,
+                "character": 0
+            },
+            "message": "Class 'NipsaService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "consider-using-set-comprehension",
+            "location": {
+                "path": "h/services/nipsa.py",
+                "module": "h.services.nipsa",
+                "function": "NipsaService.fetch_all_flagged_userids",
+                "line": 35,
+                "character": 32
+            },
+            "message": "Consider using a set comprehension"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/nipsa.py",
+                "module": "h.services.nipsa",
+                "function": "nipsa_factory",
+                "line": 83,
+                "character": 18
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/user_password.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/services/user_password.py",
+                "module": null,
+                "function": null,
+                "line": 13,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/user_password.py",
+                "module": null,
+                "function": null,
+                "line": 21,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/user_password.py",
+                "module": "h.services.user_password",
+                "function": "UserPasswordService",
+                "line": 11,
+                "character": 0
+            },
+            "message": "Class 'UserPasswordService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/user_password.py",
+                "module": "h.services.user_password",
+                "function": "user_password_service_factory",
+                "line": 63,
+                "character": 34
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/user_password.py",
+                "module": "h.services.user_password",
+                "function": "user_password_service_factory",
+                "line": 63,
+                "character": 43
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/group_update.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/group_update.py",
+                "module": "h.services.group_update",
+                "function": "GroupUpdateService",
+                "line": 10,
+                "character": 0
+            },
+            "message": "Class 'GroupUpdateService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/group_update.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/group_update.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/group_update.py",
+                "module": null,
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/group_update.py",
+                "module": "h.services.group_update",
+                "function": "group_update_factory",
+                "line": 59,
+                "character": 25
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/user_signup.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/services/user_signup.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/user_signup.py",
+                "module": "h.services.user_signup",
+                "function": "UserSignupService",
+                "line": 12,
+                "character": 0
+            },
+            "message": "Class 'UserSignupService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/services/user_signup.py",
+                "module": "h.services.user_signup",
+                "function": "UserSignupService.__init__",
+                "line": 16,
+                "character": 4
+            },
+            "message": "Too many arguments (7/5)"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-outer-name",
+            "location": {
+                "path": "h/services/user_signup.py",
+                "module": "h.services.user_signup",
+                "function": "UserSignupService.__init__",
+                "line": 19,
+                "character": 8
+            },
+            "message": "Redefining name 'mailer' from outer scope (line 9)"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/user_signup.py",
+                "module": "h.services.user_signup",
+                "function": "user_signup_service_factory",
+                "line": 113,
+                "character": 32
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/group.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/group.py",
+                "module": "h.services.group",
+                "function": "GroupService",
+                "line": 12,
+                "character": 0
+            },
+            "message": "Class 'GroupService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/group.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/group.py",
+                "module": "h.services.group",
+                "function": "groups_factory",
+                "line": 122,
+                "character": 19
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/groupfinder.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/groupfinder.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/groupfinder.py",
+                "module": null,
+                "function": null,
+                "line": 17,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/groupfinder.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/groupfinder.py",
+                "module": "h.services.groupfinder",
+                "function": "groupfinder_service_factory",
+                "line": 30,
+                "character": 32
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/groupfinder.py",
+                "module": null,
+                "function": null,
+                "line": 30,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/groupfinder.py",
+                "module": "h.services.groupfinder",
+                "function": "GroupfinderService",
+                "line": 15,
+                "character": 0
+            },
+            "message": "Class 'GroupfinderService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D210",
+            "location": {
+                "path": "h/services/links.py",
+                "module": null,
+                "function": null,
+                "line": 3,
+                "character": 0
+            },
+            "message": "No whitespaces allowed surrounding docstring text"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/services/links.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/links.py",
+                "module": null,
+                "function": null,
+                "line": 81,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Register', not 'Registers')"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/links.py",
+                "module": "h.services.links",
+                "function": "LinksService",
+                "line": 14,
+                "character": 0
+            },
+            "message": "Class 'LinksService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/services/links.py",
+                "module": "h.services.links",
+                "function": "LinksService.get",
+                "line": 59,
+                "character": 8
+            },
+            "message": "Variable name \"g\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/services/links.py",
+                "module": "h.services.links",
+                "function": "LinksService.get_all",
+                "line": 65,
+                "character": 19
+            },
+            "message": "Variable name \"g\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/links.py",
+                "module": "h.services.links",
+                "function": "links_factory",
+                "line": 74,
+                "character": 18
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/user.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/services/user.py",
+                "module": null,
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/user.py",
+                "module": null,
+                "function": null,
+                "line": 121,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/services/user.py",
+                "module": "h.services.user",
+                "function": "UserService.update_preferences",
+                "line": 167,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/user.py",
+                "module": null,
+                "function": null,
+                "line": 167,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/user.py",
+                "module": "h.services.user",
+                "function": "UserService",
+                "line": 18,
+                "character": 0
+            },
+            "message": "Class 'UserService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-variable",
+            "location": {
+                "path": "h/services/user.py",
+                "module": "h.services.user",
+                "function": "UserService.__init__.flush_cache",
+                "line": 37,
+                "character": 8
+            },
+            "message": "Unused variable 'flush_cache'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/user.py",
+                "module": "h.services.user",
+                "function": "user_service_factory",
+                "line": 177,
+                "character": 25
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/oauth_provider.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/oauth_provider.py",
+                "module": null,
+                "function": null,
+                "line": 37,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/oauth_provider.py",
+                "module": null,
+                "function": null,
+                "line": 75,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'n')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/oauth_provider.py",
+                "module": null,
+                "function": null,
+                "line": 75,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'Custom')"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/services/oauth_provider.py",
+                "module": "h.services.oauth_provider",
+                "function": "OAuthProviderService.generate_access_token",
+                "line": 99,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/oauth_provider.py",
+                "module": "h.services.oauth_provider",
+                "function": "OAuthProviderService.generate_access_token",
+                "line": 99,
+                "character": 36
+            },
+            "message": "Unused argument 'oauth_request'"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/oauth_provider.py",
+                "module": null,
+                "function": null,
+                "line": 99,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/services/oauth_provider.py",
+                "module": "h.services.oauth_provider",
+                "function": "OAuthProviderService.generate_refresh_token",
+                "line": 102,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/oauth_provider.py",
+                "module": "h.services.oauth_provider",
+                "function": "OAuthProviderService.generate_refresh_token",
+                "line": 102,
+                "character": 37
+            },
+            "message": "Unused argument 'oauth_request'"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/oauth_provider.py",
+                "module": null,
+                "function": null,
+                "line": 102,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/oauth_provider.py",
+                "module": "h.services.oauth_provider",
+                "function": "oauth_provider_service_factory",
+                "line": 106,
+                "character": 35
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/oauth_provider.py",
+                "module": null,
+                "function": null,
+                "line": 106,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/delete_group.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/delete_group.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/delete_group.py",
+                "module": "h.services.delete_group",
+                "function": "DeleteGroupService",
+                "line": 14,
+                "character": 0
+            },
+            "message": "Class 'DeleteGroupService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/delete_group.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/delete_group.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/delete_group.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/services/delete_group.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/delete_group.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/services/delete_group.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood ('Delete', not 'Deletes')"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/delete_group.py",
+                "module": "h.services.delete_group",
+                "function": "delete_group_service_factory",
+                "line": 38,
+                "character": 33
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/delete_group.py",
+                "module": null,
+                "function": null,
+                "line": 38,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/annotation_stats.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/annotation_stats.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/services/annotation_stats.py",
+                "module": null,
+                "function": null,
+                "line": 46,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/annotation_stats.py",
+                "module": "h.services.annotation_stats",
+                "function": "AnnotationStatsService",
+                "line": 11,
+                "character": 0
+            },
+            "message": "Class 'AnnotationStatsService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/annotation_stats.py",
+                "module": "h.services.annotation_stats",
+                "function": "annotation_stats_factory",
+                "line": 60,
+                "character": 29
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/annotation_moderation.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/annotation_moderation.py",
+                "module": "h.services.annotation_moderation",
+                "function": "AnnotationModerationService",
+                "line": 8,
+                "character": 0
+            },
+            "message": "Class 'AnnotationModerationService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/annotation_moderation.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/annotation_moderation.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/annotation_moderation.py",
+                "module": null,
+                "function": null,
+                "line": 44,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/services/annotation_moderation.py",
+                "module": null,
+                "function": null,
+                "line": 63,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/annotation_moderation.py",
+                "module": "h.services.annotation_moderation",
+                "function": "annotation_moderation_service_factory",
+                "line": 75,
+                "character": 42
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/annotation_moderation.py",
+                "module": null,
+                "function": null,
+                "line": 75,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/services/annotation_moderation.py",
+                "module": "h.services.annotation_moderation",
+                "function": "AnnotationModerationService.hidden",
+                "line": 12,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pylint",
+            "code": "consider-using-set-comprehension",
+            "location": {
+                "path": "h/services/annotation_moderation.py",
+                "module": "h.services.annotation_moderation",
+                "function": "AnnotationModerationService.all_hidden",
+                "line": 41,
+                "character": 15
+            },
+            "message": "Consider using a set comprehension"
+        },
+        {
+            "source": "pylint",
+            "code": "no-self-use",
+            "location": {
+                "path": "h/services/annotation_moderation.py",
+                "module": "h.services.annotation_moderation",
+                "function": "AnnotationModerationService.unhide",
+                "line": 62,
+                "character": 4
+            },
+            "message": "Method could be a function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/flag_count.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/flag_count.py",
+                "module": "h.services.flag_count",
+                "function": "FlagCountService",
+                "line": 10,
+                "character": 0
+            },
+            "message": "Class 'FlagCountService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/services/flag_count.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/services/flag_count.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/flag_count.py",
+                "module": "h.services.flag_count",
+                "function": "flag_count_service_factory",
+                "line": 57,
+                "character": 31
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/services/flag_count.py",
+                "module": null,
+                "function": null,
+                "line": 57,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/settings.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/settings.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/settings.py",
+                "module": null,
+                "function": null,
+                "line": 27,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/services/settings.py",
+                "module": null,
+                "function": null,
+                "line": 36,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/settings.py",
+                "module": "h.services.settings",
+                "function": "SettingsService",
+                "line": 8,
+                "character": 0
+            },
+            "message": "Class 'SettingsService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/settings.py",
+                "module": "h.services.settings",
+                "function": "settings_factory",
+                "line": 46,
+                "character": 21
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/list_organizations.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/services/list_organizations.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/services/list_organizations.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/services/list_organizations.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/list_organizations.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'd')"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/services/list_organizations.py",
+                "module": null,
+                "function": null,
+                "line": 41,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/list_organizations.py",
+                "module": null,
+                "function": null,
+                "line": 41,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'd')"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/list_organizations.py",
+                "module": "h.services.list_organizations",
+                "function": "ListOrganizationsService",
+                "line": 8,
+                "character": 0
+            },
+            "message": "Class 'ListOrganizationsService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/list_organizations.py",
+                "module": "h.services.list_organizations",
+                "function": "list_organizations_factory",
+                "line": 40,
+                "character": 31
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/services/group_links.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/services/group_links.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/services/group_links.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/group_links.py",
+                "module": null,
+                "function": null,
+                "line": 8,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 't')"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/services/group_links.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'p')"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/services/group_links.py",
+                "module": "h.services.group_links",
+                "function": "GroupLinksService",
+                "line": 6,
+                "character": 0
+            },
+            "message": "Class 'GroupLinksService' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/services/group_links.py",
+                "module": "h.services.group_links",
+                "function": "group_links_factory",
+                "line": 35,
+                "character": 24
+            },
+            "message": "Unused argument 'context'"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/__main__.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 53,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 53,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 53,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 62,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 77,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 100,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 108,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 112,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 126,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 126,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'g')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 134,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "arguments-differ",
+            "location": {
+                "path": "h/websocket.py",
+                "module": "h.websocket",
+                "function": "WSGIServer.stop",
+                "line": 138,
+                "character": 4
+            },
+            "message": "Parameters differ from overridden 'stop' method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 138,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 143,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/websocket.py",
+                "module": "h.websocket",
+                "function": "create_app",
+                "line": 151,
+                "character": 15
+            },
+            "message": "Unused argument 'global_config'"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/websocket.py",
+                "module": null,
+                "function": null,
+                "line": 151,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "h/websocket.py",
+                "module": "h.websocket",
+                "function": "WebSocketWSGIHandler.run_application",
+                "line": 82,
+                "character": 31
+            },
+            "message": "Access to a protected member _sock of a client class"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/websocket.py",
+                "module": "h.websocket",
+                "function": "WebSocketWSGIHandler.run_application",
+                "line": 90,
+                "character": 12
+            },
+            "message": "Variable name \"ws\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "logging-not-lazy",
+            "location": {
+                "path": "h/websocket.py",
+                "module": "h.websocket",
+                "function": "GEventWebSocketPool.track",
+                "line": 109,
+                "character": 8
+            },
+            "message": "Specify string format arguments as logging function parameters"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "h/websocket.py",
+                "module": "h.websocket",
+                "function": "GEventWebSocketPool.clear",
+                "line": 116,
+                "character": 28
+            },
+            "message": "Access to a protected member _run of a client class"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/assets.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/assets.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/assets.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/assets.py",
+                "module": null,
+                "function": null,
+                "line": 56,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/assets.py",
+                "module": null,
+                "function": null,
+                "line": 107,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "h/assets.py",
+                "module": null,
+                "function": null,
+                "line": 150,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/assets.py",
+                "module": "h.assets",
+                "function": "_CachedFile",
+                "line": 13,
+                "character": 0
+            },
+            "message": "Class '_CachedFile' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/assets.py",
+                "module": "h.assets",
+                "function": "Environment",
+                "line": 54,
+                "character": 0
+            },
+            "message": "Class 'Environment' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "deprecated-method",
+            "location": {
+                "path": "h/assets.py",
+                "module": "h.assets",
+                "function": "_load_bundles",
+                "line": 140,
+                "character": 8
+            },
+            "message": "Using deprecated method readfp()"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/assets.py",
+                "module": "h.assets",
+                "function": null,
+                "line": 146,
+                "character": 0
+            },
+            "message": "Constant name \"assets_view\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/assets.py",
+                "module": "h.assets",
+                "function": null,
+                "line": 147,
+                "character": 0
+            },
+            "message": "Constant name \"assets_view\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/presenters/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 3,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/presenters/__init__.py",
+                "module": null,
+                "function": null,
+                "line": 3,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 't')"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/presenters/document_json.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/presenters/document_json.py",
+                "module": "h.presenters.document_json",
+                "function": "DocumentJSONPresenter",
+                "line": 6,
+                "character": 0
+            },
+            "message": "Class 'DocumentJSONPresenter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/presenters/document_json.py",
+                "module": null,
+                "function": null,
+                "line": 6,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/presenters/document_json.py",
+                "module": null,
+                "function": null,
+                "line": 7,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/document_json.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/presenters/document_json.py",
+                "module": "h.presenters.document_json",
+                "function": "DocumentJSONPresenter.asdict",
+                "line": 14,
+                "character": 8
+            },
+            "message": "Variable name \"d\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/presenters/document_html.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/presenters/document_html.py",
+                "module": null,
+                "function": null,
+                "line": 13,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/document_html.py",
+                "module": null,
+                "function": null,
+                "line": 181,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/document_html.py",
+                "module": null,
+                "function": null,
+                "line": 187,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/presenters/document_html.py",
+                "module": null,
+                "function": null,
+                "line": 198,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/presenters/document_html.py",
+                "module": "h.presenters.document_html",
+                "function": "DocumentHTMLPresenter",
+                "line": 10,
+                "character": 0
+            },
+            "message": "Class 'DocumentHTMLPresenter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/document_html.py",
+                "module": "h.presenters.document_html",
+                "function": "DocumentHTMLPresenter.filename",
+                "line": 30,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/document_html.py",
+                "module": "h.presenters.document_html",
+                "function": "DocumentHTMLPresenter.href",
+                "line": 51,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/document_html.py",
+                "module": "h.presenters.document_html",
+                "function": "DocumentHTMLPresenter.hostname_or_filename",
+                "line": 73,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/document_html.py",
+                "module": "h.presenters.document_html",
+                "function": "DocumentHTMLPresenter.link_text",
+                "line": 147,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/document_html.py",
+                "module": "h.presenters.document_html",
+                "function": "DocumentHTMLPresenter.title",
+                "line": 175,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/document_html.py",
+                "module": "h.presenters.document_html",
+                "function": "_format_document_link.truncate",
+                "line": 214,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/presenters/organization_json.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/presenters/organization_json.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/organization_json.py",
+                "module": null,
+                "function": null,
+                "line": 13,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/presenters/organization_json.py",
+                "module": "h.presenters.organization_json",
+                "function": "OrganizationJSONPresenter",
+                "line": 6,
+                "character": 0
+            },
+            "message": "Class 'OrganizationJSONPresenter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/presenters/annotation_searchindex.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/presenters/annotation_searchindex.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/presenters/annotation_searchindex.py",
+                "module": null,
+                "function": null,
+                "line": 14,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "super-init-not-called",
+            "location": {
+                "path": "h/presenters/annotation_searchindex.py",
+                "module": "h.presenters.annotation_searchindex",
+                "function": "AnnotationSearchIndexPresenter.__init__",
+                "line": 14,
+                "character": 4
+            },
+            "message": "__init__ method from base class 'AnnotationBasePresenter' is not called"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_searchindex.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_searchindex.py",
+                "module": null,
+                "function": null,
+                "line": 57,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 34,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'The')"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 47,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'The')"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 56,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 56,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 56,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'An')"
+        },
+        {
+            "source": "pep257",
+            "code": "D213",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 82,
+                "character": 0
+            },
+            "message": "Multi-line docstring summary should start at the second line"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 82,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 141,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 145,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 149,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 153,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 157,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 161,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": null,
+                "function": null,
+                "line": 165,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": "h.presenters.annotation_html",
+                "function": "AnnotationHTMLPresenter",
+                "line": 12,
+                "character": 0
+            },
+            "message": "Class 'AnnotationHTMLPresenter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "inconsistent-return-statements",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": "h.presenters.annotation_html",
+                "function": "AnnotationHTMLPresenter._get_selection",
+                "line": 22,
+                "character": 4
+            },
+            "message": "Either all return statements in a function should return an expression, or none of them should."
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": "h.presenters.annotation_html",
+                "function": "AnnotationHTMLPresenter.document_link",
+                "line": 94,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": "h.presenters.annotation_html",
+                "function": "AnnotationHTMLPresenter.filename",
+                "line": 102,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": "h.presenters.annotation_html",
+                "function": "AnnotationHTMLPresenter.hostname_or_filename",
+                "line": 110,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": "h.presenters.annotation_html",
+                "function": "AnnotationHTMLPresenter.href",
+                "line": 118,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": "h.presenters.annotation_html",
+                "function": "AnnotationHTMLPresenter.link_text",
+                "line": 126,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/annotation_html.py",
+                "module": "h.presenters.annotation_html",
+                "function": "AnnotationHTMLPresenter.title",
+                "line": 134,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/presenters/document_searchindex.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/presenters/document_searchindex.py",
+                "module": "h.presenters.document_searchindex",
+                "function": "DocumentSearchIndexPresenter",
+                "line": 6,
+                "character": 0
+            },
+            "message": "Class 'DocumentSearchIndexPresenter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/presenters/document_searchindex.py",
+                "module": null,
+                "function": null,
+                "line": 6,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/presenters/document_searchindex.py",
+                "module": null,
+                "function": null,
+                "line": 7,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/document_searchindex.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/presenters/document_searchindex.py",
+                "module": "h.presenters.document_searchindex",
+                "function": "DocumentSearchIndexPresenter.asdict",
+                "line": 14,
+                "character": 8
+            },
+            "message": "Variable name \"d\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/presenters/user_json.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/presenters/user_json.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/user_json.py",
+                "module": null,
+                "function": null,
+                "line": 21,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/presenters/user_json.py",
+                "module": "h.presenters.user_json",
+                "function": "UserJSONPresenter",
+                "line": 6,
+                "character": 0
+            },
+            "message": "Class 'UserJSONPresenter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/presenters/annotation_jsonld.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/presenters/annotation_jsonld.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D205",
+            "location": {
+                "path": "h/presenters/annotation_jsonld.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "1 blank line required between summary line and description (found 0)"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/presenters/annotation_jsonld.py",
+                "module": null,
+                "function": null,
+                "line": 10,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'e')"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_jsonld.py",
+                "module": null,
+                "function": null,
+                "line": 19,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_jsonld.py",
+                "module": null,
+                "function": null,
+                "line": 32,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_jsonld.py",
+                "module": null,
+                "function": null,
+                "line": 36,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_jsonld.py",
+                "module": null,
+                "function": null,
+                "line": 45,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "h/presenters/annotation_jsonld.py",
+                "module": null,
+                "function": null,
+                "line": 76,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/presenters/annotation_jsonld.py",
+                "module": "h.presenters.annotation_jsonld",
+                "function": "AnnotationJSONLDPresenter.bodies",
+                "line": 40,
+                "character": 12
+            },
+            "message": "Variable name \"t\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D200",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": null,
+                "function": null,
+                "line": 3,
+                "character": 0
+            },
+            "message": "One-line docstring should fit on one line with quotes (found 3)"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": "h.presenters.annotation_base",
+                "function": "AnnotationBasePresenter",
+                "line": 12,
+                "character": 0
+            },
+            "message": "Class 'AnnotationBasePresenter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": null,
+                "function": null,
+                "line": 12,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": null,
+                "function": null,
+                "line": 13,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pylint",
+            "code": "inconsistent-return-statements",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": "h.presenters.annotation_base",
+                "function": "AnnotationBasePresenter.created",
+                "line": 18,
+                "character": 4
+            },
+            "message": "Either all return statements in a function should return an expression, or none of them should."
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "inconsistent-return-statements",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": "h.presenters.annotation_base",
+                "function": "AnnotationBasePresenter.updated",
+                "line": 23,
+                "character": 4
+            },
+            "message": "Either all return statements in a function should return an expression, or none of them should."
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": null,
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D401",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": null,
+                "function": null,
+                "line": 29,
+                "character": 0
+            },
+            "message": "First line should be in imperative mood; try rephrasing (found 'A')"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": null,
+                "function": null,
+                "line": 33,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": null,
+                "function": null,
+                "line": 40,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": null,
+                "function": null,
+                "line": 47,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": "h.presenters.annotation_base",
+                "function": "AnnotationBasePresenter.text",
+                "line": 34,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pylint",
+            "code": "no-else-return",
+            "location": {
+                "path": "h/presenters/annotation_base.py",
+                "module": "h.presenters.annotation_base",
+                "function": "AnnotationBasePresenter.tags",
+                "line": 41,
+                "character": 8
+            },
+            "message": "Unnecessary \"else\" after \"return\""
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/presenters/annotation_json.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D211",
+            "location": {
+                "path": "h/presenters/annotation_json.py",
+                "module": null,
+                "function": null,
+                "line": 18,
+                "character": 0
+            },
+            "message": "No blank lines allowed before class docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/presenters/annotation_json.py",
+                "module": null,
+                "function": null,
+                "line": 20,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/annotation_json.py",
+                "module": null,
+                "function": null,
+                "line": 39,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "h/presenters/group_json.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/presenters/group_json.py",
+                "module": null,
+                "function": null,
+                "line": 11,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/group_json.py",
+                "module": null,
+                "function": null,
+                "line": 16,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D400",
+            "location": {
+                "path": "h/presenters/group_json.py",
+                "module": null,
+                "function": null,
+                "line": 67,
+                "character": 0
+            },
+            "message": "First line should end with a period (not 'N')"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "h/presenters/group_json.py",
+                "module": null,
+                "function": null,
+                "line": 69,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "h/presenters/group_json.py",
+                "module": null,
+                "function": null,
+                "line": 72,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/presenters/group_json.py",
+                "module": "h.presenters.group_json",
+                "function": "GroupJSONPresenter",
+                "line": 8,
+                "character": 0
+            },
+            "message": "Class 'GroupJSONPresenter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/presenters/group_json.py",
+                "module": "h.presenters.group_json",
+                "function": "GroupsJSONPresenter",
+                "line": 66,
+                "character": 0
+            },
+            "message": "Class 'GroupsJSONPresenter' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 44,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 62,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 67,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 74,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 82,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 85,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 92,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 100,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D105",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 103,
+                "character": 0
+            },
+            "message": "Missing docstring in magic method"
+        },
+        {
+            "source": "pep257",
+            "code": "D202",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 111,
+                "character": 0
+            },
+            "message": "No blank lines allowed after function docstring (found 1)"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 128,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 137,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D101",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 141,
+                "character": 0
+            },
+            "message": "Missing docstring in public class"
+        },
+        {
+            "source": "pep257",
+            "code": "D107",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 142,
+                "character": 0
+            },
+            "message": "Missing docstring in __init__"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 146,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 159,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D102",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 186,
+                "character": 0
+            },
+            "message": "Missing docstring in public method"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": null,
+                "function": null,
+                "line": 190,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-import",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": "lint",
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "Unused import logging"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-import",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": "lint",
+                "function": null,
+                "line": 23,
+                "character": 0
+            },
+            "message": "Unused import multiprocessing"
+        },
+        {
+            "source": "pylint",
+            "code": "protected-access",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": "lint",
+                "function": "Ratchet.check",
+                "line": 151,
+                "character": 20
+            },
+            "message": "Access to a protected member _files_by_path of a client class"
+        },
+        {
+            "source": "pylint",
+            "code": "broad-except",
+            "location": {
+                "path": "scripts/lint.py",
+                "module": "lint",
+                "function": "Ratchet.check",
+                "line": 154,
+                "character": 19
+            },
+            "message": "Catching too general exception Exception"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "scripts/update-icon-font.py",
+                "module": "update-icon-font",
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Module name \"update-icon-font\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "scripts/update-icon-font.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "scripts/update-icon-font.py",
+                "module": null,
+                "function": null,
+                "line": 9,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-import",
+            "location": {
+                "path": "scripts/update-icon-font.py",
+                "module": "update-icon-font",
+                "function": null,
+                "line": 5,
+                "character": 0
+            },
+            "message": "Unused b64encode imported from base64"
+        },
+        {
+            "source": "pep257",
+            "code": "D100",
+            "location": {
+                "path": "docs/conf.py",
+                "module": null,
+                "function": null,
+                "line": 1,
+                "character": 0
+            },
+            "message": "Missing docstring in public module"
+        },
+        {
+            "source": "pep257",
+            "code": "D103",
+            "location": {
+                "path": "docs/conf.py",
+                "module": null,
+                "function": null,
+                "line": 107,
+                "character": 0
+            },
+            "message": "Missing docstring in public function"
+        },
+        {
+            "source": "pylint",
+            "code": "multiple-imports",
+            "location": {
+                "path": "docs/conf.py",
+                "module": "conf",
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Multiple imports on one line (sys, os)"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-import",
+            "location": {
+                "path": "docs/conf.py",
+                "module": "conf",
+                "function": null,
+                "line": 15,
+                "character": 0
+            },
+            "message": "Unused import sys"
+        },
+        {
+            "source": "pylint",
+            "code": "redefined-builtin",
+            "location": {
+                "path": "docs/conf.py",
+                "module": "conf",
+                "function": null,
+                "line": 58,
+                "character": 0
+            },
+            "message": "Redefining built-in 'copyright'"
+        },
+        {
+            "source": "pylint",
+            "code": "import-error",
+            "location": {
+                "path": "docs/conf.py",
+                "module": "conf",
+                "function": null,
+                "line": 116,
+                "character": 4
+            },
+            "message": "Unable to import 'sphinx_rtd_theme'"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 23,
+                "character": 4
+            },
+            "message": "Class name \"text_type\" doesn't conform to PascalCase naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 24,
+                "character": 4
+            },
+            "message": "Constant name \"string_types\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 25,
+                "character": 4
+            },
+            "message": "Class name \"xrange\" doesn't conform to PascalCase naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 26,
+                "character": 4
+            },
+            "message": "Constant name \"unichr\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 30,
+                "character": 4
+            },
+            "message": "Constant name \"xrange\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 31,
+                "character": 4
+            },
+            "message": "Constant name \"unichr\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 41,
+                "character": 4
+            },
+            "message": "Constant name \"url_quote\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 42,
+                "character": 4
+            },
+            "message": "Constant name \"url_quote_plus\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 43,
+                "character": 4
+            },
+            "message": "Constant name \"url_unquote\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 44,
+                "character": 4
+            },
+            "message": "Constant name \"url_unquote_plus\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 49,
+                "character": 4
+            },
+            "message": "Constant name \"url_quote\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 50,
+                "character": 4
+            },
+            "message": "Constant name \"url_quote_plus\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 51,
+                "character": 4
+            },
+            "message": "Constant name \"url_unquote\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": null,
+                "line": 52,
+                "character": 4
+            },
+            "message": "Constant name \"url_unquote_plus\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": "native",
+                "line": 64,
+                "character": 4
+            },
+            "message": "Argument name \"s\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/_compat.py",
+                "module": "h._compat",
+                "function": "native",
+                "line": 85,
+                "character": 4
+            },
+            "message": "Argument name \"s\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "global-statement",
+            "location": {
+                "path": "h/auth/__init__.py",
+                "module": "h.auth",
+                "function": "includeme",
+                "line": 41,
+                "character": 4
+            },
+            "message": "Using the global statement"
+        },
+        {
+            "source": "pylint",
+            "code": "global-statement",
+            "location": {
+                "path": "h/auth/__init__.py",
+                "module": "h.auth",
+                "function": "includeme",
+                "line": 42,
+                "character": 4
+            },
+            "message": "Using the global statement"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/celery.py",
+                "module": "h.celery",
+                "function": null,
+                "line": 27,
+                "character": 0
+            },
+            "message": "Constant name \"celery\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/celery.py",
+                "module": "h.celery",
+                "function": "bootstrap_worker",
+                "line": 91,
+                "character": 0
+            },
+            "message": "Unused argument 'kwargs'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/celery.py",
+                "module": "h.celery",
+                "function": "reset_nipsa_cache",
+                "line": 97,
+                "character": 0
+            },
+            "message": "Unused argument 'kwargs'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/celery.py",
+                "module": "h.celery",
+                "function": "transaction_commit",
+                "line": 104,
+                "character": 0
+            },
+            "message": "Unused argument 'kwargs'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/celery.py",
+                "module": "h.celery",
+                "function": "transaction_abort",
+                "line": 110,
+                "character": 0
+            },
+            "message": "Unused argument 'kwargs'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/celery.py",
+                "module": "h.celery",
+                "function": "report_failure",
+                "line": 116,
+                "character": 0
+            },
+            "message": "Unused argument 'kw'"
+        },
+        {
+            "source": "pylint",
+            "code": "ungrouped-imports",
+            "location": {
+                "path": "h/db/__init__.py",
+                "module": "h.db",
+                "function": null,
+                "line": 22,
+                "character": 0
+            },
+            "message": "Imports from package sqlalchemy are not grouped"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/db/__init__.py",
+                "module": "h.db",
+                "function": null,
+                "line": 38,
+                "character": 0
+            },
+            "message": "Constant name \"metadata\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/db/__init__.py",
+                "module": "h.db",
+                "function": null,
+                "line": 50,
+                "character": 0
+            },
+            "message": "Constant name \"Session\" doesn't conform to UPPER_CASE naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "invalid-name",
+            "location": {
+                "path": "h/db/__init__.py",
+                "module": "h.db",
+                "function": "_session",
+                "line": 82,
+                "character": 8
+            },
+            "message": "Variable name \"tm\" doesn't conform to snake_case naming style"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-argument",
+            "location": {
+                "path": "h/db/__init__.py",
+                "module": "h.db",
+                "function": "_session.close_the_sqlalchemy_session",
+                "line": 109,
+                "character": 37
+            },
+            "message": "Unused argument 'request'"
+        },
+        {
+            "source": "pylint",
+            "code": "unused-variable",
+            "location": {
+                "path": "h/db/__init__.py",
+                "module": "h.db",
+                "function": "_session.close_the_sqlalchemy_session",
+                "line": 109,
+                "character": 4
+            },
+            "message": "Unused variable 'close_the_sqlalchemy_session'"
+        },
+        {
+            "source": "pylint",
+            "code": "useless-object-inheritance",
+            "location": {
+                "path": "h/settings.py",
+                "module": "h.settings",
+                "function": "SettingsManager",
+                "line": 19,
+                "character": 0
+            },
+            "message": "Class 'SettingsManager' inherits from object, can be safely removed from bases in python3"
+        },
+        {
+            "source": "pylint",
+            "code": "too-many-arguments",
+            "location": {
+                "path": "h/settings.py",
+                "module": "h.settings",
+                "function": "SettingsManager.set",
+                "line": 47,
+                "character": 4
+            },
+            "message": "Too many arguments (7/5)"
+        }
+    ]
+}

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Ratchet mechanism Prospector wrapper script.
+
+A Prospector wrapper script that implements a "ratchet mechanism" based on a
+record of preexisting Prospector warnings in a lint.json file.
+
+When you run this script it runs Prospector and fails (exits with non-zero) if
+any file has a different number of Prospector messages (either more or fewer)
+than is recorded for that file in lint.json.
+
+Files with Prospector messages don't cause this script to fail if the file has
+the same number of messages as in lint.json.
+
+The idea is that preexisting messages won't fail this linter, but adding any
+new linter messages will cause this linter to fail.
+"""
+from __future__ import unicode_literals
+
+import argparse
+import json
+import logging
+import multiprocessing
+import os
+import subprocess
+import sys
+
+
+#: The path to this script file.
+SCRIPT_PATH = os.path.realpath(__file__)
+
+#: The path to the data file.
+DATA_PATH = os.path.splitext(SCRIPT_PATH)[0] + ".json"
+
+
+class Message:
+    """
+    A wrapper class for a Prospector message.
+
+    Handles parsing a message from Prospector's JSON output and providing easy
+    access to the contents of that message.
+    """
+
+    def __init__(self, message_dict):
+        self.dict = message_dict
+
+        #: The actual human-readable linter message, e.g. "Unused argument 'request'".
+        self.message = self.dict["message"]
+
+        #: The relative path to the file that this message comes from, e.g. "h/views/organizations.py".
+        self.path = self.dict["location"]["path"]
+
+        #: The line number that this message comes from as an int, e.g. 27.
+        self.line_number = self.dict["location"]["line"]
+
+        #: The linter that this message came from, e.g. "pylint" or "pep257".
+        self.linter = self.dict["source"]
+
+        #: The linter's code name for this message, e.g. "import-error" or "D202".
+        self.code = self.dict["code"]
+
+    def __str__(self):
+        return (
+            f"{self.path}:{self.line_number} {self.linter} {self.code} {self.message}"
+        )
+
+    def __repr__(self):
+        return str(self)
+
+
+class LintedFile:
+    """A file path and its associated messages from a run of Prospector."""
+
+    def __init__(self, path, messages=None):
+        self.path = path
+
+        if messages is None:
+            messages = []
+
+        self.messages = messages
+
+    def __str__(self):
+        return f"{self.path} with {len(self.messages)} messages"
+
+    def __repr__(self):
+        return str(self)
+
+
+class ProspectorOutput:
+    """The output from a run of Prospector."""
+
+    def __init__(self, output):
+        # Prospector's JSON output as a dict.
+        self._output = json.loads(output)
+
+        # Prospector's messages grouped by file.
+        # A dict mapping file path strings to LintedFile objects/
+        self._files_by_path = self._group_messages_by_file()
+
+    def save(self):
+        open(DATA_PATH, "w").write(json.dumps(self._output, indent=4))
+
+    def __getitem__(self, path):
+        try:
+            linted_file = self._files_by_path[path]
+        except KeyError:
+            linted_file = self._files_by_path[path] = LintedFile(path)
+        return linted_file
+
+    def _group_messages_by_file(self):
+        """Return Prospector's messages grouped by file."""
+
+        messages = [Message(message) for message in self._output["messages"]]
+
+        # A dict mapping path strings to LintedFile objects containing all the
+        # messages for those paths as Message objects.
+        files_by_path = {}
+
+        for message in messages:
+            if message.path not in files_by_path:
+                files_by_path[message.path] = LintedFile(message.path)
+
+            files_by_path[message.path].messages.append(message)
+
+        return files_by_path
+
+    @classmethod
+    def from_prospector(cls, paths):
+        try:
+            output = subprocess.check_output(["tox", "-qqe", "py36-prospector", "--", "--output-format", "json"] + paths)
+        except subprocess.CalledProcessError as err:
+            output = err.output
+
+        return cls(output)
+
+    @classmethod
+    def from_file(cls):
+        return cls(open(DATA_PATH).read())
+
+
+class Ratchet:
+    def __init__(self):
+        self._messages_from_file = None
+        self._messages_from_prospector = None
+
+    def check(self, paths):
+        self._messages_from_file = ProspectorOutput.from_file()
+        self._messages_from_prospector = ProspectorOutput.from_prospector(paths)
+
+        errors = []
+        for path in self._messages_from_prospector._files_by_path:
+            try:
+                self.check_path(path)
+            except Exception as err:
+                errors.append(err)
+
+        return errors
+
+    def check_path(self, path):
+        current_file = self._messages_from_prospector[path]
+        current_num_messages = len(current_file.messages)
+
+        saved_file = self._messages_from_file[path]
+        saved_num_messages = len(saved_file.messages)
+
+        if current_num_messages == saved_num_messages:
+            return
+
+        difference = abs(current_num_messages - saved_num_messages)
+
+        if current_num_messages > saved_num_messages:
+            raise RuntimeError(
+                f"{difference} new linter messages found in {path}.\n\n"
+                f"You need to remove {difference} linter messages from {path}.\n"
+                f"You've added {difference} new linter messages to {path}.\n"
+                f"{path} has {saved_num_messages} messages in {DATA_PATH} but "
+                f"{current_num_messages} currently."
+            )
+
+        raise RuntimeError(
+            f"{difference} fewer linter messages found in {path}.\n\n"
+            f"You need to run `./scripts/lint.py --save` to update lint.json "
+            f"because you've removed {difference} linter messages from {path}."
+        )
+
+    def save(self):
+        self._messages_from_prospector.save()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", nargs="*")
+    parser.add_argument(
+        "-s",
+        "--save",
+        action="store_true",
+        help="Create or update lint.json with the current linter messages",
+    )
+
+    args = parser.parse_args()
+
+    ratchet = Ratchet()
+
+    errors = ratchet.check(args.path)
+
+
+    if args.save:
+        ratchet.save()
+    else:
+        for error in errors:
+            print(error)
+
+        if errors:
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -50,20 +50,21 @@ passenv =
     codecov: CI TRAVIS*
 deps =
     tests: coverage
-    {tests,functests,docstrings,checkdocstrings}: pytest
-    {tests,functests,docstrings,checkdocstrings}: factory-boy
-    {tests,docstrings,checkdocstrings}: mock
-    {tests,docstrings,checkdocstrings}: hypothesis
+    prospector: prospector[with_pyroma]
+    {tests,functests,docstrings,checkdocstrings,prospector}: pytest
+    {tests,functests,docstrings,checkdocstrings,prospector}: factory-boy
+    {tests,docstrings,checkdocstrings,prospector}: mock
+    {tests,docstrings,checkdocstrings,prospector}: hypothesis
     lint: flake8
     lint: flake8-future-import
     {format,checkformatting}: black
     coverage: coverage
     codecov: codecov
-    {functests,docstrings,checkdocstrings}: webtest
+    {functests,docstrings,checkdocstrings,prospector}: webtest
     {docs,docstrings}: sphinx-autobuild
     {docs,checkdocs,docstrings,checkdocstrings}: sphinx
     {docs,checkdocs,docstrings,checkdocstrings}: sphinx_rtd_theme
-    {tests,functests,docstrings,checkdocstrings}: -r requirements.txt
+    {tests,functests,docstrings,checkdocstrings,prospector}: -r requirements.txt
     dev: ipython
     dev: ipdb
     dev: -r requirements-dev.in
@@ -77,6 +78,7 @@ commands =
     lint: flake8 h
     lint: flake8 tests
     lint: flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
+    prospector: prospector {posargs:}
     format: black h tests
     checkformatting: black --check h tests
     tests: coverage run -m pytest {posargs:tests/h/}


### PR DESCRIPTION
Usage:

```shellsession
$ ./scripts/lint.py
```

It should fail only if you've added or remove any linter errors. `./scripts/lint.py --save` updates `lint.json` with the current `prospector` output.