### PR TITLE
Thin out API index view and use links helper

### DIFF
--- a/h/views/api/helpers/links.py
+++ b/h/views/api/helpers/links.py
@@ -55,3 +55,35 @@ def register_link(link, versions, registry):
         if version not in registry.api_links:
             registry.api_links[version] = []
         registry.api_links[version].append(link)
+
+
+def format_nested_links(api_links, version, templater):
+    """Format API link metadata as nested dicts for V1 variant of API index"""
+    formatted_links = {}
+    for link in api_links:
+        method_info = {
+            "method": link.primary_method(),
+            "url": templater.route_template(link.route_name),
+            "desc": link.description,
+        }
+        _set_at_path(formatted_links, link.name.split("."), method_info)
+
+    return formatted_links
+
+
+def _set_at_path(dict_, path, value):
+    """
+    Set the value at a given `path` within a nested `dict`.
+
+    :param dict_: The root `dict` to update
+    :param path: List of path components
+    :param value: Value to assign
+    """
+    key = path[0]
+    if key not in dict_:
+        dict_[key] = {}
+
+    if len(path) == 1:
+        dict_[key] = value
+    else:
+        _set_at_path(dict_[key], path[1:], value)

--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from h.views.api.config import api_config
 from h.views.api.helpers.angular import AngularRouteTemplater
-from h.views.api.helpers import links
+from h.views.api.helpers import links as link_helpers
 
 
 @api_config(versions=["v1"], route_name="api.index")
@@ -24,4 +24,4 @@ def index(context, request):
         request.route_url, params=["id", "pubid", "user", "userid", "username"]
     )
 
-    return {"links": links.format_nested_links(api_links, "v1", templater)}
+    return {"links": link_helpers.format_nested_links(api_links, "v1", templater)}

--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from h.views.api.config import api_config
 from h.views.api.helpers.angular import AngularRouteTemplater
+from h.views.api.helpers import links
 
 
 @api_config(versions=["v1"], route_name="api.index")
@@ -23,31 +24,4 @@ def index(context, request):
         request.route_url, params=["id", "pubid", "user", "userid", "username"]
     )
 
-    links = {}
-    for link in api_links:
-        method_info = {
-            "method": link.primary_method(),
-            "url": templater.route_template(link.route_name),
-            "desc": link.description,
-        }
-        _set_at_path(links, link.name.split("."), method_info)
-
-    return {"links": links}
-
-
-def _set_at_path(dict_, path, value):
-    """
-    Set the value at a given `path` within a nested `dict`.
-
-    :param dict_: The root `dict` to update
-    :param path: List of path components
-    :param value: Value to assign
-    """
-    key = path[0]
-    if key not in dict_:
-        dict_[key] = {}
-
-    if len(path) == 1:
-        dict_[key] = value
-    else:
-        _set_at_path(dict_[key], path[1:], value)
+    return {"links": links.format_nested_links(api_links, "v1", templater)}

--- a/tests/functional/api/test_api.py
+++ b/tests/functional/api/test_api.py
@@ -13,19 +13,6 @@ import pytest
 native_str = str
 
 
-@pytest.mark.functional
-class TestGetIndex(object):
-    def test_api_index(self, app):
-        """
-        Test the API index view.
-
-        This view is tested more thoroughly in the view tests, but this test
-        checks the view doesn't error out and returns appropriate-looking JSON.
-        """
-        res = app.get("/api/")
-        assert "links" in res.json
-
-
 class TestCorsPreflight(object):
     def test_cors_preflight(self, app):
         # Simulate a CORS preflight request made by the browser from a client

--- a/tests/functional/api/test_index.py
+++ b/tests/functional/api/test_index.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+# String type for request/response headers and metadata in WSGI.
+#
+# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
+# though it has different meanings.
+#
+# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
+native_str = str
+
+
+@pytest.mark.functional
+class TestGetIndex(object):
+    def test_it_returns_links(self, app):
+        res = app.get("/api/")
+
+        assert "links" in res.json
+        assert res.status_code == 200
+
+    def test_it_returns_links_for_resources(self, app):
+        res = app.get("/api/")
+
+        for resource in ["annotation", "group", "user", "profile", "search", "links"]:
+            assert resource in res.json["links"]
+
+    @pytest.mark.parametrize(
+        "resource,expected_services",
+        [
+            (
+                "annotation",
+                ["create", "read", "update", "delete", "flag", "hide", "unhide"],
+            ),
+            ("group", ["create", "read", "update", "create_or_update"]),
+            ("profile", ["read", "update"]),
+            ("user", ["create", "update"]),
+        ],
+    )
+    def test_it_returns_expected_resource_service_links(
+        self, app, resource, expected_services
+    ):
+        res = app.get("/api/")
+
+        for service in expected_services:
+            assert service in res.json["links"][resource]
+            assert "method" in res.json["links"][resource][service]
+            assert "url" in res.json["links"][resource][service]
+
+    @pytest.mark.parametrize(
+        "resource,nested_resource,expected_services",
+        [("profile", "groups", ["read"]), ("group", "member", ["add", "delete"])],
+    )
+    def test_it_returns_expected_nested_resource_service_links(
+        self, app, resource, nested_resource, expected_services
+    ):
+        res = app.get("/api/")
+
+        assert nested_resource in res.json["links"][resource]
+
+        for service in expected_services:
+            assert service in res.json["links"][resource][nested_resource]
+            assert "method" in res.json["links"][resource][nested_resource][service]
+            assert "url" in res.json["links"][resource][nested_resource][service]

--- a/tests/h/views/api/index_test.py
+++ b/tests/h/views/api/index_test.py
@@ -2,212 +2,58 @@
 
 from __future__ import unicode_literals
 
-from pyramid import testing
+import pytest
+import mock
+
 from pyramid.config import Configurator
 
 from h.views.api import index as views
 
 
 class TestIndex(object):
-    def test_it_returns_the_right_links_for_annotation_endpoints(
-        self, pyramid_config, pyramid_request
-    ):
+    def test_it_returns_links(self, pyramid_request):
+        result = views.index(None, pyramid_request)
 
+        assert "links" in result
+
+    def test_it_instantiates_a_templater(self, pyramid_request, AngularRouteTemplater):
+        views.index(None, pyramid_request)
+
+        AngularRouteTemplater.assert_called_once_with(
+            pyramid_request.route_url,
+            params=["id", "pubid", "user", "userid", "username"],
+        )
+
+    def test_it_returns_links_for_the_right_version(
+        self, pyramid_request, AngularRouteTemplater, link_helpers
+    ):
+        views.index(None, pyramid_request)
+
+        link_helpers.format_nested_links.assert_called_once_with(
+            pyramid_request.registry.api_links["v1"],
+            "v1",
+            AngularRouteTemplater.return_value,
+        )
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_config, pyramid_request):
         # Scan `h.views.api_annotations` for API link metadata specified in @api_config
         # declarations.
         config = Configurator()
         config.scan("h.views.api.annotations")
-        pyramid_request.registry.api_links = config.registry.api_links
-
+        # Any route referenced in `h.views.api.annotations` needs to be added here
         pyramid_config.add_route("api.search", "/dummy/search")
         pyramid_config.add_route("api.annotations", "/dummy/annotations")
         pyramid_config.add_route("api.annotation", "/dummy/annotations/:id")
-        pyramid_config.add_route("api.links", "/dummy/links")
-
-        result = views.index(testing.DummyResource(), pyramid_request)
-
-        host = "http://example.com"  # Pyramid's default host URL'
-        links = result["links"]
-        assert links["annotation"]["create"]["method"] == "POST"
-        assert links["annotation"]["create"]["url"] == (host + "/dummy/annotations")
-        assert links["annotation"]["delete"]["method"] == "DELETE"
-        assert links["annotation"]["delete"]["url"] == (host + "/dummy/annotations/:id")
-        assert links["annotation"]["read"]["method"] == "GET"
-        assert links["annotation"]["read"]["url"] == (host + "/dummy/annotations/:id")
-        assert links["annotation"]["update"]["method"] == "PATCH"
-        assert links["annotation"]["update"]["url"] == (host + "/dummy/annotations/:id")
-        assert links["search"]["method"] == "GET"
-        assert links["search"]["url"] == host + "/dummy/search"
-
-        # Make sure no extra links we didn't test for
-        assert set(links["annotation"].keys()) == set(
-            ["create", "read", "delete", "update"]
-        )
-        assert set(links.keys()) == set(["annotation", "search"])
-
-    def test_it_returns_the_right_links_for_flag_endpoints(
-        self, pyramid_config, pyramid_request
-    ):
-
-        config = Configurator()
-        config.scan("h.views.api.flags")
         pyramid_request.registry.api_links = config.registry.api_links
-        host = "http://example.com"  # Pyramid's default host URL'
 
-        pyramid_config.add_route("api.annotation_flag", "/dummy/annotations/:id/flag")
+        pyramid_request.route_url = mock.Mock()
+        return pyramid_request
 
-        result = views.index(testing.DummyResource(), pyramid_request)
+    @pytest.fixture
+    def link_helpers(self, patch):
+        return patch("h.views.api.index.link_helpers")
 
-        links = result["links"]
-
-        assert links["annotation"]["flag"]["method"] == "PUT"
-        assert links["annotation"]["flag"]["url"] == (
-            host + "/dummy/annotations/:id/flag"
-        )
-
-    def test_it_returns_the_right_links_for_group_endpoints(
-        self, pyramid_config, pyramid_request
-    ):
-
-        config = Configurator()
-        config.scan("h.views.api.groups")
-        pyramid_request.registry.api_links = config.registry.api_links
-        host = "http://example.com"  # Pyramid's default host URL'
-
-        pyramid_config.add_route("api.groups", "/dummy/groups")
-        pyramid_config.add_route("api.group", "/dummy/groups/:id")
-        pyramid_config.add_route(
-            "api.group_upsert", "/dummy/groups/:id", request_method="PUT"
-        )
-        pyramid_config.add_route(
-            "api.group_member", "/dummy/groups/:pubid/members/:userid"
-        )
-
-        result = views.index(testing.DummyResource(), pyramid_request)
-
-        links = result["links"]
-        # Groups collections
-        assert links["groups"]["read"]["method"] == "GET"
-        assert links["groups"]["read"]["url"] == (host + "/dummy/groups")
-
-        # Group resources
-        assert links["group"]["create"]["method"] == "POST"
-        assert links["group"]["create"]["url"] == (host + "/dummy/groups")
-        assert links["group"]["read"]["method"] == "GET"
-        assert links["group"]["read"]["url"] == (host + "/dummy/groups/:id")
-        assert links["group"]["update"]["method"] == "PATCH"
-        assert links["group"]["update"]["url"] == (host + "/dummy/groups/:id")
-        assert links["group"]["create_or_update"]["method"] == "PUT"
-        assert links["group"]["create_or_update"]["url"] == (host + "/dummy/groups/:id")
-
-        # Group membership
-        assert links["group"]["member"]["add"]["method"] == "POST"
-        assert links["group"]["member"]["add"]["url"] == (
-            host + "/dummy/groups/:pubid/members/:userid"
-        )
-        assert links["group"]["member"]["delete"]["method"] == "DELETE"
-        assert links["group"]["member"]["delete"]["url"] == (
-            host + "/dummy/groups/:pubid/members/:userid"
-        )
-
-        # Make sure no extra links we didn't test for
-        assert set(links["group"].keys()) == set(
-            ["member", "create", "read", "create_or_update", "update"]
-        )
-        assert set(links["group"]["member"].keys()) == set(["add", "delete"])
-
-    def test_it_returns_the_right_links_for_links_endpoints(
-        self, pyramid_config, pyramid_request
-    ):
-
-        config = Configurator()
-        config.scan("h.views.api.links")
-        pyramid_request.registry.api_links = config.registry.api_links
-        host = "http://example.com"  # Pyramid's default host URL'
-
-        pyramid_config.add_route("api.links", "/dummy/links")
-
-        result = views.index(testing.DummyResource(), pyramid_request)
-
-        links = result["links"]
-
-        assert links["links"]["method"] == "GET"
-        assert links["links"]["url"] == (host + "/dummy/links")
-
-    def test_it_returns_the_right_links_for_moderation_endpoints(
-        self, pyramid_config, pyramid_request
-    ):
-
-        config = Configurator()
-        config.scan("h.views.api.moderation")
-        pyramid_request.registry.api_links = config.registry.api_links
-        host = "http://example.com"  # Pyramid's default host URL'
-
-        pyramid_config.add_route("api.annotation_hide", "/dummy/annotations/:id/hide")
-
-        result = views.index(testing.DummyResource(), pyramid_request)
-
-        links = result["links"]
-
-        assert links["annotation"]["hide"]["method"] == "PUT"
-        assert links["annotation"]["hide"]["url"] == (
-            host + "/dummy/annotations/:id/hide"
-        )
-        assert links["annotation"]["unhide"]["method"] == "DELETE"
-        assert links["annotation"]["unhide"]["url"] == (
-            host + "/dummy/annotations/:id/hide"
-        )
-
-        assert set(links["annotation"].keys()) == set(["hide", "unhide"])
-
-    def test_it_returns_the_right_links_for_profile_endpoints(
-        self, pyramid_config, pyramid_request
-    ):
-
-        config = Configurator()
-        config.scan("h.views.api.profile")
-        pyramid_request.registry.api_links = config.registry.api_links
-        host = "http://example.com"  # Pyramid's default host URL'
-
-        pyramid_config.add_route("api.profile", "/dummy/profile")
-        pyramid_config.add_route("api.profile_groups", "/dummy/profile/groups")
-
-        result = views.index(testing.DummyResource(), pyramid_request)
-
-        links = result["links"]
-
-        assert links["profile"]["read"]["method"] == "GET"
-        assert links["profile"]["read"]["url"] == (host + "/dummy/profile")
-        assert links["profile"]["update"]["method"] == "PATCH"
-        assert links["profile"]["update"]["url"] == (host + "/dummy/profile")
-
-        assert links["profile"]["groups"]["read"]["method"] == "GET"
-        assert links["profile"]["groups"]["read"]["url"] == (
-            host + "/dummy/profile/groups"
-        )
-
-        assert set(links["profile"].keys()) == set(["read", "update", "groups"])
-        assert set(links["profile"]["groups"].keys()) == set(["read"])
-
-    def test_it_returns_the_right_links_for_user_endpoints(
-        self, pyramid_config, pyramid_request
-    ):
-
-        config = Configurator()
-        config.scan("h.views.api.users")
-        pyramid_request.registry.api_links = config.registry.api_links
-        host = "http://example.com"  # Pyramid's default host URL'
-
-        pyramid_config.add_route("api.users", "/dummy/users")
-        pyramid_config.add_route("api.user", "/dummy/users/:username")
-
-        result = views.index(testing.DummyResource(), pyramid_request)
-
-        links = result["links"]
-
-        assert links["user"]["create"]["method"] == "POST"
-        assert links["user"]["create"]["url"] == (host + "/dummy/users")
-        assert links["user"]["update"]["method"] == "PATCH"
-        assert links["user"]["update"]["url"] == (host + "/dummy/users/:username")
-
-        assert set(links["user"].keys()) == set(["create", "update"])
+    @pytest.fixture
+    def AngularRouteTemplater(self, patch):
+        return patch("h.views.api.index.AngularRouteTemplater")


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/940

This smallish PR factors out some helper code from the API's index view and puts it into the `links` helper. Thinning out this view will allow easier version branching. This index view may be one of the first to diverge in API v2.