### PR TITLE
Add API v2 to our app

### DIFF
--- a/h/views/api/__init__.py
+++ b/h/views/api/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-API_VERSIONS = ["v1"]
+API_VERSIONS = ["v1", "v2"]
 """All of the app's known API versions"""
 
 API_VERSION_DEFAULT = "v1"

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -38,7 +38,7 @@ _ = i18n.TranslationStringFactory(__package__)
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.search",
     link_name="search",
     description="Search for annotations",
@@ -66,7 +66,7 @@ def search(request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.annotations",
     request_method="POST",
     permission="create",
@@ -88,7 +88,7 @@ def create(request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.annotation",
     request_method="GET",
     permission="read",
@@ -102,7 +102,7 @@ def read(context, request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.annotation.jsonld",
     request_method="GET",
     permission="read",
@@ -118,7 +118,7 @@ def read_jsonld(context, request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.annotation",
     request_method=("PATCH", "PUT"),
     permission="update",
@@ -148,7 +148,7 @@ def update(context, request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.annotation",
     request_method="DELETE",
     permission="delete",

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -184,7 +184,7 @@ class OAuthAccessTokenController(object):
 
         self.oauth = self.request.find_service(name="oauth_provider")
 
-    @api_config(versions=["v1"], route_name="token", request_method="POST")
+    @api_config(versions=["v1", "v2"], route_name="token", request_method="POST")
     def post(self):
         headers, body, status = self.oauth.create_token_response(
             self.request.url,
@@ -204,7 +204,7 @@ class OAuthRevocationController(object):
 
         self.oauth = self.request.find_service(name="oauth_provider")
 
-    @api_config(versions=["v1"], route_name="oauth_revoke", request_method="POST")
+    @api_config(versions=["v1", "v2"], route_name="oauth_revoke", request_method="POST")
     def post(self):
         headers, body, status = self.oauth.create_revocation_response(
             self.request.url,
@@ -218,7 +218,7 @@ class OAuthRevocationController(object):
             raise exception_response(status, body=body)
 
 
-@api_config(versions=["v1"], route_name="api.debug_token", request_method="GET")
+@api_config(versions=["v1", "v2"], route_name="api.debug_token", request_method="GET")
 def debug_token(request):
     if not request.auth_token:
         raise OAuthTokenError(
@@ -237,7 +237,7 @@ def debug_token(request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     context=OAuthTokenError,
     # This is a handler called only if a request fails, so the CORS
     # preflight request will have been handled by the original view.

--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -6,7 +6,7 @@ from h.views.api.helpers import links
 from h.views.api.helpers.media_types import media_type_for_version
 from h.views.api.decorators.response import version_media_type_header
 
-from h.views.api import API_VERSIONS
+from h.views.api import API_VERSIONS, API_VERSION_DEFAULT
 
 
 #: Decorator that adds CORS headers to API responses.
@@ -64,7 +64,6 @@ def add_api_view(
                                   `route_name` must be specified.
     :param dict settings: Arguments to pass on to ``config.add_view``
     """
-    settings.setdefault("accept", "application/json")
     settings.setdefault("renderer", "json")
     settings.setdefault("decorator", (cors_policy, version_media_type_header))
 
@@ -78,7 +77,11 @@ def add_api_view(
 
         links.register_link(link, versions, config.registry)
 
-    config.add_view(view=view, **settings)
+    if API_VERSION_DEFAULT in versions:
+        # If this view claims to support the default API version, register it
+        # with the default (application/json) media-type accept handler
+        settings.setdefault("accept", "application/json")
+        config.add_view(view=view, **settings)
 
     for version in versions:
         if version not in API_VERSIONS:

--- a/h/views/api/decorators/response.py
+++ b/h/views/api/decorators/response.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 
 from h.views.api import API_VERSION_DEFAULT
-from h.views.api.helpers.media_types import media_type_for_version
+from h.views.api.helpers.media_types import media_type_for_version, version_media_types
 
 
 def version_media_type_header(wrapped):
@@ -12,9 +12,17 @@ def version_media_type_header(wrapped):
 
     def wrapper(context, request):
         response = wrapped(context, request)
-        # TODO: expand with logic for multiple versions once the app knows
-        # about multiple versions
+        # Assume default version...
         version_media_type = media_type_for_version(API_VERSION_DEFAULT)
+        # ...Unless we can determine otherwise from the Accept header
+        if request.accept:
+            version_accepts = [t for t in request.accept if t in version_media_types()]
+            if any(version_accepts):
+                # If the Accept header contains any values that match a known version
+                # media type, that's the version that would have been matched
+                # and used
+                version_media_type = version_accepts[0]
+
         response.headers["Hypothesis-Media-Type"] = version_media_type
         return response
 

--- a/h/views/api/flags.py
+++ b/h/views/api/flags.py
@@ -12,7 +12,7 @@ from h.tasks import mailer
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.annotation_flag",
     request_method="PUT",
     link_name="annotation.flag",

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -20,7 +20,7 @@ from h.views.api.config import api_config
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.groups",
     request_method="GET",
     link_name="groups.read",
@@ -43,7 +43,7 @@ def groups(request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.groups",
     request_method="POST",
     permission="create",
@@ -81,7 +81,7 @@ def create(request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.group",
     request_method="GET",
     permission="read",
@@ -97,7 +97,7 @@ def read(group, request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.group",
     request_method="PATCH",
     permission="admin",
@@ -131,7 +131,7 @@ def update(group, request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.group_upsert",
     request_method="PUT",
     permission="upsert",
@@ -194,7 +194,7 @@ def upsert(context, request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.group_member",
     request_method="DELETE",
     link_name="group.member.delete",
@@ -216,7 +216,7 @@ def remove_member(group, request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.group_member",
     request_method="POST",
     link_name="group.member.add",

--- a/h/views/api/helpers/links.py
+++ b/h/views/api/helpers/links.py
@@ -57,7 +57,7 @@ def register_link(link, versions, registry):
         registry.api_links[version].append(link)
 
 
-def format_nested_links(api_links, version, templater):
+def format_nested_links(api_links, templater):
     """Format API link metadata as nested dicts for V1 variant of API index"""
     formatted_links = {}
     for link in api_links:

--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -24,7 +24,7 @@ def index(context, request):
         request.route_url, params=["id", "pubid", "user", "userid", "username"]
     )
 
-    return {"links": link_helpers.format_nested_links(api_links, "v1", templater)}
+    return {"links": link_helpers.format_nested_links(api_links, templater)}
 
 
 @api_config(versions=["v2"], route_name="api.index", link_name="index")
@@ -40,4 +40,4 @@ def index_v2(context, request):
         request.route_url, params=["id", "pubid", "user", "userid", "username"]
     )
 
-    return {"links": link_helpers.format_nested_links(api_links, "v2", templater)}
+    return {"links": link_helpers.format_nested_links(api_links, templater)}

--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -25,3 +25,19 @@ def index(context, request):
     )
 
     return {"links": link_helpers.format_nested_links(api_links, "v1", templater)}
+
+
+@api_config(versions=["v2"], route_name="api.index", link_name="index")
+def index_v2(context, request):
+    """Return the API descriptor document.
+
+    Clients may use this to discover endpoints for the API.
+    """
+
+    api_links = request.registry.api_links["v2"]
+
+    templater = AngularRouteTemplater(
+        request.route_url, params=["id", "pubid", "user", "userid", "username"]
+    )
+
+    return {"links": link_helpers.format_nested_links(api_links, "v2", templater)}

--- a/h/views/api/links.py
+++ b/h/views/api/links.py
@@ -7,7 +7,7 @@ from h.views.api.helpers.angular import AngularRouteTemplater
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.links",
     link_name="links",
     renderer="json_sorted",

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -9,7 +9,7 @@ from h.views.api.config import api_config
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.annotation_hide",
     request_method="PUT",
     link_name="annotation.hide",
@@ -28,7 +28,7 @@ def create(context, request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.annotation_hide",
     request_method="DELETE",
     link_name="annotation.unhide",

--- a/h/views/api/profile.py
+++ b/h/views/api/profile.py
@@ -11,7 +11,7 @@ from h.views.api.config import api_config
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.profile",
     request_method="GET",
     link_name="profile.read",
@@ -23,7 +23,7 @@ def profile(request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.profile_groups",
     request_method="GET",
     link_name="profile.groups.read",
@@ -47,7 +47,7 @@ def profile_groups(request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.profile",
     request_method="PATCH",
     permission="update",

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -14,7 +14,7 @@ from h.services.user_unique import DuplicateUserError
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.users",
     request_method="POST",
     link_name="user.create",
@@ -65,7 +65,7 @@ def create(request):
 
 
 @api_config(
-    versions=["v1"],
+    versions=["v1", "v2"],
     route_name="api.user",
     request_method="PATCH",
     link_name="user.update",

--- a/tests/functional/api/test_index.py
+++ b/tests/functional/api/test_index.py
@@ -21,6 +21,17 @@ class TestGetIndex(object):
         assert "links" in res.json
         assert res.status_code == 200
 
+    @pytest.mark.parametrize(
+        "media_type",
+        ["application/vnd.hypothesis.v1+json", "application/vnd.hypothesis.v2+json"],
+    )
+    def test_it_supports_versions(self, app, media_type):
+        headers = {native_str("accept"): native_str(media_type)}
+
+        res = app.get("/api/", headers=headers)
+
+        assert res.headers["Hypothesis-Media-Type"] == native_str(media_type)
+
     def test_it_returns_links_for_resources(self, app):
         res = app.get("/api/")
 
@@ -39,7 +50,7 @@ class TestGetIndex(object):
             ("user", ["create", "update"]),
         ],
     )
-    def test_it_returns_expected_resource_service_links(
+    def test_it_returns_expected_resource_service_links_for_v1(
         self, app, resource, expected_services
     ):
         res = app.get("/api/")
@@ -53,10 +64,54 @@ class TestGetIndex(object):
         "resource,nested_resource,expected_services",
         [("profile", "groups", ["read"]), ("group", "member", ["add", "delete"])],
     )
-    def test_it_returns_expected_nested_resource_service_links(
+    def test_it_returns_expected_nested_resource_service_links_for_v1(
         self, app, resource, nested_resource, expected_services
     ):
         res = app.get("/api/")
+
+        assert nested_resource in res.json["links"][resource]
+
+        for service in expected_services:
+            assert service in res.json["links"][resource][nested_resource]
+            assert "method" in res.json["links"][resource][nested_resource][service]
+            assert "url" in res.json["links"][resource][nested_resource][service]
+
+    @pytest.mark.parametrize(
+        "resource,expected_services",
+        [
+            (
+                "annotation",
+                ["create", "read", "update", "delete", "flag", "hide", "unhide"],
+            ),
+            ("group", ["create", "read", "update", "create_or_update"]),
+            ("profile", ["read", "update"]),
+            ("user", ["create", "update"]),
+        ],
+    )
+    def test_it_returns_expected_resource_service_links_for_v2(
+        self, app, resource, expected_services
+    ):
+        headers = {
+            native_str("accept"): native_str("application/vnd.hypothesis.v2+json")
+        }
+        res = app.get("/api/", headers=headers)
+
+        for service in expected_services:
+            assert service in res.json["links"][resource]
+            assert "method" in res.json["links"][resource][service]
+            assert "url" in res.json["links"][resource][service]
+
+    @pytest.mark.parametrize(
+        "resource,nested_resource,expected_services",
+        [("profile", "groups", ["read"]), ("group", "member", ["add", "delete"])],
+    )
+    def test_it_returns_expected_nested_resource_service_links_for_v2(
+        self, app, resource, nested_resource, expected_services
+    ):
+        headers = {
+            native_str("accept"): native_str("application/vnd.hypothesis.v2+json")
+        }
+        res = app.get("/api/", headers=headers)
 
         assert nested_resource in res.json["links"][resource]
 

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -94,3 +94,28 @@ class TestIndexEndpointVersions(object):
         res = app.get("/api/", headers=headers, expect_errors=True)
 
         assert res.status_code == 415
+
+    def test_index_adds_v1_response_header(self, app):
+        """
+        An Accept header with the value of 'application/json' will be serviced
+        by the default version of the API, which is v1
+        """
+
+        res = app.get("/api/")
+
+        assert (
+            res.headers["Hypothesis-Media-Type"] == "application/vnd.hypothesis.v1+json"
+        )
+
+    def test_index_adds_v2_response_header(self, app):
+        """
+        Set a v2 Accept header and we should get a version media type
+        response header.
+        """
+        headers = {"Accept": str("application/vnd.hypothesis.v2+json")}
+
+        res = app.get("/api/", headers=headers)
+
+        assert (
+            res.headers["Hypothesis-Media-Type"] == "application/vnd.hypothesis.v2+json"
+        )

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -63,6 +63,17 @@ class TestIndexEndpointVersions(object):
         assert res.status_code == 200
         assert "links" in res.json
 
+    def test_index_200s_with_v2_header(self, app):
+        """
+        Set a v2 Accept header and we should get a 200 response.
+        """
+        headers = {"Accept": str("application/vnd.hypothesis.v2+json")}
+
+        res = app.get("/api/", headers=headers)
+
+        assert res.status_code == 200
+        assert "links" in res.json
+
     def test_index_415s_with_invalid_version_header(self, app):
         """
         Set a v3 Accept header and we should get a 415 response.

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -65,10 +65,10 @@ class TestIndexEndpointVersions(object):
 
     def test_index_415s_with_invalid_version_header(self, app):
         """
-        Set a v2 Accept header and we should get a 415 response.
-        (For now because the version doesn't exist quite yet)
+        Set a v3 Accept header and we should get a 415 response.
+        (For now because the version doesn't exist yet)
         """
-        headers = {"Accept": str("application/vnd.hypothesis.v2+json")}
+        headers = {"Accept": str("application/vnd.hypothesis.v3+json")}
 
         res = app.get("/api/", headers=headers, expect_errors=True)
 

--- a/tests/h/views/api/config_test.py
+++ b/tests/h/views/api/config_test.py
@@ -10,12 +10,23 @@ from h.views.api.decorators.response import version_media_type_header
 
 @pytest.mark.usefixtures("cors")
 class TestAddApiView(object):
-    def test_it_sets_accept_setting(self, pyramid_config, view):
+    def test_it_sets_default_accept_if_view_supports_default_version(
+        self, pyramid_config, view
+    ):
         api_config.add_api_view(
             pyramid_config, view, versions=["v1"], route_name="thing.read"
         )
         (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["accept"] == "application/json"
+
+    def test_it_doesnt_set_default_accept_if_view_doesnt_support_default_version(
+        self, pyramid_config, view
+    ):
+        api_config.add_api_view(
+            pyramid_config, view, versions=["v2"], route_name="thing.read"
+        )
+        (_, kwargs) = pyramid_config.add_view.call_args_list[0]
+        assert kwargs["accept"] != "application/json"
 
     def test_it_allows_accept_setting_override(self, pyramid_config, view):
         api_config.add_api_view(

--- a/tests/h/views/api/config_test.py
+++ b/tests/h/views/api/config_test.py
@@ -102,7 +102,7 @@ class TestAddApiView(object):
     def test_it_raises_ValueError_on_unrecognized_version(self, pyramid_config, view):
         with pytest.raises(ValueError, match="Unrecognized API version"):
             api_config.add_api_view(
-                pyramid_config, view, versions=["v2"], route_name="thing.read"
+                pyramid_config, view, versions=["v3"], route_name="thing.read"
             )
 
     @pytest.mark.parametrize(

--- a/tests/h/views/api/decorators/response_test.py
+++ b/tests/h/views/api/decorators/response_test.py
@@ -4,7 +4,7 @@ import mock
 import pytest
 
 from pyramid.response import Response
-
+from webob.acceptparse import MIMENilAccept, MIMEAccept
 
 from h.views.api.decorators.response import version_media_type_header
 
@@ -15,20 +15,49 @@ class TestVersionMediaTypeHeader(object):
 
         assert testview.called
 
-    def test_it_sets_response_header_to_default_media_type(
-        self, pyramid_request, testview, media_type_for_version
+    def test_it_sets_response_header_to_default_media_type_if_accept_not_set(
+        self, pyramid_request, testview
     ):
         res = version_media_type_header(testview)(None, pyramid_request)
         assert (
-            res.headers["Hypothesis-Media-Type"] == media_type_for_version.return_value
+            res.headers["Hypothesis-Media-Type"] == "application/vnd.hypothesis.v1+json"
         )
 
+    @pytest.mark.parametrize(
+        "accept,expected_header",
+        [
+            (
+                "application/vnd.hypothesis.v2+json",
+                "application/vnd.hypothesis.v2+json",
+            ),
+            (
+                "application/vnd.hypothesis.v1+json",
+                "application/vnd.hypothesis.v1+json",
+            ),
+            # application/json will be served by the default version of the API
+            ("application/json", "application/vnd.hypothesis.v1+json"),
+            # ditto for *
+            ("*", "application/vnd.hypothesis.v1+json"),
+        ],
+    )
+    def test_it_sets_response_header_based_on_value_of_accept(
+        self, pyramid_request, testview, accept, expected_header
+    ):
+        pyramid_request.accept = MIMEAccept(accept)
 
-@pytest.fixture
-def media_type_for_version(patch):
-    return patch("h.views.api.decorators.response.media_type_for_version")
+        res = version_media_type_header(testview)(None, pyramid_request)
+
+        assert res.headers["Hypothesis-Media-Type"] == expected_header
 
 
 @pytest.fixture
 def testview():
     return mock.Mock(return_value=Response("OK"))
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    # Set an empty accept on the request, imitating what pyramid does
+    # in real life if no Accept header is set on the incoming request
+    pyramid_request.accept = MIMENilAccept()
+    return pyramid_request

--- a/tests/h/views/api/helpers/media_types_test.py
+++ b/tests/h/views/api/helpers/media_types_test.py
@@ -36,6 +36,7 @@ class TestValidMediaTypes(object):
             "*/*",
             "application/json",
             "application/vnd.hypothesis.v1+json",
+            "application/vnd.hypothesis.v2+json",
         ]
 
 
@@ -48,5 +49,6 @@ class TestVersionMediaTypes(object):
 
     def test_it_returns_all_known_versions_if_versions_is_None(self):
         assert media_types.version_media_types() == [
-            "application/vnd.hypothesis.v1+json"
+            "application/vnd.hypothesis.v1+json",
+            "application/vnd.hypothesis.v2+json",
         ]

--- a/tests/h/views/api/index_test.py
+++ b/tests/h/views/api/index_test.py
@@ -35,25 +35,55 @@ class TestIndex(object):
             AngularRouteTemplater.return_value,
         )
 
-    @pytest.fixture
-    def pyramid_request(self, pyramid_config, pyramid_request):
-        # Scan `h.views.api_annotations` for API link metadata specified in @api_config
-        # declarations.
-        config = Configurator()
-        config.scan("h.views.api.annotations")
-        # Any route referenced in `h.views.api.annotations` needs to be added here
-        pyramid_config.add_route("api.search", "/dummy/search")
-        pyramid_config.add_route("api.annotations", "/dummy/annotations")
-        pyramid_config.add_route("api.annotation", "/dummy/annotations/:id")
-        pyramid_request.registry.api_links = config.registry.api_links
 
-        pyramid_request.route_url = mock.Mock()
-        return pyramid_request
+class TestIndexV2(object):
+    def test_it_returns_links(self, pyramid_request):
+        result = views.index_v2(None, pyramid_request)
 
-    @pytest.fixture
-    def link_helpers(self, patch):
-        return patch("h.views.api.index.link_helpers")
+        assert "links" in result
 
-    @pytest.fixture
-    def AngularRouteTemplater(self, patch):
-        return patch("h.views.api.index.AngularRouteTemplater")
+    def test_it_instantiates_a_templater(self, pyramid_request, AngularRouteTemplater):
+        views.index_v2(None, pyramid_request)
+
+        AngularRouteTemplater.assert_called_once_with(
+            pyramid_request.route_url,
+            params=["id", "pubid", "user", "userid", "username"],
+        )
+
+    def test_it_returns_links_for_the_right_version(
+        self, pyramid_request, AngularRouteTemplater, link_helpers
+    ):
+        views.index_v2(None, pyramid_request)
+
+        link_helpers.format_nested_links.assert_called_once_with(
+            pyramid_request.registry.api_links["v2"],
+            "v2",
+            AngularRouteTemplater.return_value,
+        )
+
+
+@pytest.fixture
+def pyramid_request(pyramid_config, pyramid_request):
+    # Scan `h.views.api_annotations` for API link metadata specified in @api_config
+    # declarations.
+    config = Configurator()
+    config.scan("h.views.api.annotations")
+    config.scan("h.views.api.index")
+    # Any route referenced in `h.views.api.annotations` needs to be added here
+    pyramid_config.add_route("api.search", "/dummy/search")
+    pyramid_config.add_route("api.annotations", "/dummy/annotations")
+    pyramid_config.add_route("api.annotation", "/dummy/annotations/:id")
+    pyramid_request.registry.api_links = config.registry.api_links
+
+    pyramid_request.route_url = mock.Mock()
+    return pyramid_request
+
+
+@pytest.fixture
+def link_helpers(patch):
+    return patch("h.views.api.index.link_helpers")
+
+
+@pytest.fixture
+def AngularRouteTemplater(patch):
+    return patch("h.views.api.index.AngularRouteTemplater")

--- a/tests/h/views/api/index_test.py
+++ b/tests/h/views/api/index_test.py
@@ -30,9 +30,7 @@ class TestIndex(object):
         views.index(None, pyramid_request)
 
         link_helpers.format_nested_links.assert_called_once_with(
-            pyramid_request.registry.api_links["v1"],
-            "v1",
-            AngularRouteTemplater.return_value,
+            pyramid_request.registry.api_links["v1"], AngularRouteTemplater.return_value
         )
 
 
@@ -56,9 +54,7 @@ class TestIndexV2(object):
         views.index_v2(None, pyramid_request)
 
         link_helpers.format_nested_links.assert_called_once_with(
-            pyramid_request.registry.api_links["v2"],
-            "v2",
-            AngularRouteTemplater.return_value,
+            pyramid_request.registry.api_links["v2"], AngularRouteTemplater.return_value
         )
 
 


### PR DESCRIPTION
This PR makes the `h` application aware of "v2" of the API and makes all current endpoints respond to "v2" requests as well as (default) "v1" requests. I had originally thought I'd take care of [documentation first](https://github.com/hypothesis/product-backlog/issues/976) but there's a bit of a chicken-and-egg situation here, so I opted to put in the actual support first.

The diff of this looks large, but it's primarily boilerplate and adding (boilerplate) tests to assure multi-version support. Material things that happen here:

* "v2" is added as a "known version" of the API. Requests that set an `Accept` header to the version 2 media type ("application/vnd.hypothesis.v2+json") are valid.
* The intelligence of the response view decorator for API views has been increased such that it can set the right custom `Hypothesis-Media-Type` response header indicating which version of the API served the request.
* For the `index` endpoint, a new view has been added to support v2. This is merely to illustrate how this would work; both the v1 and v2 views do the same thing other than the v1 view returning v1 service links and the v2 view returning v2 service links (a refactor is in order to DRY these views out a little later, but they're thin so I don't feel terrible with the duplication right now, especially as I'd like to revisit the response for this endpoint for v2).
* For all other API views: they now support both v1 and v2. In other words, at this point, v1 and v2 of our API are effectively identical for the moment.

Documentation is the _very next step_ here, but I wanted to get the thing we're documenting in place first.

Part of https://github.com/hypothesis/product-backlog/issues/940