### PR TITLE
Make API view config use helper to assign version-specific accept values

### DIFF
--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -3,6 +3,7 @@ import venusian
 
 from h.views.api.helpers import cors
 from h.views.api.helpers import links
+from h.views.api.helpers.media_types import media_type_for_version
 
 from h.views.api import API_VERSIONS
 
@@ -86,7 +87,7 @@ def add_api_view(
 
         # config.add_view only allows one, string value for `accept`, so we
         # have to re-invoke it to add additional accept headers
-        settings["accept"] = "application/vnd.hypothesis." + version + "+json"
+        settings["accept"] = media_type_for_version(version)
         config.add_view(view=view, **settings)
 
     if enable_preflight:

--- a/tests/h/views/api/config_test.py
+++ b/tests/h/views/api/config_test.py
@@ -84,12 +84,16 @@ class TestAddApiView(object):
         (_, kwargs) = pyramid_config.add_view.call_args
         assert kwargs["decorator"] == decorator
 
-    def test_it_adds_default_version_accept(self, pyramid_config, view):
+    def test_it_adds_default_version_accept(
+        self, pyramid_config, view, media_type_for_version
+    ):
         api_config.add_api_view(
             pyramid_config, view, versions=["v1"], route_name="thing.read"
         )
         (_, kwargs) = pyramid_config.add_view.call_args_list[1]
-        assert kwargs["accept"] == "application/vnd.hypothesis.v1+json"
+
+        media_type_for_version.assert_called_once_with("v1")
+        assert kwargs["accept"] == media_type_for_version.return_value
 
     def test_it_raises_ValueError_on_unrecognized_version(self, pyramid_config, view):
         with pytest.raises(ValueError, match="Unrecognized API version"):
@@ -143,6 +147,10 @@ class TestAddApiView(object):
             )
         else:
             links.register_link.assert_not_called()
+
+    @pytest.fixture
+    def media_type_for_version(self, patch):
+        return patch("h.views.api.config.media_type_for_version")
 
     @pytest.fixture
     def links(self, patch):


### PR DESCRIPTION
This tiny PR simply makes the API view config use the media type helper for formatting version-specific `accept` media types.

Part of https://github.com/hypothesis/product-backlog/issues/940