### PR TITLE
Add Media-Type response headers to API responses

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -42,10 +42,19 @@ info:
     Though not required, we urge clients to set an `Accept` header with a media
     type corresponding to the desired version, e.g.
 
-    `Accept: application/vnd.hypothesis.v1+json`
+    ```
+    Accept: application/vnd.hypothesis.v1+json
+    ```
 
     If an `Accept` header is set with an unrecognized media type, the API will
     return an HTTP 415 (Unsupported Media Type) error.
+
+    Responses to API requests include a header indicating which API version was used
+    to handle the request, e.g.:
+
+    ```
+    X-Hypothesis-Media-Type: application/vnd.hypothesis.v1+json
+    ```
 
     ## Errors
 

--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -4,6 +4,7 @@ import venusian
 from h.views.api.helpers import cors
 from h.views.api.helpers import links
 from h.views.api.helpers.media_types import media_type_for_version
+from h.views.api.decorators.response import version_media_type_header
 
 from h.views.api import API_VERSIONS
 
@@ -65,7 +66,7 @@ def add_api_view(
     """
     settings.setdefault("accept", "application/json")
     settings.setdefault("renderer", "json")
-    settings.setdefault("decorator", cors_policy)
+    settings.setdefault("decorator", (cors_policy, version_media_type_header))
 
     if link_name:
         link = links.ServiceLink(

--- a/h/views/api/decorators/__init__.py
+++ b/h/views/api/decorators/__init__.py
@@ -6,5 +6,11 @@ from h.views.api.decorators.client_errors import (
     normalize_not_found,
     validate_media_types,
 )
+from h.views.api.decorators.response import version_media_type_header
 
-__all__ = ("unauthorized_to_not_found", "normalize_not_found", "validate_media_types")
+__all__ = (
+    "unauthorized_to_not_found",
+    "normalize_not_found",
+    "validate_media_types",
+    "version_media_type_header",
+)

--- a/h/views/api/decorators/response.py
+++ b/h/views/api/decorators/response.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""API view decorators for response headers"""
+
+from __future__ import unicode_literals
+
+from h.views.api import API_VERSION_DEFAULT
+from h.views.api.helpers.media_types import media_type_for_version
+
+
+def version_media_type_header(wrapped):
+    """View decorator to add response header indicating API version"""
+
+    def wrapper(context, request):
+        response = wrapped(context, request)
+        # TODO: expand with logic for multiple versions once the app knows
+        # about multiple versions
+        version_media_type = media_type_for_version(API_VERSION_DEFAULT)
+        response.headers["Hypothesis-Media-Type"] = version_media_type
+        return response
+
+    return wrapper

--- a/h/views/api/helpers/media_types.py
+++ b/h/views/api/helpers/media_types.py
@@ -18,7 +18,7 @@ def media_type_for_version(version, subtype="json"):
     return "application/vnd.hypothesis.{}+{}".format(version, subtype)
 
 
-def valid_media_types(versions=None):
+def valid_media_types():
     """
     Return a list of all valid API media types
 
@@ -31,13 +31,23 @@ def valid_media_types(versions=None):
     * An Accept header containing at least one of the media types returned by
       this function.
 
-    :arg versions: List of version strings to include in the valid media types.
-                   Defaults to the app's known version list.
+    :rtype: list(str)
+    """
+    valid_types = ["*/*", "application/json"] + version_media_types()
+    return valid_types
+
+
+def version_media_types(versions=None):
+    """
+    Return the media types corresponding to versions
+
+    :arg versions: media types will be returned for these versions, e.g. "v1",
+                   defaults to all known versions
     :type versions: list(str) or None
     :rtype: list(str)
     """
     versions = versions or API_VERSIONS
-    valid_types = ["*/*", "application/json"]
+    version_types = []
     for version in versions:
-        valid_types.append(media_type_for_version(version))
-    return valid_types
+        version_types.append(media_type_for_version(version))
+    return version_types

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -18,6 +18,19 @@ native_str = str
 
 @pytest.mark.functional
 class TestIndexEndpointVersions(object):
+    def test_index_sets_version_response_header(self, app):
+        """
+        A custom response header should be present confirming the version of
+        the API used.
+        """
+        res = app.get("/api/")
+
+        assert res.status_code == 200
+        assert "Hypothesis-Media-Type" in res.headers
+        assert (
+            res.headers["Hypothesis-Media-Type"] == "application/vnd.hypothesis.v1+json"
+        )
+
     def test_index_200s_when_accept_empty(self, app):
         """
         Don't send any Accept headers and we should get a 200 response.

--- a/tests/h/views/api/config_test.py
+++ b/tests/h/views/api/config_test.py
@@ -5,6 +5,7 @@ import mock
 import pytest
 
 from h.views.api import config as api_config
+from h.views.api.decorators.response import version_media_type_header
 
 
 @pytest.mark.usefixtures("cors")
@@ -45,12 +46,15 @@ class TestAddApiView(object):
         (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["renderer"] == "xml"
 
-    def test_it_sets_cors_decorator(self, pyramid_config, view):
+    def test_it_sets_default_decorators(self, pyramid_config, view):
         api_config.add_api_view(
             pyramid_config, view, versions=["v1"], route_name="thing.read"
         )
         (_, kwargs) = pyramid_config.add_view.call_args_list[0]
-        assert kwargs["decorator"] == api_config.cors_policy
+        assert kwargs["decorator"] == (
+            api_config.cors_policy,
+            version_media_type_header,
+        )
 
     def test_it_adds_cors_preflight_view(self, pyramid_config, view, cors):
         api_config.add_api_view(

--- a/tests/h/views/api/decorators/response_test.py
+++ b/tests/h/views/api/decorators/response_test.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import mock
+import pytest
+
+from pyramid.response import Response
+
+
+from h.views.api.decorators.response import version_media_type_header
+
+
+class TestVersionMediaTypeHeader(object):
+    def test_it_calls_wrapped_view_function(self, pyramid_request, testview):
+        version_media_type_header(testview)(None, pyramid_request)
+
+        assert testview.called
+
+    def test_it_sets_response_header_to_default_media_type(
+        self, pyramid_request, testview, media_type_for_version
+    ):
+        res = version_media_type_header(testview)(None, pyramid_request)
+        assert (
+            res.headers["Hypothesis-Media-Type"] == media_type_for_version.return_value
+        )
+
+
+@pytest.fixture
+def media_type_for_version(patch):
+    return patch("h.views.api.decorators.response.media_type_for_version")
+
+
+@pytest.fixture
+def testview():
+    return mock.Mock(return_value=Response("OK"))

--- a/tests/h/views/api/helpers/media_types_test.py
+++ b/tests/h/views/api/helpers/media_types_test.py
@@ -32,9 +32,21 @@ class TestMediaTypeForVersion(object):
 
 class TestValidMediaTypes(object):
     def test_it_returns_list_containing_version_types(self):
-        assert media_types.valid_media_types(["foo", "bar"]) == [
+        assert media_types.valid_media_types() == [
             "*/*",
             "application/json",
+            "application/vnd.hypothesis.v1+json",
+        ]
+
+
+class TestVersionMediaTypes(object):
+    def test_it_returns_media_types_for_versions(self):
+        assert media_types.version_media_types(["foo", "bar"]) == [
             "application/vnd.hypothesis.foo+json",
             "application/vnd.hypothesis.bar+json",
+        ]
+
+    def test_it_returns_all_known_versions_if_versions_is_None(self):
+        assert media_types.version_media_types() == [
+            "application/vnd.hypothesis.v1+json"
         ]


### PR DESCRIPTION
This PR completes out the set of tasks for configuring Pyramid to handle accept header content negotiation, and, as such, support the technical versioning of our API.

This last piece adds a response header to all successful (non-error) responses from API endpoints (views). The value of that response header, `X-Hypothesis-Media-Type`, indicates which version of the API serviced the request, so clients can confirm that they got the version they expected. This approach is cribbed from [github's REST API](https://developer.github.com/v3/#current-version), with a small difference in that I chose to represent the entire media type in its value, versus a truncated version.

I prefer `X-` prefixed custom headers because they're much, much easier to spot and identify immediately as custom headers. But argue against me if you will!

The current logic for what to set the header value to is static/dumb. Expanding that logic is part of adding `"v2"` to the app's list of known API versions.

Fixes https://github.com/hypothesis/product-backlog/issues/941