### PR TITLE
[Scope Granularity: Part 4 of 5]: Update group admin form and schema

### DIFF
--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -166,14 +166,17 @@ class CreateAdminGroupSchema(CSRFSchema):
         missing=False,
     )
 
-    origins = colander.SequenceSchema(
+    scopes = colander.SequenceSchema(
         colander.Sequence(),
-        colander.SchemaNode(colander.String(), name="origin", validator=colander.url),
-        title=_("Scope Origins"),
-        hint=_('Origins where this group appears (e.g. "https://example.com")'),
-        widget=SequenceWidget(add_subitem_text_template=_("Add origin"), min_len=1),
+        colander.SchemaNode(colander.String(), name="scope", validator=colander.url),
+        title=_("Scopes"),
+        hint=_(
+            "Define where this group appears. A web page's URL must start with one or more"
+            " of the entered scope strings (e.g. 'http://www.example.com')"
+        ),
+        widget=SequenceWidget(add_subitem_text_template=_("Add scope"), min_len=1),
         validator=colander.Length(
-            min=1, min_err=_("At least one origin must be specified")
+            min=1, min_err=_("At least one scope must be specified")
         ),
     )
 

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -93,7 +93,7 @@ class GroupCreateViews(object):
             group = create_fns[type_](
                 name=appstruct["name"],
                 userid=creator_userid,
-                scopes=appstruct["origins"],
+                scopes=appstruct["scopes"],
                 description=appstruct["description"],
                 organization=organization,
                 enforce_scope=appstruct["enforce_scope"],
@@ -181,7 +181,7 @@ class GroupEditViews(object):
             """Update the group resource on successful form validation"""
 
             organization = self.organizations[appstruct["organization"]]
-            scopes = [GroupScope(scope=o) for o in appstruct["origins"]]
+            scopes = [GroupScope(scope=o) for o in appstruct["scopes"]]
 
             self.group_update_svc.update(
                 group,
@@ -223,7 +223,7 @@ class GroupEditViews(object):
                 "name": group.name,
                 "members": [m.username for m in group.members],
                 "organization": group.organization.pubid,
-                "origins": [s.origin for s in group.scopes],
+                "scopes": [s.scope for s in group.scopes],
                 "enforce_scope": group.enforce_scope,
             }
         )

--- a/tests/h/schemas/forms/admin/group_test.py
+++ b/tests/h/schemas/forms/admin/group_test.py
@@ -65,17 +65,15 @@ class TestCreateGroupSchema(object):
 
         bound_schema.deserialize(group_data)
 
-    @pytest.mark.parametrize("invalid_origin", ["not-a-url"])
-    def test_it_raises_if_origin_invalid(
-        self, group_data, bound_schema, invalid_origin
-    ):
-        group_data["origins"] = [invalid_origin]
-        with pytest.raises(colander.Invalid, match="origins.*Must be a URL"):
+    @pytest.mark.parametrize("invalid_scope", ["not-a-url"])
+    def test_it_raises_if_origin_invalid(self, group_data, bound_schema, invalid_scope):
+        group_data["scopes"] = [invalid_scope]
+        with pytest.raises(colander.Invalid, match="scopes.*Must be a URL"):
             bound_schema.deserialize(group_data)
 
     def test_it_raises_if_no_origins(self, group_data, bound_schema):
-        group_data["origins"] = []
-        with pytest.raises(colander.Invalid, match="At least one origin"):
+        group_data["scopes"] = []
+        with pytest.raises(colander.Invalid, match="At least one scope"):
             bound_schema.deserialize(group_data)
 
     def test_it_raises_if_group_type_changed(
@@ -166,7 +164,7 @@ def group_data(factories):
         "creator": factories.User().username,
         "description": "Lorem ipsum dolor sit amet consectetuer",
         "organization": "__default__",
-        "origins": ["http://www.foo.com", "https://www.foo.com"],
+        "scopes": ["http://www.foo.com", "https://www.foo.com"],
         "enforce_scope": True,
     }
 

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -180,7 +180,7 @@ class TestGroupCreateView(object):
             "description": None,
             "members": [],
             "organization": default_org.pubid,
-            "origins": ["http://example.com"],
+            "scopes": ["http://example.com"],
             "enforce_scope": True,
         }
 
@@ -267,7 +267,7 @@ class TestGroupEditViews(object):
                     "group_type": "open",
                     "name": "Updated group",
                     "organization": updated_org.pubid,
-                    "origins": ["http://somewhereelse.com", "http://www.gladiolus.org"],
+                    "scopes": ["http://somewhereelse.com", "http://www.gladiolus.org"],
                     "members": [],
                     "enforce_scope": False,
                 }
@@ -320,7 +320,7 @@ class TestGroupEditViews(object):
                     "name": "a name",
                     "members": ["phil", "sue"],
                     "organization": group.organization.pubid,
-                    "origins": ["http://www.example.com"],
+                    "scopes": ["http://www.example.com"],
                     "enforce_scope": group.enforce_scope,
                 }
             )
@@ -358,7 +358,7 @@ class TestGroupEditViews(object):
             "name": group.name,
             "members": [m.username for m in group.members],
             "organization": group.organization.pubid,
-            "origins": [s.origin for s in group.scopes],
+            "scopes": [s.scope for s in group.scopes],
             "enforce_scope": group.enforce_scope,
         }
 


### PR DESCRIPTION
This PR is part of hypothesis/product-backlog#908 and based on #5577

This part of the feature updates the form schema and view for admin-groups. The changes here are not functional, but naming- and wording-related (the form works without these changes, that is; these changes are for users and clarity).