### PR TITLE
Convert more API Documentation to Open API

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -121,6 +121,8 @@ components:
   # Reusable responses
   # -------------------------
   responses:
+    NoContent:
+      description: Success (No Content)
     BadRequest:
       description: Bad Request
       content:
@@ -333,6 +335,86 @@ paths:
                       - true
                   id:
                     type: string
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+
+  # ---------------------------------------------------------------------------
+  # Annotation Moderation Operations: Flagging
+  # ---------------------------------------------------------------------------
+  /annotations/{id}/flag:
+
+    # --------------------------------------------------------
+    # PUT annotations/{id}/flag - Add a flag to an annotation
+    # --------------------------------------------------------
+    put:
+      tags:
+        - annotations
+      summary: Flag an annotation
+      description: >
+        Flag an annotation for review (moderation). The moderator of the group
+        containing the annotation will be notified of the flag and can decide
+        whether or not to hide the annotation. Note that flags persist and
+        cannot be removed once they are set.
+      security:
+        - ApiKey: []
+      parameters:
+        - $ref: '#/components/parameters/AnnotationID'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+
+  # ---------------------------------------------------------------------------
+  # Annotation Moderation Operations: Hiding/Unhiding
+  # ---------------------------------------------------------------------------
+  /annotations/{id}/hide:
+
+    # ----------------------------------------------------------
+    # PUT annotations/{id}/hide - Hide (moderate) an annotation
+    # ----------------------------------------------------------
+    put:
+      tags:
+        - annotations
+      summary: Hide an annotation
+      description: >
+        Hide an annotation. The authenticated user needs to have the moderate
+        permission for the group that contains the annotation—this permission
+        is granted to the user who created the group.
+      security:
+        - ApiKey: []
+      parameters:
+        - $ref: '#/components/parameters/AnnotationID'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+
+    # ----------------------------------------------------------
+    # DELETE annotations/{id}/hide - Unhide  an annotation
+    # ----------------------------------------------------------
+    delete:
+      tags:
+        - annotations
+      summary: Show an annotation
+      description: >
+        Show/"un-hide" an annotation. The authenticated user needs to have the
+        moderate permission for the group that contains the annotation—this
+        permission is granted to the user who created the group.
+      security:
+        - ApiKey: []
+      parameters:
+        - $ref: '#/components/parameters/AnnotationID'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
         '404':
           $ref: '#/components/responses/NotFound'
         '415':

--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -31,6 +31,13 @@ components:
   # Reusable parameters
   # -------------------------
   parameters:
+    AnnotationID:
+      name: id
+      in: path
+      required: true
+      schema:
+        description: The annotation's unique identifier
+        type: string
     GroupID:
       name: id
       in: path
@@ -125,6 +132,10 @@ components:
   # Resusable resource schemas
   # ------------------------------
   schemas:
+    Annotation:
+      $ref: './schemas/annotation-schema.json'
+    AnnotationCreate:
+      $ref: './schemas/annotation-schema.json'
     Group:
       $ref: './schemas/group.yaml#/Group'
     GroupCreate:
@@ -145,6 +156,120 @@ components:
 # API OPERATIONS
 # -----------------------------------------------------------------------------
 paths:
+
+  # ---------------------------------------------------------------------------
+  # Operations on Annotation collections
+  # ---------------------------------------------------------------------------
+  /annotations:
+
+    post:
+      tags:
+        - annotations
+      summary: Create a new annotation
+      security:
+        - ApiKey: []
+      requestBody:
+          description: Full representation of Annotation resource
+          required: true
+          content:
+            application/*json:
+              schema:
+                $ref: '#/components/schemas/AnnotationCreate'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Annotation'
+
+  # ---------------------------------------------------------------------------
+  # Operations on single Annotation resources
+  # ---------------------------------------------------------------------------
+  /annotations/{id}:
+
+    # -----------------------------------------------------
+    # GET annotations/{id} - Fetch an Annotation
+    # -----------------------------------------------------
+    get:
+      tags:
+        - annotations
+      summary: Fetch an Annotation
+      security:
+        - ApiKey: []
+        - {} # Unauthenticated OK, depending on annotation status
+      parameters:
+        - $ref: '#/components/parameters/AnnotationID'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Annotation'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    # ------------------------------------------------------------------
+    # PATCH annotations/{id} - Update an Annotation (PUT also supported)
+    # ------------------------------------------------------------------
+    patch:
+      tags:
+        - annotations
+      summary: Update an Annotation
+      description: >
+        This endpoint is available under both the `PATCH` and `PUT`
+        request methods. Both endpoints have PATCH-characteristics
+        as defined in [RFC5789](https://tools.ietf.org/html/rfc5789#section-1),
+        meaning the request body does not have to include the whole annotation
+        object.
+
+        New implementations should use the `PATCH` request method, and existing
+        implementations continue to work under `PUT` but should switch to `PATCH`.
+      security:
+        - ApiKey: []
+      parameters:
+        - $ref: '#/components/parameters/AnnotationID'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Annotation'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    # ------------------------------------------------------------------
+    # DELETE annotations/{id} - Delete an Annotation
+    # ------------------------------------------------------------------
+    delete:
+      tags:
+        - annotations
+      summary: Delete an Annotation
+      security:
+        - ApiKey: []
+      parameters:
+        - $ref: '#/components/parameters/AnnotationID'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - deleted
+                  - id
+                properties:
+                  deleted:
+                    type: boolean
+                    enum:
+                      - true
+                  id:
+                    type: string
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   # ---------------------------------------------------------------------------
   # Operations on Group collections

--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -121,19 +121,30 @@ components:
   # Reusable responses
   # -------------------------
   responses:
-    Conflict:
-      description: >
-        An error indicating a resource conflict, typically because a
-        duplicate resource already exists.
+    BadRequest:
+      description: Bad Request
       content:
         application/*json:
           schema:
-            $ref: './schemas/errors.yaml#/Conflict'
+            $ref: './schemas/errors.yaml#/Error'
+    Conflict:
+      description: Conflict
+      content:
+        application/*json:
+          schema:
+            $ref: './schemas/errors.yaml#/Error'
     NotFound:
-      description: >
-        The specified resource was not found, or you do not have permission
-        to access it
-
+      description: Not Found or Permission Denied
+      content:
+        application/*json:
+          schema:
+            $ref: './schemas/errors.yaml#/Error'
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/*json:
+          schema:
+            $ref: './schemas/errors.yaml#/Error'
 
   # --------------------------
   # Resusable security schemes
@@ -224,6 +235,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Annotation'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # Operations on single Annotation resources
@@ -251,6 +268,8 @@ paths:
                 $ref: '#/components/schemas/Annotation'
         '404':
           $ref: '#/components/responses/NotFound'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
 
     # ------------------------------------------------------------------
     # PATCH annotations/{id} - Update an Annotation (PUT also supported)
@@ -279,8 +298,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Annotation'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
 
     # ------------------------------------------------------------------
     # DELETE annotations/{id} - Delete an Annotation
@@ -312,6 +335,8 @@ paths:
                     type: string
         '404':
           $ref: '#/components/responses/NotFound'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # Operations on Group collections
@@ -362,6 +387,9 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Group'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+
     post:
       tags:
         - groups
@@ -386,8 +414,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Group'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
 
 
   # ---------------------------------------------------------------------------
@@ -422,6 +456,8 @@ paths:
                 $ref: '#/components/schemas/Group'
         '404':
           $ref: '#/components/responses/NotFound'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
 
     # -----------------------------------------------------
     # PATCH groups/{id} - Update a Group
@@ -451,10 +487,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Group'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
 
     # ---------------------------------------------------------------------
     # PUT groups/{id} - Replace (Create or Update) a Group, a.k.a. "upsert"
@@ -483,10 +523,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Group'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # Operations on the currently-authenticated user (Profile)
@@ -512,6 +556,8 @@ paths:
             application/*json:
               schema:
                 $ref: '#/components/schemas/Profile'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
 
   /profile/groups:
     # -------------------------------------------------------------
@@ -535,7 +581,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Group'
-
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # Operations on User Collections
@@ -565,8 +612,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # Operations on single User Resources
@@ -598,5 +651,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'

--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -223,6 +223,20 @@ components:
 paths:
 
   # ---------------------------------------------------------------------------
+  # Service Root
+  # ---------------------------------------------------------------------------
+  /:
+    get:
+      tags:
+        - general
+      summary: Service root
+      description: Provides a list of links to resources offered by the API.
+      responses:
+        '200':
+          description: Success
+      security: []
+
+  # ---------------------------------------------------------------------------
   # Operations on Annotation collections
   # ---------------------------------------------------------------------------
   /annotations:

--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -9,6 +9,48 @@ info:
   license:
     name: BSD (2-Clause)
     url: https://github.com/hypothesis/h/blob/master/LICENSE
+  description: |
+
+    # Introduction
+
+    This is a reference for the Hypothesis HTTP API version 1.0.
+    See [the API overview](../api/) for an introduction to the API and information
+    on how authorization works.
+
+    ## API Versions
+
+    TBD
+
+    ## Errors
+
+    The API uses standard HTTP status codes to indicate the success or failure
+    of requests. The body of the response will be JSON in the following format:
+
+    ```
+    {
+      "status": "failure",
+      "reason": "a human-readable string about what went wrong"
+    }
+    ```
+
+    ## Expanding Resources
+
+    Resources often contain links to related resources in their response bodies.
+    Some endpoints support resource expansion, allowing those related resources
+    to be expanded inline within the response.
+
+    To expand resources (where supported), use the `expand` request parameter.
+    Documentation for endpoints identify which resources are expandable, if any.
+
+    ```
+    GET /api/things?expand=organization&expand=foobar
+    ```
+
+    Values for `expand` are the fields to expand. The above would expand
+    `organization` and `foobar` fields within the (hypothetical) returned `thing`
+    objects. You can expand multiple fields by providing multiple values in the
+    `expand` Array.
+
 servers:
   - url: https://api.hypothes.is/api
 

--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -116,6 +116,16 @@ components:
         The user's username
       schema:
         type: string
+    UserID:
+      name: user
+      in: path
+      required: true
+      description: >
+        Unique identifier for a user, with specified authority.
+        The userID should be of the format `acct:<username>@<authority>`
+      schema:
+        type: string
+        pattern: "acct:(?i)^[A-Z0-9._]+${3,30}@.*$"
 
   # -------------------------
   # Reusable responses
@@ -611,6 +621,66 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+
+  # ---------------------------------------------------------------------------
+  # Operations on Group Membership
+  # ---------------------------------------------------------------------------
+  /groups/{id}/members/{user}:
+
+    # ----------------------------------------------------------
+    # POST groups/{id}/members/{user} - Add user to group
+    # ----------------------------------------------------------
+    post:
+      tags:
+        - groups
+      summary: Add member to group
+      description: >
+        Add a user as a member to a group. This endpoint is only accessible to
+        requests authenticated with `AuthClient` credentials and is restricted
+        to users and groups within the associated authority.
+      security:
+        - AuthClient: []
+      parameters:
+        - $ref: '#/components/parameters/GroupID'
+        - $ref: '#/components/parameters/UserID'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+
+    # ----------------------------------------------------------
+    # DELETE groups/{id}/members/{user} - Remove user from group
+    # ----------------------------------------------------------
+    delete:
+      tags:
+        - groups
+      summary: Remove member from group
+      description: >
+        Remove a user from a group. At present, this endpoint only allows
+        the removal as one's self (authenticated with API Key) from the
+        indicated group.
+      security:
+        - ApiKey: []
+      parameters:
+        - $ref: '#/components/parameters/GroupID'
+        - name: user
+          in: path
+          description: Currently, only the literal value `me` is accepted
+          required: true
+          schema:
+            type: string
+            enum:
+              - me
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '415':
           $ref: '#/components/responses/UnsupportedMediaType'
 

--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -17,27 +17,12 @@ info:
     See [the API overview](../api/) for an introduction to the API and information
     on how authorization works.
 
-    ## API Versions
-
-    TBD
-
-    ## Errors
-
-    The API uses standard HTTP status codes to indicate the success or failure
-    of requests. The body of the response will be JSON in the following format:
-
-    ```
-    {
-      "status": "failure",
-      "reason": "a human-readable string about what went wrong"
-    }
-    ```
-
-    ## Expanding Resources
+    # Expanding Resources
 
     Resources often contain links to related resources in their response bodies.
     Some endpoints support resource expansion, allowing those related resources
     to be expanded inline within the response.
+
 
     To expand resources (where supported), use the `expand` request parameter.
     Documentation for endpoints identify which resources are expandable, if any.
@@ -50,6 +35,49 @@ info:
     `organization` and `foobar` fields within the (hypothetical) returned `thing`
     objects. You can expand multiple fields by providing multiple values in the
     `expand` Array.
+
+    # Versions
+
+    ## Version History
+
+    TBD
+
+    ## Specifying API Version
+
+    By default, API requests will receive the **v1** version of the Hypothesis API.
+    Though not required, we urge clients to set an `Accept` header with a media
+    type corresponding to the desired version, e.g.
+
+    `Accept: application/vnd.hypothesis.v1+json`
+
+    If an `Accept` header is set with an unrecognized media type, the API will
+    return an HTTP 415 (Unsupported Media Type) error.
+
+    # Errors
+
+    The API uses standard HTTP status codes to indicate the success or failure
+    of requests. The body of the response will be JSON in the following format:
+
+    ```
+    {
+      "status": "failure",
+      "reason": "a human-readable string about what went wrong"
+    }
+    ```
+
+    ## HTTP Status Codes
+
+    | Code        | Title         | Notes                                       |
+    | ----------- | ------------- | ---------------------------------------------
+    | 200         | OK            | Successful request                          |
+    | 204         | No Content    | Successful request; no body returned (e.g. for `DELETE` operations) |
+    | 400         | Bad Request   | The server could not process the request because it was malformed |
+    | 403         | Unauthorized  | v1 of the API only returns 404s, to avoid leaking resource existence |
+    | 404         | Not Found     | Resource not found or permission failure    |
+    | 409         | Conflict      | Resource could not be created because of a conflict—resource already exists |
+    | 415         | Unsupported Media Type | The request's `Accept` header designates an unrecognized media type |
+    | 500         | Server Error  | An error occurred with our API |
+
 
 servers:
   - url: https://api.hypothes.is/api

--- a/docs/_extra/api-reference/schemas/errors.yaml
+++ b/docs/_extra/api-reference/schemas/errors.yaml
@@ -1,4 +1,4 @@
-Conflict:
+Error:
   type: object
   required:
     - status
@@ -9,4 +9,4 @@ Conflict:
         - failure
     reason:
       type: string
-      description: One or more human-readable errors describing the conflict.
+      description: One or more human-readable errors describing the problem.


### PR DESCRIPTION
Good progress! With this PR, I've done the following to our new (as yet invisible) Open API docs:

* Added annotation endpoint documentation
* Added group-membership documentation
* Added annotation moderation endpoint documentation
* Added the service root endpoint documentation
* Expanded and updated the error documentation
* Started to flesh out the Introductory content (WIP)

Much of this is ported verbatim from our existing docs with some cleanup (and compatibility changes).

The annotation response documentation is inaccurate, but it's the same as our current docs and I'm not going to jump into that just now...there are a few other shortcomings that we can address as we go...

I believe the only endpoint to add to these new docs is the search endpoint. Getting there! 

Part of https://github.com/hypothesis/product-backlog/issues/946