### PR TITLE
Add helper module for media-type-related functions

### DIFF
--- a/h/views/api/helpers/media_types.py
+++ b/h/views/api/helpers/media_types.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from h.views.api import API_VERSIONS
+
+
+def media_type_for_version(version, subtype="json"):
+    """
+    Return the media type corresponding to a particular version string
+
+    :arg version:  The major API version, e.g. ``"v1"``
+    :type version: str
+    :arg subtype:  The "subtype" of the content type desired; defaults
+                   to ``"json"``
+    :type subtype: str or None
+    :rtype: str
+    """
+    return "application/vnd.hypothesis.{}+{}".format(version, subtype)
+
+
+def valid_media_types(versions=None):
+    """
+    Return a list of all valid API media types
+
+    This represents a list of all of the Accept header values that are known to
+    the API. This includes all version-specific media types.
+
+    An HTTP request to the API must contain either:
+
+    * An empty Accept header
+    * An Accept header containing at least one of the media types returned by
+      this function.
+
+    :arg versions: List of version strings to include in the valid media types.
+                   Defaults to the app's known version list.
+    :type versions: list(str) or None
+    :rtype: list(str)
+    """
+    versions = versions or API_VERSIONS
+    valid_types = ["*/*", "application/json"]
+    for version in versions:
+        valid_types.append(media_type_for_version(version))
+    return valid_types

--- a/tests/h/views/api/helpers/media_types_test.py
+++ b/tests/h/views/api/helpers/media_types_test.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from h.views.api.helpers import media_types
+
+
+class TestMediaTypeForVersion(object):
+    @pytest.mark.parametrize(
+        "version,expected",
+        [
+            ("v1", "application/vnd.hypothesis.v1+json"),
+            ("elephant", "application/vnd.hypothesis.elephant+json"),
+        ],
+    )
+    def test_it_formats_version_into_media_type_string(self, version, expected):
+        assert media_types.media_type_for_version(version) == expected
+
+    @pytest.mark.parametrize(
+        "version,subtype,expected",
+        [
+            ("v1", "json", "application/vnd.hypothesis.v1+json"),
+            ("elephant", "json", "application/vnd.hypothesis.elephant+json"),
+            ("v2", "json.ld", "application/vnd.hypothesis.v2+json.ld"),
+            ("v3", "whatever", "application/vnd.hypothesis.v3+whatever"),
+        ],
+    )
+    def test_it_appends_subtype_when_provided(self, version, subtype, expected):
+        assert media_types.media_type_for_version(version, subtype) == expected
+
+
+class TestValidMediaTypes(object):
+    def test_it_returns_list_containing_version_types(self):
+        assert media_types.valid_media_types(["foo", "bar"]) == [
+            "*/*",
+            "application/json",
+            "application/vnd.hypothesis.foo+json",
+            "application/vnd.hypothesis.bar+json",
+        ]


### PR DESCRIPTION
This small PR adds a helper module for some common needs related to media types for the API views. The helper module is not yet used by anything.