### PR TITLE
Add a Pylint-based `make analyze` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ help:
 	@echo "make shell             Launch a Python shell in the dev environment"
 	@echo "make sql               Connect to the dev database with a psql shell"
 	@echo "make lint              Run the code linter(s) and print any warnings"
+	@echo "make analyze           Slower and more thorough code quality analysis (pylint)"
 	@echo "make format            Correctly format the code"
 	@echo "make checkformatting   Crash if the code isn't correctly formatted"
 	@echo "make test              Run the unit tests"
@@ -43,6 +44,10 @@ sql:
 .PHONY: lint
 lint:
 	tox -qe py36-lint
+
+.PHONY: analyze
+analyze:
+	tox -qqe py36-analyze
 
 .PHONY: format
 format:

--- a/pylintrc
+++ b/pylintrc
@@ -4,6 +4,14 @@
 # number of processors available to use.
 jobs=0
 
+load-plugins=pylint.extensions.bad_builtin,
+             pylint.extensions.check_elif,
+             pylint.extensions.comparetozero,
+             pylint.extensions.docparams,
+             pylint.extensions.emptystring,
+             pylint.extensions.overlapping_exceptions,
+             pylint.extensions.redefined_variable_type,
+
 [MESSAGES CONTROL]
 
 # Disable the message, report, category or checker with the given id(s). You

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,29 @@
+[MASTER]
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+[MESSAGES CONTROL]
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=missing-docstring,
+        imports
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=colorized
+
+# Deactivate the evaluation score.
+score=no

--- a/pylintrc
+++ b/pylintrc
@@ -24,7 +24,7 @@ load-plugins=pylint.extensions.bad_builtin,
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
 disable=missing-docstring,
-        imports
+        imports,
 
 [REPORTS]
 

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ commands =
     lint: flake8 h
     lint: flake8 tests
     lint: flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
-    analyze: pylint -j 0 --score=no --output-format=colorized --disable=missing-docstring,imports {posargs:h tests}
+    analyze: pylint {posargs:h tests}
     format: black h tests
     checkformatting: black --check h tests
     tests: coverage run -m pytest {posargs:tests/h/}

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ commands =
     lint: flake8 h
     lint: flake8 tests
     lint: flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
-    analyze: pylint -j 0 --score=no --output-format=colorized {posargs:h tests}
+    analyze: pylint -j 0 --score=no --output-format=colorized --disable=missing-docstring {posargs:h tests}
     format: black h tests
     checkformatting: black --check h tests
     tests: coverage run -m pytest {posargs:tests/h/}

--- a/tox.ini
+++ b/tox.ini
@@ -50,20 +50,21 @@ passenv =
     codecov: CI TRAVIS*
 deps =
     tests: coverage
-    {tests,functests,docstrings,checkdocstrings}: pytest
-    {tests,functests,docstrings,checkdocstrings}: factory-boy
-    {tests,docstrings,checkdocstrings}: mock
-    {tests,docstrings,checkdocstrings}: hypothesis
+    {tests,functests,docstrings,checkdocstrings,analyze}: pytest
+    {tests,functests,docstrings,checkdocstrings,analyze}: factory-boy
+    {tests,docstrings,checkdocstrings,analyze}: mock
+    {tests,docstrings,checkdocstrings,analyze}: hypothesis
     lint: flake8
     lint: flake8-future-import
     {format,checkformatting}: black
     coverage: coverage
     codecov: codecov
-    {functests,docstrings,checkdocstrings}: webtest
+    {functests,docstrings,checkdocstrings,analyze}: webtest
     {docs,docstrings}: sphinx-autobuild
     {docs,checkdocs,docstrings,checkdocstrings}: sphinx
     {docs,checkdocs,docstrings,checkdocstrings}: sphinx_rtd_theme
-    {tests,functests,docstrings,checkdocstrings}: -r requirements.txt
+    {tests,functests,docstrings,checkdocstrings,analyze}: -r requirements.txt
+    analyze: pylint
     dev: ipython
     dev: ipdb
     dev: -r requirements-dev.in
@@ -77,6 +78,7 @@ commands =
     lint: flake8 h
     lint: flake8 tests
     lint: flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
+    analyze: pylint -j 0 --score=no --output-format=colorized {posargs:h tests}
     format: black h tests
     checkformatting: black --check h tests
     tests: coverage run -m pytest {posargs:tests/h/}

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ commands =
     lint: flake8 h
     lint: flake8 tests
     lint: flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
-    analyze: pylint -j 0 --score=no --output-format=colorized --disable=missing-docstring {posargs:h tests}
+    analyze: pylint -j 0 --score=no --output-format=colorized --disable=missing-docstring,imports {posargs:h tests}
     format: black h tests
     checkformatting: black --check h tests
     tests: coverage run -m pytest {posargs:tests/h/}


### PR DESCRIPTION
**The name `analyze` is open to alternative suggestions!**

Adds a `make analyze` command that runs PyLint. Does slower but much more in-depth analysis than `make lint` / `flake8`.

This doesn't run `make analyze` on CI yet. For an example of a PR that would add that see: <https://github.com/hypothesis/h/pull/5557>. Example `make analyze` output from #5557: <https://travis-ci.org/hypothesis/h/jobs/500457499>.

Runs in about 20s on my machine. It's much slower on Travis (about 3.5mins, which includes installing the deps into a venv and then running `pylint`), but it runs in parallel with the rest of the Travis jobs, and is no slower than the other slowest jobs already on Travis, so I don't think it adds much (any?) time to the Travis build.

Usage:

* To analyze everything: `make analyze`

* Analyze everything but filter the results to only certain files: `make analyze | ag views` or `grep views`

* To analyze only some files, which is faster, you have to call `tox` directly (skipping `make`) so that you can pass the path(s) through to PyLint: `tox -qqe py36-analyze h/models/user.py h/views/status.py ...`

You can also run `pylint` directly, instead of via `tox`, which shaves about 2s off its run time. Just save the below command in a shell alias. Note that I'm running the copy of `pylint` from Tox's venv here, this is because PyLint requires all of h's production and test dependencies installed in order to do its analysis correctly:

```shellsession
$ .tox/py36-analyze/bin/pylint [PATHS]
```

* * *

Currently our projects are inconsistent about which Python linters they use. My plan is to have two consistent commands in each of our projects:

1. `make lint` will run `flake8` and all projects will use CI to enforce that `make lint` is clean.

2. `make analyze` will run `pylint`. Projects that can will use CI to enforce that `make analyze` is clean too but some projects (such as h) may not be able to run `make analyze` on CI yet.

Advantages of this approach:

* Consistency about which linters are used for all our projects (even if they differ about which are run on CI)
* Ability to enforce `make lint` on CI for all projects right away (and `make analyze` for some)
* We have both `flake8` and `pylint` at our disposal in all projects. These are the two most popular linters. They both have lots of plugins. We can use plugins from either of them.

* * *

To get h to `make analyze`-clean I think we can run some sort of "ratchet" script on CI. Here's an abandoned earlier attempt at such a script (but based on Prospector instead of on running PyLint directly): https://github.com/hypothesis/h/pull/5553