### PR TITLE
Add document Service

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -36,6 +36,9 @@ def includeme(config):
     config.register_service_factory(
         ".developer_token.developer_token_service_factory", name="developer_token"
     )
+    config.register_service_factory(
+        ".document.document_service_factory", name="document"
+    )
     config.register_service_factory(".feature.feature_service_factory", name="feature")
     config.register_service_factory(".flag.flag_service_factory", name="flag")
     config.register_service_factory(

--- a/h/services/document.py
+++ b/h/services/document.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+
+from h.models import Document, Annotation
+
+MAX_DOCUMENT_COUNT = 100
+
+
+class DocumentService(object):
+    def __init__(self, session):
+        self._session = session
+
+    def fetch_by_groupid(self, groupid, userid=None):
+        """
+        Return documents that have been annotated within a given group.
+
+        Return a list of documents that have at least one annotation visible to
+        the user within the group indicated. Results are ordered by last document
+        activity, descending (document records are updated any time an annotation
+        referencing them is added or updated).
+
+        Right now a simple limit is imposed for performance and usability reasons.
+
+        Note: It is the responsibility of the caller to first verify that the user
+        (or anonymous) has read authorization for the group indicated.
+        While this method filters out individual annotations that are private
+        or not owned by the user, it does not protect access to annotations
+        within the group itself.
+        """
+
+        is_shared = Annotation.shared.is_(True)
+        is_visible_to_user = (
+            is_shared if not userid else sa.or_(Annotation.userid == userid, is_shared)
+        )
+
+        return (
+            self._session.query(Document)
+            .join(Annotation)
+            .filter(Annotation.groupid == groupid)
+            .filter(is_visible_to_user)
+            .order_by(Document.updated.desc())
+            .limit(MAX_DOCUMENT_COUNT)
+            .all()
+        )
+
+
+def document_service_factory(context, request):
+    return DocumentService(request.db)

--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -17,7 +17,7 @@ class Group(ModelFactory):
         model = models.Group
         sqlalchemy_session_persistence = "flush"
 
-    name = factory.Sequence(lambda n: "Test Group {n}".format(n=str(n)))
+    name = factory.Sequence(lambda n: "Group {n}".format(n=str(n)))
     authority = "example.com"
     creator = factory.SubFactory(User)
     joinable_by = JoinableBy.authority
@@ -36,7 +36,7 @@ class Group(ModelFactory):
 
 class OpenGroup(Group):
 
-    name = factory.Sequence(lambda n: "Test Open Group {n}".format(n=str(n)))
+    name = factory.Sequence(lambda n: "Open Group {n}".format(n=str(n)))
 
     joinable_by = None
     readable_by = ReadableBy.world
@@ -45,7 +45,7 @@ class OpenGroup(Group):
 
 
 class RestrictedGroup(Group):
-    name = factory.Sequence(lambda n: "Test Restricted Group {n}".format(n=str(n)))
+    name = factory.Sequence(lambda n: "Restricted Group {n}".format(n=str(n)))
 
     joinable_by = None
     readable_by = ReadableBy.world

--- a/tests/h/services/document_test.py
+++ b/tests/h/services/document_test.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.services.document import DocumentService
+
+
+class TestFetchByGroupid(object):
+    def test_it_returns_documents_annotated_within_group(
+        self, svc, groups, annotations, matchers
+    ):
+        docs = svc.fetch_by_groupid(groupid=groups["target_group"].pubid)
+
+        assert docs == matchers.UnorderedList([anno.document for anno in annotations])
+
+    def test_it_does_not_return_documents_annotated_in_other_groups(
+        self, groups, annotations, other_annotations, svc, matchers
+    ):
+        docs = svc.fetch_by_groupid(groupid=groups["target_group"].pubid)
+        for other_anno in other_annotations:
+            assert other_anno.document not in docs
+
+    def test_it_returns_each_document_only_once(
+        self, svc, groups, annotations, db_session
+    ):
+        # This will make both annotations point to the same document
+        annotations[1].document = annotations[0].document
+        annotations[2].document = annotations[0].document
+        docs = svc.fetch_by_groupid(groupid=groups["target_group"].pubid)
+
+        # But only one instance of the document is returned
+        assert docs == [annotations[0].document]
+
+    def test_it_returns_only_documents_with_shared_annotations_when_no_user(
+        self, annotations, groups, svc, db_session
+    ):
+        annotations[1].shared = False
+        annotations[2].shared = False
+
+        docs = svc.fetch_by_groupid(groupid=groups["target_group"].pubid)
+
+        assert docs == [annotations[0].document]
+
+    def test_it_returns_only_documents_with_visible_annotations_for_user(
+        self, svc, annotations, groups, target_user, other_user, db_session, matchers
+    ):
+        # This makes an "only me" annotation, associated with our target user
+        annotations[1].shared = False
+        annotations[1].userid = target_user.userid
+
+        # This makes an "only me" annotation, associated with a different user
+        annotations[2].shared = False
+        annotations[2].userid = other_user.userid
+
+        docs = svc.fetch_by_groupid(
+            groupid=groups["target_group"].pubid, userid=target_user.userid
+        )
+
+        # The "only me" annotation for THIS user should be returned, but not the
+        # "only me" annotation associated with another user
+        assert docs == matchers.UnorderedList(
+            [annotations[0].document, annotations[1].document]
+        )
+
+    def test_it_returns_documents_ordered_by_last_activity_desc(
+        self, svc, annotations, groups, factories, db_session, matchers
+    ):
+        # Update the document associated with ``annotations[1]``...
+        annotations[1].document.title = "Bleep bloop"
+
+        # this will create the newest/latest document in the DB
+        new_annotation = factories.Annotation(
+            groupid=groups["target_group"].pubid, shared=True
+        )
+
+        docs = svc.fetch_by_groupid(groupid=groups["target_group"].pubid)
+
+        # ``new_annotation`` has the most recently-updated document, followed by
+        # the updated ``annotations[1]``, then the other two annotation's
+        # documents in reverse created (i.e. updated) order
+        assert docs == [
+            new_annotation.document,
+            annotations[1].document,
+            annotations[2].document,
+            annotations[0].document,
+        ]
+
+
+@pytest.fixture
+def target_user(factories):
+    return factories.User()
+
+
+@pytest.fixture
+def other_user(factories):
+    return factories.User()
+
+
+@pytest.fixture
+def groups(factories):
+    return {"target_group": factories.Group(), "other_group": factories.Group()}
+
+
+@pytest.fixture
+def annotations(factories, groups):
+    return [
+        factories.Annotation(groupid=groups["target_group"].pubid, shared=True),
+        factories.Annotation(groupid=groups["target_group"].pubid, shared=True),
+        factories.Annotation(groupid=groups["target_group"].pubid, shared=True),
+    ]
+
+
+@pytest.fixture
+def other_annotations(factories, groups):
+    return [
+        factories.Annotation(groupid=groups["other_group"].pubid, shared=True),
+        factories.Annotation(groupid=groups["other_group"].pubid, shared=True),
+        factories.Annotation(groupid=groups["other_group"].pubid, shared=True),
+    ]
+
+
+@pytest.fixture
+def svc(db_session):
+    return DocumentService(session=db_session)


### PR DESCRIPTION
This PR adds a new, simple `document` service. Specifically, it provides a method on that service to retrieve documents that have been annotated within a specified group. It's purposely overtly simple at this point.

This service will be used to provide a nested API endpoint under groups (e.g. `GET /groups/{pubid}/documents`) as needed for LMS/activity views.

Part of https://github.com/orgs/hypothesis/projects/23#card-20354124

There is an additional commit in this PR that makes a fix to the naming of Restricted Groups created with the Group test factory. The previous name string would exceed maximum group name length (25 chars) constraints if more than 999 groups are created during a test run. As of this feature, we are creating more than 999 groups during a test run so this change is necessary to make (unrelated) tests not fail.