### PR TITLE
Update to Celery >= 4.3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ alembic
 backports.functools_lru_cache
 bcrypt
 bleach
-celery >= 4.2.1
+celery >= 4.3
 certifi  # Required to connect to Elasticsearch over SSL.
 cffi
 click

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ alembic==0.9.7
 amqp==2.4.1               # via kombu
 backports.functools-lru-cache==1.2.1
 bcrypt==3.1.3
-billiard==3.5.0.3         # via celery
+billiard==3.6.0.0         # via celery
 bleach==3.0.2
-celery==4.2.1
+celery==4.3.0
 certifi==2018.8.24
 cffi==1.11.5
 chameleon==2.24           # via deform
@@ -31,7 +31,7 @@ itsdangerous==0.24
 jinja2==2.10              # via pyramid-jinja2
 jsonpointer==1.0
 jsonschema==2.5.1
-kombu==4.3.0
+kombu==4.5.0
 mako==1.0.4               # via alembic
 markupsafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.8.3
@@ -67,7 +67,7 @@ translationstring==1.3    # via colander, deform, pyramid
 unidecode==0.4.19         # via python-slugify
 urllib3==1.24.1           # via elasticsearch, sentry-sdk
 venusian==1.0
-vine==1.1.4               # via amqp
+vine==1.3.0               # via amqp, celery
 webencodings==0.5.1       # via bleach
 webob==1.6.1              # via pyramid
 ws4py==0.4.2


### PR DESCRIPTION
This brings support for Python 3.7. I think this was the only thing blocking the whole app from working with Python 3.7, but I'd have to re-check.

Aside from the tests I've done some sanity checking locally of functionality that involves dispatching tasks.