### PR TITLE
Feature: Scope granularity

### DIFF
--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -39,11 +39,11 @@ class GroupJSONPresenter(object):
             model["scopes"]["enforced"] = (
                 self.group.enforce_scope if self.group.scopes else False
             )
-            # At this presentation layer, format scope origins to look like
+            # At this presentation layer, format scopes to look like
             # patterns—currently a simple wildcarded prefix—to give us more
             # flexibility in making scope more granular later
             model["scopes"]["uri_patterns"] = [
-                scope.origin + "*" for scope in self.group.scopes
+                scope.scope + "*" for scope in self.group.scopes
             ]
         return model
 

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -60,6 +60,9 @@ def includeme(config):
     config.register_service_factory(".links.links_factory", name="links")
     config.register_service_factory(".group_list.group_list_factory", name="group_list")
     config.register_service_factory(
+        ".group_scope.group_scope_factory", name="group_scope"
+    )
+    config.register_service_factory(
         ".list_organizations.list_organizations_factory", name="list_organizations"
     )
     config.register_service_factory(".nipsa.nipsa_factory", name="nipsa")

--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -43,12 +43,12 @@ class GroupCreateService(object):
             name=name,
             userid=userid,
             type_flags=PRIVATE_GROUP_TYPE_FLAGS,
-            origins=[],
+            scopes=[],
             add_creator_as_member=True,
             **kwargs
         )
 
-    def create_open_group(self, name, userid, origins, **kwargs):
+    def create_open_group(self, name, userid, scopes, **kwargs):
         """
         Create a new open group.
 
@@ -56,7 +56,8 @@ class GroupCreateService(object):
 
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
-        :param origins: the list of origins that the group will be scoped to
+        :param scopes: the list of URIs that the group will be scoped to
+        :type scopes: list(str)
         :param kwargs: optional attributes to set on the group, as keyword
             arguments
 
@@ -66,12 +67,12 @@ class GroupCreateService(object):
             name=name,
             userid=userid,
             type_flags=OPEN_GROUP_TYPE_FLAGS,
-            origins=origins,
+            scopes=scopes,
             add_creator_as_member=False,
             **kwargs
         )
 
-    def create_restricted_group(self, name, userid, origins, **kwargs):
+    def create_restricted_group(self, name, userid, scopes, **kwargs):
         """
         Create a new restricted group.
 
@@ -80,7 +81,8 @@ class GroupCreateService(object):
 
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
-        :param origins: the list of origins that the group will be scoped to
+        :param scopes: the list of URIs that the group will be scoped to
+        :type scopes: list(str)
         :param kwargs: optional attributes to set on the group, as keyword
             arguments
 
@@ -90,13 +92,13 @@ class GroupCreateService(object):
             name=name,
             userid=userid,
             type_flags=RESTRICTED_GROUP_TYPE_FLAGS,
-            origins=origins,
+            scopes=scopes,
             add_creator_as_member=True,
             **kwargs
         )
 
     def _create(
-        self, name, userid, type_flags, origins, add_creator_as_member, **kwargs
+        self, name, userid, type_flags, scopes, add_creator_as_member, **kwargs
     ):
         """
         Create a group and save it to the DB.
@@ -104,17 +106,18 @@ class GroupCreateService(object):
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
         :param type_flags: the type of this group
-        :param origins: the list of origins that the group will be scoped to
+        :param scopes: the list of scopes (URIs) that the group will be scoped to
+        :type scopes: list(str)
         :param add_creator_as_member: if the group creator should be added as a member
         :param kwargs: optional attributes to set on the group, as keyword
             arguments
         """
-        if origins is None:
-            origins = []
+        if scopes is None:
+            scopes = []
 
         creator = self.user_fetcher(userid)
 
-        scopes = [GroupScope(origin=o) for o in origins]
+        group_scopes = [GroupScope(scope=s) for s in scopes]
 
         if "organization" in kwargs:
             self._validate_authorities_match(
@@ -128,7 +131,7 @@ class GroupCreateService(object):
             joinable_by=type_flags.joinable_by,
             readable_by=type_flags.readable_by,
             writeable_by=type_flags.writeable_by,
-            scopes=scopes,
+            scopes=group_scopes,
             **kwargs
         )
         self.session.add(group)

--- a/h/services/group_list.py
+++ b/h/services/group_list.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from h import models
 from h.models import group
-from h.util import group_scope as scope_util
 
 
 class GroupListService(object):
@@ -17,7 +16,7 @@ class GroupListService(object):
     ALl public methods return relevant group model objects.
     """
 
-    def __init__(self, session, default_authority):
+    def __init__(self, session, default_authority, group_scope_service):
         """
         Create a new group_list service.
 
@@ -25,6 +24,7 @@ class GroupListService(object):
         :param default_authority: the authority to use as a default
         """
         self._session = session
+        self._group_scope_service = group_scope_service
         self.default_authority = default_authority
 
     def _authority(self, user=None, authority=None):
@@ -105,12 +105,17 @@ class GroupListService(object):
           via the API.
         """
         authority = self._authority(user, authority)
-        scoped_groups = self.scoped_groups(authority, document_uri)
+        scoped_groups = []
+        private_groups = []
+
+        if document_uri:
+            scoped_groups = self.scoped_groups(authority, document_uri)
 
         world_group = self.world_group(authority)
         world_group = [world_group] if world_group else []
 
-        private_groups = self.private_groups(user)
+        if user:
+            private_groups = self.private_groups(user)
 
         return scoped_groups + world_group + private_groups
 
@@ -147,35 +152,25 @@ class GroupListService(object):
         return [group for group in user_groups if group.type == "private"]
 
     def scoped_groups(self, authority, document_uri):
-        """
-        Return scoped groups for the URI and authority
+        if not document_uri:
+            return []
+        matching_scopes = self._group_scope_service.fetch_by_scope(document_uri)
+        matching_scope_groupids = [scope.group_id for scope in matching_scopes]
 
-        Only open and restricted groups are "supposed" to have scope, but
-        technically this query is agnostic to the group's type—it will return
-        any group who has a scope that matches the document_uri's scope.
-
-        Note: If private groups are ever allowed to be scoped, this needs
-        attention.
-
-        :param authority: Filter groups by this authority
-        :type authority: string
-        :arg document_uri: Use this URI to find groups with matching scopes
-        :type document_uri: string
-        :rtype: list of :class:`h.models.group`
-        """
-        origin = scope_util.uri_scope(document_uri)
-        if not origin:
+        if not matching_scope_groupids:
             return []
 
-        groups = (
-            self._session.query(models.GroupScope, models.Group)
-            .filter(models.Group.id == models.GroupScope.group_id)
-            .filter(models.GroupScope.origin == origin)
+        # Retrieve groups for these IDs
+        scoped_groups = (
+            self._session.query(models.Group)
+            .filter(models.Group.id.in_(matching_scope_groupids))
             .filter(models.Group.authority == authority)
+            .filter(
+                models.Group.readable_by == group.ReadableBy.world
+            )  # Only "public" groups
+            .group_by(models.Group.id)  # de-dupe
             .all()
         )
-
-        scoped_groups = [group for groupscope, group in groups]
         return self._sort(scoped_groups)
 
     def world_group(self, authority):
@@ -225,6 +220,9 @@ class GroupListService(object):
 
 def group_list_factory(context, request):
     """Return a GroupListService instance for the passed context and request."""
+    group_scope_service = request.find_service(name="group_scope")
     return GroupListService(
-        session=request.db, default_authority=request.default_authority
+        session=request.db,
+        default_authority=request.default_authority,
+        group_scope_service=group_scope_service,
     )

--- a/h/services/group_list.py
+++ b/h/services/group_list.py
@@ -168,7 +168,6 @@ class GroupListService(object):
             .filter(
                 models.Group.readable_by == group.ReadableBy.world
             )  # Only "public" groups
-            .group_by(models.Group.id)  # de-dupe
             .all()
         )
         return self._sort(scoped_groups)

--- a/h/services/group_scope.py
+++ b/h/services/group_scope.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.models import GroupScope
+from h.util import group_scope as scope_util
+
+
+class GroupScopeService(object):
+    def __init__(self, session):
+        self._session = session
+
+    def fetch_by_scope(self, url):
+        """Return GroupScope records that match the given URL
+
+        :arg url: URL to find matching scopes for
+        :type url: str
+        :rtype: list(:class:`~h.models.group_scope.GroupScope`)
+        """
+        origin = scope_util.parse_origin(url)
+        if not origin:
+            return []
+        origin_scopes = (
+            self._session.query(GroupScope).filter(GroupScope.origin == origin).all()
+        )
+        return [
+            scope
+            for scope in origin_scopes
+            if scope_util.uri_in_scope(url, [scope.scope])
+        ]
+
+
+def group_scope_factory(context, request):
+    return GroupScopeService(session=request.db)

--- a/h/storage.py
+++ b/h/storage.py
@@ -24,7 +24,7 @@ from pyramid import i18n
 
 from h import models, schemas
 from h.db import types
-from h.util.group_scope import match as group_scope_match
+from h.util.group_scope import uri_in_scope
 from h.models.document import update_document_metadata
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -250,10 +250,10 @@ def _validate_group_scope(group, target_uri):
     # annotations outside of its scope, there's nothing to do here
     if not group.scopes or group.enforce_scope is False:
         return
-    # The scope (origin) of the target URI must match at least one
+    # The target URI must match at least one
     # of a group's defined scopes, if the group has any
-    group_scopes = [scope.origin for scope in group.scopes]
-    if not group_scope_match(target_uri, group_scopes):
+    group_scopes = [scope.scope for scope in group.scopes]
+    if not uri_in_scope(target_uri, group_scopes):
         raise schemas.ValidationError(
             "group scope: "
             + _("Annotations for this target URI " "are not allowed in this group")

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -5,19 +5,6 @@ from __future__ import unicode_literals
 from h._compat import urlparse
 
 
-def match(uri, scopes):
-    """
-    Return boolean: Does the URI's scope match any of the scopes?
-
-    Return True if the scope of URI is present in the scopes list
-
-    :param uri: URI string in question
-    :param scopes: List of scope (URI origin) strings
-    """
-    scope = uri_scope(uri)
-    return scope in scopes
-
-
 def uri_in_scope(uri, scopes):
     """
     Does the URI match any of the scope patterns?
@@ -31,18 +18,6 @@ def uri_in_scope(uri, scopes):
     :rtype: bool
     """
     return any((uri.startswith(scope) for scope in scopes))
-
-
-# TODO: This concept no longer makes sense with more granular scoping. There is
-# no equivalent 1:1 uri <-> scope relationship. Remove this function soon.
-def uri_scope(uri):
-    """
-    Return the scope for a given URI
-
-    Parse a scope from a URI string. Presently a scope is an origin, so this
-    proxies to parse_origin.
-    """
-    return parse_origin(uri)
 
 
 def uri_to_scope(uri):

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -18,25 +18,67 @@ def match(uri, scopes):
     return scope in scopes
 
 
+def uri_in_scope(uri, scopes):
+    """
+    Does the URI match any of the scope patterns?
+
+    Return True if the URI matches one or more patterns in scopes (if the
+    URI string begins with any of the scope strings)
+
+    :arg uri: URI string in question
+    :arg scopes: List of URIs that define scope
+    :type scopes: list(str)
+    :rtype: bool
+    """
+    return any((uri.startswith(scope) for scope in scopes))
+
+
+# TODO: This concept no longer makes sense with more granular scoping. There is
+# no equivalent 1:1 uri <-> scope relationship. Remove this function soon.
 def uri_scope(uri):
     """
     Return the scope for a given URI
 
     Parse a scope from a URI string. Presently a scope is an origin, so this
-    proxies to _parse_origin.
+    proxies to parse_origin.
     """
-    return _parse_origin(uri)
+    return parse_origin(uri)
 
 
-def _parse_origin(uri):
+def uri_to_scope(uri):
     """
-    Return the origin of a URI or None if empty or invalid.
+    Return a tuple representing the origin and path of a URI
+
+    :arg uri: The URI from which to derive scope
+    :type uri: str
+    :rtype: tuple(str, str or None)
+    """
+    # A URL with no origin component will result in a `None` value for
+    # origin, while a URL with no path component will result in an empty
+    # string for path.
+    origin = parse_origin(uri)
+    path = _parse_path(uri) or None
+    return (origin, path)
+
+
+def _parse_path(uri):
+    """Return the path component of a URI string"""
+    if uri is None:
+        return None
+    parsed = urlparse.urlsplit(uri)
+    return parsed.path
+
+
+def parse_origin(uri):
+    """
+    Return the origin of a URL or None if empty or invalid.
 
     Per https://tools.ietf.org/html/rfc6454#section-7 :
     Return ``<scheme> + '://' + <host> + <port>``
-    for a URI.
+    for a URL.
 
-    :param uri: URI string
+    :param uri: URL string
+    :rtype: str or None
     """
 
     if uri is None:

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -93,7 +93,7 @@ class GroupCreateViews(object):
             group = create_fns[type_](
                 name=appstruct["name"],
                 userid=creator_userid,
-                origins=appstruct["origins"],
+                scopes=appstruct["origins"],
                 description=appstruct["description"],
                 organization=organization,
                 enforce_scope=appstruct["enforce_scope"],
@@ -181,7 +181,7 @@ class GroupEditViews(object):
             """Update the group resource on successful form validation"""
 
             organization = self.organizations[appstruct["organization"]]
-            scopes = [GroupScope(origin=o) for o in appstruct["origins"]]
+            scopes = [GroupScope(scope=o) for o in appstruct["origins"]]
 
             self.group_update_svc.update(
                 group,

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -93,7 +93,7 @@ class GroupCreateViews(object):
             group = create_fns[type_](
                 name=appstruct["name"],
                 userid=creator_userid,
-                scopes=appstruct["origins"],
+                scopes=appstruct["scopes"],
                 description=appstruct["description"],
                 organization=organization,
                 enforce_scope=appstruct["enforce_scope"],
@@ -181,7 +181,7 @@ class GroupEditViews(object):
             """Update the group resource on successful form validation"""
 
             organization = self.organizations[appstruct["organization"]]
-            scopes = [GroupScope(scope=o) for o in appstruct["origins"]]
+            scopes = [GroupScope(scope=o) for o in appstruct["scopes"]]
 
             self.group_update_svc.update(
                 group,
@@ -223,7 +223,7 @@ class GroupEditViews(object):
                 "name": group.name,
                 "members": [m.username for m in group.members],
                 "organization": group.organization.pubid,
-                "origins": [s.origin for s in group.scopes],
+                "scopes": [s.scope for s in group.scopes],
                 "enforce_scope": group.enforce_scope,
             }
         )

--- a/tests/common/factories/group_scope.py
+++ b/tests/common/factories/group_scope.py
@@ -14,5 +14,5 @@ class GroupScope(ModelFactory):
         model = models.GroupScope
         sqlalchemy_session_persistence = "flush"
 
-    origin = factory.Faker("url")
+    scope = factory.Faker("url")
     group = factory.SubFactory("tests.common.factories.OpenGroup")

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -51,7 +51,7 @@ class TestGroupJSONPresenter(object):
         group = factories.OpenGroup(
             name="My Group",
             pubid="groupy",
-            scopes=[factories.GroupScope(origin="http://foo.com")],
+            scopes=[factories.GroupScope(scope="http://foo.com")],
             organization=factories.Organization(),
         )
         group_context = GroupContext(group)
@@ -134,8 +134,8 @@ class TestGroupJSONPresenter(object):
         group = factories.OpenGroup(
             enforce_scope=False,
             scopes=[
-                factories.GroupScope(origin="http://foo.com"),
-                factories.GroupScope(origin="https://foo.com"),
+                factories.GroupScope(scope="http://foo.com/bar"),
+                factories.GroupScope(scope="https://foo.com/baz"),
             ],
         )
         group_context = GroupContext(group)
@@ -146,7 +146,7 @@ class TestGroupJSONPresenter(object):
         assert "scopes" in model
         assert model["scopes"]["enforced"] is False
         assert set(model["scopes"]["uri_patterns"]) == set(
-            ["http://foo.com*", "https://foo.com*"]
+            ["http://foo.com/bar*", "https://foo.com/baz*"]
         )
 
     def test_expanded_scopes_uri_patterns_empty_if_no_scopes(

--- a/tests/h/schemas/forms/admin/group_test.py
+++ b/tests/h/schemas/forms/admin/group_test.py
@@ -65,17 +65,17 @@ class TestCreateGroupSchema(object):
 
         bound_schema.deserialize(group_data)
 
-    @pytest.mark.parametrize("invalid_origin", ["not-a-url"])
-    def test_it_raises_if_origin_invalid(
-        self, group_data, bound_schema, invalid_origin
-    ):
-        group_data["origins"] = [invalid_origin]
-        with pytest.raises(colander.Invalid, match="origins.*Must be a URL"):
+    @pytest.mark.parametrize(
+        "invalid_scope", ["not-a-url", "foo:123", "example.com", "example.com/bar"]
+    )
+    def test_it_raises_if_origin_invalid(self, group_data, bound_schema, invalid_scope):
+        group_data["scopes"] = [invalid_scope]
+        with pytest.raises(colander.Invalid, match="scope.*must be a complete URL"):
             bound_schema.deserialize(group_data)
 
     def test_it_raises_if_no_origins(self, group_data, bound_schema):
-        group_data["origins"] = []
-        with pytest.raises(colander.Invalid, match="At least one origin"):
+        group_data["scopes"] = []
+        with pytest.raises(colander.Invalid, match="At least one scope"):
             bound_schema.deserialize(group_data)
 
     def test_it_raises_if_group_type_changed(
@@ -166,7 +166,7 @@ def group_data(factories):
         "creator": factories.User().username,
         "description": "Lorem ipsum dolor sit amet consectetuer",
         "organization": "__default__",
-        "origins": ["http://www.foo.com", "https://www.foo.com"],
+        "scopes": ["http://www.foo.com", "https://www.foo.com"],
         "enforce_scope": True,
     }
 

--- a/tests/h/services/group_create_test.py
+++ b/tests/h/services/group_create_test.py
@@ -121,7 +121,7 @@ class TestCreatePrivateGroup(object):
 
 class TestCreateOpenGroup(object):
     def test_it_returns_group_model(self, creator, svc, origins):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert isinstance(group, Group)
 
@@ -133,10 +133,7 @@ class TestCreateOpenGroup(object):
         self, creator, svc, origins, group_attr, expected_value
     ):
         group = svc.create_open_group(
-            "test group",
-            creator.userid,
-            origins=origins,
-            description="test description",
+            "test group", creator.userid, scopes=origins, description="test description"
         )
 
         assert getattr(group, group_attr) == expected_value
@@ -150,17 +147,17 @@ class TestCreateOpenGroup(object):
         assert group.authority == creator.authority
 
     def test_it_skips_setting_description_when_missing(self, svc, creator, origins):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert group.description is None
 
     def test_it_sets_group_creator(self, svc, creator, origins):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert group.creator == creator
 
     def test_it_does_not_add_group_creator_to_members(self, svc, creator, origins):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert creator not in group.members
 
@@ -173,14 +170,14 @@ class TestCreateOpenGroup(object):
         ],
     )
     def test_it_sets_access_flags(self, svc, creator, origins, flag, expected_value):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert getattr(group, flag) == expected_value
 
     def test_it_creates_group_with_no_organization_by_default(
         self, default_organization, creator, svc, origins
     ):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert group.organization is None
 
@@ -190,7 +187,7 @@ class TestCreateOpenGroup(object):
         org = factories.Organization()
 
         group = svc.create_open_group(
-            "Anteater fans", creator.userid, origins=origins, organization=org
+            "Anteater fans", creator.userid, scopes=origins, organization=org
         )
 
         assert group.organization == org
@@ -198,7 +195,7 @@ class TestCreateOpenGroup(object):
     def test_it_creates_group_with_enforce_scope_True_by_default(
         self, creator, svc, origins, db_session
     ):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         db_session.flush()
 
@@ -208,7 +205,7 @@ class TestCreateOpenGroup(object):
         self, creator, svc, origins, db_session
     ):
         group = svc.create_open_group(
-            "Anteater fans", creator.userid, origins=origins, enforce_scope=False
+            "Anteater fans", creator.userid, scopes=origins, enforce_scope=False
         )
 
         db_session.flush()
@@ -216,13 +213,13 @@ class TestCreateOpenGroup(object):
         assert group.enforce_scope is False
 
     def test_it_adds_group_to_session(self, db_session, creator, svc, origins):
-        group = svc.create_open_group("Anteater fans", creator.userid, origins=origins)
+        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert group in db_session
 
     def test_it_does_not_publish_join_event(self, svc, creator, publish, origins):
         svc.create_open_group(
-            "Dishwasher disassemblers", creator.userid, origins=origins
+            "Dishwasher disassemblers", creator.userid, scopes=origins
         )
 
         publish.assert_not_called()
@@ -231,7 +228,7 @@ class TestCreateOpenGroup(object):
         origins = ["https://biopub.org", "http://example.com", "https://wikipedia.com"]
 
         group = svc.create_open_group(
-            name="test_group", userid=creator.userid, origins=origins
+            name="test_group", userid=creator.userid, scopes=origins
         )
 
         assert group.scopes == matchers.UnorderedList(
@@ -245,10 +242,10 @@ class TestCreateOpenGroup(object):
         # already exists (this is because a single scope can only belong to
         # one group, so the existing scope can't be reused with the new group).
         origins = ["https://biopub.org", "http://example.com"]
-        scopes = [factories.GroupScope(origin=h) for h in origins]
+        scopes = [factories.GroupScope(scope=h) for h in origins]
 
         group = svc.create_open_group(
-            name="test_group", userid=creator.userid, origins=origins
+            name="test_group", userid=creator.userid, scopes=origins
         )
         for scope in scopes:
             assert scope not in group.scopes
@@ -257,7 +254,7 @@ class TestCreateOpenGroup(object):
 class TestCreateRestrictedGroup(object):
     def test_it_returns_group_model(self, creator, svc, origins):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert isinstance(group, Group)
@@ -270,10 +267,7 @@ class TestCreateRestrictedGroup(object):
         self, creator, svc, origins, group_attr, expected_value
     ):
         group = svc.create_restricted_group(
-            "test group",
-            creator.userid,
-            origins=origins,
-            description="test description",
+            "test group", creator.userid, scopes=origins, description="test description"
         )
 
         assert getattr(group, group_attr) == expected_value
@@ -288,21 +282,21 @@ class TestCreateRestrictedGroup(object):
 
     def test_it_skips_setting_description_when_missing(self, svc, creator, origins):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert group.description is None
 
     def test_it_sets_group_creator(self, svc, creator, origins):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert group.creator == creator
 
     def test_it_adds_group_creator_to_members(self, svc, creator, origins):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert creator in group.members
@@ -317,7 +311,7 @@ class TestCreateRestrictedGroup(object):
     )
     def test_it_sets_access_flags(self, svc, creator, origins, flag, expected_value):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert getattr(group, flag) == expected_value
@@ -326,7 +320,7 @@ class TestCreateRestrictedGroup(object):
         self, default_organization, creator, svc, origins
     ):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert group.organization is None
@@ -337,7 +331,7 @@ class TestCreateRestrictedGroup(object):
         org = factories.Organization()
 
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins, organization=org
+            "Anteater fans", creator.userid, scopes=origins, organization=org
         )
 
         assert group.organization == org
@@ -346,7 +340,7 @@ class TestCreateRestrictedGroup(object):
         self, creator, svc, origins, db_session
     ):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         db_session.flush()
@@ -357,7 +351,7 @@ class TestCreateRestrictedGroup(object):
         self, creator, svc, origins, db_session
     ):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins, enforce_scope=False
+            "Anteater fans", creator.userid, scopes=origins, enforce_scope=False
         )
 
         db_session.flush()
@@ -366,14 +360,14 @@ class TestCreateRestrictedGroup(object):
 
     def test_it_adds_group_to_session(self, db_session, creator, svc, origins):
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, origins=origins
+            "Anteater fans", creator.userid, scopes=origins
         )
 
         assert group in db_session
 
     def test_it_publishes_join_event(self, svc, creator, publish, origins):
         group = svc.create_restricted_group(
-            "Dishwasher disassemblers", creator.userid, origins=origins
+            "Dishwasher disassemblers", creator.userid, scopes=origins
         )
 
         publish.assert_called_once_with("group-join", group.pubid, creator.userid)
@@ -382,7 +376,7 @@ class TestCreateRestrictedGroup(object):
         origins = ["https://biopub.org", "http://example.com", "https://wikipedia.com"]
 
         group = svc.create_restricted_group(
-            name="test_group", userid=creator.userid, origins=origins
+            name="test_group", userid=creator.userid, scopes=origins
         )
 
         assert group.scopes == matchers.UnorderedList(
@@ -397,7 +391,7 @@ class TestCreateRestrictedGroup(object):
             svc.create_restricted_group(
                 name="test_group",
                 userid=creator.userid,
-                origins=origins,
+                scopes=origins,
                 description="test_description",
                 organization=org,
             )
@@ -409,10 +403,10 @@ class TestCreateRestrictedGroup(object):
         # already exists (this is because a single scope can only belong to
         # one group, so the existing scope can't be reused with the new group).
         origins = ["https://biopub.org", "http://example.com"]
-        scopes = [factories.GroupScope(origin=h) for h in origins]
+        scopes = [factories.GroupScope(scope=h) for h in origins]
 
         group = svc.create_restricted_group(
-            name="test_group", userid=creator.userid, origins=origins
+            name="test_group", userid=creator.userid, scopes=origins
         )
 
         for scope in scopes:

--- a/tests/h/services/group_list_test.py
+++ b/tests/h/services/group_list_test.py
@@ -373,12 +373,12 @@ def scoped_open_groups(factories, authority, origin, user):
             name="Blender",
             authority=authority,
             creator=user,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.OpenGroup(
             name="Antigone",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
     ]
 
@@ -390,12 +390,12 @@ def scoped_restricted_groups(factories, authority, origin, user):
             name="Forensic",
             authority=authority,
             creator=user,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.RestrictedGroup(
             name="Affluent",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
     ]
 
@@ -420,13 +420,13 @@ def scoped_restricted_user_groups(factories, authority, user, origin):
             name="Alpha",
             authority=authority,
             creator=user,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.RestrictedGroup(
             name="Beta",
             authority=authority,
             creator=user,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
     ]
 
@@ -465,19 +465,19 @@ def mixed_groups(factories, user, authority, origin):
             name="Yaks",
             pubid="yaks",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.RestrictedGroup(
             name="Xander",
             pubid="xander",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
         factories.OpenGroup(
             name="wadsworth",
             pubid="wadsworth",
             authority=authority,
-            scopes=[factories.GroupScope(origin=origin)],
+            scopes=[factories.GroupScope(scope=origin)],
         ),
     ]
 

--- a/tests/h/services/group_list_test.py
+++ b/tests/h/services/group_list_test.py
@@ -7,216 +7,89 @@ import mock
 
 from h.services.group_list import GroupListService
 from h.services.group_list import group_list_factory
+from h.services.group_scope import GroupScopeService
 from h.models.group import Group
 
 
 class TestListGroupsSessionGroups(object):
-    def test_it_returns_no_scoped_open_groups_except_world(
-        self, svc, user, default_authority, mixed_groups
-    ):
-        results = svc.session_groups(user=user, authority=default_authority)
+    def test_it_retrieves_world_group(self, svc, user, default_authority):
+        groups = svc.session_groups(default_authority, user)
 
-        non_world_groups = [group for group in results if group.pubid != "__world__"]
+        assert "__world__" in [group.pubid for group in groups]
 
-        for group in non_world_groups:
-            assert group.type != "open"
+    def test_it_excludes_world_group_if_not_found(self, svc, other_authority):
+        groups = svc.session_groups(other_authority)
 
-    def test_it_returns_no_unscoped_open_groups(
-        self, svc, user, authority, unscoped_open_groups
-    ):
-        results = svc.session_groups(user=user, authority=authority)
+        assert "__world__" not in [group.pubid for group in groups]
 
-        assert results == []
+    def test_it_includes_user_groups(self, svc, user, default_authority, sample_groups):
+        groups = svc.session_groups(default_authority, user)
 
-    def test_it_returns_scoped_restricted_groups_if_user_member(
-        self, svc, user, scoped_restricted_user_groups, authority
-    ):
-        user.groups = scoped_restricted_user_groups
-        results = svc.session_groups(user=user, authority=authority)
-
-        assert results == user.groups
-        for group in results:
-            assert group.type == "restricted"
-
-    def test_it_excludes_scoped_restricted_groups_if_user_not_member(
-        self, svc, user, scoped_restricted_groups, authority
-    ):
-        expected = [
-            group for group in scoped_restricted_groups if user in group.members
-        ]
-        results = svc.session_groups(user=user, authority=authority)
-
-        assert results == expected
-
-    def test_it_returns_the_world_group(self, svc, user, default_authority):
-        results = svc.session_groups(user=user, authority=default_authority)
-
-        assert results[0].pubid == "__world__"
-
-    def test_it_returns_world_group_only_if_no_user(
-        self,
-        svc,
-        default_authority,
-        unscoped_restricted_groups,
-        scoped_restricted_groups,
-        unscoped_open_groups,
-        scoped_open_groups,
-    ):
-        results = svc.session_groups(user=None, authority=default_authority)
-
-        assert results[0].pubid == "__world__"
-        assert len(results) == 1
-
-    def test_it_returns_private_groups_for_user(
-        self, user, svc, authority, private_groups
-    ):
-        user.groups = private_groups
-        results = svc.session_groups(user=user, authority=authority)
-
-        for group in user.groups:
-            assert group in results
-            assert group.type == "private"
-
-    def test_world_group_is_first(self, user, svc, default_authority, private_groups):
-        user.groups = private_groups
-        results = svc.session_groups(user=user, authority=default_authority)
-
-        world_group = results.pop(0)
-        assert world_group.pubid == "__world__"
-        for group in results:
-            assert group.type == "private"
+        assert sample_groups["private"] in groups
 
 
 class TestListGroupsRequestGroups(object):
-    def test_it_returns_world_group(self, svc, default_authority):
-        results = svc.request_groups(authority=default_authority)
+    def test_it_returns_world_group(self, svc, default_authority, sample_groups):
+        groups = svc.request_groups(authority=default_authority)
 
-        assert results[0].pubid == "__world__"
+        assert "__world__" in [group.pubid for group in groups]
 
-    def test_it_overrides_authority_with_user_authority(self, svc, user):
-        svc.scoped_groups = mock.Mock()
-        svc.scoped_groups.return_value = []
-        svc.world_group = mock.Mock()
-
-        svc.request_groups(authority="foople.com", user=user)
-
-        svc.scoped_groups.assert_called_once_with(user.authority, None)
-        svc.world_group.assert_called_once_with(user.authority)
-
-    def test_it_defaults_to_default_authority(self, svc, default_authority):
-        svc.scoped_groups = mock.Mock()
-        svc.scoped_groups.return_value = []
-        svc.world_group = mock.Mock()
-
-        svc.request_groups()
-
-        svc.scoped_groups.assert_called_once_with(default_authority, None)
-        svc.world_group.assert_called_once_with(default_authority)
-
-    def test_it_returns_matching_scoped_open_groups(
-        self, svc, authority, document_uri, scoped_open_groups
+    def test_user_authority_supersedes_default_authority_for_world_group(
+        self, svc, other_authority_user, default_authority
     ):
-        results = svc.request_groups(authority=authority, document_uri=document_uri)
+        groups = svc.request_groups(
+            authority=default_authority, user=other_authority_user
+        )
 
-        group_names = [group.name for group in results]
-        assert set(results) == set(scoped_open_groups)
-        assert group_names == ["Antigone", "Blender"]
+        # The world group is on the default_authority but the user's authority
+        # is different, so the world group is not returned
+        assert "__world__" not in [group.pubid for group in groups]
 
-    def test_it_returns_matching_scoped_restricted_groups(
-        self, svc, authority, document_uri, scoped_restricted_groups
+    def test_it_returns_scoped_groups_for_authority_and_document_uri(
+        self, svc, group_scope_service, default_authority, document_uri, sample_groups
     ):
-        results = svc.request_groups(authority=authority, document_uri=document_uri)
+        groups = svc.request_groups(
+            authority=default_authority, document_uri=document_uri
+        )
 
-        group_names = [group.name for group in results]
-        assert group_names == ["Affluent", "Forensic"]
-        assert set(results) == set(scoped_restricted_groups)
+        assert sample_groups["open"] in groups
+        assert sample_groups["restricted"] in groups
+        assert sample_groups["other_authority"] not in groups
 
     def test_it_returns_no_scoped_groups_if_uri_missing(
-        self, svc, authority, scoped_open_groups, scoped_restricted_groups
+        self, svc, default_authority, group_scope_service
     ):
-        results = svc.request_groups(authority=authority)
+        svc.request_groups(authority=default_authority)
 
-        assert results == []
-
-    def test_it_returns_no_unscoped_open_groups(
-        self, svc, authority, scoped_open_groups, unscoped_open_groups
-    ):
-        results = svc.request_groups(authority=authority)
-
-        assert results == []
-
-    def test_it_returns_no_unscoped_restricted_groups(
-        self, svc, authority, unscoped_restricted_groups
-    ):
-        results = svc.request_groups(authority=authority)
-
-        assert results == []
-
-    def test_it_returns_no_unscoped_restricted_user_groups(
-        self, svc, authority, user, unscoped_restricted_groups
-    ):
-        user.groups = unscoped_restricted_groups
-        results = svc.request_groups(user=user, authority=authority)
-
-        assert results == []
+        assert group_scope_service.fetch_by_scope.call_count == 0
 
     def test_it_returns_private_groups_if_user(
-        self, svc, user, authority, private_groups
+        self, svc, user, default_authority, sample_groups
     ):
-        user.groups = private_groups
-        results = svc.request_groups(user=user, authority=authority)
+        groups = svc.request_groups(user=user, authority=default_authority)
 
-        assert results == private_groups
+        assert sample_groups["private"] in groups
 
-    def test_it_returns_no_group_dupes(
-        self,
-        svc,
-        user,
-        authority,
-        private_groups,
-        document_uri,
-        scoped_restricted_user_groups,
+    def test_it_returns_no_private_groups_if_no_user(
+        self, svc, default_authority, sample_groups
     ):
-        user.groups = private_groups + scoped_restricted_user_groups
-        results = svc.request_groups(
-            user=user, authority=authority, document_uri=document_uri
+        groups = svc.request_groups(authority=default_authority)
+
+        assert sample_groups["private"] not in groups
+
+    def test_returns_ordered_list_of_groups(
+        self, svc, default_authority, user, document_uri, sample_groups
+    ):
+        groups = svc.request_groups(
+            authority=default_authority, user=user, document_uri=document_uri
         )
 
-        assert results == scoped_restricted_user_groups + private_groups
-
-    def test_returned_open_groups_must_match_authority(
-        self, svc, alternate_authority, unscoped_open_groups, scoped_open_groups
-    ):
-        results = svc.request_groups(authority=alternate_authority)
-
-        assert results == []
-
-    def test_returned_restricted_groups_must_match_authority(
-        self, svc, alternate_authority, scoped_restricted_groups
-    ):
-        results = svc.request_groups(authority=alternate_authority)
-
-        assert results == []
-
-    def test_groups_are_sorted_by_type(
-        self, svc, user, mixed_groups, authority, document_uri
-    ):
-        expected_sorted_types = ["open", "restricted", "open", "private", "private"]
-        results = svc.request_groups(
-            user=user, authority=authority, document_uri=document_uri
-        )
-
-        assert [group.type for group in results] == expected_sorted_types
-
-    def test_groups_are_sorted_alphabetically(
-        self, svc, user, mixed_groups, authority, document_uri
-    ):
-        expected_sorted_pubids = ["wadsworth", "xander", "yaks", "spectacle", "yams"]
-        results = svc.request_groups(
-            user=user, authority=authority, document_uri=document_uri
-        )
-
-        assert [group.pubid for group in results] == expected_sorted_pubids
+        assert [group.pubid for group in groups] == [
+            sample_groups["open"].pubid,
+            sample_groups["restricted"].pubid,
+            "__world__",
+            sample_groups["private"].pubid,
+        ]
 
 
 class TestUserGroups(object):
@@ -235,15 +108,36 @@ class TestUserGroups(object):
 
         assert u_groups == []
 
+    @pytest.fixture
+    def user_groups(self, user, factories):
+        return [
+            factories.Group(creator=user, name="Gamma"),
+            factories.Group(creator=user, name="Oomph"),
+            factories.Group(creator=user, name="Beta"),
+            factories.Group(creator=user, name="Alpha"),
+        ]
+
 
 class TestPrivateGroups(object):
-    def test_it_returns_a_users_private_groups(self, svc, user, user_groups):
-        user.groups = user_groups
+    def test_it_retrieves_all_user_groups(self, svc, user):
+        svc.user_groups = mock.Mock(return_value=[])
+
+        svc.private_groups(user)
+
+        svc.user_groups.assert_called_once_with(user)
+
+    def test_it_returns_only_private_groups(self, svc, user, factories):
+        private_group = factories.Group()
+        open_group = factories.OpenGroup()
+        restricted_group = factories.RestrictedGroup()
+
+        user.groups = [private_group, open_group, restricted_group]
 
         p_groups = svc.private_groups(user)
 
-        group_names = [group.name for group in p_groups]
-        assert group_names == ["Alpha", "Beta", "Gamma"]
+        assert private_group in p_groups
+        assert open_group not in p_groups
+        assert restricted_group not in p_groups
 
     def test_it_returns_empty_list_if_no_user(self, svc):
         p_groups = svc.private_groups(user=None)
@@ -251,34 +145,48 @@ class TestPrivateGroups(object):
         assert p_groups == []
 
 
-@pytest.mark.use_fixtures("scoped_groups")
 class TestScopedGroups(object):
-    def test_it_returns_scoped_groups_that_match_document_uri_and_authority(
-        self, svc, document_uri, authority, scoped_groups
+    def test_it_fetches_matching_scopes_from_group_scope_service(
+        self, svc, default_authority, document_uri, group_scope_service
     ):
-        s_groups = svc.scoped_groups(authority, document_uri)
+        svc.scoped_groups(default_authority, document_uri)
 
-        group_names = [group.name for group in s_groups]
-        assert group_names == ["Affluent", "Antigone", "Blender", "Forensic"]
+        group_scope_service.fetch_by_scope.assert_called_once_with(document_uri)
 
-    def test_it_returns_empty_list_if_no_scope_matches(self, svc, authority):
-        s_groups = svc.scoped_groups(authority, "https://www.whatever.org")
-
-        assert s_groups == []
-
-    def test_it_returns_empty_list_if_no_authority_matches(self, svc, document_uri):
-        s_groups = svc.scoped_groups("inventive.org", document_uri)
-
-        assert s_groups == []
-
-    def test_it_returns_empty_list_if_uri_scope_parsing_fails(
-        self, svc, document_uri, authority, scope_util
+    def test_it_returns_empty_list_if_no_matching_scopes(
+        self, svc, default_authority, document_uri, sample_groups, group_scope_service
     ):
-        scope_util.uri_scope.return_value = None
+        group_scope_service.fetch_by_scope.return_value = []
 
-        s_groups = svc.scoped_groups(authority, document_uri)
+        results = svc.scoped_groups(default_authority, document_uri)
 
-        assert s_groups == []
+        assert results == []
+
+    def test_it_returns_matching_public_groups(
+        self, svc, sample_groups, document_uri, default_authority, matchers
+    ):
+        results = svc.scoped_groups(default_authority, document_uri)
+
+        assert results == matchers.UnorderedList(
+            [sample_groups["restricted"], sample_groups["open"]]
+        )
+
+    def test_it_returns_matches_from_authority_only(
+        self, svc, sample_groups, document_uri, default_authority
+    ):
+        results = svc.scoped_groups(default_authority, document_uri)
+
+        assert sample_groups["other_authority"] not in results
+
+    def test_it_de_dupes_groups(
+        self, svc, sample_groups, document_uri, default_authority
+    ):
+        results = svc.scoped_groups(default_authority, document_uri)
+
+        # The mocked GroupScope service returns the scope for the "open"
+        # group twice, but the group only appears once in the results
+        assert sample_groups["open"] in results
+        assert len(results) == 2
 
 
 class TestWorldGroup(object):
@@ -293,21 +201,23 @@ class TestWorldGroup(object):
         assert isinstance(w_group, Group)
         assert w_group.pubid == "__world__"
 
-    def test_it_returns_None_if_no_world_group_for_authority(self, svc, authority):
+    def test_it_returns_None_if_no_world_group_for_authority(
+        self, svc, other_authority
+    ):
         # No "__world__" group exists in THIS test module's authority
 
-        w_group = svc.world_group(authority)
+        w_group = svc.world_group(other_authority)
 
         assert w_group is None
 
 
 class TestGroupListFactory(object):
-    def test_group_list_factory(self, pyramid_request):
+    def test_group_list_factory(self, pyramid_request, group_scope_service):
         svc = group_list_factory(None, pyramid_request)
 
         assert isinstance(svc, GroupListService)
 
-    def test_uses_request_default_authority(self, pyramid_request):
+    def test_uses_request_default_authority(self, pyramid_request, group_scope_service):
         pyramid_request.default_authority = "bar.com"
 
         svc = group_list_factory(None, pyramid_request)
@@ -316,7 +226,7 @@ class TestGroupListFactory(object):
 
 
 @pytest.fixture
-def authority():
+def other_authority():
     """Return a consistent, different authority for groups in these tests"""
     return "surreptitious.com"
 
@@ -332,28 +242,13 @@ def default_authority(pyramid_request):
 
 
 @pytest.fixture
-def alternate_authority():
-    return "bar.com"
+def user(factories):
+    return factories.User()
 
 
 @pytest.fixture
-def default_user(factories, default_authority):
-    return factories.User(authority=default_authority)
-
-
-@pytest.fixture
-def user(factories, authority):
-    return factories.User(authority=authority)
-
-
-@pytest.fixture
-def user_groups(user, factories):
-    return [
-        factories.Group(name="Beta"),
-        factories.Group(name="Gamma"),
-        factories.RestrictedGroup(name="Oomph"),
-        factories.Group(name="Alpha"),
-    ]
+def other_authority_user(factories, other_authority):
+    return factories.User(authority=other_authority)
 
 
 @pytest.fixture
@@ -367,128 +262,40 @@ def document_uri():
 
 
 @pytest.fixture
-def scoped_open_groups(factories, authority, origin, user):
-    return [
-        factories.OpenGroup(
-            name="Blender",
-            authority=authority,
-            creator=user,
-            scopes=[factories.GroupScope(scope=origin)],
+def sample_groups(factories, other_authority, document_uri, default_authority, user):
+    return {
+        "open": factories.OpenGroup(
+            authority=default_authority,
+            scopes=[factories.GroupScope(scope=document_uri)],
         ),
-        factories.OpenGroup(
-            name="Antigone",
-            authority=authority,
-            scopes=[factories.GroupScope(scope=origin)],
+        "restricted": factories.RestrictedGroup(
+            authority=default_authority,
+            scopes=[factories.GroupScope(scope=document_uri)],
         ),
+        "other_authority": factories.OpenGroup(
+            authority=other_authority, scopes=[factories.GroupScope(scope=document_uri)]
+        ),
+        "private": factories.Group(creator=user),
+    }
+
+
+@pytest.fixture
+def group_scope_service(pyramid_config, sample_groups):
+    service = mock.create_autospec(GroupScopeService, spec_set=True, instance=True)
+    service.fetch_by_scope.return_value = [
+        sample_groups["open"].scopes[0],
+        sample_groups["open"].scopes[0],  # This verifies that the groups are de-duped
+        sample_groups["restricted"].scopes[0],
+        sample_groups["other_authority"].scopes[0],
     ]
+    pyramid_config.register_service(service, name="group_scope")
+    return service
 
 
 @pytest.fixture
-def scoped_restricted_groups(factories, authority, origin, user):
-    return [
-        factories.RestrictedGroup(
-            name="Forensic",
-            authority=authority,
-            creator=user,
-            scopes=[factories.GroupScope(scope=origin)],
-        ),
-        factories.RestrictedGroup(
-            name="Affluent",
-            authority=authority,
-            scopes=[factories.GroupScope(scope=origin)],
-        ),
-    ]
-
-
-@pytest.fixture
-def scoped_groups(scoped_open_groups, scoped_restricted_groups):
-    return scoped_open_groups + scoped_restricted_groups
-
-
-@pytest.fixture
-def unscoped_restricted_groups(factories, authority, user):
-    return [
-        factories.RestrictedGroup(authority=authority, creator=user),
-        factories.RestrictedGroup(authority=authority),
-    ]
-
-
-@pytest.fixture
-def scoped_restricted_user_groups(factories, authority, user, origin):
-    return [
-        factories.RestrictedGroup(
-            name="Alpha",
-            authority=authority,
-            creator=user,
-            scopes=[factories.GroupScope(scope=origin)],
-        ),
-        factories.RestrictedGroup(
-            name="Beta",
-            authority=authority,
-            creator=user,
-            scopes=[factories.GroupScope(scope=origin)],
-        ),
-    ]
-
-
-@pytest.fixture
-def unscoped_open_groups(factories, authority, user):
-    return [
-        factories.OpenGroup(authority=authority, creator=user),
-        factories.OpenGroup(authority=authority),
-    ]
-
-
-@pytest.fixture
-def alternate_unscoped_open_groups(factories, alternate_authority):
-    return [
-        factories.OpenGroup(authority=alternate_authority),
-        factories.OpenGroup(authority=alternate_authority),
-    ]
-
-
-@pytest.fixture
-def private_groups(factories, authority):
-    return [factories.Group(authority=authority), factories.Group(authority=authority)]
-
-
-@pytest.fixture
-def mixed_groups(factories, user, authority, origin):
-    """Return a list of open groups with different names and scope/not scoped"""
-    user.groups = [
-        factories.Group(name="Yams", pubid="yams", authority=authority),
-        factories.Group(name="Spectacle", pubid="spectacle", authority=authority),
-    ]
-    return [
-        factories.OpenGroup(name="Zebra", pubid="zebra", authority=authority),
-        factories.OpenGroup(
-            name="Yaks",
-            pubid="yaks",
-            authority=authority,
-            scopes=[factories.GroupScope(scope=origin)],
-        ),
-        factories.RestrictedGroup(
-            name="Xander",
-            pubid="xander",
-            authority=authority,
-            scopes=[factories.GroupScope(scope=origin)],
-        ),
-        factories.OpenGroup(
-            name="wadsworth",
-            pubid="wadsworth",
-            authority=authority,
-            scopes=[factories.GroupScope(scope=origin)],
-        ),
-    ]
-
-
-@pytest.fixture
-def scope_util(patch):
-    return patch("h.services.group_list.scope_util")
-
-
-@pytest.fixture
-def svc(pyramid_request, db_session):
+def svc(pyramid_request, db_session, group_scope_service):
     return GroupListService(
-        session=db_session, default_authority=pyramid_request.default_authority
+        session=db_session,
+        default_authority=pyramid_request.default_authority,
+        group_scope_service=group_scope_service,
     )

--- a/tests/h/services/group_scope_test.py
+++ b/tests/h/services/group_scope_test.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.services.group_scope import group_scope_factory, GroupScopeService
+
+
+class TestFetchByScope(object):
+    def test_it_returns_empty_list_if_origin_not_parseable(
+        self, svc, scope_util, document_uri
+    ):
+        scope_util.parse_origin.return_value = None
+        scopes = svc.fetch_by_scope(document_uri)
+
+        assert scopes == []
+
+    def test_it_only_returns_scopes_that_pass_util_scope_test(
+        self, svc, scope_util, sample_scopes
+    ):
+        scope_util.uri_in_scope.return_value = False
+        scope_util.parse_origin.return_value = "http://foo.com"
+
+        # All sample_scopes match this URL, but fail the `uri_in_scope` test
+        scopes = svc.fetch_by_scope("http://foo.com")
+
+        assert scope_util.uri_in_scope.call_count == len(sample_scopes)
+        assert scopes == []
+
+    def test_it_returns_list_of_matching_scopes(self, svc, document_uri, sample_scopes):
+        results = svc.fetch_by_scope(document_uri)
+
+        matching_scope_scopes = [scope.scope for scope in results]
+        assert len(results) == 2
+        assert "http://foo.com" in matching_scope_scopes
+        assert "http://foo.com/bar/" in matching_scope_scopes
+
+
+class TestGroupScopeFactory(object):
+    def test_it_returns_group_scope_service_instance(self, pyramid_request):
+        svc = group_scope_factory(None, pyramid_request)
+
+        assert isinstance(svc, GroupScopeService)
+
+
+@pytest.fixture
+def svc(db_session, pyramid_request):
+    pyramid_request.db = db_session
+    return group_scope_factory({}, pyramid_request)
+
+
+@pytest.fixture
+def scope_util(patch):
+    return patch("h.services.group_scope.scope_util")
+
+
+@pytest.fixture
+def document_uri():
+    return "http://foo.com/bar/foo.html"
+
+
+@pytest.fixture
+def sample_scopes(factories):
+    return [
+        factories.GroupScope(scope="http://foo.com"),
+        factories.GroupScope(scope="http://foo.com/bar/"),
+        factories.GroupScope(scope="http://foo.com/bar/baz/"),
+        factories.GroupScope(
+            scope="http://foo.com/bar/baz/foo.html?q=something&wut=how"
+        ),
+    ]

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -240,8 +240,8 @@ class TestCreateAnnotation(object):
     def test_it_allows_when_target_uri_matches_multiple_group_scope(
         self, pyramid_request, pyramid_config, group_service, factories, models
     ):
-        scope = factories.GroupScope(origin="http://www.foo.com")
-        scope2 = factories.GroupScope(origin="http://www.bar.com")
+        scope = factories.GroupScope(scope="http://www.foo.com")
+        scope2 = factories.GroupScope(scope="http://www.bar.com")
         group_service.find.return_value = factories.OpenGroup(scopes=[scope, scope2])
         data = self.annotation_data()
         data["target_uri"] = "http://www.bar.com/boo/bah.html"
@@ -638,7 +638,7 @@ def datetime(patch):
 
 @pytest.fixture
 def scoped_open_group(factories):
-    scope = factories.GroupScope(origin="http://www.foo.com")
+    scope = factories.GroupScope(scope="http://www.foo.com")
     return factories.OpenGroup(scopes=[scope])
 
 

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -28,6 +28,50 @@ def test_it_parses_scope_from_uri(uri, expected_scope):
     assert scope == expected_scope
 
 
+class TestURIInScope(object):
+    @pytest.mark.parametrize(
+        "uri,in_origin,in_path,in_other",
+        [
+            ("https://www.foo.com", True, False, False),
+            ("http://foo.com", False, False, False),
+            ("http://www.foo.com/bar/qux.html", True, True, True),
+            ("http://www.foo.com/bar/baz/qux.html", True, True, True),
+            ("http://foo.com/", False, False, False),
+            ("http://www.foo.com/bar.baz", True, False, False),
+            ("www.foo.com", False, False, False),
+            ("randoscheme://foo.com", False, False, False),
+            ("foo", False, False, False),
+            ("https://www.foo.com/bar/baz", True, False, False),
+            ("", False, False, False),
+        ],
+    )
+    def test_it_returns_True_if_uri_matches_one_or_more_scopes(
+        self, scope_lists, uri, in_origin, in_path, in_other
+    ):
+        assert scope_util.uri_in_scope(uri, scope_lists["origin_only"]) == in_origin
+        assert scope_util.uri_in_scope(uri, scope_lists["with_path"]) == in_path
+        assert scope_util.uri_in_scope(uri, scope_lists["with_other"]) == in_other
+
+    @pytest.fixture
+    def match(self, patch):
+        return patch("h.util.group_scope.re.match")
+
+    @pytest.fixture
+    def scope_lists(self):
+        return {
+            "origin_only": ["http://www.foo.com", "https://www.foo.com"],
+            "with_path": [
+                "http://www.foo.com/bar/baz",
+                "http://www.foo.com/bar/qux",
+                "http://www.foo.com/bar/baz/qux",
+            ],
+            "with_other": [
+                "http://www.foo.com/bar/baz/qux.html",
+                "http://www.foo.com/bar/qux",
+            ],
+        }
+
+
 class TestScopeMatch(object):
     @pytest.mark.parametrize(
         "uri,expected",
@@ -67,3 +111,38 @@ class TestScopeMatch(object):
     @pytest.fixture
     def multiple_scopes(self):
         return ["http://www.foo.com", "http://www.bar.com"]
+
+
+class TestURIToScope(object):
+    @pytest.mark.parametrize(
+        "uri,expected_scope",
+        [
+            ("https://www.foo.com/foo", ("https://www.foo.com", "/foo")),
+            ("https://foo.com/bar/baz", ("https://foo.com", "/bar/baz")),
+            ("http://foo.com", ("http://foo.com", None)),
+            ("/foo/bar", (None, "/foo/bar")),
+            (
+                "https://foo.com/foo/bar/baz.html",
+                ("https://foo.com", "/foo/bar/baz.html"),
+            ),
+            ("http://foo.com//bar/baz", ("http://foo.com", "//bar/baz")),
+            ("http://foo.com/bar?what=how", ("http://foo.com", "/bar")),
+        ],
+    )
+    def test_it_parses_origin_and_path_from_uri(self, uri, expected_scope):
+        assert scope_util.uri_to_scope(uri) == expected_scope
+
+
+class TestParseOrigin(object):
+    @pytest.mark.parametrize(
+        "uri,expected_origin",
+        [
+            ("https://www.foo.com/foo/qux/bar.html", "https://www.foo.com"),
+            ("http://foo.com/baz", "http://foo.com"),
+            ("http://foo.com:3553/bar", "http://foo.com:3553"),
+            ("http://www.foo.bar.com", "http://www.foo.bar.com"),
+            ("foo.com", None),
+        ],
+    )
+    def test_it_parses_origin_from_uri(self, uri, expected_origin):
+        assert scope_util.parse_origin(uri) == expected_origin

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -6,28 +6,6 @@ import pytest
 from h.util import group_scope as scope_util
 
 
-@pytest.mark.parametrize(
-    "uri,expected_scope",
-    [
-        ("https://www.foo.com", "https://www.foo.com"),
-        ("http://foo.com", "http://foo.com"),
-        ("https://foo.com/bar", "https://foo.com"),
-        ("http://foo.com/", "http://foo.com"),
-        ("http://www.foo.com/bar/baz.html", "http://www.foo.com"),
-        ("randoscheme://foo.com", "randoscheme://foo.com"),
-        ("foo", None),
-        ("foo.com", None),
-        ("http://www.foo.com/bar/baz.html?query=whatever", "http://www.foo.com"),
-        ("", None),
-        (None, None),
-    ],
-)
-def test_it_parses_scope_from_uri(uri, expected_scope):
-    scope = scope_util.uri_scope(uri)
-
-    assert scope == expected_scope
-
-
 class TestURIInScope(object):
     @pytest.mark.parametrize(
         "uri,in_origin,in_path,in_other",
@@ -53,10 +31,6 @@ class TestURIInScope(object):
         assert scope_util.uri_in_scope(uri, scope_lists["with_other"]) == in_other
 
     @pytest.fixture
-    def match(self, patch):
-        return patch("h.util.group_scope.re.match")
-
-    @pytest.fixture
     def scope_lists(self):
         return {
             "origin_only": ["http://www.foo.com", "https://www.foo.com"],
@@ -70,47 +44,6 @@ class TestURIInScope(object):
                 "http://www.foo.com/bar/qux",
             ],
         }
-
-
-class TestScopeMatch(object):
-    @pytest.mark.parametrize(
-        "uri,expected",
-        [
-            ("http://www.foo.com/bar/baz/ding.html", True),
-            ("https://www.foo.com/bar/baz/ding.html", False),
-            ("http://www.foo.com/", True),
-            ("http://foo.com/bar.html", False),
-            ("foo.com/bar.html", False),
-        ],
-    )
-    def test_it_matches_against_single_scope(self, uri, expected, single_scope):
-        result = scope_util.match(uri, single_scope)
-
-        assert result == expected
-
-    @pytest.mark.parametrize(
-        "uri,expected",
-        [
-            ("http://www.foo.com/bar/baz/ding.html", True),
-            ("http://www.bar.com/bar/baz/ding.html", True),
-            ("http://www.foo.com/", True),
-            ("http://www.bar.com", True),
-            ("http://bar.com/bar.html", False),
-            ("bar.com/bar.html", False),
-        ],
-    )
-    def test_it_matches_against_multiple_scopes(self, uri, expected, multiple_scopes):
-        result = scope_util.match(uri, multiple_scopes)
-
-        assert result == expected
-
-    @pytest.fixture
-    def single_scope(self):
-        return ["http://www.foo.com"]
-
-    @pytest.fixture
-    def multiple_scopes(self):
-        return ["http://www.foo.com", "http://www.bar.com"]
 
 
 class TestURIToScope(object):

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -180,7 +180,7 @@ class TestGroupCreateView(object):
             "description": None,
             "members": [],
             "organization": default_org.pubid,
-            "origins": ["http://example.com"],
+            "scopes": ["http://example.com"],
             "enforce_scope": True,
         }
 
@@ -267,7 +267,7 @@ class TestGroupEditViews(object):
                     "group_type": "open",
                     "name": "Updated group",
                     "organization": updated_org.pubid,
-                    "origins": ["http://somewhereelse.com", "http://www.gladiolus.org"],
+                    "scopes": ["http://somewhereelse.com", "http://www.gladiolus.org"],
                     "members": [],
                     "enforce_scope": False,
                 }
@@ -320,7 +320,7 @@ class TestGroupEditViews(object):
                     "name": "a name",
                     "members": ["phil", "sue"],
                     "organization": group.organization.pubid,
-                    "origins": ["http://www.example.com"],
+                    "scopes": ["http://www.example.com"],
                     "enforce_scope": group.enforce_scope,
                 }
             )
@@ -358,7 +358,7 @@ class TestGroupEditViews(object):
             "name": group.name,
             "members": [m.username for m in group.members],
             "organization": group.organization.pubid,
-            "origins": [s.origin for s in group.scopes],
+            "scopes": [s.scope for s in group.scopes],
             "enforce_scope": group.enforce_scope,
         }
 

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -113,7 +113,7 @@ class TestGroupCreateView(object):
             name="My New Group",
             userid=user_svc.fetch.return_value.userid,
             description=None,
-            origins=["http://example.com"],
+            scopes=["http://example.com"],
             organization=default_org,
             enforce_scope=True,
         )
@@ -140,7 +140,7 @@ class TestGroupCreateView(object):
             name="My New Group",
             userid=user_svc.fetch.return_value.userid,
             description=None,
-            origins=["http://example.com"],
+            scopes=["http://example.com"],
             organization=default_org,
             enforce_scope=True,
         )
@@ -285,7 +285,7 @@ class TestGroupEditViews(object):
             description="New description",
             name="Updated group",
             scopes=[
-                GroupScope(origin=o)
+                GroupScope(scope=o)
                 for o in ["http://somewhereelse.com", "http://www.gladiolus.org"]
             ],
             enforce_scope=False,


### PR DESCRIPTION
See https://github.com/hypothesis/h/pull/5577 for original description

Fixes https://github.com/hypothesis/product-backlog/issues/908

Updates since #5577:

* Integrated some of @seanh feedback
* Squashed into fewer commits

Known plausible next steps:

* Vet our code for consistency between `uri` and `url` (goes beyond these changes)
* Potentially rid ourselves of `path`, `origin` fields entirely
* Refactor `GroupList` service into smaller chunks