### PR TITLE
Mark supervisor as a runtime dependency of h

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN apk add --no-cache --virtual build-deps \
     libffi-dev \
     postgresql-dev \
     python-dev \
-  && pip install --no-cache-dir -U pip supervisor \
+  && pip install --no-cache-dir -U pip \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del build-deps
 

--- a/requirements.in
+++ b/requirements.in
@@ -39,6 +39,7 @@ python-dateutil
 python-slugify < 1.2.0
 sentry-sdk
 statsd
+supervisor >= 4.0.0
 transaction
 venusian
 wsaccel

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ jsonschema==2.5.1
 kombu==4.3.0
 mako==1.0.4               # via alembic
 markupsafe==0.23          # via jinja2, mako, pyramid-jinja2
+meld3==1.0.2              # via supervisor
 mistune==0.8.3
 newrelic==4.10.0.112
 oauthlib==2.0.2
@@ -62,6 +63,7 @@ sentry-sdk==0.6.2
 six==1.10.0               # via bcrypt, bleach, elasticsearch-dsl, python-dateutil
 sqlalchemy==1.1.4
 statsd==3.2.1
+supervisor==4.0.0
 transaction==2.1.2
 translationstring==1.3    # via colander, deform, pyramid
 unidecode==0.4.19         # via python-slugify


### PR DESCRIPTION
Even though this dependency is only used when running h from the Docker
container, adding it to the declarative list of Python dependencies in
requirements.txt allows Dependabot, GitHub security alerts etc. to be
aware of the dependency. It also means that we can ensure the version
used when building the Docker container does not unexpectedly change if
a new version is released.

As part of this, set the minimum requirement to the recently released v4.0.0
which brings support for Python 3.