### PR TITLE
Refactor API exception views for 4xx errors; raise 415s when appropriate

### DIFF
--- a/h/views/api/decorators/__init__.py
+++ b/h/views/api/decorators/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from h.views.api.decorators.client_errors import (
+    unauthorized_to_not_found,
+    normalize_not_found,
+    validate_media_types,
+)
+
+__all__ = ("unauthorized_to_not_found", "normalize_not_found", "validate_media_types")

--- a/h/views/api/decorators/client_errors.py
+++ b/h/views/api/decorators/client_errors.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""API view decorators for exception views"""
+
+from __future__ import unicode_literals
+
+from pyramid.httpexceptions import HTTPNotFound, HTTPUnsupportedMediaType
+
+from h.views.api.helpers.media_types import valid_media_types
+
+
+def unauthorized_to_not_found(wrapped):
+    """View decorator to convert all 403 exceptions to 404s"""
+
+    def wrapper(context, request):
+        # We convert all 403s to 404s—replace the current context with a 404
+        # FIXME: We should be more nuanced about when we do this
+        response = wrapped(_standard_not_found(), request)
+        return response
+
+    return wrapper
+
+
+def normalize_not_found(wrapped):
+    """View decorator to make 404 error messages more readable"""
+
+    def wrapper(context, request):
+        # Replace incoming 404 with one that has a sensible message
+        response = wrapped(_standard_not_found(), request)
+        return response
+
+    return wrapper
+
+
+def validate_media_types(wrapped):
+    """View decorator to convert certain 4xx errors to 415s"""
+
+    def wrapper(context, request):
+        # If Accept has been set
+        if request.accept:
+            # At least one of the media types in Accept must be known to the app
+            if not any([t in valid_media_types() for t in request.accept]):
+                # If no Accept media types are known, convert to a 415 error
+                context = HTTPUnsupportedMediaType("Unsupported media type")
+        response = wrapped(context, request)
+        return response
+
+    return wrapper
+
+
+def _standard_not_found():
+    # The default message is not helpful: it's the path
+    # that failed to match any view. Replace it.
+    return HTTPNotFound(
+        "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
+    )

--- a/h/views/api/errors.py
+++ b/h/views/api/errors.py
@@ -17,6 +17,11 @@ from pyramid import httpexceptions
 from h.i18n import TranslationString as _  # noqa: N813
 from h.util.view import handle_exception, json_view
 from h.views.api.config import cors_policy
+from h.views.api.decorators import (
+    unauthorized_to_not_found,
+    normalize_not_found,
+    validate_media_types,
+)
 from h.views.api.exceptions import OAuthAuthorizeError
 
 # All exception views below need to apply the `cors_policy` decorator for the
@@ -24,17 +29,20 @@ from h.views.api.exceptions import OAuthAuthorizeError
 # origin as h itself.
 
 
-# Within the API, render a JSON 403/404 message.
-@forbidden_view_config(path_info="/api/", renderer="json", decorator=cors_policy)
-@notfound_view_config(path_info="/api/", renderer="json", decorator=cors_policy)
-def api_notfound(request):
-    """Handle a request for an unknown/forbidden resource within the API."""
-    request.response.status_code = 404
-    message = _(
-        "Either the resource you requested doesn't exist, or you are "
-        "not currently authorized to see it."
-    )
-    return {"status": "failure", "reason": message}
+# Handle raised 403 and 404 exceptions
+@forbidden_view_config(
+    path_info="/api/",
+    renderer="json",
+    decorator=(cors_policy, unauthorized_to_not_found),
+)
+@notfound_view_config(
+    path_info="/api/",
+    renderer="json",
+    decorator=(cors_policy, normalize_not_found, validate_media_types),
+)
+def api_notfound(context, request):
+    request.response.status_code = context.status_code
+    return {"status": "failure", "reason": context.message}
 
 
 @view_config(
@@ -50,7 +58,7 @@ def oauth_error(context, request):
 def api_error(context, request):
     """Handle an expected/deliberately thrown API exception."""
     request.response.status_code = context.status_code
-    return {"status": "failure", "reason": str(context)}
+    return {"status": "failure", "reason": context.detail}
 
 
 @json_view(context=Exception, path_info="/api/", decorator=cors_policy)

--- a/tests/functional/api/test_errors.py
+++ b/tests/functional/api/test_errors.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+"""
+Functional tests for client API errors
+
+Uses create-group endpoint as it can raise all relevant client error codes.
+"""
+
+from __future__ import unicode_literals
+
+import pytest
+import base64
+import re
+
+
+from h.models.auth_client import GrantType
+
+native_str = str
+
+
+@pytest.mark.functional
+class Test400Errors(object):
+    """Creating a group can raise all of the client errors we want to test"""
+
+    def test_it_400s_if_invalid_payload(self, app, append_token_auth):
+        group = {}
+        headers = append_token_auth()
+        res = app.post_json("/api/groups", group, headers=headers, expect_errors=True)
+
+        assert res.status_code == 400
+        stripped = _strip_unicode_literal(res.json["reason"])
+        assert stripped == "'name' is a required property"
+
+    def test_it_400s_for_create_group_if_groupid_set_on_default_authority(
+        self, app, append_token_auth
+    ):
+        group = {"name": "My Group", "groupid": "3434kjkjk"}
+        headers = append_token_auth()
+        res = app.post_json("/api/groups", group, headers=headers, expect_errors=True)
+        stripped = _strip_unicode_literal(res.json["reason"])
+        # FIXME: The `reason` is double-escaped
+        expected = "groupid: '3434kjkjk' does not match \"^group:([a-zA-Z0-9._\\\\-+!~*()']{1,1024})@(.*)$\""
+
+        assert res.status_code == 400
+        assert stripped == expected
+
+
+@pytest.mark.functional
+class Test404Errors(object):
+    # TODO: Some of these 404s should really be 403s
+    def test_it_404s_if_authz_fail_with_valid_accept(self, app, append_auth_client):
+        headers = append_auth_client()
+        headers[native_str("Accept")] = native_str("application/json")
+        group = {"name": "My Group"}
+
+        res = app.post_json("/api/groups", group, headers=headers, expect_errors=True)
+
+        assert res.status_code == 404
+        assert (
+            res.json["reason"]
+            == "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
+        )
+
+    def test_it_404s_if_authz_fail_with_missing_accept(self, app, append_auth_client):
+        headers = append_auth_client()
+        group = {"name": "My Group"}
+
+        res = app.post_json("/api/groups", group, headers=headers, expect_errors=True)
+
+        assert res.status_code == 404
+        assert (
+            res.json["reason"]
+            == "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
+        )
+
+    def test_it_404s_if_not_found_with_valid_accept_and_no_authz(self, app):
+        headers = {}
+        headers[native_str("Accept")] = native_str("application/json")
+
+        res = app.get("/api/not_a_thing", headers=headers, expect_errors=True)
+
+        assert res.status_code == 404
+        assert (
+            res.json["reason"]
+            == "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
+        )
+
+    def test_it_404s_if_not_found_with_missing_accept_and_no_authz(self, app):
+        res = app.get("/api/not_a_thing", expect_errors=True)
+
+        assert res.status_code == 404
+        assert (
+            res.json["reason"]
+            == "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
+        )
+
+
+@pytest.mark.functional
+class Test409Errors(object):
+    def test_it_409s_on_create_group_if_groupid_is_duplicate(
+        self, app, append_auth_client, third_party_user
+    ):
+        headers = append_auth_client()
+        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        group = {"name": "My Group", "groupid": "group:333vcdfkj~@thirdparty.com"}
+
+        res = app.post_json("/api/groups", group, headers=headers)
+        res = app.post_json("/api/groups", group, headers=headers, expect_errors=True)
+
+        assert res.status_code == 409
+        assert (
+            res.json["reason"]
+            == "group with groupid 'group:333vcdfkj~@thirdparty.com' already exists"
+        )
+
+
+@pytest.mark.functional
+class Test415Errors(object):
+    def test_it_415s_if_not_found_with_bad_accept(self, app):
+        headers = {}
+        headers[native_str("Accept")] = native_str("application/totally_random")
+        res = app.get("/api/not_a_thing", headers=headers, expect_errors=True)
+
+        assert res.status_code == 415
+        assert res.json["reason"] == "Unsupported media type"
+
+    def test_it_415s_if_path_extant_but_bad_accept(self, app):
+        headers = {}
+        headers[native_str("Accept")] = native_str("application/totally_random")
+        res = app.get("/api/groups", headers=headers, expect_errors=True)
+
+        assert res.status_code == 415
+        assert res.json["reason"] == "Unsupported media type"
+
+
+@pytest.fixture
+def third_party_user(db_session, factories):
+    user = factories.User(authority="thirdparty.com")
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
+def auth_client(db_session, factories):
+    auth_client = factories.ConfidentialAuthClient(
+        authority="thirdparty.com", grant_type=GrantType.client_credentials
+    )
+    db_session.commit()
+    return auth_client
+
+
+@pytest.fixture
+def append_auth_client(auth_client):
+    user_pass = "{client_id}:{secret}".format(
+        client_id=auth_client.id, secret=auth_client.secret
+    )
+    encoded = base64.standard_b64encode(user_pass.encode("utf-8"))
+
+    def append_header(headers=None):
+        headers = headers or {}
+        headers[native_str("Authorization")] = native_str(
+            "Basic {creds}".format(creds=encoded.decode("ascii"))
+        )
+        return headers
+
+    return append_header
+
+
+@pytest.fixture
+def user_with_token(db_session, factories):
+    user = factories.User()
+    token = factories.DeveloperToken(userid=user.userid)
+    db_session.commit()
+    return (user, token)
+
+
+@pytest.fixture
+def append_token_auth(user_with_token):
+    def append_header(headers=None):
+        headers = headers or {}
+        user, token = user_with_token
+        headers[native_str("Authorization")] = native_str(
+            "Bearer {}".format(token.value)
+        )
+        return headers
+
+    return append_header
+
+
+@pytest.fixture
+def valid_accept():
+    headers = {}
+    headers[native_str("Accept")] = "application/json"
+    return headers
+
+
+def _strip_unicode_literal(original):
+    # Strip "u" literal prefixes that get added in front of property names in
+    # certain error messages in Python 2.
+    # See https://github.com/hypothesis/h/commit/992fa8005389ed52ebd076ae230d862b24449f2f
+    return re.sub(r"u(['\"])([^']+)'", "\\1\\2'", original)

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -18,7 +18,7 @@ native_str = str
 
 @pytest.mark.functional
 class TestIndexEndpointVersions(object):
-    def test_api_index_default(self, app):
+    def test_index_200s_when_accept_empty(self, app):
         """
         Don't send any Accept headers and we should get a 200 response.
         """
@@ -27,7 +27,7 @@ class TestIndexEndpointVersions(object):
         assert res.status_code == 200
         assert "links" in res.json
 
-    def test_api_index_application_json(self, app):
+    def test_index_200s_with_application_json(self, app):
         """
         Send ``application/json`` and we should get a 200 response from the
         default version.
@@ -39,7 +39,7 @@ class TestIndexEndpointVersions(object):
         assert res.status_code == 200
         assert "links" in res.json
 
-    def test_api_index_v1(self, app):
+    def test_index_200s_with_v1_header(self, app):
         """
         Set a v1 Accept header and we should get a 200 response.
         """
@@ -50,23 +50,23 @@ class TestIndexEndpointVersions(object):
         assert res.status_code == 200
         assert "links" in res.json
 
-    def test_api_index_v2(self, app):
+    def test_index_415s_with_invalid_version_header(self, app):
         """
-        Set a v2 Accept header and we should get a 404 response.
+        Set a v2 Accept header and we should get a 415 response.
         (For now because the version doesn't exist quite yet)
         """
         headers = {"Accept": str("application/vnd.hypothesis.v2+json")}
 
         res = app.get("/api/", headers=headers, expect_errors=True)
 
-        assert res.status_code == 404
+        assert res.status_code == 415
 
-    def test_api_index_invalid_accept(self, app):
+    def test_index_415s_with_invalid_accept_header_value(self, app):
         """
-        Set a generally-invalid Accept header and we should always get a 404.
+        Set a generally-invalid Accept header and we should always get a 415.
         """
         headers = {"Accept": str("nonsensical")}
 
         res = app.get("/api/", headers=headers, expect_errors=True)
 
-        assert res.status_code == 404
+        assert res.status_code == 415

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -19,7 +19,7 @@ TEST_SETTINGS = {
     "es.index": ELASTICSEARCH_INDEX,
     "h.app_url": "http://example.com",
     "h.authority": "example.com",
-    "pyramid.debug_all": True,
+    "pyramid.debug_all": False,
     "secret_key": "notasecret",
     "sqlalchemy.url": os.environ.get(
         "TEST_DATABASE_URL", "postgresql://postgres@localhost/htest"

--- a/tests/h/views/api/decorators/__init__.py
+++ b/tests/h/views/api/decorators/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/views/api/decorators/client_errors_test.py
+++ b/tests/h/views/api/decorators/client_errors_test.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import mock
+import pytest
+
+from pyramid.response import Response
+from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound, HTTPUnsupportedMediaType
+from webob.acceptparse import MIMEAccept, MIMENilAccept
+
+from h.views.api.decorators.client_errors import (
+    unauthorized_to_not_found,
+    normalize_not_found,
+    validate_media_types,
+)
+
+
+class TestUnauthorizedToNotFound(object):
+    def test_it_calls_wrapped_view_function(self, pyramid_request, testview):
+
+        unauthorized_to_not_found(testview)(None, pyramid_request)
+
+        assert testview.called
+
+    def test_it_replaces_context_with_404_exception(self, pyramid_request, testview):
+        wrapped = unauthorized_to_not_found(testview)
+
+        wrapped(HTTPForbidden(), pyramid_request)
+
+        context, _ = testview.call_args[0]
+
+        assert isinstance(context, HTTPNotFound)
+
+    def test_it_sets_appropriate_404_message(self, pyramid_request, testview):
+        wrapped = unauthorized_to_not_found(testview)
+
+        wrapped(HTTPNotFound(), pyramid_request)
+
+        context, _ = testview.call_args[0]
+        assert (
+            context.message
+            == "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
+        )
+
+
+class TestNormalizeNotFound(object):
+    def test_it_sets_appropriate_message(self, pyramid_request, testview):
+        wrapped = normalize_not_found(testview)
+
+        wrapped(HTTPNotFound(), pyramid_request)
+
+        context, _ = testview.call_args[0]
+        assert (
+            context.message
+            == "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
+        )
+
+    def test_context_is_not_found(self, pyramid_request, testview):
+        wrapped = normalize_not_found(testview)
+
+        # This view decorator would never have a reason to deal with
+        # a 403 as a context, but it would be valid
+        wrapped(HTTPForbidden(), pyramid_request)
+
+        context, _ = testview.call_args[0]
+        assert isinstance(context, HTTPNotFound)
+
+
+class TestValidateMediaTypes(object):
+    def test_it_calls_wrapped_view_function(self, pyramid_request, testview):
+        validate_media_types(testview)(None, pyramid_request)
+
+        assert testview.called
+
+    def test_it_does_not_modify_context_if_accept_not_set(
+        self, pyramid_request, testview
+    ):
+        fake_context = mock.Mock()
+        validate_media_types(testview)(fake_context, pyramid_request)
+
+        context, _ = testview.call_args[0]
+        assert context == fake_context
+
+    def test_it_does_not_modify_context_if_any_accept_values_ok(
+        self, pyramid_request, testview
+    ):
+        # At least one of these is valid
+        pyramid_request.accept = MIMEAccept("application/json, foo/bar")
+        fake_context = mock.Mock()
+        validate_media_types(testview)(fake_context, pyramid_request)
+
+        context, _ = testview.call_args[0]
+        assert context == fake_context
+
+    def test_it_replaces_context_with_415_if_accept_set_and_invalid(
+        self, pyramid_request, testview
+    ):
+        # None of these is valid
+        pyramid_request.accept = MIMEAccept("application/something+json, foo/bar")
+        fake_context = mock.Mock()
+        validate_media_types(testview)(fake_context, pyramid_request)
+
+        context, _ = testview.call_args[0]
+        assert isinstance(context, HTTPUnsupportedMediaType)
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        # Set an empty accept on the request, imitating what pyramid does
+        # in real life if no Accept header is set on the incoming request
+        pyramid_request.accept = MIMENilAccept()
+        return pyramid_request
+
+
+@pytest.fixture
+def testview():
+    return mock.Mock(return_value=Response("OK"))

--- a/tests/h/views/api/errors_test.py
+++ b/tests/h/views/api/errors_test.py
@@ -3,13 +3,13 @@
 from __future__ import unicode_literals
 
 from mock import Mock
-from pyramid.httpexceptions import HTTPExpectationFailed
+from pyramid.httpexceptions import HTTPExpectationFailed, HTTPNotFound
 
 from h.views.api import errors as views
 
 
 def test_api_notfound_view(pyramid_request):
-    result = views.api_notfound(pyramid_request)
+    result = views.api_notfound(HTTPNotFound("Some Reason"), pyramid_request)
 
     assert pyramid_request.response.status_int == 404
     assert result["status"] == "failure"


### PR DESCRIPTION
The bad news is that a lot of this is rehash of #5558 but the good news is that this variant includes the work to make the API respond with 415s in the right cases—this isn't just a prep PR, it's _the_ PR now.

This PR makes the following meaningful change: The API will respond with a 415 if a client request contains an invalid Accept header. It's OK for an Accept header not to be set, but if an Accept header is set, at least one of the media types it specifies must match a known media type. If this check fails, a 415 will be returned. 415 will supersede 404s—if you throw bad media types at the app, it's going to 415 you whether or not the endpoint exists.

To support this, this PR makes the following technical changes:

* A new decorator module has been added for API exception views. This decorator module has several decorators, which are composed on Forbidden and Not Found exception-handling view to correctly handle what should happen.
* Functional tests have been added for API client error states.
* Debug has been turned _off_ in functional tests as it interferes with Pyramid responses.

The differences between this and #5558:

* The actual 415-raising logic is extant here.
* View decorators are granular and, I think, a lot easier to grok
* Functional tests have been somewhat refactored (however, I was unable to remove `db.commit()`s without tests failing)
