### PR TITLE
Refactor API "Links"

### DIFF
--- a/h/views/api/helpers/links.py
+++ b/h/views/api/helpers/links.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""Helpers for generating and retrieving service link metadata"""
+
+from __future__ import unicode_literals
+
+
+class ServiceLink(object):
+    """Encapsulate metadata about an API service"""
+
+    def __init__(self, name, route_name, method="GET", description=None):
+        self.name = name
+        self.route_name = route_name
+        self.method = method
+        self.description = description
+
+    def primary_method(self):
+        """
+        Determine the primary HTTP method for this service
+
+        If the ``method`` indicated is a tuple, the first entry will be
+        returned.
+
+        :rtype: str
+        """
+        method = self.method
+        if isinstance(method, tuple):
+            # If the view matches multiple methods, assume the first one is
+            # preferred
+            method = method[0]
+        return method
+
+
+def register_link(link, versions, registry):
+    """
+    Register an API service's metadata for its supported versions
+
+    Add an entry for the indicated ``link`` onto the ``registry`` for each
+    of the versions it claims to supported. These entries include basic
+    endpoint metadata like description and primary HTTP method.
+
+    These data structures are later referenced to deliver an index of our
+    API endpoints at `GET /api/`.
+
+    :arg link: The link to add metadata about
+    :type link: :class:`~h.views.api.helpers.links.ServiceLink`
+    :arg versions: Supported versions (e.g. ``"v1"``)
+    :type versions: list(str)
+    :arg registry: Pyramid registry to put metadata in; mutated in place
+    :type registry: :class:`pyramid.registry.Registry`
+    """
+
+    if not hasattr(registry, "api_links"):
+        registry.api_links = {}
+    for version in versions:
+        if version not in registry.api_links:
+            registry.api_links[version] = []
+        registry.api_links[version].append(link)

--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -13,7 +13,7 @@ def index(context, request):
     Clients may use this to discover endpoints for the API.
     """
 
-    api_links = request.registry.api_links
+    api_links = request.registry.api_links["v1"]
 
     # We currently need to keep a list of the parameter names we use in our API
     # paths and pass these explicitly into the templater. As and when new
@@ -26,11 +26,11 @@ def index(context, request):
     links = {}
     for link in api_links:
         method_info = {
-            "method": link["method"],
-            "url": templater.route_template(link["route_name"]),
-            "desc": link["description"],
+            "method": link.primary_method(),
+            "url": templater.route_template(link.route_name),
+            "desc": link.description,
         }
-        _set_at_path(links, link["name"].split("."), method_info)
+        _set_at_path(links, link.name.split("."), method_info)
 
     return {"links": links}
 

--- a/tests/h/views/api/helpers/links_test.py
+++ b/tests/h/views/api/helpers/links_test.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from h.views.api.helpers import links
+
+
+class TestServiceLink(object):
+    @pytest.mark.parametrize(
+        "name,route_name,method,description,expected_method",
+        [
+            ("Create Foo", "foo.create", "POST", None, "POST"),
+            ("Create Foo", "foo.create", ("POST", "PATCH"), None, "POST"),
+            ("Create Foo", "foo.create", "GET", "Forever and a Day", "GET"),
+        ],
+    )
+    def test_primary_method_returns_correct_HTTP_method(
+        self, name, route_name, method, description, expected_method
+    ):
+        assert (
+            links.ServiceLink(name, route_name, method, description).primary_method()
+            == expected_method
+        )
+
+
+class TestRegisterLink(object):
+    def test_it_creates_attrs_on_registry_if_not_present(
+        self, versions, pyramid_config
+    ):
+        links.register_link(_service_link(), versions, pyramid_config.registry)
+
+        assert hasattr(pyramid_config.registry, "api_links")
+        assert "v1" in pyramid_config.registry.api_links
+        assert "v2" in pyramid_config.registry.api_links
+
+    def test_it_registers_link_for_every_version(self, versions, pyramid_config):
+        link = _service_link()
+
+        links.register_link(link, versions, pyramid_config.registry)
+
+        assert link in pyramid_config.registry.api_links["v1"]
+        assert link in pyramid_config.registry.api_links["v2"]
+
+    def test_it_does_not_register_link_for_unsupported_versions(
+        self, versions, pyramid_config
+    ):
+        first_service = _service_link()
+        second_service = _service_link("doodad")
+
+        links.register_link(first_service, versions, pyramid_config.registry)
+        links.register_link(second_service, ["v1"], pyramid_config.registry)
+
+        assert first_service in pyramid_config.registry.api_links["v2"]
+        assert second_service not in pyramid_config.registry.api_links["v2"]
+
+
+def _service_link(name="api.example_service"):
+    return links.ServiceLink(
+        name="name",
+        route_name="api.example_service",
+        method="POST",
+        description="Create a new Foo",
+    )
+
+
+@pytest.fixture
+def versions():
+    return ["v1", "v2"]


### PR DESCRIPTION
The index endpoint of our API (`GET /api/`) returns information about all of the API services available.

This PR does some refactoring to make this compatible with multiple versions of the API. It also factors the link registration out of the config decorator itself into a helper.

There is no user-/client-visible change here.

Part of https://github.com/hypothesis/product-backlog/issues/940