### PR TITLE
[Scope Granularity: Part 5 of 5]: Update presenter, util cleanup

### DIFF
--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -43,7 +43,7 @@ class GroupJSONPresenter(object):
             # patterns—currently a simple wildcarded prefix—to give us more
             # flexibility in making scope more granular later
             model["scopes"]["uri_patterns"] = [
-                scope.origin + "*" for scope in self.group.scopes
+                scope.scope + "*" for scope in self.group.scopes
             ]
         return model
 

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -5,19 +5,6 @@ from __future__ import unicode_literals
 from h._compat import urlparse
 
 
-def match(uri, scopes):
-    """
-    Return boolean: Does the URI's scope match any of the scopes?
-
-    Return True if the scope of URI is present in the scopes list
-
-    :param uri: URI string in question
-    :param scopes: List of scope (URI origin) strings
-    """
-    scope = uri_scope(uri)
-    return scope in scopes
-
-
 def uri_in_scope(uri, scopes):
     """
     Does the URI match any of the scope patterns?
@@ -35,18 +22,6 @@ def uri_in_scope(uri, scopes):
     if len(scope_matches):
         return True
     return False
-
-
-# TODO: This concept no longer makes sense with more granular scoping. There is
-# no equivalent 1:1 uri <-> scope relationship. Remove this function soon.
-def uri_scope(uri):
-    """
-    Return the scope for a given URI
-
-    Parse a scope from a URI string. Presently a scope is an origin, so this
-    proxies to parse_origin.
-    """
-    return parse_origin(uri)
 
 
 def uri_to_scope(uri):

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -134,8 +134,8 @@ class TestGroupJSONPresenter(object):
         group = factories.OpenGroup(
             enforce_scope=False,
             scopes=[
-                factories.GroupScope(scope="http://foo.com"),
-                factories.GroupScope(scope="https://foo.com"),
+                factories.GroupScope(scope="http://foo.com/bar"),
+                factories.GroupScope(scope="https://foo.com/baz"),
             ],
         )
         group_context = GroupContext(group)
@@ -146,7 +146,7 @@ class TestGroupJSONPresenter(object):
         assert "scopes" in model
         assert model["scopes"]["enforced"] is False
         assert set(model["scopes"]["uri_patterns"]) == set(
-            ["http://foo.com*", "https://foo.com*"]
+            ["http://foo.com/bar*", "https://foo.com/baz*"]
         )
 
     def test_expanded_scopes_uri_patterns_empty_if_no_scopes(

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -6,28 +6,6 @@ import pytest
 from h.util import group_scope as scope_util
 
 
-@pytest.mark.parametrize(
-    "uri,expected_scope",
-    [
-        ("https://www.foo.com", "https://www.foo.com"),
-        ("http://foo.com", "http://foo.com"),
-        ("https://foo.com/bar", "https://foo.com"),
-        ("http://foo.com/", "http://foo.com"),
-        ("http://www.foo.com/bar/baz.html", "http://www.foo.com"),
-        ("randoscheme://foo.com", "randoscheme://foo.com"),
-        ("foo", None),
-        ("foo.com", None),
-        ("http://www.foo.com/bar/baz.html?query=whatever", "http://www.foo.com"),
-        ("", None),
-        (None, None),
-    ],
-)
-def test_it_parses_scope_from_uri(uri, expected_scope):
-    scope = scope_util.uri_scope(uri)
-
-    assert scope == expected_scope
-
-
 class TestURIInScope(object):
     @pytest.mark.parametrize(
         "uri,in_origin,in_path,in_other",
@@ -70,47 +48,6 @@ class TestURIInScope(object):
                 "http://www.foo.com/bar/qux",
             ],
         }
-
-
-class TestScopeMatch(object):
-    @pytest.mark.parametrize(
-        "uri,expected",
-        [
-            ("http://www.foo.com/bar/baz/ding.html", True),
-            ("https://www.foo.com/bar/baz/ding.html", False),
-            ("http://www.foo.com/", True),
-            ("http://foo.com/bar.html", False),
-            ("foo.com/bar.html", False),
-        ],
-    )
-    def test_it_matches_against_single_scope(self, uri, expected, single_scope):
-        result = scope_util.match(uri, single_scope)
-
-        assert result == expected
-
-    @pytest.mark.parametrize(
-        "uri,expected",
-        [
-            ("http://www.foo.com/bar/baz/ding.html", True),
-            ("http://www.bar.com/bar/baz/ding.html", True),
-            ("http://www.foo.com/", True),
-            ("http://www.bar.com", True),
-            ("http://bar.com/bar.html", False),
-            ("bar.com/bar.html", False),
-        ],
-    )
-    def test_it_matches_against_multiple_scopes(self, uri, expected, multiple_scopes):
-        result = scope_util.match(uri, multiple_scopes)
-
-        assert result == expected
-
-    @pytest.fixture
-    def single_scope(self):
-        return ["http://www.foo.com"]
-
-    @pytest.fixture
-    def multiple_scopes(self):
-        return ["http://www.foo.com", "http://www.bar.com"]
 
 
 class TestURIToScope(object):


### PR DESCRIPTION
This PR is part of hypothesis/product-backlog#908 and based on #5577

This cleanup PR updates the scope value returned by the presenter for API representation of Group resources[1] and removes some now-unused functions from the `group_scope` util.

1: Note that although this represents a change in the API response, it doesn't _really_. Groups that have scopes that are origin-only will still have identical scopes in the API response as they do now. However, we'll want to look at client-side logic for determining whether a URI is in scope to make sure it would work with scopes that contain path parts.