### PR TITLE
Pin Docker base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build node portion of the H app.
-FROM node:alpine as build
+FROM node:11.12.0-alpine as build
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
To the latest version.

This is to enable Dependabot Docker updates to work.