### PR TITLE
Add HTML page for v1 of API

### DIFF
--- a/docs/_extra/api-reference/v1/index.html
+++ b/docs/_extra/api-reference/v1/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hypothesis API documentation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <redoc spec-url="../hypothesis-v1.yaml" expand-responses="200,201"></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.4/bundles/redoc.standalone.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This small PR adds a new HTML page in our `docs` directories that will serve as home for the v1.0 API documentation. Assuming build goes right, once this is merged and deployed, one should be able to view v1.0 documentation at https://h.readthedocs.io/en/latest/api-reference/v1.0/

The new page is not linked from anywhere. The idea is to give H folks a chance to review the v1.0 documentation and provide any feedback before we make this the main/default docs and start working on v2.

Some minor, but nice changes:

* Uses newest version of `redoc`
* Sets a config to expand successful responses with bodies (200, 201) so that some response bodies are auto-expanded and less hidden.

Part of https://github.com/hypothesis/product-backlog/issues/940