### PR TITLE
Port search docs to Open API, fix invalid Annotation and other Schemas

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -297,6 +297,249 @@ paths:
           $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
+  # GET /search - Search annotations
+  # ---------------------------------------------------------------------------
+  /search:
+    get:
+      tags:
+        - annotations
+      summary: Search for annotations
+      parameters:
+        - name: limit
+          in: query
+          description: The maximum number of annotations to return.
+          schema:
+            type: integer
+            minimum: 0
+            default: 20
+            maximum: 200
+        - name: sort
+          in: query
+          schema:
+            description: The field by which annotations should be sorted.
+            type: string
+            enum: [created, updated, group, id, user]
+            default: updated
+        - name: search_after
+          in: query
+          example: 2019-01-03T19:46:09.334539+00:00
+          description: >
+            <p>Define a start point for a subset (page) of annotation search results.</p>
+
+            <p>Working against the sorted, full set of annotation records matching the current
+            search query, the service will examine the values present in the field by which
+            annotations are sorted (i.e. `sort`). The returned subset
+            of search results will begin with the first annotation whose `sort` field's value
+            comes after the value of `search_after` sequentially.</p>
+
+            <p>The format of this property depends on the current value of `sort`.
+            When `search_after` is used in conjunction with a chronological `sort` value—e.g.
+            `updated`, `created`—this parameter should be formatted as an ISO 8601 string. It
+            may also be formatted in ms (milliseconds) since the Epoch.</p>
+
+            <p><em>Expanded example</em> — Given a query containing:</p>
+
+            <p><blockquote>`sort=created&search_after=2019-01-03T19:46:09.334539+00:00`</blockquote></p>
+
+            <p>The returned results would begin with the record immediately subsequent to the annotation
+            created at `2019-01-03T19:46:09.334539+00:00` in the full set of results. If there is no
+            annotation in the full result set whose `created` value exactly matches
+            `2019-01-03T19:46:09.334539+00:00`,
+            the returned subset will begin with the first annotation whose `created` value
+            comes sequentially "after" `2019-01-03T19:46:09.334539+00:00` in the full, sorted set.</p>
+
+            <p><em>Note:</em> `search_after` provides an efficient, stateless paging mechanism. Its
+            use is preferred over that of `offset`.</p>
+
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description: >
+            <p>The number of initial annotations to skip in the result set.</p>
+
+            <p>May be used for pagination of result sets. The usage of `search_after` is preferred,
+            especially for large batches, as it is considerably more efficient.</p>
+          schema:
+            type: integer
+            maximum: 9800
+            default: 0
+        - name: order
+          in: query
+          description: The order in which the results should be sorted.
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+        - name: uri
+          in: query
+          description: |
+            Limit the results to annotations matching the specific URI or equivalent URIs.
+
+            URI can be a URL (a web page address) or a URN representing another kind of
+            resource such as DOI (Digital Object Identifier) or a PDF fingerprint.
+
+            Examples:
+
+            * `http://example.com/articles/01/name` (URL)
+            * `doi:10.1.1/1234` (DOI)
+            * `urn:x-pdf:1234` (PDF fingerprint)
+          schema:
+            type: string
+            format: uri
+        - name: url
+          in: query
+          description: Alias of `uri`
+          schema:
+            type: string
+            format: uri
+        - name: uri.parts
+          in: query
+          example: 'yogur'
+          description: |
+            <p>Limit the results to annotations containing the given keyword (tokenized chunk) in
+            the URI. The value must exactly match an individual URI keyword.</p>
+
+            <p>URIs are split on characters `#+/:=?.-` into their keywords.</p>
+
+            <p><em>Expanded example </em> — given a value of `yogur`, annotations with any of the
+            following URIs would match:
+
+            * `https://www.yogur.com/foo/bar`
+            * `https://www.example.com/yogur/eatmore.html`
+            * `https://www.example.com/foo/eat-more-yogur-this-year`
+
+            The following would not be matches:
+
+            * `https://www.yogurt.com/foo/bar`
+            * `https://www.example.com/yogurt/eatmore.html`
+            * `https://www.example.com/foo/eat-more-yogurt-this-year`
+
+          schema:
+            type: string
+        - name: wildcard_uri
+          in: query
+          example: "http://foo.com/*"
+          description: |
+            <p>Limit the results to annotations whose URIs match the wildcard pattern.</p>
+
+            <p>`*` will match any character sequence (including an empty one),
+            and a `_` will match any single character. Wildcards are only permitted
+            within the path and query parts of the URI. Escaping wildcards is not supported.</p>
+
+            Examples of valid values:
+
+            * `http://foo.com/*`
+            * `urn:x-pdf:*`
+            * `file://localhost/_bc.pdf`
+
+            Examples of invalid values (not within path or query parts of URI):
+
+            * `*foo.com`
+            * `u_n:*`
+            * `file://*`
+            * `http://foo.com*`
+
+            <mark>This feature is experimental and the API may change.</mark>
+          schema:
+            type: string
+        - name: user
+          in: query
+          example: acct:username@hypothes.is
+          description: Limit the results to annotations made by the specified user.
+          schema:
+            type: string
+            pattern: "acct:^[A-Z0-9._]{3,30}@.*$"
+        - name: group
+          in: query
+          example: "8JmD3iz1"
+          description: Limit the results to annotations made in the specified group (by group ID).
+          schema:
+            type: string
+        - name: tag
+          in: query
+          example: "artificial intelligence"
+          description: |
+            Limit the results to annotations tagged with the specified value.
+
+            For example: `artificial intelligence` will find all annotations whose tags
+            contain both `artificial` **AND** `intelligence`.
+          schema:
+            type: string
+        - name: tags
+          in: query
+          example:
+            - artificial
+            - intelligence
+          description: |
+            Similar to `tag` but allows a comma-separated list of multiple tags.
+
+            For example: `[intelligence,artificial]` will find all annotations whose tags
+            contain both `artificial` **AND** `intelligence`.
+          schema:
+            type: array
+            items:
+              type:
+                string
+        - name: any
+          in: query
+          example: "ribosome"
+          description: |
+            Limit the results to annotations who contain the indicated keyword
+            in any of the following fields:
+
+            * `quote`
+            * `tags`
+            * `text`
+            * `url`
+          schema:
+            type: string
+        - name: quote
+          in: query
+          example: "unicorn helmets"
+          description: >
+            <p>Limit the results to annotations that contain this text inside
+            the text that was annotated.</p>
+
+            <p>For example: `unicorn helmets` would return all annotations containing
+            `unicorn` **OR** `helmets` in their quoted (i.e. annotated) text.</p>
+          schema:
+            type: string
+        - name: references
+          in: query
+          description: Returns annotations that are replies to this parent annotation ID.
+          schema:
+            type: string
+        - name: text
+          in: query
+          example: "penguin strength"
+          description: >
+            <p>Limit the results to annotations that contain this text in their
+            textual body.</p>
+
+            <p>For example: `penguin strength` would return all annotations containing
+            `penguin` **OR** `strength` in their text (body) content.</p>
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - rows
+                  - total
+                properties:
+                  rows:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Annotation'
+                  total:
+                    description: Total number of results matching query.
+                    type: integer
+  # ---------------------------------------------------------------------------
   # Operations on single Annotation resources
   # ---------------------------------------------------------------------------
   /annotations/{id}:

--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -11,13 +11,13 @@ info:
     url: https://github.com/hypothesis/h/blob/master/LICENSE
   description: |
 
-    # Introduction
+    # Hypothesis API
 
     This is a reference for the Hypothesis HTTP API version 1.0.
     See [the API overview](../api/) for an introduction to the API and information
     on how authorization works.
 
-    # Expanding Resources
+    ## Expanding Resources
 
     Resources often contain links to related resources in their response bodies.
     Some endpoints support resource expansion, allowing those related resources
@@ -36,13 +36,7 @@ info:
     objects. You can expand multiple fields by providing multiple values in the
     `expand` Array.
 
-    # Versions
-
-    ## Version History
-
-    TBD
-
-    ## Specifying API Version
+    ## Versions
 
     By default, API requests will receive the **v1** version of the Hypothesis API.
     Though not required, we urge clients to set an `Accept` header with a media
@@ -53,7 +47,7 @@ info:
     If an `Accept` header is set with an unrecognized media type, the API will
     return an HTTP 415 (Unsupported Media Type) error.
 
-    # Errors
+    ## Errors
 
     The API uses standard HTTP status codes to indicate the success or failure
     of requests. The body of the response will be JSON in the following format:
@@ -65,12 +59,12 @@ info:
     }
     ```
 
-    ## HTTP Status Codes
+    ### HTTP Status Codes
+
+    Any API service may raise any of the following common errors.
 
     | Code        | Title         | Notes                                       |
     | ----------- | ------------- | ---------------------------------------------
-    | 200         | OK            | Successful request                          |
-    | 204         | No Content    | Successful request; no body returned (e.g. for `DELETE` operations) |
     | 400         | Bad Request   | The server could not process the request because it was malformed |
     | 403         | Unauthorized  | v1 of the API only returns 404s, to avoid leaking resource existence |
     | 404         | Not Found     | Resource not found or permission failure    |
@@ -292,12 +286,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Annotation'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # GET /search - Search annotations
@@ -566,10 +554,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Annotation'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
     # ------------------------------------------------------------------
     # PATCH annotations/{id} - Update an Annotation (PUT also supported)
@@ -598,12 +582,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Annotation'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
     # ------------------------------------------------------------------
     # DELETE annotations/{id} - Delete an Annotation
@@ -633,10 +611,6 @@ paths:
                       - true
                   id:
                     type: string
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # Annotation Moderation Operations: Flagging
@@ -662,10 +636,6 @@ paths:
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # Annotation Moderation Operations: Hiding/Unhiding
@@ -690,10 +660,6 @@ paths:
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
     # ----------------------------------------------------------
     # DELETE annotations/{id}/hide - Unhide  an annotation
@@ -713,10 +679,6 @@ paths:
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # Operations on Group collections
@@ -767,8 +729,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Group'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
     post:
       tags:
@@ -794,14 +754,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Group'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
 
   # ---------------------------------------------------------------------------
@@ -834,10 +786,6 @@ paths:
             application/*json:
               schema:
                 $ref: '#/components/schemas/Group'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
     # -----------------------------------------------------
     # PATCH groups/{id} - Update a Group
@@ -867,14 +815,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Group'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
     # ---------------------------------------------------------------------
     # PUT groups/{id} - Replace (Create or Update) a Group, a.k.a. "upsert"
@@ -903,14 +843,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Group'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # Operations on Group Membership
@@ -936,10 +868,6 @@ paths:
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
     # ----------------------------------------------------------
     # DELETE groups/{id}/members/{user} - Remove user from group
@@ -967,10 +895,6 @@ paths:
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # Operations on the currently-authenticated user (Profile)
@@ -996,8 +920,6 @@ paths:
             application/*json:
               schema:
                 $ref: '#/components/schemas/Profile'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
   /profile/groups:
     # -------------------------------------------------------------
@@ -1021,8 +943,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Group'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # Operations on User Collections
@@ -1052,14 +972,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'
 
   # ---------------------------------------------------------------------------
   # Operations on single User Resources
@@ -1091,11 +1003,3 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaType'

--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -226,9 +226,9 @@ components:
   # ------------------------------
   schemas:
     Annotation:
-      $ref: './schemas/annotation-schema.json'
+      $ref: './schemas/annotation.yaml#/Annotation'
     AnnotationCreate:
-      $ref: './schemas/annotation-schema.json'
+      $ref: './schemas/annotation-create.yaml#/Annotation'
     Group:
       $ref: './schemas/group.yaml#/Group'
     GroupCreate:
@@ -269,6 +269,9 @@ paths:
   # ---------------------------------------------------------------------------
   /annotations:
 
+    # ---------------------------------------------------------------------------
+    # POST annotations - Create an annotation
+    # ---------------------------------------------------------------------------
     post:
       tags:
         - annotations

--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -273,7 +273,11 @@ paths:
       security:
         - ApiKey: []
       requestBody:
-          description: Full representation of Annotation resource
+          description: >
+            Full representation of Annotation resource and applicable relationships.
+            _Note_: While the API accepts arbitrary Annotation selectors in the
+            `target.selector` property, the Hypothesis client currently supports
+            `TextQuoteSelector`, `RangeSelector` and `TextPositionSelector` selector.
           required: true
           content:
             application/*json:

--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -153,7 +153,7 @@ components:
         The userID should be of the format `acct:<username>@<authority>`
       schema:
         type: string
-        pattern: "acct:(?i)^[A-Z0-9._]+${3,30}@.*$"
+        pattern: "acct:^[A-Za-z0-9._]{3,30}@.*$"
 
   # -------------------------
   # Reusable responses

--- a/docs/_extra/api-reference/schemas/annotation-create.yaml
+++ b/docs/_extra/api-reference/schemas/annotation-create.yaml
@@ -1,0 +1,83 @@
+Annotation:
+  type: object
+  required:
+    - uri
+  properties:
+    uri:
+      type: string
+      format: uri
+      description: The URI to the annotation's target
+
+    document:
+      type: object
+      description: Further metadata about the target document
+      properties:
+        title:
+          type: array
+          items:
+            type: string
+        dc:
+          type: object
+          properties:
+            identifier:
+              type: array
+              items:
+                type: string
+        highwire:
+          type: object
+          properties:
+            doi:
+              type: array
+              items:
+                type: string
+            pdf_url:
+              type: array
+              items:
+                type: string
+        link:
+          type: array
+          items:
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              "type":
+                type: string
+
+    text:
+      type: string
+      description: The text content of the annotation body
+    tags:
+      type: array
+      items:
+        type: string
+    group:
+      type: string
+      description: >
+        The unique identifier for the annotation's group. If an
+        annotation is a reply to another annotation (see `references`), this field
+        will be ignored—replies belong to the same group as their parent annotations.
+    permissions:
+      type: object
+    target:
+      type: object
+      properties:
+        selector:
+          type: array
+          description: An array of selectors that refine this annotation's target
+          items:
+            type: object
+            description: >
+              A selector for refining the annotation target. See
+              [the Web Annotation Data Model W3C Recommendation](https://www.w3.org/TR/annotation-model/#selectors)
+              for details about different selector types and properties.
+            properties:
+              "type":
+                type: string
+    references:
+      type: array
+      description: Annotation IDs for any annotations this annotation references (e.g. is a reply to)
+      items:
+        type: string

--- a/docs/_extra/api-reference/schemas/annotation.yaml
+++ b/docs/_extra/api-reference/schemas/annotation.yaml
@@ -26,7 +26,7 @@ Annotation:
       format: date-time
     user:
       type: string
-      pattern: "acct:^[A-Z0-9._]{3,30}@.*$"
+      pattern: "acct:^[A-Za-z0-9._]{3,30}@.*$"
       description: user account ID in the format `"acct:<username>@<authority>"`
       example: "acct:felicity_nunsun@hypothes.is"
     uri:

--- a/docs/_extra/api-reference/schemas/annotation.yaml
+++ b/docs/_extra/api-reference/schemas/annotation.yaml
@@ -1,0 +1,87 @@
+Annotation:
+  type: object
+  required:
+    - id
+    - created
+    - updated
+    - user
+    - uri
+    - text
+    - tags
+    - group
+    - permissions
+    - target
+    - document
+    - links
+    - hidden
+    - flagged
+  properties:
+    id:
+      type: string
+    created:
+      type: string
+      format: date-time
+    updated:
+      type: string
+      format: date-time
+    user:
+      type: string
+      pattern: "acct:^[A-Z0-9._]{3,30}@.*$"
+      description: user account ID in the format `"acct:<username>@<authority>"`
+      example: "acct:felicity_nunsun@hypothes.is"
+    uri:
+      type: string
+      format: uri
+    text:
+      type: string
+      description: The text content of the annotation body
+    tags:
+      type: array
+      items:
+        type: string
+    group:
+      type: string
+      description: The unique identifier for the annotation's group
+    permissions:
+      type: object
+    target:
+      type: object
+      properties:
+        source:
+          type: string
+          format: uri
+          description: The target URI for the annotation
+        selector:
+          type: array
+          description: An array of selectors that refine this annotation's target
+          items:
+            type: object
+            description: >
+              A selector for refining the annotation target. See
+              [the Web Annotation Data Model W3C Recommendation](https://www.w3.org/TR/annotation-model/#selectors)
+              for details about different selector types and properties.
+            properties:
+              "type":
+                type: string
+
+    links:
+      type: object
+      description: An object containing hypermedia links for this annotation
+    hidden:
+      type: boolean
+      description: Whether this annotation is hidden from public view
+    flagged:
+      type: boolean
+      description: Whether this annotation has one or more flags for moderation
+    references:
+      type: array
+      description: Annotation IDs for any annotations this annotation references (e.g. is a reply to)
+      items:
+        type: string
+    user_info:
+      type: object
+      properties:
+        display_name:
+          type: string
+          description: The annotation creator's display name
+          example: "Felicity Nunsun"

--- a/docs/_extra/api-reference/schemas/profile.yaml
+++ b/docs/_extra/api-reference/schemas/profile.yaml
@@ -30,8 +30,8 @@ Profile:
       additionalProperties:
         type: boolean
     userid:
-      oneOf:
-        - type: string
-          description: This property will be a string of the format `"acct:username@authority"` if the request is authenticated
-        - type: null
-          description: This property will be `null` for unauthenticated requests (no available `userid`)
+      type: string
+      description: >
+        This property will be a string of the format `"acct:username@authority"`
+        if the request is authenticated. This property will be `null` if the
+        request is not authenticated.


### PR DESCRIPTION
Hurrah! With this PR we are at parity (or better) with our existing docs.

Fixes https://github.com/hypothesis/product-backlog/issues/946

In this PR:

* Docs for the search endpoint are ported over to Open API. I've left these mostly as they were.
* Valid schemas for Annotation resources and the Annotation Create body schema. The pre-existing Annotation schema was quite inaccurate—we knew that—but it was also invalid and breaking in the newer Open API docs. I've attempted to cook up reasonably-accurate schema for both the full Annotation resource and a valid create-annotation schema.
* Small fixes to other validation issues
* Organization of documentation sections and the consolidation of error documentation to reduce repetitiveness

It's likely that the new Annotation schemas here aren't quite perfect. For example, I avoided documenting the structure of the `permissions` objects until I understand them better. However, _these are far closer to reality_ than where we started and I'd like to treat this as an iterative project (do point out if I have things _dead wrong_ somewhere, however!).