### PR TITLE
Change mocking in frontend tests to use mockable-imports Babel plugin

### DIFF
--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -43,9 +43,11 @@ module.exports = function(config) {
 
     browserify: {
       debug: true,
-      configure: function (bundle) {
-        bundle.plugin('proxyquire-universal');
-      },
+      transform: [
+        ['babelify', {
+          plugins: ['mockable-imports'],
+        }],
+      ],
     },
 
     mochaReporter: {

--- a/h/static/scripts/tests/base/raven-test.js
+++ b/h/static/scripts/tests/base/raven-test.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
-const noCallThru = require('../util').noCallThru;
+const raven = require('../../base/raven');
 
 describe('raven', () => {
   let fakeRavenJS;
-  let raven;
 
   beforeEach(() => {
     fakeRavenJS = {
@@ -17,9 +15,13 @@ describe('raven', () => {
       setUserContext: sinon.stub(),
     };
 
-    raven = proxyquire('../../base/raven', noCallThru({
+    raven.$imports.$mock({
       'raven-js': fakeRavenJS,
-    }));
+    });
+  });
+
+  afterEach(() => {
+    raven.$imports.$restore();
   });
 
   describe('.init()', () => {

--- a/h/static/scripts/tests/controllers/form-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-controller-test.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
-
 const { hyphenate } = require('../../util/string');
-const { noCallThru } = require('../util');
 const upgradeElements = require('../../base/upgrade-elements');
+const FormController = require('../../controllers/form-controller');
 
 /**
  * Converts a map of data attribute names to string values into a string
@@ -72,8 +70,8 @@ describe('FormController', () => {
 
   function initForm(template) {
     fakeSubmitForm = sinon.stub();
-    const FormController = proxyquire('../../controllers/form-controller', {
-      '../util/submit-form': noCallThru(fakeSubmitForm),
+    FormController.$imports.$mock({
+      '../util/submit-form': fakeSubmitForm,
     });
 
     const container = document.createElement('div');
@@ -107,6 +105,7 @@ describe('FormController', () => {
   afterEach(() => {
     ctrl.beforeRemove();
     ctrl.element.remove();
+    FormController.$imports.$restore();
   });
 
   function isEditing() {

--- a/h/static/scripts/tests/util.js
+++ b/h/static/scripts/tests/util.js
@@ -1,28 +1,6 @@
 'use strict';
 
 /**
- * Utility function for use with 'proxyquire' that prevents calls to
- * stubs 'calling through' to the _original_ dependency if a particular
- * function or property is not set on a stub, which is proxyquire's default
- * but usually undesired behavior.
- *
- * See https://github.com/thlorenz/proxyquireify#nocallthru
- *
- * Usage:
- *   var moduleUnderTest = proxyquire('./module-under-test', noCallThru({
- *     './dependency-foo': fakeFoo,
- *   }));
- *
- * @param {Object} stubs - A map of dependency paths to stubs, or a single
- *   stub.
- */
-function noCallThru(stubs) {
-  // This function is trivial but serves as documentation for why
-  // '@noCallThru' is used.
-  return Object.assign(stubs, {'@noCallThru':true});
-}
-
-/**
  * Helper for writing parameterized tests.
  *
  * This is a wrapper around the `it()` function for creating a Mocha test case
@@ -77,6 +55,5 @@ function unroll(description, testFn, fixtures) {
 }
 
 module.exports = {
-  noCallThru: noCallThru,
   unroll: unroll,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3440,16 +3440,6 @@
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
       "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U="
     },
-    "fill-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-      "dev": true,
-      "requires": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
-      }
-    },
     "fill-range": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
@@ -5407,12 +5397,6 @@
         "kind-of": "^3.0.2"
       }
     },
-    "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-      "dev": true
-    },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -7186,12 +7170,6 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
-    },
     "merge-stream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
@@ -7421,12 +7399,6 @@
           }
         }
       }
-    },
-    "module-not-found-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
-      "dev": true
     },
     "mold-source-map": {
       "version": "0.4.0",
@@ -8096,12 +8068,6 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
-    "pff": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pff/-/pff-1.0.0.tgz",
-      "integrity": "sha1-6l8J7mVxyuKSp4/CgJBaOGVmjng=",
-      "dev": true
-    },
     "phantomjs-prebuilt": {
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
@@ -8364,113 +8330,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
-    },
-    "proxyquire": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.7.11.tgz",
-      "integrity": "sha1-E7SU6x5x+yHMPr42meY3077Br54=",
-      "dev": true,
-      "requires": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.0",
-        "resolve": "~1.1.7"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        }
-      }
-    },
-    "proxyquire-universal": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/proxyquire-universal/-/proxyquire-universal-1.0.8.tgz",
-      "integrity": "sha1-LQiENl92uvjakQsb5sf5yULYZAo=",
-      "dev": true,
-      "requires": {
-        "replace-requires": "~1.0.1",
-        "through2": "~0.6.3",
-        "transformify": "^0.1.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        }
-      }
-    },
-    "proxyquireify": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/proxyquireify/-/proxyquireify-3.2.1.tgz",
-      "integrity": "sha1-Fb7hATYKzJHc2G7k2aRF+Klx7qA=",
-      "dev": true,
-      "requires": {
-        "browser-pack": "^6.0.0",
-        "detective": "~4.1.0",
-        "fill-keys": "^1.0.0",
-        "has-require": "^1.1.0",
-        "module-not-found-error": "~1.0.1",
-        "require-deps": "~1.0.1",
-        "through": "~2.2.7",
-        "xtend": "^3.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-          "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
-          "dev": true
-        },
-        "detective": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
-          "integrity": "sha1-nEusHp+4uzT38YyuCA6h0Dr/LNo=",
-          "dev": true,
-          "requires": {
-            "acorn": "^1.0.3",
-            "defined": "^1.0.0",
-            "escodegen": "^1.4.1"
-          }
-        },
-        "through": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
-          "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
-          "dev": true
-        }
-      }
     },
     "public-encrypt": {
       "version": "4.0.2",
@@ -9115,15 +8974,6 @@
       "dev": true,
       "requires": {
         "throttleit": "^1.0.0"
-      }
-    },
-    "require-deps": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-deps/-/require-deps-1.0.1.tgz",
-      "integrity": "sha1-JBXPScNb02pdMXc5UQjT8jcgUmM=",
-      "dev": true,
-      "requires": {
-        "pff": "~1.0.0"
       }
     },
     "require-directory": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -769,6 +769,12 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-mockable-imports": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-mockable-imports/-/babel-plugin-mockable-imports-1.3.1.tgz",
+      "integrity": "sha512-wL8G7tHx6HRFrKwTznbKN21CTDcwwF/yM+QrSqpicAydyoU6XpFACEr5dC/WXaAqkvmRJ9HU6ZYbxBqId/hfZA==",
+      "dev": true
+    },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
@@ -3683,7 +3689,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3701,11 +3708,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3718,15 +3727,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3829,7 +3841,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3839,6 +3852,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3851,17 +3865,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3878,6 +3895,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3956,7 +3974,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3966,6 +3985,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4041,7 +4061,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4071,6 +4092,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4088,6 +4110,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4126,11 +4149,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -65,9 +65,6 @@
     "karma-phantomjs-launcher": "^1.0.1",
     "karma-sinon": "^1.0.5",
     "mocha": "^5.2.0",
-    "proxyquire": "^1.7.4",
-    "proxyquire-universal": "^1.0.8",
-    "proxyquireify": "^3.2.1",
     "sinon": "^1.17.3",
     "syn": "^0.2.2",
     "websocket": "^1.0.22"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "whatwg-fetch": "^0.10.1"
   },
   "devDependencies": {
+    "babel-plugin-mockable-imports": "^1.3.1",
     "chai": "^3.5.0",
     "check-dependencies": "^0.12.0",
     "diff": "^2.2.2",


### PR DESCRIPTION
This PR changes the way mocking works in the frontend tests to match [a recent change](https://github.com/hypothesis/client/pull/1061) in the client. The change in h is fairly small because proxyquire was not used that extensively.