### PR TITLE
Simplify scripts/gulp/create-style-bundle.js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,5 +6,8 @@
     "prefer-arrow-callback": "error",
     "prefer-const": ["error", { "destructuring": "all" }],
     "space-before-blocks": "error"
+  },
+  "parserOptions": {
+    "ecmaVersion": 2017
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -152,13 +152,12 @@ var styleBundleEntryFiles = [
   './h/static/styles/site.scss',
 ];
 
-function buildStyleBundle(entryFile, options) {
+function buildStyleBundle(entryFile) {
   return createStyleBundle({
     input: entryFile,
     output: './build/styles/' + path.basename(entryFile, '.scss') + '.css',
     minify: IS_PRODUCTION_BUILD,
     urlRewriter: rewriteCSSURL,
-    watch: options.watch,
   });
 }
 


### PR DESCRIPTION
This PR came out of working on https://github.com/hypothesis/lms/pull/590.

With a newer version of Node and use of Dart Sass instead of Node Sass
the implementation can be simplified somewhat.

 - Remove unnecessary use of promises. Synchronous rendering via
   `renderSync` is recommended when using Dart Sass

 - Remove unused options

 - Remove unnecessary error handling. Dart Sass prints the error
   location automatically