### PR TITLE
WIP: Feature: Scope granularity

### DIFF
--- a/h/models/group_scope.py
+++ b/h/models/group_scope.py
@@ -4,7 +4,9 @@ from __future__ import unicode_literals
 
 import sqlalchemy as sa
 
+from h._compat import urlparse
 from h.db import Base
+from h.util.group_scope import uri_to_scope
 
 
 class GroupScope(Base):
@@ -48,6 +50,18 @@ class GroupScope(Base):
     #: * ``https://foo.com/bar/baz.html`` in scope
     #: * ``https://foo.com/ding/foo.html`` NOT in scope
     path = sa.Column(sa.UnicodeText, nullable=True)
+
+    @property
+    def scope(self):
+        """Return a URI composed from the origin and path attrs"""
+        return urlparse.urljoin(self.origin, self.path)
+
+    @scope.setter
+    def scope(self, value):
+        """Take a URI and split it into origin, path"""
+        parsed_scope = uri_to_scope(value)
+        self.origin = parsed_scope[0]
+        self.path = parsed_scope[1]
 
     def __repr__(self):
         return "<GroupScope %s>" % self.origin

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -43,7 +43,7 @@ class GroupJSONPresenter(object):
             # patterns—currently a simple wildcarded prefix—to give us more
             # flexibility in making scope more granular later
             model["scopes"]["uri_patterns"] = [
-                scope.origin + "*" for scope in self.group.scopes
+                scope.scope + "*" for scope in self.group.scopes
             ]
         return model
 

--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -166,14 +166,17 @@ class CreateAdminGroupSchema(CSRFSchema):
         missing=False,
     )
 
-    origins = colander.SequenceSchema(
+    scopes = colander.SequenceSchema(
         colander.Sequence(),
-        colander.SchemaNode(colander.String(), name="origin", validator=colander.url),
-        title=_("Scope Origins"),
-        hint=_('Origins where this group appears (e.g. "https://example.com")'),
-        widget=SequenceWidget(add_subitem_text_template=_("Add origin"), min_len=1),
+        colander.SchemaNode(colander.String(), name="scope", validator=colander.url),
+        title=_("Scopes"),
+        hint=_(
+            "Define where this group appears. A web page's URL must start with one or more"
+            " of the entered scope strings (e.g. 'http://www.example.com')"
+        ),
+        widget=SequenceWidget(add_subitem_text_template=_("Add scope"), min_len=1),
         validator=colander.Length(
-            min=1, min_err=_("At least one origin must be specified")
+            min=1, min_err=_("At least one scope must be specified")
         ),
     )
 

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -60,6 +60,9 @@ def includeme(config):
     config.register_service_factory(".links.links_factory", name="links")
     config.register_service_factory(".group_list.group_list_factory", name="group_list")
     config.register_service_factory(
+        ".group_scope.group_scope_factory", name="group_scope"
+    )
+    config.register_service_factory(
         ".list_organizations.list_organizations_factory", name="list_organizations"
     )
     config.register_service_factory(".nipsa.nipsa_factory", name="nipsa")

--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -43,12 +43,12 @@ class GroupCreateService(object):
             name=name,
             userid=userid,
             type_flags=PRIVATE_GROUP_TYPE_FLAGS,
-            origins=[],
+            scopes=[],
             add_creator_as_member=True,
             **kwargs
         )
 
-    def create_open_group(self, name, userid, origins, **kwargs):
+    def create_open_group(self, name, userid, scopes, **kwargs):
         """
         Create a new open group.
 
@@ -56,7 +56,8 @@ class GroupCreateService(object):
 
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
-        :param origins: the list of origins that the group will be scoped to
+        :param scopes: the list of URIs that the group will be scoped to
+        :type scopes: list(str)
         :param kwargs: optional attributes to set on the group, as keyword
             arguments
 
@@ -66,12 +67,12 @@ class GroupCreateService(object):
             name=name,
             userid=userid,
             type_flags=OPEN_GROUP_TYPE_FLAGS,
-            origins=origins,
+            scopes=scopes,
             add_creator_as_member=False,
             **kwargs
         )
 
-    def create_restricted_group(self, name, userid, origins, **kwargs):
+    def create_restricted_group(self, name, userid, scopes, **kwargs):
         """
         Create a new restricted group.
 
@@ -80,7 +81,8 @@ class GroupCreateService(object):
 
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
-        :param origins: the list of origins that the group will be scoped to
+        :param scopes: the list of URIs that the group will be scoped to
+        :type scopes: list(str)
         :param kwargs: optional attributes to set on the group, as keyword
             arguments
 
@@ -90,13 +92,13 @@ class GroupCreateService(object):
             name=name,
             userid=userid,
             type_flags=RESTRICTED_GROUP_TYPE_FLAGS,
-            origins=origins,
+            scopes=scopes,
             add_creator_as_member=True,
             **kwargs
         )
 
     def _create(
-        self, name, userid, type_flags, origins, add_creator_as_member, **kwargs
+        self, name, userid, type_flags, scopes, add_creator_as_member, **kwargs
     ):
         """
         Create a group and save it to the DB.
@@ -104,17 +106,18 @@ class GroupCreateService(object):
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
         :param type_flags: the type of this group
-        :param origins: the list of origins that the group will be scoped to
+        :param scopes: the list of scopes (URIs) that the group will be scoped to
+        :type scopes: list(str)
         :param add_creator_as_member: if the group creator should be added as a member
         :param kwargs: optional attributes to set on the group, as keyword
             arguments
         """
-        if origins is None:
-            origins = []
+        if scopes is None:
+            scopes = []
 
         creator = self.user_fetcher(userid)
 
-        scopes = [GroupScope(origin=o) for o in origins]
+        group_scopes = [GroupScope(scope=s) for s in scopes]
 
         if "organization" in kwargs:
             self._validate_authorities_match(
@@ -128,7 +131,7 @@ class GroupCreateService(object):
             joinable_by=type_flags.joinable_by,
             readable_by=type_flags.readable_by,
             writeable_by=type_flags.writeable_by,
-            scopes=scopes,
+            scopes=group_scopes,
             **kwargs
         )
         self.session.add(group)

--- a/h/services/group_list.py
+++ b/h/services/group_list.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from h import models
 from h.models import group
-from h.util import group_scope as scope_util
 
 
 class GroupListService(object):
@@ -17,7 +16,7 @@ class GroupListService(object):
     ALl public methods return relevant group model objects.
     """
 
-    def __init__(self, session, default_authority):
+    def __init__(self, session, default_authority, group_scope_service):
         """
         Create a new group_list service.
 
@@ -25,6 +24,7 @@ class GroupListService(object):
         :param default_authority: the authority to use as a default
         """
         self._session = session
+        self._group_scope_service = group_scope_service
         self.default_authority = default_authority
 
     def _authority(self, user=None, authority=None):
@@ -105,12 +105,17 @@ class GroupListService(object):
           via the API.
         """
         authority = self._authority(user, authority)
-        scoped_groups = self.scoped_groups(authority, document_uri)
+        scoped_groups = []
+        private_groups = []
+
+        if document_uri:
+            scoped_groups = self.scoped_groups(authority, document_uri)
 
         world_group = self.world_group(authority)
         world_group = [world_group] if world_group else []
 
-        private_groups = self.private_groups(user)
+        if user:
+            private_groups = self.private_groups(user)
 
         return scoped_groups + world_group + private_groups
 
@@ -147,35 +152,23 @@ class GroupListService(object):
         return [group for group in user_groups if group.type == "private"]
 
     def scoped_groups(self, authority, document_uri):
-        """
-        Return scoped groups for the URI and authority
+        matching_scopes = self._group_scope_service.fetch_by_scope(document_uri)
+        matching_scope_groupids = [scope.group_id for scope in matching_scopes]
 
-        Only open and restricted groups are "supposed" to have scope, but
-        technically this query is agnostic to the group's type—it will return
-        any group who has a scope that matches the document_uri's scope.
-
-        Note: If private groups are ever allowed to be scoped, this needs
-        attention.
-
-        :param authority: Filter groups by this authority
-        :type authority: string
-        :arg document_uri: Use this URI to find groups with matching scopes
-        :type document_uri: string
-        :rtype: list of :class:`h.models.group`
-        """
-        origin = scope_util.uri_scope(document_uri)
-        if not origin:
+        if not matching_scope_groupids:
             return []
 
-        groups = (
-            self._session.query(models.GroupScope, models.Group)
-            .filter(models.Group.id == models.GroupScope.group_id)
-            .filter(models.GroupScope.origin == origin)
+        # Retrieve groups for these IDs
+        scoped_groups = (
+            self._session.query(models.Group)
+            .filter(models.Group.id.in_(matching_scope_groupids))
             .filter(models.Group.authority == authority)
+            .filter(
+                models.Group.readable_by == group.ReadableBy.world
+            )  # Only "public" groups
+            .group_by(models.Group.id)  # de-dupe
             .all()
         )
-
-        scoped_groups = [group for groupscope, group in groups]
         return self._sort(scoped_groups)
 
     def world_group(self, authority):
@@ -225,6 +218,9 @@ class GroupListService(object):
 
 def group_list_factory(context, request):
     """Return a GroupListService instance for the passed context and request."""
+    group_scope_service = request.find_service(name="group_scope")
     return GroupListService(
-        session=request.db, default_authority=request.default_authority
+        session=request.db,
+        default_authority=request.default_authority,
+        group_scope_service=group_scope_service,
     )

--- a/h/services/group_scope.py
+++ b/h/services/group_scope.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.models import GroupScope
+from h.util import group_scope as scope_util
+
+
+class GroupScopeService(object):
+    def __init__(self, session):
+        self._session = session
+
+    def fetch_by_origin(self, uri):
+        # Retrieve all GroupScope records in the DB that have an `origin` component
+        # that matches the given uri's origin. This will give us a set of
+        # results whose scopes may match the `document_uri`
+        # Refactor into scopes_for_origin
+        origin = scope_util.parse_origin(uri)
+        if not origin:
+            return []
+        origin_scopes = (
+            self._session.query(GroupScope).filter(GroupScope.origin == origin).all()
+        )
+        return origin_scopes
+
+    def fetch_by_scope(self, uri):
+        origin_scopes = self.fetch_by_origin(uri)
+        return [
+            scope
+            for scope in origin_scopes
+            if scope_util.uri_in_scope(uri, [scope.scope])
+        ]
+
+
+def group_scope_factory(context, request):
+    return GroupScopeService(session=request.db)

--- a/h/storage.py
+++ b/h/storage.py
@@ -24,7 +24,7 @@ from pyramid import i18n
 
 from h import models, schemas
 from h.db import types
-from h.util.group_scope import match as group_scope_match
+from h.util.group_scope import uri_in_scope
 from h.models.document import update_document_metadata
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -250,10 +250,10 @@ def _validate_group_scope(group, target_uri):
     # annotations outside of its scope, there's nothing to do here
     if not group.scopes or group.enforce_scope is False:
         return
-    # The scope (origin) of the target URI must match at least one
+    # The target URI must match at least one
     # of a group's defined scopes, if the group has any
-    group_scopes = [scope.origin for scope in group.scopes]
-    if not group_scope_match(target_uri, group_scopes):
+    group_scopes = [scope.scope for scope in group.scopes]
+    if not uri_in_scope(target_uri, group_scopes):
         raise schemas.ValidationError(
             "group scope: "
             + _("Annotations for this target URI " "are not allowed in this group")

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -18,6 +18,8 @@ def match(uri, scopes):
     return scope in scopes
 
 
+# TODO: This concept no longer makes sense with more granular scoping. There is
+# no equivalent 1:1 uri <-> scope relationship. Remove this function soon.
 def uri_scope(uri):
     """
     Return the scope for a given URI
@@ -26,6 +28,30 @@ def uri_scope(uri):
     proxies to _parse_origin.
     """
     return _parse_origin(uri)
+
+
+def uri_to_scope(uri):
+    """
+    Return a tuple representing the origin and path of a URI
+
+    :arg uri: The URI from which to derive scope
+    :type uri: str
+    :rtype: tuple(str, str or None)
+    """
+    # A URL with no origin component will result in a `None` value for
+    # origin, while a URL with no path component will result in an empty
+    # string for path.
+    origin = _parse_origin(uri)
+    path = _parse_path(uri) or None
+    return (origin, path)
+
+
+def _parse_path(uri):
+    """Return the path component of a URI string"""
+    if uri is None:
+        return None
+    parsed = urlparse.urlsplit(uri)
+    return parsed[2]
 
 
 def _parse_origin(uri):

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -7,19 +7,6 @@ import re
 from h._compat import urlparse
 
 
-def match(uri, scopes):
-    """
-    Return boolean: Does the URI's scope match any of the scopes?
-
-    Return True if the scope of URI is present in the scopes list
-
-    :param uri: URI string in question
-    :param scopes: List of scope (URI origin) strings
-    """
-    scope = uri_scope(uri)
-    return scope in scopes
-
-
 def pattern_for_scope(scope):
     """
     Return a regex string that represents this scope string.
@@ -64,18 +51,6 @@ def uri_in_scope(uri, scopes):
     if re.match(pattern_str, uri):
         return True
     return False
-
-
-# TODO: This concept no longer makes sense with more granular scoping. There is
-# no equivalent 1:1 uri <-> scope relationship. Remove this function soon.
-def uri_scope(uri):
-    """
-    Return the scope for a given URI
-
-    Parse a scope from a URI string. Presently a scope is an origin, so this
-    proxies to parse_origin.
-    """
-    return parse_origin(uri)
 
 
 def uri_to_scope(uri):

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -93,7 +93,7 @@ class GroupCreateViews(object):
             group = create_fns[type_](
                 name=appstruct["name"],
                 userid=creator_userid,
-                origins=appstruct["origins"],
+                scopes=appstruct["origins"],
                 description=appstruct["description"],
                 organization=organization,
                 enforce_scope=appstruct["enforce_scope"],
@@ -181,7 +181,7 @@ class GroupEditViews(object):
             """Update the group resource on successful form validation"""
 
             organization = self.organizations[appstruct["organization"]]
-            scopes = [GroupScope(origin=o) for o in appstruct["origins"]]
+            scopes = [GroupScope(scope=o) for o in appstruct["origins"]]
 
             self.group_update_svc.update(
                 group,

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -93,7 +93,7 @@ class GroupCreateViews(object):
             group = create_fns[type_](
                 name=appstruct["name"],
                 userid=creator_userid,
-                scopes=appstruct["origins"],
+                scopes=appstruct["scopes"],
                 description=appstruct["description"],
                 organization=organization,
                 enforce_scope=appstruct["enforce_scope"],
@@ -181,7 +181,7 @@ class GroupEditViews(object):
             """Update the group resource on successful form validation"""
 
             organization = self.organizations[appstruct["organization"]]
-            scopes = [GroupScope(scope=o) for o in appstruct["origins"]]
+            scopes = [GroupScope(scope=o) for o in appstruct["scopes"]]
 
             self.group_update_svc.update(
                 group,
@@ -223,7 +223,7 @@ class GroupEditViews(object):
                 "name": group.name,
                 "members": [m.username for m in group.members],
                 "organization": group.organization.pubid,
-                "origins": [s.origin for s in group.scopes],
+                "scopes": [s.scope for s in group.scopes],
                 "enforce_scope": group.enforce_scope,
             }
         )

--- a/tests/common/factories/group_scope.py
+++ b/tests/common/factories/group_scope.py
@@ -14,5 +14,5 @@ class GroupScope(ModelFactory):
         model = models.GroupScope
         sqlalchemy_session_persistence = "flush"
 
-    origin = factory.Faker("url")
+    scope = factory.Faker("url")
     group = factory.SubFactory("tests.common.factories.OpenGroup")

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -2,34 +2,36 @@
 
 from __future__ import unicode_literals
 
+import pytest
+
 from sqlalchemy import inspect
 
 from h.models import GroupScope
 
 
 class TestGroupScope(object):
-    def test_save_and_retrieve_origin(self, db_session, factories):
-        origin = "http://example.com"
-        factories.GroupScope(origin=origin)
+    def test_save_and_retrieve_scope(self, db_session, factories):
+        scope = "http://example.com"
+        factories.GroupScope(scope=scope)
 
         group_scope = db_session.query(GroupScope).one()
 
-        assert group_scope.origin == origin
+        assert group_scope.scope == scope
 
-    def test_subdomains_are_allowed_in_origin(self, db_session, factories):
-        factories.GroupScope(origin="http://www.example.com")
+    def test_subdomains_are_allowed_in_scope(self, db_session, factories):
+        factories.GroupScope(scope="http://www.example.com")
         db_session.flush()
 
-    def test_port_is_allowed_in_origin(self, db_session, factories):
-        factories.GroupScope(origin="http://localhost:5000")
+    def test_port_is_allowed_in_scope(self, db_session, factories):
+        factories.GroupScope(scope="http://localhost:5000")
         db_session.flush()
 
-    def test_there_is_no_validation_of_origin(self, db_session, factories):
-        factories.GroupScope(origin="diplodocus : 123")
-        db_session.flush()
+    def test_it_raises_if_scope_has_no_origin(self, db_session, factories):
+        with pytest.raises(ValueError, match="Invalid URL"):
+            factories.GroupScope(scope="diplodocus : 123")
 
     def test_setting_scope_property_sets_origin_and_path(self, factories):
-        group_scope = GroupScope(scope="http://www.foo.com/bar/baz")
+        group_scope = factories.GroupScope(scope="http://www.foo.com/bar/baz")
 
         assert group_scope.origin == "http://www.foo.com"
         assert group_scope.path == "/bar/baz"
@@ -38,11 +40,19 @@ class TestGroupScope(object):
     def test_setting_scope_with_no_path_element_sets_None_for_path_attr(
         self, factories
     ):
-        group_scope = GroupScope(scope="http://www.foo.com")
+        group_scope = factories.GroupScope(scope="http://www.foo.com")
 
         assert group_scope.origin == "http://www.foo.com"
         assert group_scope.path is None
         assert group_scope.scope == "http://www.foo.com"
+
+    def test_it_raises_if_origin_set_directly(self, factories):
+        with pytest.raises(AttributeError):
+            factories.GroupScope(origin="http://www.foo.com")
+
+    def test_it_raises_if_path_set_directly(self, factories):
+        with pytest.raises(AttributeError):
+            factories.GroupScope(path="/foo/bar")
 
     def test_you_can_get_a_groupscopes_group_by_the_group_property(self, factories):
         group = factories.OpenGroup()
@@ -82,46 +92,46 @@ class TestGroupScope(object):
 
         assert db_session.query(GroupScope).all() == []
 
-    def test_multiple_groupscopes_can_have_the_same_origin(self, db_session, factories):
-        origin = "http://example.com"
+    def test_multiple_groupscopes_can_have_the_same_scope(self, db_session, factories):
+        scope = "http://example.com"
         group_1 = factories.OpenGroup()
         group_2 = factories.OpenGroup()
         group_3 = factories.OpenGroup()
 
         # Different groupscopes, belonging to different groups, can have the
         # same origin.
-        factories.GroupScope(origin=origin, group=group_1)
-        factories.GroupScope(origin=origin, group=group_2)
-        factories.GroupScope(origin=origin, group=group_3)
+        factories.GroupScope(scope=scope, group=group_1)
+        factories.GroupScope(scope=scope, group=group_2)
+        factories.GroupScope(scope=scope, group=group_3)
         db_session.flush()
 
     def test_editing_a_groups_scopes_doesnt_affect_other_groups(self, factories):
-        origin = "http://example.com"
+        scope = "http://example.com"
         group_1 = factories.OpenGroup()
         group_2 = factories.OpenGroup()
         group_3 = factories.OpenGroup()
-        factories.GroupScope(origin=origin, group=group_1)
-        factories.GroupScope(origin=origin, group=group_2)
-        factories.GroupScope(origin=origin, group=group_3)
+        factories.GroupScope(scope=scope, group=group_1)
+        factories.GroupScope(scope=scope, group=group_2)
+        factories.GroupScope(scope=scope, group=group_3)
 
-        group_1.scopes[0].origin = "http://neworigin.com"
+        group_1.scopes[0].scope = "http://neworigin.com"
 
-        assert group_1.scopes[0].origin == "http://neworigin.com"
-        assert group_2.scopes[0].origin == origin
-        assert group_3.scopes[0].origin == origin
+        assert group_1.scopes[0].scope == "http://neworigin.com"
+        assert group_2.scopes[0].scope == scope
+        assert group_3.scopes[0].scope == scope
 
     def test_deleting_a_groups_scopes_doesnt_affect_other_groups(
         self, db_session, factories
     ):
-        origin = "http://example.com"
+        scope = "http://example.com"
         group_1 = factories.OpenGroup()
         group_2 = factories.OpenGroup()
         group_3 = factories.OpenGroup()
         db_session.add_all(
             (
-                factories.GroupScope(origin=origin, group=group_1),
-                factories.GroupScope(origin=origin, group=group_2),
-                factories.GroupScope(origin=origin, group=group_3),
+                factories.GroupScope(scope=scope, group=group_1),
+                factories.GroupScope(scope=scope, group=group_2),
+                factories.GroupScope(scope=scope, group=group_3),
             )
         )
         db_session.flush()
@@ -145,3 +155,15 @@ class TestGroupScope(object):
         # editing one group's scopes to affect another group.
         assert group_2.scopes == [group_scope]
         assert group_1.scopes == []
+
+    def test_query_on_origin_possible_after_setting_scope(self, factories, db_session):
+        factories.GroupScope(scope="http://banana.com")
+
+        result = (
+            db_session.query(GroupScope)
+            .filter(GroupScope.origin == "http://banana.com")
+            .one()
+        )
+
+        assert result.scope == "http://banana.com"
+        assert result.origin == "http://banana.com"

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -28,6 +28,22 @@ class TestGroupScope(object):
         factories.GroupScope(origin="diplodocus : 123")
         db_session.flush()
 
+    def test_setting_scope_property_sets_origin_and_path(self, factories):
+        group_scope = GroupScope(scope="http://www.foo.com/bar/baz")
+
+        assert group_scope.origin == "http://www.foo.com"
+        assert group_scope.path == "/bar/baz"
+        assert group_scope.scope == "http://www.foo.com/bar/baz"
+
+    def test_setting_scope_with_no_path_element_sets_None_for_path_attr(
+        self, factories
+    ):
+        group_scope = GroupScope(scope="http://www.foo.com")
+
+        assert group_scope.origin == "http://www.foo.com"
+        assert group_scope.path is None
+        assert group_scope.scope == "http://www.foo.com"
+
     def test_you_can_get_a_groupscopes_group_by_the_group_property(self, factories):
         group = factories.OpenGroup()
         group_scope = factories.GroupScope(group=group)

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -51,7 +51,7 @@ class TestGroupJSONPresenter(object):
         group = factories.OpenGroup(
             name="My Group",
             pubid="groupy",
-            scopes=[factories.GroupScope(origin="http://foo.com")],
+            scopes=[factories.GroupScope(scope="http://foo.com")],
             organization=factories.Organization(),
         )
         group_context = GroupContext(group)
@@ -134,8 +134,8 @@ class TestGroupJSONPresenter(object):
         group = factories.OpenGroup(
             enforce_scope=False,
             scopes=[
-                factories.GroupScope(origin="http://foo.com"),
-                factories.GroupScope(origin="https://foo.com"),
+                factories.GroupScope(scope="http://foo.com"),
+                factories.GroupScope(scope="https://foo.com"),
             ],
         )
         group_context = GroupContext(group)

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -134,8 +134,8 @@ class TestGroupJSONPresenter(object):
         group = factories.OpenGroup(
             enforce_scope=False,
             scopes=[
-                factories.GroupScope(scope="http://foo.com"),
-                factories.GroupScope(scope="https://foo.com"),
+                factories.GroupScope(scope="http://foo.com/bar"),
+                factories.GroupScope(scope="https://foo.com/baz"),
             ],
         )
         group_context = GroupContext(group)
@@ -146,7 +146,7 @@ class TestGroupJSONPresenter(object):
         assert "scopes" in model
         assert model["scopes"]["enforced"] is False
         assert set(model["scopes"]["uri_patterns"]) == set(
-            ["http://foo.com*", "https://foo.com*"]
+            ["http://foo.com/bar*", "https://foo.com/baz*"]
         )
 
     def test_expanded_scopes_uri_patterns_empty_if_no_scopes(

--- a/tests/h/schemas/forms/admin/group_test.py
+++ b/tests/h/schemas/forms/admin/group_test.py
@@ -65,17 +65,15 @@ class TestCreateGroupSchema(object):
 
         bound_schema.deserialize(group_data)
 
-    @pytest.mark.parametrize("invalid_origin", ["not-a-url"])
-    def test_it_raises_if_origin_invalid(
-        self, group_data, bound_schema, invalid_origin
-    ):
-        group_data["origins"] = [invalid_origin]
-        with pytest.raises(colander.Invalid, match="origins.*Must be a URL"):
+    @pytest.mark.parametrize("invalid_scope", ["not-a-url"])
+    def test_it_raises_if_origin_invalid(self, group_data, bound_schema, invalid_scope):
+        group_data["scopes"] = [invalid_scope]
+        with pytest.raises(colander.Invalid, match="scopes.*Must be a URL"):
             bound_schema.deserialize(group_data)
 
     def test_it_raises_if_no_origins(self, group_data, bound_schema):
-        group_data["origins"] = []
-        with pytest.raises(colander.Invalid, match="At least one origin"):
+        group_data["scopes"] = []
+        with pytest.raises(colander.Invalid, match="At least one scope"):
             bound_schema.deserialize(group_data)
 
     def test_it_raises_if_group_type_changed(
@@ -166,7 +164,7 @@ def group_data(factories):
         "creator": factories.User().username,
         "description": "Lorem ipsum dolor sit amet consectetuer",
         "organization": "__default__",
-        "origins": ["http://www.foo.com", "https://www.foo.com"],
+        "scopes": ["http://www.foo.com", "https://www.foo.com"],
         "enforce_scope": True,
     }
 

--- a/tests/h/services/group_create_test.py
+++ b/tests/h/services/group_create_test.py
@@ -121,7 +121,7 @@ class TestCreatePrivateGroup(object):
 
 class TestCreateOpenGroup(object):
     def test_it_returns_group_model(self, creator, svc, origins):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert isinstance(group, Group)
 
@@ -133,10 +133,7 @@ class TestCreateOpenGroup(object):
         self, creator, svc, origins, group_attr, expected_value
     ):
         group = svc.create_open_group(
-            "test group",
-            creator.userid,
-            origins=origins,
-            description="test description",
+            "test group", creator.userid, scopes=origins, description="test description"
         )
 
         assert getattr(group, group_attr) == expected_value
@@ -150,17 +147,17 @@ class TestCreateOpenGroup(object):
         assert group.authority == creator.authority
 
     def test_it_skips_setting_description_when_missing(self, svc, creator, origins):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert group.description is None
 
     def test_it_sets_group_creator(self, svc, creator, origins):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert group.creator == creator
 
     def test_it_does_not_add_group_creator_to_members(self, svc, creator, origins):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert creator not in group.members
 
@@ -173,14 +170,14 @@ class TestCreateOpenGroup(object):
         ],
     )
     def test_it_sets_access_flags(self, svc, creator, origins, flag, expected_value):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert getattr(group, flag) == expected_value
 
     def test_it_creates_group_with_no_organization_by_default(
         self, default_organization, creator, svc, origins
     ):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert group.organization is None
 
@@ -190,7 +187,7 @@ class TestCreateOpenGroup(object):
         org = factories.Organization()
 
         group = svc.create_open_group(
-            "Anteater fans", creator.userid, origins=origins, organization=org
+            "Anteater fans", creator.userid, scopes=origins, organization=org
         )
 
         assert group.organization == org
@@ -198,7 +195,7 @@ class TestCreateOpenGroup(object):
     def test_it_creates_group_with_enforce_scope_True_by_default(
         self, creator, svc, origins, db_session
     ):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         db_session.flush()
 
@@ -208,7 +205,7 @@ class TestCreateOpenGroup(object):
         self, creator, svc, origins, db_session
     ):
         group = svc.create_open_group(
-            "Anteater fans", creator.userid, origins=origins, enforce_scope=False
+            "Anteater fans", creator.userid, scopes=origins, enforce_scope=False
         )
 
         db_session.flush()
@@ -216,13 +213,13 @@ class TestCreateOpenGroup(object):
         assert group.enforce_scope is False
 
     def test_it_adds_group_to_session(self, db_session, creator, svc, origins):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert group in db_session
 
     def test_it_does_not_publish_join_event(self, svc, creator, publish, origins):
         svc.create_open_group(
-            "Dishwasher disassemblers", creator.userid, origins=origins
+            "Dishwasher disassemblers", creator.userid, scopes=origins
         )
 
         publish.assert_not_called()
@@ -231,7 +228,7 @@ class TestCreateOpenGroup(object):
         origins = ["https://biopub.org", "http://example.com", "https://wikipedia.com"]
 
         group = svc.create_open_group(
-            name="test_group", userid=creator.userid, origins=origins
+            name="test_group", userid=creator.userid, scopes=origins
         )
 
         assert group.scopes == matchers.UnorderedList(
@@ -245,10 +242,10 @@ class TestCreateOpenGroup(object):
         # already exists (this is because a single scope can only belong to
         # one group, so the existing scope can't be reused with the new group).
         origins = ["https://biopub.org", "http://example.com"]
-        scopes = [factories.GroupScope(origin=h) for h in origins]
+        scopes = [factories.GroupScope(scope=h) for h in origins]
 
         group = svc.create_open_group(
-            name="test_group", userid=creator.userid, origins=origins
+            name="test_group", userid=creator.userid, scopes=origins
         )
         for scope in scopes:
             assert scope not in group.scopes
@@ -257,7 +254,7 @@ class TestCreateOpenGroup(object):
 class TestCreateRestrictedGroup(object):
     def test_it_returns_group_model(self, creator, svc, origins):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert isinstance(group, Group)
@@ -270,10 +267,7 @@ class TestCreateRestrictedGroup(object):
         self, creator, svc, origins, group_attr, expected_value
     ):
         group = svc.create_restricted_group(
-            "test group",
-            creator.userid,
-            origins=origins,
-            description="test description",
+            "test group", creator.userid, scopes=origins, description="test description"
         )
 
         assert getattr(group, group_attr) == expected_value
@@ -288,21 +282,21 @@ class TestCreateRestrictedGroup(object):
 
     def test_it_skips_setting_description_when_missing(self, svc, creator, origins):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert group.description is None
 
     def test_it_sets_group_creator(self, svc, creator, origins):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert group.creator == creator
 
     def test_it_adds_group_creator_to_members(self, svc, creator, origins):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert creator in group.members
@@ -317,7 +311,7 @@ class TestCreateRestrictedGroup(object):
     )
     def test_it_sets_access_flags(self, svc, creator, origins, flag, expected_value):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert getattr(group, flag) == expected_value
@@ -326,7 +320,7 @@ class TestCreateRestrictedGroup(object):
         self, default_organization, creator, svc, origins
     ):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert group.organization is None
@@ -337,7 +331,7 @@ class TestCreateRestrictedGroup(object):
         org = factories.Organization()
 
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins, organization=org
+            "Anteater fans", creator.userid, scopes=origins, organization=org
         )
 
         assert group.organization == org
@@ -346,7 +340,7 @@ class TestCreateRestrictedGroup(object):
         self, creator, svc, origins, db_session
     ):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         db_session.flush()
@@ -357,7 +351,7 @@ class TestCreateRestrictedGroup(object):
         self, creator, svc, origins, db_session
     ):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins, enforce_scope=False
+            "Anteater fans", creator.userid, scopes=origins, enforce_scope=False
         )
 
         db_session.flush()
@@ -366,14 +360,14 @@ class TestCreateRestrictedGroup(object):
 
     def test_it_adds_group_to_session(self, db_session, creator, svc, origins):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert group in db_session
 
     def test_it_publishes_join_event(self, svc, creator, publish, origins):
         group = svc.create_restricted_group(
-            "Dishwasher disassemblers", creator.userid, origins=origins
+            "Dishwasher disassemblers", creator.userid, scopes=origins
         )
 
         publish.assert_called_once_with("group-join", group.pubid, creator.userid)
@@ -382,7 +376,7 @@ class TestCreateRestrictedGroup(object):
         origins = ["https://biopub.org", "http://example.com", "https://wikipedia.com"]
 
         group = svc.create_restricted_group(
-            name="test_group", userid=creator.userid, origins=origins
+            name="test_group", userid=creator.userid, scopes=origins
         )
 
         assert group.scopes == matchers.UnorderedList(
@@ -397,7 +391,7 @@ class TestCreateRestrictedGroup(object):
             svc.create_restricted_group(
                 name="test_group",
                 userid=creator.userid,
-                origins=origins,
+                scopes=origins,
                 description="test_description",
                 organization=org,
             )
@@ -409,10 +403,10 @@ class TestCreateRestrictedGroup(object):
         # already exists (this is because a single scope can only belong to
         # one group, so the existing scope can't be reused with the new group).
         origins = ["https://biopub.org", "http://example.com"]
-        scopes = [factories.GroupScope(origin=h) for h in origins]
+        scopes = [factories.GroupScope(scope=h) for h in origins]
 
         group = svc.create_restricted_group(
-            name="test_group", userid=creator.userid, origins=origins
+            name="test_group", userid=creator.userid, scopes=origins
         )
 
         for scope in scopes:

--- a/tests/h/services/group_list_test.py
+++ b/tests/h/services/group_list_test.py
@@ -373,12 +373,12 @@ def scoped_open_groups(factories, authority, origin, user):
             name="Blender",
             authority=authority,
             creator=user,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.OpenGroup(
             name="Antigone",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
     ]
 
@@ -390,12 +390,12 @@ def scoped_restricted_groups(factories, authority, origin, user):
             name="Forensic",
             authority=authority,
             creator=user,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.RestrictedGroup(
             name="Affluent",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
     ]
 
@@ -420,13 +420,13 @@ def scoped_restricted_user_groups(factories, authority, user, origin):
             name="Alpha",
             authority=authority,
             creator=user,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.RestrictedGroup(
             name="Beta",
             authority=authority,
             creator=user,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
     ]
 
@@ -465,19 +465,19 @@ def mixed_groups(factories, user, authority, origin):
             name="Yaks",
             pubid="yaks",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.RestrictedGroup(
             name="Xander",
             pubid="xander",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.OpenGroup(
             name="wadsworth",
             pubid="wadsworth",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
     ]
 

--- a/tests/h/services/group_scope_test.py
+++ b/tests/h/services/group_scope_test.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+import mock
+
+from h.services.group_scope import group_scope_factory, GroupScopeService
+
+
+class TestFetchByOrigin(object):
+    def test_it_proxies_to_scope_util_for_origin_parsing(
+        self, svc, scope_util, document_uri
+    ):
+        scope_util.parse_origin.return_value = "parsed"
+        svc.fetch_by_origin(document_uri)
+
+        scope_util.parse_origin.assert_called_once_with(document_uri)
+
+    def test_it_returns_empty_list_if_origin_not_parseable(
+        self, svc, scope_util, document_uri
+    ):
+        scope_util.parse_origin.return_value = None
+        scopes = svc.fetch_by_origin(document_uri)
+
+        assert scopes == []
+
+    @pytest.mark.parametrize(
+        "uri,should_match",
+        [
+            ("https://www.foo.com", False),
+            ("http://foo.com", True),
+            ("https://foo.com/bar", False),
+            ("http://foo.com/bar/baz/", True),
+            ("http://www.foo.com/bar/baz.html", False),
+            ("randoscheme://foo.com", False),
+            ("foo", False),
+            ("foo.com", False),
+            ("http://foo.com/bar/baz.html?query=whatever", True),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_it_returns_scopes_that_match_uri_origin(
+        self, svc, sample_scopes, uri, should_match
+    ):
+        matches = svc.fetch_by_origin(uri)
+
+        if should_match:
+            assert matches == sample_scopes
+        else:
+            assert matches == []
+
+
+class TestFetchByScope(object):
+    def test_it_proxies_to_fetch_by_origin(self, svc, document_uri):
+        svc.fetch_by_origin = mock.Mock(return_value=[])
+
+        svc.fetch_by_scope(document_uri)
+
+        svc.fetch_by_origin.assert_called_once_with(document_uri)
+
+    def test_it_returns_list_of_matching_scopes(self, svc, document_uri, sample_scopes):
+        results = svc.fetch_by_scope(document_uri)
+
+        matching_scope_scopes = [scope.scope for scope in results]
+        assert len(results) == 2
+        assert "http://foo.com" in matching_scope_scopes
+        assert "http://foo.com/bar/" in matching_scope_scopes
+
+
+class TestGroupScopeFactory(object):
+    def test_it_returns_group_scope_service_instance(self, pyramid_request):
+        svc = group_scope_factory(None, pyramid_request)
+
+        assert isinstance(svc, GroupScopeService)
+
+
+@pytest.fixture
+def svc(db_session, pyramid_request):
+    pyramid_request.db = db_session
+    return group_scope_factory({}, pyramid_request)
+
+
+@pytest.fixture
+def scope_util(patch):
+    return patch("h.services.group_scope.scope_util")
+
+
+@pytest.fixture
+def document_uri():
+    return "http://foo.com/bar/foo.html"
+
+
+@pytest.fixture
+def sample_scopes(factories):
+    return [
+        factories.GroupScope(scope="http://foo.com"),
+        factories.GroupScope(scope="http://foo.com/bar/"),
+        factories.GroupScope(scope="http://foo.com/bar/baz/"),
+        factories.GroupScope(
+            scope="http://foo.com/bar/baz/foo.html?q=something&wut=how"
+        ),
+    ]

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -240,8 +240,8 @@ class TestCreateAnnotation(object):
     def test_it_allows_when_target_uri_matches_multiple_group_scope(
         self, pyramid_request, pyramid_config, group_service, factories, models
     ):
-        scope = factories.GroupScope(origin="http://www.foo.com")
-        scope2 = factories.GroupScope(origin="http://www.bar.com")
+        scope = factories.GroupScope(scope="http://www.foo.com")
+        scope2 = factories.GroupScope(scope="http://www.bar.com")
         group_service.find.return_value = factories.OpenGroup(scopes=[scope, scope2])
         data = self.annotation_data()
         data["target_uri"] = "http://www.bar.com/boo/bah.html"
@@ -638,7 +638,7 @@ def datetime(patch):
 
 @pytest.fixture
 def scoped_open_group(factories):
-    scope = factories.GroupScope(origin="http://www.foo.com")
+    scope = factories.GroupScope(scope="http://www.foo.com")
     return factories.OpenGroup(scopes=[scope])
 
 

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -28,6 +28,87 @@ def test_it_parses_scope_from_uri(uri, expected_scope):
     assert scope == expected_scope
 
 
+class TestPatternForScope(object):
+    @pytest.mark.parametrize(
+        "scope,expected_pattern",
+        [
+            ("https://www.foo.com", "^https\\:\\/\\/www\\.foo\\.com.*"),
+            ("http://foo.com", "^http\\:\\/\\/foo\\.com.*"),
+            ("https://foo.com/bar", "^https\\:\\/\\/foo\\.com\\/bar.*"),
+            (
+                "http://www.foo.com/bar/baz.html",
+                "^http\\:\\/\\/www\\.foo\\.com\\/bar\\/baz\\.html.*",
+            ),
+            ("foo", "^foo.*"),
+            (None, "(?!x)x"),
+        ],
+    )
+    def test_it_converts_uri_to_valid_pattern(self, scope, expected_pattern):
+        assert scope_util.pattern_for_scope(scope) == expected_pattern
+
+
+class TestURIInScope(object):
+    @pytest.mark.parametrize(
+        "scopes,expected_pattern",
+        [
+            (["foo", "bar", "baz"], "^foo.*|^bar.*|^baz.*"),
+            (["http://bing.com/bar"], "^http\\:\\/\\/bing\\.com\\/bar.*"),
+            (
+                ["http://example.com/foo", "https://example.com/foo"],
+                "^http\\:\\/\\/example\\.com\\/foo.*|^https\\:\\/\\/example\\.com\\/foo.*",
+            ),
+        ],
+    )
+    def test_it_creates_valid_single_pattern_string(
+        self, scopes, expected_pattern, match
+    ):
+        scope_util.uri_in_scope("http://foo.com", scopes)
+
+        match.assert_called_once_with(expected_pattern, "http://foo.com")
+
+    @pytest.mark.parametrize(
+        "uri,in_origin,in_path,in_other",
+        [
+            ("https://www.foo.com", True, False, False),
+            ("http://foo.com", False, False, False),
+            ("http://www.foo.com/bar/qux.html", True, True, True),
+            ("http://www.foo.com/bar/baz/qux.html", True, True, True),
+            ("http://foo.com/", False, False, False),
+            ("http://www.foo.com/bar.baz", True, False, False),
+            ("www.foo.com", False, False, False),
+            ("randoscheme://foo.com", False, False, False),
+            ("foo", False, False, False),
+            ("https://www.foo.com/bar/baz", True, False, False),
+            ("", False, False, False),
+        ],
+    )
+    def test_it_returns_True_if_uri_matches_one_or_more_scopes(
+        self, scope_lists, uri, in_origin, in_path, in_other
+    ):
+        assert scope_util.uri_in_scope(uri, scope_lists["origin_only"]) == in_origin
+        assert scope_util.uri_in_scope(uri, scope_lists["with_path"]) == in_path
+        assert scope_util.uri_in_scope(uri, scope_lists["with_other"]) == in_other
+
+    @pytest.fixture
+    def match(self, patch):
+        return patch("h.util.group_scope.re.match")
+
+    @pytest.fixture
+    def scope_lists(self):
+        return {
+            "origin_only": ["http://www.foo.com", "https://www.foo.com"],
+            "with_path": [
+                "http://www.foo.com/bar/baz",
+                "http://www.foo.com/bar/qux",
+                "http://www.foo.com/bar/baz/qux",
+            ],
+            "with_other": [
+                "http://www.foo.com/bar/baz/qux.html",
+                "http://www.foo.com/bar/qux",
+            ],
+        }
+
+
 class TestScopeMatch(object):
     @pytest.mark.parametrize(
         "uri,expected",
@@ -87,3 +168,18 @@ class TestURIToScope(object):
     )
     def test_it_parses_origin_and_path_from_uri(self, uri, expected_scope):
         assert scope_util.uri_to_scope(uri) == expected_scope
+
+
+class TestParseOrigin(object):
+    @pytest.mark.parametrize(
+        "uri,expected_origin",
+        [
+            ("https://www.foo.com/foo/qux/bar.html", "https://www.foo.com"),
+            ("http://foo.com/baz", "http://foo.com"),
+            ("http://foo.com:3553/bar", "http://foo.com:3553"),
+            ("http://www.foo.bar.com", "http://www.foo.bar.com"),
+            ("foo.com", None),
+        ],
+    )
+    def test_it_parses_origin_from_uri(self, uri, expected_origin):
+        assert scope_util.parse_origin(uri) == expected_origin

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -67,3 +67,23 @@ class TestScopeMatch(object):
     @pytest.fixture
     def multiple_scopes(self):
         return ["http://www.foo.com", "http://www.bar.com"]
+
+
+class TestURIToScope(object):
+    @pytest.mark.parametrize(
+        "uri,expected_scope",
+        [
+            ("https://www.foo.com/foo", ("https://www.foo.com", "/foo")),
+            ("https://foo.com/bar/baz", ("https://foo.com", "/bar/baz")),
+            ("http://foo.com", ("http://foo.com", None)),
+            ("/foo/bar", (None, "/foo/bar")),
+            (
+                "https://foo.com/foo/bar/baz.html",
+                ("https://foo.com", "/foo/bar/baz.html"),
+            ),
+            ("http://foo.com//bar/baz", ("http://foo.com", "//bar/baz")),
+            ("http://foo.com/bar?what=how", ("http://foo.com", "/bar")),
+        ],
+    )
+    def test_it_parses_origin_and_path_from_uri(self, uri, expected_scope):
+        assert scope_util.uri_to_scope(uri) == expected_scope

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -6,28 +6,6 @@ import pytest
 from h.util import group_scope as scope_util
 
 
-@pytest.mark.parametrize(
-    "uri,expected_scope",
-    [
-        ("https://www.foo.com", "https://www.foo.com"),
-        ("http://foo.com", "http://foo.com"),
-        ("https://foo.com/bar", "https://foo.com"),
-        ("http://foo.com/", "http://foo.com"),
-        ("http://www.foo.com/bar/baz.html", "http://www.foo.com"),
-        ("randoscheme://foo.com", "randoscheme://foo.com"),
-        ("foo", None),
-        ("foo.com", None),
-        ("http://www.foo.com/bar/baz.html?query=whatever", "http://www.foo.com"),
-        ("", None),
-        (None, None),
-    ],
-)
-def test_it_parses_scope_from_uri(uri, expected_scope):
-    scope = scope_util.uri_scope(uri)
-
-    assert scope == expected_scope
-
-
 class TestPatternForScope(object):
     @pytest.mark.parametrize(
         "scope,expected_pattern",
@@ -107,47 +85,6 @@ class TestURIInScope(object):
                 "http://www.foo.com/bar/qux",
             ],
         }
-
-
-class TestScopeMatch(object):
-    @pytest.mark.parametrize(
-        "uri,expected",
-        [
-            ("http://www.foo.com/bar/baz/ding.html", True),
-            ("https://www.foo.com/bar/baz/ding.html", False),
-            ("http://www.foo.com/", True),
-            ("http://foo.com/bar.html", False),
-            ("foo.com/bar.html", False),
-        ],
-    )
-    def test_it_matches_against_single_scope(self, uri, expected, single_scope):
-        result = scope_util.match(uri, single_scope)
-
-        assert result == expected
-
-    @pytest.mark.parametrize(
-        "uri,expected",
-        [
-            ("http://www.foo.com/bar/baz/ding.html", True),
-            ("http://www.bar.com/bar/baz/ding.html", True),
-            ("http://www.foo.com/", True),
-            ("http://www.bar.com", True),
-            ("http://bar.com/bar.html", False),
-            ("bar.com/bar.html", False),
-        ],
-    )
-    def test_it_matches_against_multiple_scopes(self, uri, expected, multiple_scopes):
-        result = scope_util.match(uri, multiple_scopes)
-
-        assert result == expected
-
-    @pytest.fixture
-    def single_scope(self):
-        return ["http://www.foo.com"]
-
-    @pytest.fixture
-    def multiple_scopes(self):
-        return ["http://www.foo.com", "http://www.bar.com"]
 
 
 class TestURIToScope(object):

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -180,7 +180,7 @@ class TestGroupCreateView(object):
             "description": None,
             "members": [],
             "organization": default_org.pubid,
-            "origins": ["http://example.com"],
+            "scopes": ["http://example.com"],
             "enforce_scope": True,
         }
 
@@ -267,7 +267,7 @@ class TestGroupEditViews(object):
                     "group_type": "open",
                     "name": "Updated group",
                     "organization": updated_org.pubid,
-                    "origins": ["http://somewhereelse.com", "http://www.gladiolus.org"],
+                    "scopes": ["http://somewhereelse.com", "http://www.gladiolus.org"],
                     "members": [],
                     "enforce_scope": False,
                 }
@@ -320,7 +320,7 @@ class TestGroupEditViews(object):
                     "name": "a name",
                     "members": ["phil", "sue"],
                     "organization": group.organization.pubid,
-                    "origins": ["http://www.example.com"],
+                    "scopes": ["http://www.example.com"],
                     "enforce_scope": group.enforce_scope,
                 }
             )
@@ -358,7 +358,7 @@ class TestGroupEditViews(object):
             "name": group.name,
             "members": [m.username for m in group.members],
             "organization": group.organization.pubid,
-            "origins": [s.origin for s in group.scopes],
+            "scopes": [s.scope for s in group.scopes],
             "enforce_scope": group.enforce_scope,
         }
 

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -113,7 +113,7 @@ class TestGroupCreateView(object):
             name="My New Group",
             userid=user_svc.fetch.return_value.userid,
             description=None,
-            origins=["http://example.com"],
+            scopes=["http://example.com"],
             organization=default_org,
             enforce_scope=True,
         )
@@ -140,7 +140,7 @@ class TestGroupCreateView(object):
             name="My New Group",
             userid=user_svc.fetch.return_value.userid,
             description=None,
-            origins=["http://example.com"],
+            scopes=["http://example.com"],
             organization=default_org,
             enforce_scope=True,
         )
@@ -285,7 +285,7 @@ class TestGroupEditViews(object):
             description="New description",
             name="Updated group",
             scopes=[
-                GroupScope(origin=o)
+                GroupScope(scope=o)
                 for o in ["http://somewhereelse.com", "http://www.gladiolus.org"]
             ],
             enforce_scope=False,


### PR DESCRIPTION
This PR is a master WIP PR for the work to satisfy https://github.com/hypothesis/product-backlog/issues/908

If the general approach is deemed sound, I'll open a set of stacked PRs to break this down. The diff is large, but 2/3 or 3/4 of it is tests. If the reviewer(s) here so deem, tests could be ignored for now and evaluated in the component PRs later.

## Overview

The GroupScope model is changed to add a `scope` (hybrid) property and to make the `origin` and `path` properties read-only.  A GroupScope’s `scope` may be set to any URL; the model (via util function) splits and persists that appropriately in the `origin` and `path` columns.  Retrieving a `GroupScope`’s `scope` is the inverse: the model gloms it back together again.  Application logic is updated throughout to set `scope` instead of `origin`. 

A new `GroupScope` service owns the logic of determining whether a URI matches a set of known scope(s) (i.e. “Is this URI within the scope of this group?”) and what scopes match a given URI (i.e. “give me all of the groupscope records that match this URI”). The `GroupList` service no longer deals with `GroupScope` logic directly.

`GroupList.scoped_groups` has been rewritten. It no longer joins on the `GroupScope` table in its query. Instead, it uses the matching scopes returned by the `GroupScope` service to filter matching groups. In doing this, it became necessary to rewrite the tests for the `GroupList` service module. They were non-unit-isolated (written more as integration tests) and this started breaking down once the dependency on the `GroupScope` service was introduced. I rewrote the module’s tests as unit tests.

I should emphasize that any existing `GroupScope` records with `origin` only (that is, any pre-existing `GroupScope` records) operate just fine after these changes; `path` is an optional part of `scope`.

## Patterns/Specifics

* The model is in charge of providing abstraction between `scope` and the constituent `origin` and `path` components. At this point, it’s still possible to read `origin` and `path` properties on `GroupScope` objects, but not set them. We might consider making them not even readable in the future.
* The `group_scope` util module functions are in charge of all string-level matching and parsing operations, but has no knowledge about models or services.
* The `GroupScope` service is in charge of querying the DB for scope-related things
* The `GroupList` service’s `scoped_groups` method depends on the `GroupScope` service for scoping and further filters groups to make sure they match the pertinent authority.
* The admin group form schema has been updated to change wording and references away from `origin` to `scope`. The form works as-is because the model takes care of splitting up the entered URIs into the right constituent parts.
* Application logic has been updated throughout to use `scope` instead of `origin`, where necessary

## Things to Look For

* Is the matching approach sound, especially for answering the "what groups match this URI" question?
* Is the `scope` property on `h.models.group_scope.GroupScope` sensible? Does it need to be filterable as well or can that wait?
* Are the relationships between `GroupList` and `GroupScope` services OK?
* Does the responsibility breakdown between the model, the util module and the services seem OK?
* Will this scale OK for the foreseeable future?
* Getting all groups for a given URI requires two (known) DB queries, one in `GroupScope` service and one in `GroupList` service. Is this OK?  Do the queries look OK performance-wise? Are there any places where additional queries might be spawned without me realizing?