### PR TITLE
Refactor and add Decorator for API 4xx Exception Views

### DIFF
--- a/h/views/api/decorators/__init__.py
+++ b/h/views/api/decorators/__init__.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from h.views.api.decorators.client_errors import client_error_decorator as client_error
+from h.views.api.decorators.client_errors import (
+    unauthorized_to_not_found,
+    not_found_reason,
+)
 
-__all__ = ("client_error",)
+__all__ = ("unauthorized_to_not_found", "not_found_reason")

--- a/h/views/api/decorators/__init__.py
+++ b/h/views/api/decorators/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from h.views.api.decorators.client_errors import client_error_decorator as client_error
+
+__all__ = ("client_error",)

--- a/h/views/api/decorators/client_errors.py
+++ b/h/views/api/decorators/client_errors.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound
+
+
+def client_error_decorator(wrapped):
+    """
+    Decorate client (HTTP 4xx) exception views
+
+    This decorator makes sure that the context ultimately passed to the wrapped
+    exception view is the right kind of HTTP exception and has the right
+    kind of message/details.
+
+    The exception view is passed an instance of a descendent of
+    :class:`pyramid.httpexceptions.HTTPError` object as
+    its context. We replace or modify the exception raised by Pyramid in
+    these cases:
+
+    * If the current value of ``request.accept`` is not a known/valid media type.
+      Pyramid will raise a :class:`pyramid.httpexceptions.HTTPNotFound`
+      in these cases, but we want to respond with a more useful
+      :class:`pyramid.httpexceptions.HTTPUnsupportedMediaType` (HTTP 415)
+      instead. (STILL TODO)
+    * If the supplied context is a :class:`pyramid.httpexceptions.HTTPForbidden`:
+      we currently squelch these to avoid leaking the existence of resources.
+      Replace ``context`` with a :class:`pyramid.httpexceptions.HTTPNotFound`
+
+    In addition, Pyramid sets the ``detail`` and ``message`` attributes on
+    both :class:`pyramid.httpexceptions.HTTPNotFound` and
+    :class:`pyramid.httpexceptions.HTTPNotFound` to less-than-great defaults,
+    so we set a custom message.
+    """
+
+    def wrapper(context, request):
+
+        # If we're dealing with a 403, substitute with a 404 instead
+        # FIXME: We should be more nuanced about when we do this
+        if isinstance(context, HTTPForbidden):
+            context = HTTPNotFound()
+
+        if isinstance(context, HTTPNotFound):
+            # The default message is not helpful: it's the path
+            # that failed to match any view. Replace it.
+            context.message = "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
+
+        response = wrapped(context, request)
+        return response
+
+    return wrapper

--- a/h/views/api/decorators/client_errors.py
+++ b/h/views/api/decorators/client_errors.py
@@ -1,48 +1,33 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound
+from pyramid.httpexceptions import HTTPNotFound
+
+# The default message is not helpful: it's the path
+# that failed to match any view. Replace it.
+NOT_FOUND_MESSAGE = "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
 
 
-def client_error_decorator(wrapped):
-    """
-    Decorate client (HTTP 4xx) exception views
-
-    This decorator makes sure that the context ultimately passed to the wrapped
-    exception view is the right kind of HTTP exception and has the right
-    kind of message/details.
-
-    The exception view is passed an instance of a descendent of
-    :class:`pyramid.httpexceptions.HTTPError` object as
-    its context. We replace or modify the exception raised by Pyramid in
-    these cases:
-
-    * If the current value of ``request.accept`` is not a known/valid media type.
-      Pyramid will raise a :class:`pyramid.httpexceptions.HTTPNotFound`
-      in these cases, but we want to respond with a more useful
-      :class:`pyramid.httpexceptions.HTTPUnsupportedMediaType` (HTTP 415)
-      instead. (STILL TODO)
-    * If the supplied context is a :class:`pyramid.httpexceptions.HTTPForbidden`:
-      we currently squelch these to avoid leaking the existence of resources.
-      Replace ``context`` with a :class:`pyramid.httpexceptions.HTTPNotFound`
-
-    In addition, Pyramid sets the ``detail`` and ``message`` attributes on
-    both :class:`pyramid.httpexceptions.HTTPNotFound` and
-    :class:`pyramid.httpexceptions.HTTPNotFound` to less-than-great defaults,
-    so we set a custom message.
-    """
+def unauthorized_to_not_found(wrapped):
+    """View decorator to convert all 403 exceptions to 404s"""
 
     def wrapper(context, request):
 
-        # If we're dealing with a 403, substitute with a 404 instead
+        # We convert all 403s to 404s—replace the current context with a 404
         # FIXME: We should be more nuanced about when we do this
-        if isinstance(context, HTTPForbidden):
-            context = HTTPNotFound()
+        context = HTTPNotFound(NOT_FOUND_MESSAGE)
 
-        if isinstance(context, HTTPNotFound):
-            # The default message is not helpful: it's the path
-            # that failed to match any view. Replace it.
-            context.message = "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
+        response = wrapped(context, request)
+        return response
+
+    return wrapper
+
+
+def not_found_reason(wrapped):
+    """View decorator to make 404 error messages more readable"""
+
+    def wrapper(context, request):
+        context.message = NOT_FOUND_MESSAGE
 
         response = wrapped(context, request)
         return response

--- a/h/views/api/errors.py
+++ b/h/views/api/errors.py
@@ -17,6 +17,7 @@ from pyramid import httpexceptions
 from h.i18n import TranslationString as _  # noqa: N813
 from h.util.view import handle_exception, json_view
 from h.views.api.config import cors_policy
+from h.views.api.decorators import client_error
 from h.views.api.exceptions import OAuthAuthorizeError
 
 # All exception views below need to apply the `cors_policy` decorator for the
@@ -25,16 +26,16 @@ from h.views.api.exceptions import OAuthAuthorizeError
 
 
 # Within the API, render a JSON 403/404 message.
-@forbidden_view_config(path_info="/api/", renderer="json", decorator=cors_policy)
-@notfound_view_config(path_info="/api/", renderer="json", decorator=cors_policy)
-def api_notfound(request):
+@forbidden_view_config(
+    path_info="/api/", renderer="json", decorator=(cors_policy, client_error)
+)
+@notfound_view_config(
+    path_info="/api/", renderer="json", decorator=(cors_policy, client_error)
+)
+def api_notfound(context, request):
     """Handle a request for an unknown/forbidden resource within the API."""
-    request.response.status_code = 404
-    message = _(
-        "Either the resource you requested doesn't exist, or you are "
-        "not currently authorized to see it."
-    )
-    return {"status": "failure", "reason": message}
+    request.response.status_code = context.status_code
+    return {"status": "failure", "reason": context.message}
 
 
 @view_config(

--- a/h/views/api/errors.py
+++ b/h/views/api/errors.py
@@ -17,7 +17,7 @@ from pyramid import httpexceptions
 from h.i18n import TranslationString as _  # noqa: N813
 from h.util.view import handle_exception, json_view
 from h.views.api.config import cors_policy
-from h.views.api.decorators import client_error
+from h.views.api.decorators import unauthorized_to_not_found, not_found_reason
 from h.views.api.exceptions import OAuthAuthorizeError
 
 # All exception views below need to apply the `cors_policy` decorator for the
@@ -27,10 +27,12 @@ from h.views.api.exceptions import OAuthAuthorizeError
 
 # Within the API, render a JSON 403/404 message.
 @forbidden_view_config(
-    path_info="/api/", renderer="json", decorator=(cors_policy, client_error)
+    path_info="/api/",
+    renderer="json",
+    decorator=(cors_policy, unauthorized_to_not_found),
 )
 @notfound_view_config(
-    path_info="/api/", renderer="json", decorator=(cors_policy, client_error)
+    path_info="/api/", renderer="json", decorator=(cors_policy, not_found_reason)
 )
 def api_notfound(context, request):
     """Handle a request for an unknown/forbidden resource within the API."""

--- a/h/views/api/errors.py
+++ b/h/views/api/errors.py
@@ -50,7 +50,7 @@ def oauth_error(context, request):
 def api_error(context, request):
     """Handle an expected/deliberately thrown API exception."""
     request.response.status_code = context.status_code
-    return {"status": "failure", "reason": str(context)}
+    return {"status": "failure", "reason": context.detail}
 
 
 @json_view(context=Exception, path_info="/api/", decorator=cors_policy)

--- a/tests/functional/api/test_errors.py
+++ b/tests/functional/api/test_errors.py
@@ -1,4 +1,9 @@
 # -*- coding: utf-8 -*-
+"""
+Functional tests for client API errors
+
+Uses create-group endpoint as it can raise all relevant client error codes.
+"""
 
 from __future__ import unicode_literals
 
@@ -12,18 +17,8 @@ native_str = str
 
 
 @pytest.mark.functional
-class TestCreateGroup(object):
-    def test_it_returns_http_200_with_valid_payload(self, app, token_auth_header):
-        group = {"name": "My Group"}
-        res = app.post_json("/api/groups", group, headers=token_auth_header)
-
-        assert res.status_code == 200
-
-    def test_it_ignores_non_whitelisted_fields_in_payload(self, app, token_auth_header):
-        group = {"name": "My Group", "organization": "foobar", "joinable_by": "whoever"}
-        res = app.post_json("/api/groups", group, headers=token_auth_header)
-
-        assert res.status_code == 200
+class Test400ErrorsUsingCreateGroup(object):
+    """Creating a group can raise all of the client errors we want to test"""
 
     def test_it_returns_http_400_with_invalid_payload(self, app, token_auth_header):
         group = {}
@@ -33,6 +28,17 @@ class TestCreateGroup(object):
         )
 
         assert res.status_code == 400
+
+    def test_it_returns_a_formatted_reason_with_invalid_payload(
+        self, app, token_auth_header
+    ):
+        group = {}
+
+        res = app.post_json(
+            "/api/groups", group, headers=token_auth_header, expect_errors=True
+        )
+
+        assert res.json["reason"] == "u'name' is a required property"
 
     def test_it_returns_http_400_if_groupid_set_on_default_authority(
         self, app, token_auth_header
@@ -44,6 +50,24 @@ class TestCreateGroup(object):
 
         assert res.status_code == 400
 
+    def test_it_returns_formatted_reason_if_groupid_set_on_default_authority(
+        self, app, token_auth_header
+    ):
+        # FIXME: The `reason` is double-escaped
+        group = {"name": "My Group", "groupid": "3434kjkjk"}
+        res = app.post_json(
+            "/api/groups", group, headers=token_auth_header, expect_errors=True
+        )
+
+        assert (
+            res.json["reason"]
+            == "groupid: u'3434kjkjk' does not match u\"^group:([a-zA-Z0-9._\\\\-+!~*()']{1,1024})@(.*)$\""
+        )
+
+
+@pytest.mark.functional
+class Test403ErrorsUsingCreateGroup(object):
+    # FIXME: API currently converts all 403s to 404s
     def test_it_returns_http_404_if_no_authenticated_user(
         self, app, auth_client_header
     ):
@@ -54,6 +78,20 @@ class TestCreateGroup(object):
         )
 
         assert res.status_code == 404
+
+    def test_it_returns_formatted_reason_if_no_authenticated_user(
+        self, app, auth_client_header
+    ):
+        # FIXME: This should return a 403
+        group = {"name": "My Group"}
+        res = app.post_json(
+            "/api/groups", group, headers=auth_client_header, expect_errors=True
+        )
+
+        assert (
+            res.json["reason"]
+            == "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
+        )
 
     @pytest.mark.xfail
     def test_it_returns_http_403_if_no_authenticated_user(
@@ -66,33 +104,25 @@ class TestCreateGroup(object):
 
         assert res.status_code == 403
 
-    def test_it_allows_auth_client_with_forwarded_user(
-        self, app, auth_client_header, third_party_user
-    ):
-        headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
-        group = {"name": "My Group"}
 
-        res = app.post_json("/api/groups", group, headers=headers)
+@pytest.mark.functional
+class Test404ErrorsUsingCreateGroup(object):
+    def test_it_returns_http_404_if_endpoint_nonexistent(self, app):
+        res = app.get("/api/not_a_thing", expect_errors=True)
 
-        assert res.status_code == 200
+        assert res.status_code == 404
 
-    def test_it_allows_groupdid_from_auth_client_with_forwarded_user(
-        self, app, auth_client_header, third_party_user
-    ):
-        headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
-        group = {"name": "My Group", "groupid": "group:333vcdfkj~@thirdparty.com"}
+    def test_it_returns_formatted_reason_if_endpoint_nonexistent(self, app):
+        res = app.get("/api/not_a_thing", expect_errors=True)
 
-        res = app.post_json("/api/groups", group, headers=headers)
-        data = res.json
-
-        assert res.status_code == 200
-        assert "groupid" in data
-        assert data["groupid"] == "group:{groupid}@thirdparty.com".format(
-            groupid="333vcdfkj~"
+        assert (
+            res.json["reason"]
+            == "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
         )
 
+
+@pytest.mark.functional
+class Test409ErrorsUsingCreateGroup(object):
     def test_it_returns_HTTP_Conflict_if_groupid_is_duplicate(
         self, app, auth_client_header, third_party_user
     ):
@@ -105,17 +135,20 @@ class TestCreateGroup(object):
 
         assert res.status_code == 409
 
-    def test_it_returns_http_404_with_invalid_forwarded_user_format(
-        self, app, auth_client_header
+    def test_it_returns_formatted_reason_if_group_is_duplicate(
+        self, app, auth_client_header, third_party_user
     ):
-        # FIXME: This should return a 403
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str("floopflarp")
-        group = {}
+        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        group = {"name": "My Group", "groupid": "group:333vcdfkj~@thirdparty.com"}
 
+        res = app.post_json("/api/groups", group, headers=headers)
         res = app.post_json("/api/groups", group, headers=headers, expect_errors=True)
 
-        assert res.status_code == 404
+        assert (
+            res.json["reason"]
+            == "group with groupid 'group:333vcdfkj~@thirdparty.com' already exists"
+        )
 
 
 @pytest.fixture

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -19,7 +19,7 @@ TEST_SETTINGS = {
     "es.index": ELASTICSEARCH_INDEX,
     "h.app_url": "http://example.com",
     "h.authority": "example.com",
-    "pyramid.debug_all": True,
+    "pyramid.debug_all": False,
     "secret_key": "notasecret",
     "sqlalchemy.url": os.environ.get(
         "TEST_DATABASE_URL", "postgresql://postgres@localhost/htest"

--- a/tests/h/views/api/decorators/__init__.py
+++ b/tests/h/views/api/decorators/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/views/api/decorators/client_errors_test.py
+++ b/tests/h/views/api/decorators/client_errors_test.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import mock
+import pytest
+
+from pyramid.response import Response
+
+from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound, HTTPGone
+
+from h.views.api.decorators.client_errors import client_error_decorator
+
+
+class TestClientErrorDecorator(object):
+    def test_it_calls_wrapped_view_function(self, pyramid_request, testview):
+
+        client_error_decorator(testview)(None, pyramid_request)
+
+        assert testview.called
+
+    def test_it_replaces_403s_with_404s(self, pyramid_request, testview):
+        wrapped = client_error_decorator(testview)
+
+        wrapped(HTTPForbidden(), pyramid_request)
+
+        (context, _) = testview.call_args[0]
+
+        assert isinstance(context, HTTPNotFound)
+
+    def test_it_replaces_404_message(self, pyramid_request, testview):
+        wrapped = client_error_decorator(testview)
+        default_not_found = HTTPNotFound()
+
+        wrapped(HTTPNotFound(), pyramid_request)
+
+        (context, _) = testview.call_args[0]
+        assert context.message != default_not_found.message
+
+    def test_it_does_not_replace_other_http_4xx_messages(
+        self, pyramid_request, testview
+    ):
+        wrapped = client_error_decorator(testview)
+        default_gone = HTTPGone()
+
+        wrapped(HTTPGone(), pyramid_request)
+
+        (context, _) = testview.call_args[0]
+        assert context.message == default_gone.message
+
+    @pytest.fixture
+    def testview(self):
+        return mock.Mock(return_value=Response("OK"))

--- a/tests/h/views/api/errors_test.py
+++ b/tests/h/views/api/errors_test.py
@@ -3,13 +3,13 @@
 from __future__ import unicode_literals
 
 from mock import Mock
-from pyramid.httpexceptions import HTTPExpectationFailed
+from pyramid.httpexceptions import HTTPExpectationFailed, HTTPNotFound
 
 from h.views.api import errors as views
 
 
 def test_api_notfound_view(pyramid_request):
-    result = views.api_notfound(pyramid_request)
+    result = views.api_notfound(HTTPNotFound("Some Reason"), pyramid_request)
 
     assert pyramid_request.response.status_int == 404
     assert result["status"] == "failure"


### PR DESCRIPTION
This PR makes no user-facing or functional changes, but restructures the API's exception views in a manner that will make it possible to sub in 415s instead of 404s in some cases. I almost just added that last part into this PR but I didn't want the diff to get too big.

What's in here:

* Instead of messing with the HTTP exception directly in the exception view, there is now a decorator that will alter the `context` passed to the view. When I'm done with this whole process (one more PR, I'd expect), the exception view will expect some form of `HTTPClientError` as its `context` but doesn't need to know more than that.
* Turning off `debug_all` for functional tests because it accomplishes nothing and interferes with the tests I started adding here...
* Functional tests for error response details so I can be sure I'm not inadvertently changing current behavior.
* Stop stringifying the whole `context` in the more generic `HTTPError` handler (which will be conflated into a single exception view in a later PR instead of being standalone).

Basically this is a cleanup and prep PR so I can add the functionality I've actually been trying to add for 2 or 3 days now :). That next part I have a pretty good handle on!