### PR TITLE
Add `make services`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ default: help
 .PHONY: help
 help:
 	@echo "make help              Show this help message"
+	@echo 'make services          Run the services that `make dev` requires'
+	@echo "                       (Postgres, Elasticsearch, etc) in Docker Compose"
 	@echo "make dev               Run the app in the development server"
 	@echo "make shell             Launch a Python shell in the dev environment"
 	@echo "make sql               Connect to the dev database with a psql shell"
@@ -28,6 +30,10 @@ help:
 	@echo "                       docker-compose in the 'h_default' network."
 	@echo "make clean             Delete development artefacts (cached files, "
 	@echo "                       dependencies, etc)"
+
+.PHONY: services
+services:
+	docker-compose up -d
 
 .PHONY: dev
 dev: build/manifest.json


### PR DESCRIPTION
This means you can now run `make services` instead of running
`docker-compose up -d`. This has a few advantages:

* Having everything available via `make` is consistent

* `make dev` can automatically run `make services` as well.

  So you could just run `make dev` and it'll start the services (if
  they aren't started already) and then start the dev server.

  `make shell`, `make sql`, `make tests` and `make functests` could also
  automatically start the services if they aren't started already.

  **This isn't implemented yet** because it'd require a little more
  work, but it could be added.

* `make help` can now tell you about running the services as well, and
  reading the `Makefile` can tell you that the dev server requires
  services and how to run those in `docker-compose`

* As with `make dev`, `make tests`, `make lint`, etc `make services` can
  become a consistent command across our apps even though the actual
  command needed to run the services differs.

  LMS's Postgres DB just runs in Docker directly, doesn't use Docker
  Compose, for example.

  Bouncer and Via don't have services at all so they can either not have
  a `make services` or, just to enable the same command to work across
  repos, they can have a `make services` that does nothing.

* `make services` can potentially run more than one command, if in
  future h requires other services that don't run in Docker Compose.

* If we move away from Docker Compose in future the `make services`
  command won't change.

Of course, you can still run `docker-compose` manually if you want.
Like everything else in our `Makefile`, `make services` is just an
alias. For example you'd run `docker-compose` directly to see the
service logs, to restart the services, etc.
