### PR TITLE
Fix line heights of headings in annotation bodies

### DIFF
--- a/h/static/styles/core/_typography.scss
+++ b/h/static/styles/core/_typography.scss
@@ -41,6 +41,9 @@ $touch-input-font-size: 16px;
 }
 
 @mixin styled-text() {
+  // Reset the line-height in case any parent elements have set it.
+  line-height: normal;
+
   h1, h2, h3, h4, h5, h6, p, ol, ul, img, pre, blockquote {
     margin: .618em 0;
   }


### PR DESCRIPTION
Apply the same fix that was applied to the client in
https://github.com/hypothesis/client/pull/1113

In addition to annotation cards, this mixin is also used on the /docs/help page. That still looks fine with the change.

Fixes #4790
