### PR TITLE
[Scope Granularity: Part 1 of 5]: Add service module, util and model support

### DIFF
--- a/h/models/group_scope.py
+++ b/h/models/group_scope.py
@@ -4,7 +4,9 @@ from __future__ import unicode_literals
 
 import sqlalchemy as sa
 
+from h._compat import urlparse
 from h.db import Base
+from h.util.group_scope import uri_to_scope
 
 
 class GroupScope(Base):
@@ -48,6 +50,16 @@ class GroupScope(Base):
     #: * ``https://foo.com/bar/baz.html`` in scope
     #: * ``https://foo.com/ding/foo.html`` NOT in scope
     path = sa.Column(sa.UnicodeText, nullable=True)
+
+    @property
+    def scope(self):
+        """Return a URI composed from the origin and path attrs"""
+        return urlparse.urljoin(self.origin, self.path)
+
+    @scope.setter
+    def scope(self, value):
+        """Take a URI and split it into origin, path"""
+        self.origin, self.path = uri_to_scope(value)
 
     def __repr__(self):
         return "<GroupScope %s>" % self.origin

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -60,6 +60,9 @@ def includeme(config):
     config.register_service_factory(".links.links_factory", name="links")
     config.register_service_factory(".group_list.group_list_factory", name="group_list")
     config.register_service_factory(
+        ".group_scope.group_scope_factory", name="group_scope"
+    )
+    config.register_service_factory(
         ".list_organizations.list_organizations_factory", name="list_organizations"
     )
     config.register_service_factory(".nipsa.nipsa_factory", name="nipsa")

--- a/h/services/group_scope.py
+++ b/h/services/group_scope.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.models import GroupScope
+from h.util import group_scope as scope_util
+
+
+class GroupScopeService(object):
+    def __init__(self, session):
+        self._session = session
+
+    def fetch_by_origin(self, uri):
+        """Return all GroupScope records that match on ``origin``
+
+        :arg uri: URI whose origin should be matched for
+        :type uri: str
+        :rtype: list(:class:`~h.models.group_scope.GroupScope`)
+        """
+        # Retrieve all GroupScope records in the DB that have an `origin` component
+        # that matches the given uri's origin. This will give us a set of
+        # results whose scopes may match the `document_uri`
+        # Refactor into scopes_for_origin
+        origin = scope_util.parse_origin(uri)
+        if not origin:
+            return []
+        origin_scopes = (
+            self._session.query(GroupScope).filter(GroupScope.origin == origin).all()
+        )
+        return origin_scopes
+
+    def fetch_by_scope(self, uri):
+        """Return GroupScopes that match the given URI
+
+        :arg uri: URI to find matching scopes for
+        :type uri: str
+        :rtype: list(:class:`~h.models.group_scope.GroupScope`)
+        """
+        origin_scopes = self.fetch_by_origin(uri)
+        return [
+            scope
+            for scope in origin_scopes
+            if scope_util.uri_in_scope(uri, [scope.scope])
+        ]
+
+
+def group_scope_factory(context, request):
+    return GroupScopeService(session=request.db)

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -18,6 +18,8 @@ def match(uri, scopes):
     return scope in scopes
 
 
+# TODO: This concept no longer makes sense with more granular scoping. There is
+# no equivalent 1:1 uri <-> scope relationship. Remove this function soon.
 def uri_scope(uri):
     """
     Return the scope for a given URI
@@ -26,6 +28,30 @@ def uri_scope(uri):
     proxies to _parse_origin.
     """
     return _parse_origin(uri)
+
+
+def uri_to_scope(uri):
+    """
+    Return a tuple representing the origin and path of a URI
+
+    :arg uri: The URI from which to derive scope
+    :type uri: str
+    :rtype: tuple(str, str or None)
+    """
+    # A URL with no origin component will result in a `None` value for
+    # origin, while a URL with no path component will result in an empty
+    # string for path.
+    origin = _parse_origin(uri)
+    path = _parse_path(uri) or None
+    return (origin, path)
+
+
+def _parse_path(uri):
+    """Return the path component of a URI string"""
+    if uri is None:
+        return None
+    parsed = urlparse.urlsplit(uri)
+    return parsed[2]
 
 
 def _parse_origin(uri):

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -18,6 +18,21 @@ def match(uri, scopes):
     return scope in scopes
 
 
+def uri_in_scope(uri, scopes):
+    """
+    Does the URI match any of the scope patterns?
+
+    Return True if the URI matches one or more patterns in scopes (if the
+    URI string begins with any of the scope strings)
+
+    :arg uri: URI string in question
+    :arg scopes: List of URIs that define scope
+    :type scopes: list(str)
+    :rtype: bool
+    """
+    return any((uri.startswith(scope) for scope in scopes))
+
+
 # TODO: This concept no longer makes sense with more granular scoping. There is
 # no equivalent 1:1 uri <-> scope relationship. Remove this function soon.
 def uri_scope(uri):
@@ -25,9 +40,9 @@ def uri_scope(uri):
     Return the scope for a given URI
 
     Parse a scope from a URI string. Presently a scope is an origin, so this
-    proxies to _parse_origin.
+    proxies to parse_origin.
     """
-    return _parse_origin(uri)
+    return parse_origin(uri)
 
 
 def uri_to_scope(uri):
@@ -41,7 +56,7 @@ def uri_to_scope(uri):
     # A URL with no origin component will result in a `None` value for
     # origin, while a URL with no path component will result in an empty
     # string for path.
-    origin = _parse_origin(uri)
+    origin = parse_origin(uri)
     path = _parse_path(uri) or None
     return (origin, path)
 
@@ -54,7 +69,7 @@ def _parse_path(uri):
     return parsed[2]
 
 
-def _parse_origin(uri):
+def parse_origin(uri):
     """
     Return the origin of a URI or None if empty or invalid.
 
@@ -62,7 +77,10 @@ def _parse_origin(uri):
     Return ``<scheme> + '://' + <host> + <port>``
     for a URI.
 
+    This can return None if no valid origin can be extracted from ``uri``
+
     :param uri: URI string
+    :rtype: str or None
     """
 
     if uri is None:

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -28,6 +28,22 @@ class TestGroupScope(object):
         factories.GroupScope(origin="diplodocus : 123")
         db_session.flush()
 
+    def test_setting_scope_property_sets_origin_and_path(self, factories):
+        group_scope = GroupScope(scope="http://www.foo.com/bar/baz")
+
+        assert group_scope.origin == "http://www.foo.com"
+        assert group_scope.path == "/bar/baz"
+        assert group_scope.scope == "http://www.foo.com/bar/baz"
+
+    def test_setting_scope_with_no_path_element_sets_None_for_path_attr(
+        self, factories
+    ):
+        group_scope = GroupScope(scope="http://www.foo.com")
+
+        assert group_scope.origin == "http://www.foo.com"
+        assert group_scope.path is None
+        assert group_scope.scope == "http://www.foo.com"
+
     def test_you_can_get_a_groupscopes_group_by_the_group_property(self, factories):
         group = factories.OpenGroup()
         group_scope = factories.GroupScope(group=group)

--- a/tests/h/services/group_scope_test.py
+++ b/tests/h/services/group_scope_test.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+import mock
+
+from h.services.group_scope import group_scope_factory, GroupScopeService
+
+
+class TestFetchByOrigin(object):
+    def test_it_proxies_to_scope_util_for_origin_parsing(
+        self, svc, scope_util, document_uri
+    ):
+        scope_util.parse_origin.return_value = "parsed"
+        svc.fetch_by_origin(document_uri)
+
+        scope_util.parse_origin.assert_called_once_with(document_uri)
+
+    def test_it_returns_empty_list_if_origin_not_parseable(
+        self, svc, scope_util, document_uri
+    ):
+        scope_util.parse_origin.return_value = None
+        scopes = svc.fetch_by_origin(document_uri)
+
+        assert scopes == []
+
+    @pytest.mark.parametrize(
+        "uri,should_match",
+        [
+            ("https://www.foo.com", False),
+            ("http://foo.com", True),
+            ("https://foo.com/bar", False),
+            ("http://foo.com/bar/baz/", True),
+            ("http://www.foo.com/bar/baz.html", False),
+            ("randoscheme://foo.com", False),
+            ("foo", False),
+            ("foo.com", False),
+            ("http://foo.com/bar/baz.html?query=whatever", True),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_it_returns_scopes_that_match_uri_origin(
+        self, svc, sample_scopes, uri, should_match
+    ):
+        matches = svc.fetch_by_origin(uri)
+
+        if should_match:
+            assert matches == sample_scopes
+        else:
+            assert matches == []
+
+
+class TestFetchByScope(object):
+    def test_it_proxies_to_fetch_by_origin(self, svc, document_uri):
+        svc.fetch_by_origin = mock.Mock(return_value=[])
+
+        svc.fetch_by_scope(document_uri)
+
+        svc.fetch_by_origin.assert_called_once_with(document_uri)
+
+    def test_it_returns_list_of_matching_scopes(self, svc, document_uri, sample_scopes):
+        results = svc.fetch_by_scope(document_uri)
+
+        matching_scope_scopes = [scope.scope for scope in results]
+        assert len(results) == 2
+        assert "http://foo.com" in matching_scope_scopes
+        assert "http://foo.com/bar/" in matching_scope_scopes
+
+
+class TestGroupScopeFactory(object):
+    def test_it_returns_group_scope_service_instance(self, pyramid_request):
+        svc = group_scope_factory(None, pyramid_request)
+
+        assert isinstance(svc, GroupScopeService)
+
+
+@pytest.fixture
+def svc(db_session, pyramid_request):
+    pyramid_request.db = db_session
+    return group_scope_factory({}, pyramid_request)
+
+
+@pytest.fixture
+def scope_util(patch):
+    return patch("h.services.group_scope.scope_util")
+
+
+@pytest.fixture
+def document_uri():
+    return "http://foo.com/bar/foo.html"
+
+
+@pytest.fixture
+def sample_scopes(factories):
+    return [
+        factories.GroupScope(scope="http://foo.com"),
+        factories.GroupScope(scope="http://foo.com/bar/"),
+        factories.GroupScope(scope="http://foo.com/bar/baz/"),
+        factories.GroupScope(
+            scope="http://foo.com/bar/baz/foo.html?q=something&wut=how"
+        ),
+    ]

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -67,3 +67,23 @@ class TestScopeMatch(object):
     @pytest.fixture
     def multiple_scopes(self):
         return ["http://www.foo.com", "http://www.bar.com"]
+
+
+class TestURIToScope(object):
+    @pytest.mark.parametrize(
+        "uri,expected_scope",
+        [
+            ("https://www.foo.com/foo", ("https://www.foo.com", "/foo")),
+            ("https://foo.com/bar/baz", ("https://foo.com", "/bar/baz")),
+            ("http://foo.com", ("http://foo.com", None)),
+            ("/foo/bar", (None, "/foo/bar")),
+            (
+                "https://foo.com/foo/bar/baz.html",
+                ("https://foo.com", "/foo/bar/baz.html"),
+            ),
+            ("http://foo.com//bar/baz", ("http://foo.com", "//bar/baz")),
+            ("http://foo.com/bar?what=how", ("http://foo.com", "/bar")),
+        ],
+    )
+    def test_it_parses_origin_and_path_from_uri(self, uri, expected_scope):
+        assert scope_util.uri_to_scope(uri) == expected_scope

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -28,6 +28,50 @@ def test_it_parses_scope_from_uri(uri, expected_scope):
     assert scope == expected_scope
 
 
+class TestURIInScope(object):
+    @pytest.mark.parametrize(
+        "uri,in_origin,in_path,in_other",
+        [
+            ("https://www.foo.com", True, False, False),
+            ("http://foo.com", False, False, False),
+            ("http://www.foo.com/bar/qux.html", True, True, True),
+            ("http://www.foo.com/bar/baz/qux.html", True, True, True),
+            ("http://foo.com/", False, False, False),
+            ("http://www.foo.com/bar.baz", True, False, False),
+            ("www.foo.com", False, False, False),
+            ("randoscheme://foo.com", False, False, False),
+            ("foo", False, False, False),
+            ("https://www.foo.com/bar/baz", True, False, False),
+            ("", False, False, False),
+        ],
+    )
+    def test_it_returns_True_if_uri_matches_one_or_more_scopes(
+        self, scope_lists, uri, in_origin, in_path, in_other
+    ):
+        assert scope_util.uri_in_scope(uri, scope_lists["origin_only"]) == in_origin
+        assert scope_util.uri_in_scope(uri, scope_lists["with_path"]) == in_path
+        assert scope_util.uri_in_scope(uri, scope_lists["with_other"]) == in_other
+
+    @pytest.fixture
+    def match(self, patch):
+        return patch("h.util.group_scope.re.match")
+
+    @pytest.fixture
+    def scope_lists(self):
+        return {
+            "origin_only": ["http://www.foo.com", "https://www.foo.com"],
+            "with_path": [
+                "http://www.foo.com/bar/baz",
+                "http://www.foo.com/bar/qux",
+                "http://www.foo.com/bar/baz/qux",
+            ],
+            "with_other": [
+                "http://www.foo.com/bar/baz/qux.html",
+                "http://www.foo.com/bar/qux",
+            ],
+        }
+
+
 class TestScopeMatch(object):
     @pytest.mark.parametrize(
         "uri,expected",
@@ -87,3 +131,18 @@ class TestURIToScope(object):
     )
     def test_it_parses_origin_and_path_from_uri(self, uri, expected_scope):
         assert scope_util.uri_to_scope(uri) == expected_scope
+
+
+class TestParseOrigin(object):
+    @pytest.mark.parametrize(
+        "uri,expected_origin",
+        [
+            ("https://www.foo.com/foo/qux/bar.html", "https://www.foo.com"),
+            ("http://foo.com/baz", "http://foo.com"),
+            ("http://foo.com:3553/bar", "http://foo.com:3553"),
+            ("http://www.foo.bar.com", "http://www.foo.bar.com"),
+            ("foo.com", None),
+        ],
+    )
+    def test_it_parses_origin_from_uri(self, uri, expected_origin):
+        assert scope_util.parse_origin(uri) == expected_origin


### PR DESCRIPTION
This PR is part of https://github.com/hypothesis/product-backlog/issues/908 and based on https://github.com/hypothesis/h/pull/5577

This piece of the feature _adds_ functionality but does not integrate any of it—it's standalone. These commits:

* Add a new `GroupScope` service
* Add a computed `scope` property to the `GroupScope` model
* Adds some additional scope-related functions to the `group_scope` util module

Feedback from https://github.com/hypothesis/h/pull/5577 has been integrated WRT using `startswith`/string matching versus true regexes. It is indeed simpler and will work nicely when we conflate to a single `scope` column.