### PR TITLE
WIP - Use Python 3 in h Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY package.json ./
 RUN npm ci --production
 
 # Build h js/css.
-COPY gulpfile.js ./ 
+COPY gulpfile.js ./
 COPY scripts/gulp ./scripts/gulp
 COPY h/static ./h/static
 RUN npm run build
@@ -27,8 +27,7 @@ RUN apk add --no-cache \
     libffi \
     libpq \
     nginx \
-    python2 \
-    py2-pip \
+    python3 \
     git
 
 # Create the hypothesis user, group, home directory and package directory.
@@ -54,9 +53,10 @@ RUN apk add --no-cache --virtual build-deps \
     build-base \
     libffi-dev \
     postgresql-dev \
-    python-dev \
-  && pip install --no-cache-dir -U pip \
-  && pip install --no-cache-dir -r requirements.txt \
+    python3-dev \
+  && python3 -m ensurepip \
+  && pip3 install --no-cache-dir -U pip \
+  && pip3 install --no-cache-dir -r requirements.txt \
   && apk del build-deps
 
 # Copy frontend assets.
@@ -75,6 +75,7 @@ EXPOSE 5000
 ENV PATH /var/lib/hypothesis/bin:$PATH
 ENV PYTHONIOENCODING utf_8
 ENV PYTHONPATH /var/lib/hypothesis:$PYTHONPATH
+RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 # Start the web server by default
 USER hypothesis

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,8 @@ node {
                 sh 'pip3 install -q tox>=3.8.0'
 
                 // Unit tests
-                sh 'cd /var/lib/hypothesis && tox'
+                sh 'cd /var/lib/hypothesis && tox -e py27-tests'
+                sh 'cd /var/lib/hypothesis && tox -e py36-tests'
                 // Functional tests
                 sh 'cd /var/lib/hypothesis && tox -e py27-functests'
                 sh 'cd /var/lib/hypothesis && tox -e py36-functests'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,9 +30,9 @@ node {
                                          "-e SITE_PACKAGES=true"
                                          ) {
                 // Test dependencies
-                sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev'
-                sh 'apk add --no-cache python3 python3-dev'
-                sh 'pip install -q tox>=3.8.0'
+                sh 'apk add --no-cache build-base libffi-dev postgresql-dev python3-dev'
+                sh 'apk add --no-cache python-dev' // while we continue to run tests under Python 2.7
+                sh 'pip3 install -q tox>=3.8.0'
 
                 // Unit tests
                 sh 'cd /var/lib/hypothesis && tox'


### PR DESCRIPTION
Run h and its dependencies using Python 3.

Following the update to supervisor, I've updated this branch so that the only changes are to switch the Python version.

I'm opening this PR now primarily to check what is needed to make the tests pass under Jenkins.