### PR TITLE
Change `uri` references to `url`

### DIFF
--- a/h/models/group_scope.py
+++ b/h/models/group_scope.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 
 from h._compat import urlparse
 from h.db import Base
-from h.util.group_scope import uri_to_scope
+from h.util.group_scope import parse_scope_from_url
 
 
 class GroupScope(Base):
@@ -58,7 +58,7 @@ class GroupScope(Base):
 
     @property
     def scope(self):
-        """Return a URI composed from the origin and path attrs"""
+        """Return a URL composed from the origin and path attrs"""
         return urlparse.urljoin(self._origin, self._path)
 
     @scope.setter
@@ -67,7 +67,7 @@ class GroupScope(Base):
 
         :raises ValueError: if URL is invalid (origin cannot be parsed)
         """
-        parsed_origin, parsed_path = uri_to_scope(value)
+        parsed_origin, parsed_path = parse_scope_from_url(value)
         if parsed_origin is None:
             raise ValueError("Invalid URL for scope: missing origin component")
         self._origin = parsed_origin

--- a/h/services/group_scope.py
+++ b/h/services/group_scope.py
@@ -26,7 +26,7 @@ class GroupScopeService(object):
         return [
             scope
             for scope in origin_scopes
-            if scope_util.uri_in_scope(url, [scope.scope])
+            if scope_util.url_in_scope(url, [scope.scope])
         ]
 
 

--- a/h/storage.py
+++ b/h/storage.py
@@ -24,7 +24,7 @@ from pyramid import i18n
 
 from h import models, schemas
 from h.db import types
-from h.util.group_scope import uri_in_scope
+from h.util.group_scope import url_in_scope
 from h.models.document import update_document_metadata
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -253,7 +253,7 @@ def _validate_group_scope(group, target_uri):
     # The target URI must match at least one
     # of a group's defined scopes, if the group has any
     group_scopes = [scope.scope for scope in group.scopes]
-    if not uri_in_scope(target_uri, group_scopes):
+    if not url_in_scope(target_uri, group_scopes):
         raise schemas.ValidationError(
             "group scope: "
             + _("Annotations for this target URI " "are not allowed in this group")

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -5,46 +5,43 @@ from __future__ import unicode_literals
 from h._compat import urlparse
 
 
-def uri_in_scope(uri, scopes):
+def url_in_scope(url, scope_urls):
     """
-    Does the URI match any of the scope patterns?
+    Does the URL match any of the scopes represented by ``scope_urls``?
 
-    Return True if the URI matches one or more patterns in scopes (if the
-    URI string begins with any of the scope strings)
+    Return True if the URL matches one or more of the provided patterns (if the
+    URL string begins with any of the scope URL strings)
 
-    :arg uri: URI string in question
-    :arg scopes: List of URIs that define scope
-    :type scopes: list(str)
+    :arg url: URL string in question
+    :arg scope_urls: List of URLs that define scopes to check against
+    :type scope_urls: list(str)
     :rtype: bool
     """
-    return any((uri.startswith(scope) for scope in scopes))
+    return any((url.startswith(scope_url) for scope_url in scope_urls))
 
 
-def uri_to_scope(uri):
+def parse_scope_from_url(url):
     """
-    Return a tuple representing the origin and path of a URI
+    Return a tuple representing the origin and path of a URL
 
-    :arg uri: The URI from which to derive scope
-    :type uri: str
+    :arg url: The URL from which to derive scope
+    :type url: str
     :rtype: tuple(str, str or None)
     """
-    # A URL with no origin component will result in a `None` value for
-    # origin, while a URL with no path component will result in an empty
-    # string for path.
-    origin = parse_origin(uri)
-    path = _parse_path(uri) or None
+    origin = parse_origin(url)
+    path = _parse_path(url) or None
     return (origin, path)
 
 
-def _parse_path(uri):
-    """Return the path component of a URI string"""
-    if uri is None:
+def _parse_path(url):
+    """Return the path component of a URL string"""
+    if url is None:
         return None
-    parsed = urlparse.urlsplit(uri)
+    parsed = urlparse.urlsplit(url)
     return parsed.path
 
 
-def parse_origin(uri):
+def parse_origin(url):
     """
     Return the origin of a URL or None if empty or invalid.
 
@@ -52,13 +49,13 @@ def parse_origin(uri):
     Return ``<scheme> + '://' + <host> + <port>``
     for a URL.
 
-    :param uri: URL string
+    :param url: URL string
     :rtype: str or None
     """
 
-    if uri is None:
+    if url is None:
         return None
-    parsed = urlparse.urlsplit(uri)
+    parsed = urlparse.urlsplit(url)
     # netloc contains both host and port
     origin = urlparse.SplitResult(parsed.scheme, parsed.netloc, "", "", "")
     return origin.geturl() or None

--- a/tests/h/services/group_scope_test.py
+++ b/tests/h/services/group_scope_test.py
@@ -19,13 +19,13 @@ class TestFetchByScope(object):
     def test_it_only_returns_scopes_that_pass_util_scope_test(
         self, svc, scope_util, sample_scopes
     ):
-        scope_util.uri_in_scope.return_value = False
+        scope_util.url_in_scope.return_value = False
         scope_util.parse_origin.return_value = "http://foo.com"
 
-        # All sample_scopes match this URL, but fail the `uri_in_scope` test
+        # All sample_scopes match this URL, but fail the `url_in_scope` test
         scopes = svc.fetch_by_scope("http://foo.com")
 
-        assert scope_util.uri_in_scope.call_count == len(sample_scopes)
+        assert scope_util.url_in_scope.call_count == len(sample_scopes)
         assert scopes == []
 
     def test_it_returns_list_of_matching_scopes(self, svc, document_uri, sample_scopes):

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -6,9 +6,9 @@ import pytest
 from h.util import group_scope as scope_util
 
 
-class TestURIInScope(object):
+class TestURLInScope(object):
     @pytest.mark.parametrize(
-        "uri,in_origin,in_path,in_other",
+        "url,in_origin,in_path,in_other",
         [
             ("https://www.foo.com", True, False, False),
             ("http://foo.com", False, False, False),
@@ -23,12 +23,12 @@ class TestURIInScope(object):
             ("", False, False, False),
         ],
     )
-    def test_it_returns_True_if_uri_matches_one_or_more_scopes(
-        self, scope_lists, uri, in_origin, in_path, in_other
+    def test_it_returns_True_if_url_matches_one_or_more_scopes(
+        self, scope_lists, url, in_origin, in_path, in_other
     ):
-        assert scope_util.uri_in_scope(uri, scope_lists["origin_only"]) == in_origin
-        assert scope_util.uri_in_scope(uri, scope_lists["with_path"]) == in_path
-        assert scope_util.uri_in_scope(uri, scope_lists["with_other"]) == in_other
+        assert scope_util.url_in_scope(url, scope_lists["origin_only"]) == in_origin
+        assert scope_util.url_in_scope(url, scope_lists["with_path"]) == in_path
+        assert scope_util.url_in_scope(url, scope_lists["with_other"]) == in_other
 
     @pytest.fixture
     def scope_lists(self):
@@ -46,9 +46,9 @@ class TestURIInScope(object):
         }
 
 
-class TestURIToScope(object):
+class TestParseURLFromScope(object):
     @pytest.mark.parametrize(
-        "uri,expected_scope",
+        "url,expected_scope",
         [
             ("https://www.foo.com/foo", ("https://www.foo.com", "/foo")),
             ("https://foo.com/bar/baz", ("https://foo.com", "/bar/baz")),
@@ -62,13 +62,13 @@ class TestURIToScope(object):
             ("http://foo.com/bar?what=how", ("http://foo.com", "/bar")),
         ],
     )
-    def test_it_parses_origin_and_path_from_uri(self, uri, expected_scope):
-        assert scope_util.uri_to_scope(uri) == expected_scope
+    def test_it_parses_origin_and_path_from_url(self, url, expected_scope):
+        assert scope_util.parse_scope_from_url(url) == expected_scope
 
 
 class TestParseOrigin(object):
     @pytest.mark.parametrize(
-        "uri,expected_origin",
+        "url,expected_origin",
         [
             ("https://www.foo.com/foo/qux/bar.html", "https://www.foo.com"),
             ("http://foo.com/baz", "http://foo.com"),
@@ -77,5 +77,5 @@ class TestParseOrigin(object):
             ("foo.com", None),
         ],
     )
-    def test_it_parses_origin_from_uri(self, uri, expected_origin):
-        assert scope_util.parse_origin(uri) == expected_origin
+    def test_it_parses_origin_from_url(self, url, expected_origin):
+        assert scope_util.parse_origin(url) == expected_origin


### PR DESCRIPTION
This little housekeeping PR is a follow-up to #5585

Improves consistency by using `url` in preference to `uri` for variable and function names as well as comments.