### PR TITLE
WIP: Add `path` to `groupscope`

### DIFF
--- a/h/migrations/versions/8bd83598ad77_add_path_column_to_groupscope.py
+++ b/h/migrations/versions/8bd83598ad77_add_path_column_to_groupscope.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""Add path column to groupscope, and a composite index for the (origin, path) columns"""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "8bd83598ad77"
+down_revision = "2d0ad2b1bf07"
+
+
+def upgrade():
+    op.add_column("groupscope", sa.Column("path", sa.UnicodeText(), nullable=True))
+    op.execute("COMMIT")
+    # Create a composite index for origin and path for performance
+    op.create_index(
+        op.f("ix__groupscope__scope"),
+        "groupscope",
+        ["origin", "path"],
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix__groupscope__scope"))
+    op.drop_column("groupscope", "path")

--- a/h/models/group_scope.py
+++ b/h/models/group_scope.py
@@ -18,6 +18,13 @@ class GroupScope(Base):
     """
 
     __tablename__ = "groupscope"
+
+    __table_args__ = (
+        # Add a composite index of the (origin, path) columns for better
+        # lookup performance.
+        sa.Index("ix__groupscope__scope", "origin", "path"),
+    )
+
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
     group_id = sa.Column(
         sa.Integer, sa.ForeignKey("group.id", ondelete="cascade"), nullable=False
@@ -32,6 +39,15 @@ class GroupScope(Base):
     #: https://web.hypothes.is
     #: http://localhost:5000
     origin = sa.Column(sa.UnicodeText, nullable=False)
+
+    #: A path which, concatenated with ``origin``, creates a wildcarded prefix
+    #: against which URLs may be compared for scope. This allows for scope
+    #: granularity at a path level (instead of just origin).
+    #: e.g. for a group with scope origin ``https://foo.com`` and a path ``/bar``:
+    #:
+    #: * ``https://foo.com/bar/baz.html`` in scope
+    #: * ``https://foo.com/ding/foo.html`` NOT in scope
+    path = sa.Column(sa.UnicodeText, nullable=True)
 
     def __repr__(self):
         return "<GroupScope %s>" % self.origin


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/908

This PR adds a migration to add a `path` column to the `groupscope` table, as well as a composite index to make (origin, path) lookups faster later. It also adds the same column and field to the `groupscope` model.