### PR TITLE
Convert signup controller to reusable disable-on-submit controller

### DIFF
--- a/h/static/scripts/controllers/disable-on-submit-controller.js
+++ b/h/static/scripts/controllers/disable-on-submit-controller.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const Controller = require('../base/controller');
+
+/**
+ * For this form, disable all submit elements (inputs or buttons) after
+ * the form has been submitted—helps prevent duplicate submission of form data.
+ * Note that this will only work on buttons or inputs with `type="submit"`
+ */
+class DisableOnSubmit extends Controller {
+  constructor(element) {
+    super(element);
+
+    const submitEls = element.querySelectorAll('[type="submit"]');
+
+    element.addEventListener('submit', () => {
+      for (let i = 0; i < submitEls.length; i++) {
+        submitEls[i].disabled = true;
+      }
+    });
+  }
+}
+
+module.exports = DisableOnSubmit;

--- a/h/static/scripts/controllers/index.js
+++ b/h/static/scripts/controllers/index.js
@@ -14,6 +14,7 @@
 const CharacterLimitController = require('./character-limit-controller');
 const CopyButtonController = require('./copy-button-controller');
 const ConfirmSubmitController = require('./confirm-submit-controller');
+const DisableOnSubmitController = require('./disable-on-submit-controller');
 const DropdownMenuController = require('./dropdown-menu-controller');
 const FormController = require('./form-controller');
 const FormCancelController = require('./form-cancel-controller');
@@ -27,6 +28,7 @@ module.exports = {
   '.js-character-limit': CharacterLimitController,
   '.js-copy-button': CopyButtonController,
   '.js-confirm-submit': ConfirmSubmitController,
+  '.js-disable-on-submit': DisableOnSubmitController,
   '.js-dropdown-menu': DropdownMenuController,
   '.js-form': FormController,
   '.js-form-cancel': FormCancelController,

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -18,16 +18,17 @@ const CreateGroupFormController = require('./controllers/create-group-form-contr
 const SearchBarController = require('./controllers/search-bar-controller');
 const SearchBucketController = require('./controllers/search-bucket-controller');
 const ShareWidgetController = require('./controllers/share-widget-controller');
-const SignupFormController = require('./controllers/signup-form-controller');
 
-const controllers = Object.assign({
-  '.js-authorize-form': AuthorizeFormController,
-  '.js-create-group-form': CreateGroupFormController,
-  '.js-search-bar': SearchBarController,
-  '.js-search-bucket': SearchBucketController,
-  '.js-share-widget': ShareWidgetController,
-  '.js-signup-form': SignupFormController,
-}, sharedControllers);
+const controllers = Object.assign(
+  {
+    '.js-authorize-form': AuthorizeFormController,
+    '.js-create-group-form': CreateGroupFormController,
+    '.js-search-bar': SearchBarController,
+    '.js-search-bucket': SearchBucketController,
+    '.js-share-widget': ShareWidgetController,
+  },
+  sharedControllers
+);
 
 if (window.envFlags && window.envFlags.get('js-capable')) {
   upgradeElements(document.body, controllers);

--- a/h/static/scripts/tests/controllers/signup-form-controller-test.js
+++ b/h/static/scripts/tests/controllers/signup-form-controller-test.js
@@ -1,14 +1,14 @@
 'use strict';
 
-const SignupFormController = require('../../controllers/signup-form-controller');
+const DisableOnSubmitController = require('../../controllers/disable-on-submit-controller');
 
 const TEMPLATE = `
-  <form class="js-signup-form">
-    <input type="submit" class="js-signup-btn">
+  <form class="js-any-form js-disable-on-submit">
+    <input type="submit" class="any-submit">
   </form>
   `;
 
-describe('SignupFormController', () => {
+describe('DisableOnSubmitController', () => {
   let element;
   let form;
   let submitBtn;
@@ -16,12 +16,12 @@ describe('SignupFormController', () => {
   beforeEach(() => {
     element = document.createElement('div');
     element.innerHTML = TEMPLATE;
-    form = element.querySelector('.js-signup-form');
-    submitBtn = element.querySelector('.js-signup-btn');
+    form = element.querySelector('.js-disable-on-submit');
+    submitBtn = element.querySelector('.any-submit');
   });
 
   it('disables the submit button on form submit', () => {
-    new SignupFormController(form);
+    new DisableOnSubmitController(form);
     assert.isFalse(submitBtn.disabled);
     form.dispatchEvent(new Event('submit'));
     assert.isTrue(submitBtn.disabled);

--- a/h/templates/accounts/developer.html.jinja2
+++ b/h/templates/accounts/developer.html.jinja2
@@ -19,7 +19,7 @@
       </p>
     {% endif %}
 
-      <form method="POST">
+      <form method="post" class="js-disable-on-submit">
         {% if token %}
           <button type="submit" class="btn"
                   title="{% trans %}Delete your API token and generate a new one{% endtrans%}">

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -26,8 +26,8 @@ class SignupController(object):
         self.schema = schemas.RegisterSchema().bind(request=self.request)
         self.form = request.create_form(
             self.schema,
-            buttons=(deform.Button(title=_("Sign up"), css_class="js-signup-btn"),),
-            css_class="js-signup-form",
+            buttons=(deform.Button(title=_("Sign up")),),
+            css_class="js-disable-on-submit",
         )
 
     @view_config(request_method="GET")


### PR DESCRIPTION
To provide protection around a double-submit/race condition issue on signup, there was a JS controller for the signup form that disabled the submit button after the form was submitted, to prevent multiple submissions.

This PR makes that controller generic and reusable on any form. A form with the `.js-disable-on-submit` class will disable _any_ `[type="submit"]` descendent elements (i.e. a submit input _or_ a button with type `submit`) once the form has been submitted.

This protection has additionally been added to the developer token page (for create/regenerate) to prevent dual-submit there.

This may be a little broad-stroke (the disabling all submit buttons bit) for all uses, but I think it may suffice for now?

Fixes https://github.com/hypothesis/h/issues/5552