### PR TITLE
WIP: GroupScope model `scope` attribute, scope parsing

### DIFF
--- a/h/models/group_scope.py
+++ b/h/models/group_scope.py
@@ -4,7 +4,9 @@ from __future__ import unicode_literals
 
 import sqlalchemy as sa
 
+from h._compat import urlparse
 from h.db import Base
+from h.util.group_scope import uri_to_scope
 
 
 class GroupScope(Base):
@@ -48,6 +50,18 @@ class GroupScope(Base):
     #: * ``https://foo.com/bar/baz.html`` in scope
     #: * ``https://foo.com/ding/foo.html`` NOT in scope
     path = sa.Column(sa.UnicodeText, nullable=True)
+
+    @property
+    def scope(self):
+        """Return a URI composed from the origin and path attrs"""
+        return urlparse.urljoin(self.origin, self.path)
+
+    @scope.setter
+    def scope(self, value):
+        """Take a URI and split it into origin, path"""
+        parsed_scope = uri_to_scope(value)
+        self.origin = parsed_scope[0]
+        self.path = parsed_scope[1]
 
     def __repr__(self):
         return "<GroupScope %s>" % self.origin

--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -114,7 +114,7 @@ class GroupCreateService(object):
 
         creator = self.user_fetcher(userid)
 
-        scopes = [GroupScope(origin=o) for o in origins]
+        scopes = [GroupScope(scope=o) for o in origins]
 
         if "organization" in kwargs:
             self._validate_authorities_match(

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -18,6 +18,8 @@ def match(uri, scopes):
     return scope in scopes
 
 
+# TODO: This concept no longer makes sense with more granular scoping. There is
+# no equivalent 1:1 uri <-> scope relationship. Remove this function soon.
 def uri_scope(uri):
     """
     Return the scope for a given URI
@@ -26,6 +28,30 @@ def uri_scope(uri):
     proxies to _parse_origin.
     """
     return _parse_origin(uri)
+
+
+def uri_to_scope(uri):
+    """
+    Return a tuple representing the origin and path of a URI
+
+    :arg uri: The URI from which to derive scope
+    :type uri: str
+    :rtype: tuple(str, str or None)
+    """
+    # A URL with no origin component will result in a `None` value for
+    # origin, while a URL with no path component will result in an empty
+    # string for path.
+    origin = _parse_origin(uri)
+    path = _parse_path(uri) or None
+    return (origin, path)
+
+
+def _parse_path(uri):
+    """Return the path component of a URI string"""
+    if uri is None:
+        return None
+    parsed = urlparse.urlsplit(uri)
+    return parsed[2]
 
 
 def _parse_origin(uri):

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -181,7 +181,7 @@ class GroupEditViews(object):
             """Update the group resource on successful form validation"""
 
             organization = self.organizations[appstruct["organization"]]
-            scopes = [GroupScope(origin=o) for o in appstruct["origins"]]
+            scopes = [GroupScope(scope=o) for o in appstruct["origins"]]
 
             self.group_update_svc.update(
                 group,

--- a/tests/common/factories/group_scope.py
+++ b/tests/common/factories/group_scope.py
@@ -14,5 +14,5 @@ class GroupScope(ModelFactory):
         model = models.GroupScope
         sqlalchemy_session_persistence = "flush"
 
-    origin = factory.Faker("url")
+    scope = factory.Faker("url")
     group = factory.SubFactory("tests.common.factories.OpenGroup")

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -2,34 +2,36 @@
 
 from __future__ import unicode_literals
 
+import pytest
+
 from sqlalchemy import inspect
 
 from h.models import GroupScope
 
 
 class TestGroupScope(object):
-    def test_save_and_retrieve_origin(self, db_session, factories):
-        origin = "http://example.com"
-        factories.GroupScope(origin=origin)
+    def test_save_and_retrieve_scope(self, db_session, factories):
+        scope = "http://example.com"
+        factories.GroupScope(scope=scope)
 
         group_scope = db_session.query(GroupScope).one()
 
-        assert group_scope.origin == origin
+        assert group_scope.scope == scope
 
-    def test_subdomains_are_allowed_in_origin(self, db_session, factories):
-        factories.GroupScope(origin="http://www.example.com")
+    def test_subdomains_are_allowed_in_scope(self, db_session, factories):
+        factories.GroupScope(scope="http://www.example.com")
         db_session.flush()
 
-    def test_port_is_allowed_in_origin(self, db_session, factories):
-        factories.GroupScope(origin="http://localhost:5000")
+    def test_port_is_allowed_in_scope(self, db_session, factories):
+        factories.GroupScope(scope="http://localhost:5000")
         db_session.flush()
 
-    def test_there_is_no_validation_of_origin(self, db_session, factories):
-        factories.GroupScope(origin="diplodocus : 123")
-        db_session.flush()
+    def test_it_raises_if_scope_has_no_origin(self, db_session, factories):
+        with pytest.raises(ValueError, match="Invalid URL"):
+            factories.GroupScope(scope="diplodocus : 123")
 
     def test_setting_scope_property_sets_origin_and_path(self, factories):
-        group_scope = GroupScope(scope="http://www.foo.com/bar/baz")
+        group_scope = factories.GroupScope(scope="http://www.foo.com/bar/baz")
 
         assert group_scope.origin == "http://www.foo.com"
         assert group_scope.path == "/bar/baz"
@@ -38,11 +40,19 @@ class TestGroupScope(object):
     def test_setting_scope_with_no_path_element_sets_None_for_path_attr(
         self, factories
     ):
-        group_scope = GroupScope(scope="http://www.foo.com")
+        group_scope = factories.GroupScope(scope="http://www.foo.com")
 
         assert group_scope.origin == "http://www.foo.com"
         assert group_scope.path is None
         assert group_scope.scope == "http://www.foo.com"
+
+    def test_it_raises_if_origin_set_directly(self, factories):
+        with pytest.raises(AttributeError):
+            factories.GroupScope(origin="http://www.foo.com")
+
+    def test_it_raises_if_path_set_directly(self, factories):
+        with pytest.raises(AttributeError):
+            factories.GroupScope(path="/foo/bar")
 
     def test_you_can_get_a_groupscopes_group_by_the_group_property(self, factories):
         group = factories.OpenGroup()
@@ -82,46 +92,46 @@ class TestGroupScope(object):
 
         assert db_session.query(GroupScope).all() == []
 
-    def test_multiple_groupscopes_can_have_the_same_origin(self, db_session, factories):
-        origin = "http://example.com"
+    def test_multiple_groupscopes_can_have_the_same_scope(self, db_session, factories):
+        scope = "http://example.com"
         group_1 = factories.OpenGroup()
         group_2 = factories.OpenGroup()
         group_3 = factories.OpenGroup()
 
         # Different groupscopes, belonging to different groups, can have the
         # same origin.
-        factories.GroupScope(origin=origin, group=group_1)
-        factories.GroupScope(origin=origin, group=group_2)
-        factories.GroupScope(origin=origin, group=group_3)
+        factories.GroupScope(scope=scope, group=group_1)
+        factories.GroupScope(scope=scope, group=group_2)
+        factories.GroupScope(scope=scope, group=group_3)
         db_session.flush()
 
     def test_editing_a_groups_scopes_doesnt_affect_other_groups(self, factories):
-        origin = "http://example.com"
+        scope = "http://example.com"
         group_1 = factories.OpenGroup()
         group_2 = factories.OpenGroup()
         group_3 = factories.OpenGroup()
-        factories.GroupScope(origin=origin, group=group_1)
-        factories.GroupScope(origin=origin, group=group_2)
-        factories.GroupScope(origin=origin, group=group_3)
+        factories.GroupScope(scope=scope, group=group_1)
+        factories.GroupScope(scope=scope, group=group_2)
+        factories.GroupScope(scope=scope, group=group_3)
 
-        group_1.scopes[0].origin = "http://neworigin.com"
+        group_1.scopes[0].scope = "http://neworigin.com"
 
-        assert group_1.scopes[0].origin == "http://neworigin.com"
-        assert group_2.scopes[0].origin == origin
-        assert group_3.scopes[0].origin == origin
+        assert group_1.scopes[0].scope == "http://neworigin.com"
+        assert group_2.scopes[0].scope == scope
+        assert group_3.scopes[0].scope == scope
 
     def test_deleting_a_groups_scopes_doesnt_affect_other_groups(
         self, db_session, factories
     ):
-        origin = "http://example.com"
+        scope = "http://example.com"
         group_1 = factories.OpenGroup()
         group_2 = factories.OpenGroup()
         group_3 = factories.OpenGroup()
         db_session.add_all(
             (
-                factories.GroupScope(origin=origin, group=group_1),
-                factories.GroupScope(origin=origin, group=group_2),
-                factories.GroupScope(origin=origin, group=group_3),
+                factories.GroupScope(scope=scope, group=group_1),
+                factories.GroupScope(scope=scope, group=group_2),
+                factories.GroupScope(scope=scope, group=group_3),
             )
         )
         db_session.flush()
@@ -145,3 +155,15 @@ class TestGroupScope(object):
         # editing one group's scopes to affect another group.
         assert group_2.scopes == [group_scope]
         assert group_1.scopes == []
+
+    def test_query_on_origin_possible_after_setting_scope(self, factories, db_session):
+        factories.GroupScope(scope="http://banana.com")
+
+        result = (
+            db_session.query(GroupScope)
+            .filter(GroupScope.origin == "http://banana.com")
+            .one()
+        )
+
+        assert result.scope == "http://banana.com"
+        assert result.origin == "http://banana.com"

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -28,6 +28,22 @@ class TestGroupScope(object):
         factories.GroupScope(origin="diplodocus : 123")
         db_session.flush()
 
+    def test_setting_scope_property_sets_origin_and_path(self, factories):
+        group_scope = GroupScope(scope="http://www.foo.com/bar/baz")
+
+        assert group_scope.origin == "http://www.foo.com"
+        assert group_scope.path == "/bar/baz"
+        assert group_scope.scope == "http://www.foo.com/bar/baz"
+
+    def test_setting_scope_with_no_path_element_sets_None_for_path_attr(
+        self, factories
+    ):
+        group_scope = GroupScope(scope="http://www.foo.com")
+
+        assert group_scope.origin == "http://www.foo.com"
+        assert group_scope.path is None
+        assert group_scope.scope == "http://www.foo.com"
+
     def test_you_can_get_a_groupscopes_group_by_the_group_property(self, factories):
         group = factories.OpenGroup()
         group_scope = factories.GroupScope(group=group)

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -51,7 +51,7 @@ class TestGroupJSONPresenter(object):
         group = factories.OpenGroup(
             name="My Group",
             pubid="groupy",
-            scopes=[factories.GroupScope(origin="http://foo.com")],
+            scopes=[factories.GroupScope(scope="http://foo.com")],
             organization=factories.Organization(),
         )
         group_context = GroupContext(group)
@@ -134,8 +134,8 @@ class TestGroupJSONPresenter(object):
         group = factories.OpenGroup(
             enforce_scope=False,
             scopes=[
-                factories.GroupScope(origin="http://foo.com"),
-                factories.GroupScope(origin="https://foo.com"),
+                factories.GroupScope(scope="http://foo.com"),
+                factories.GroupScope(scope="https://foo.com"),
             ],
         )
         group_context = GroupContext(group)

--- a/tests/h/services/group_create_test.py
+++ b/tests/h/services/group_create_test.py
@@ -245,7 +245,7 @@ class TestCreateOpenGroup(object):
         # already exists (this is because a single scope can only belong to
         # one group, so the existing scope can't be reused with the new group).
         origins = ["https://biopub.org", "http://example.com"]
-        scopes = [factories.GroupScope(origin=h) for h in origins]
+        scopes = [factories.GroupScope(scope=h) for h in origins]
 
         group = svc.create_open_group(
             name="test_group", userid=creator.userid, origins=origins
@@ -409,7 +409,7 @@ class TestCreateRestrictedGroup(object):
         # already exists (this is because a single scope can only belong to
         # one group, so the existing scope can't be reused with the new group).
         origins = ["https://biopub.org", "http://example.com"]
-        scopes = [factories.GroupScope(origin=h) for h in origins]
+        scopes = [factories.GroupScope(scope=h) for h in origins]
 
         group = svc.create_restricted_group(
             name="test_group", userid=creator.userid, origins=origins

--- a/tests/h/services/group_list_test.py
+++ b/tests/h/services/group_list_test.py
@@ -373,12 +373,12 @@ def scoped_open_groups(factories, authority, origin, user):
             name="Blender",
             authority=authority,
             creator=user,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.OpenGroup(
             name="Antigone",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
     ]
 
@@ -390,12 +390,12 @@ def scoped_restricted_groups(factories, authority, origin, user):
             name="Forensic",
             authority=authority,
             creator=user,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.RestrictedGroup(
             name="Affluent",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
     ]
 
@@ -420,13 +420,13 @@ def scoped_restricted_user_groups(factories, authority, user, origin):
             name="Alpha",
             authority=authority,
             creator=user,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.RestrictedGroup(
             name="Beta",
             authority=authority,
             creator=user,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
     ]
 
@@ -465,19 +465,19 @@ def mixed_groups(factories, user, authority, origin):
             name="Yaks",
             pubid="yaks",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.RestrictedGroup(
             name="Xander",
             pubid="xander",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.OpenGroup(
             name="wadsworth",
             pubid="wadsworth",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
     ]
 

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -240,8 +240,8 @@ class TestCreateAnnotation(object):
     def test_it_allows_when_target_uri_matches_multiple_group_scope(
         self, pyramid_request, pyramid_config, group_service, factories, models
     ):
-        scope = factories.GroupScope(origin="http://www.foo.com")
-        scope2 = factories.GroupScope(origin="http://www.bar.com")
+        scope = factories.GroupScope(scope="http://www.foo.com")
+        scope2 = factories.GroupScope(scope="http://www.bar.com")
         group_service.find.return_value = factories.OpenGroup(scopes=[scope, scope2])
         data = self.annotation_data()
         data["target_uri"] = "http://www.bar.com/boo/bah.html"
@@ -638,7 +638,7 @@ def datetime(patch):
 
 @pytest.fixture
 def scoped_open_group(factories):
-    scope = factories.GroupScope(origin="http://www.foo.com")
+    scope = factories.GroupScope(scope="http://www.foo.com")
     return factories.OpenGroup(scopes=[scope])
 
 

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -67,3 +67,23 @@ class TestScopeMatch(object):
     @pytest.fixture
     def multiple_scopes(self):
         return ["http://www.foo.com", "http://www.bar.com"]
+
+
+class TestURIToScope(object):
+    @pytest.mark.parametrize(
+        "uri,expected_scope",
+        [
+            ("https://www.foo.com/foo", ("https://www.foo.com", "/foo")),
+            ("https://foo.com/bar/baz", ("https://foo.com", "/bar/baz")),
+            ("http://foo.com", ("http://foo.com", None)),
+            ("/foo/bar", (None, "/foo/bar")),
+            (
+                "https://foo.com/foo/bar/baz.html",
+                ("https://foo.com", "/foo/bar/baz.html"),
+            ),
+            ("http://foo.com//bar/baz", ("http://foo.com", "//bar/baz")),
+            ("http://foo.com/bar?what=how", ("http://foo.com", "/bar")),
+        ],
+    )
+    def test_it_parses_origin_and_path_from_uri(self, uri, expected_scope):
+        assert scope_util.uri_to_scope(uri) == expected_scope


### PR DESCRIPTION
This PR looks a little bigger than it is, but I wanted to get a WIP variant out there before finishing up next steps. The material parts of this PR:

* Convert `origin` and `path` columns to be read-only by renaming the attrs as private class attrs and providing `@hybrid_property` functionality. Translation: you may read and filter by, but not set, `origin` and `path` attrs on `GroupScope` classes and instances.
* Add a new, computed `scope` property to `GroupScope` instances. This property may be read and set. The getter returns a string URL composed of the `origin` and any `path` value on the  GroupScope. Setting it with a URL string will cause it to be parsed and split into relevant `origin` and `path` values for the GroupScope. Translation: the API for setting a GroupScope's scope is now through the (shockingly-named!) `scope` property. That `scope` setter will take a URI and do what it needs to do.
* Updated places in code and tests where `GroupScope` models were previously initialized with an `origin` param. This is no longer possible. Changing those calls to use `scope` instead has the same result (`origin` will get populated with the `origin` of the URI string; the `path` property will stay empty as there are no path elements to those strings at present). This included the test factory for `GroupScope` models, which now sets a default `scope` instead of a default `origin`.

To summarize: this PR starts a transition toward the `GroupScope` model providing an API surface for scopes that deal in URIs; the model does its own internal futzing to normalize scope bits as needed.

Next steps:

* Convert read logic and scope-comparison logic to use `scope` instead of `origin`. The comparison logic works still using `origin` but we do want to make it take `path` into account, too.
* It may well be useful to make it possible to filter queries on `scope`. I'll look into that soon.

Once the above is done, the entire feature (more granular scoping) should "basically work magically"—the admin group form will take URIs and set `scope` properties on resulting `GroupScope`s and the model will take care of normalizing and persisting those scopes as `origin` and `path` components...