### PR TITLE
Remove @pytest.mark.fuzz and @pytest.mark.functional

### DIFF
--- a/tests/functional/api/groups/test_create.py
+++ b/tests/functional/api/groups/test_create.py
@@ -11,7 +11,6 @@ from h.models.auth_client import GrantType
 native_str = str
 
 
-@pytest.mark.functional
 class TestCreateGroup(object):
     def test_it_returns_http_200_with_valid_payload(self, app, token_auth_header):
         group = {"name": "My Group"}

--- a/tests/functional/api/groups/test_members.py
+++ b/tests/functional/api/groups/test_members.py
@@ -11,7 +11,6 @@ from h.models.auth_client import GrantType
 native_str = str
 
 
-@pytest.mark.functional
 class TestAddMember(object):
     def test_it_returns_http_204_when_successful(
         self, app, third_party_user, third_party_group, auth_client_header
@@ -146,7 +145,6 @@ class TestAddMember(object):
         assert res.status_code == 404
 
 
-@pytest.mark.functional
 class TestRemoveMember(object):
     def test_it_removes_authed_user_from_group(
         self, app, group, group_member_with_token

--- a/tests/functional/api/groups/test_read.py
+++ b/tests/functional/api/groups/test_read.py
@@ -11,7 +11,6 @@ from h.models.auth_client import GrantType
 native_str = str
 
 
-@pytest.mark.functional
 class TestReadGroups(object):
     # TODO: In subsequent versions of the API, this should really be a group
     # search endpoint and should have its own functional test module
@@ -59,7 +58,6 @@ class TestReadGroups(object):
         assert "scopes" in res.json[0]
 
 
-@pytest.mark.functional
 class TestReadGroup(object):
     def test_it_returns_http_200_for_world_readable_group_pubid(
         self, app, factories, db_session

--- a/tests/functional/api/groups/test_update.py
+++ b/tests/functional/api/groups/test_update.py
@@ -10,7 +10,6 @@ from h.models.auth_client import GrantType
 native_str = str
 
 
-@pytest.mark.functional
 class TestUpdateGroup(object):
     def test_it_returns_http_200_with_valid_payload_and_user_token(
         self, app, token_auth_header, first_party_group

--- a/tests/functional/api/groups/test_upsert.py
+++ b/tests/functional/api/groups/test_upsert.py
@@ -10,7 +10,6 @@ from h.models.auth_client import GrantType
 native_str = str
 
 
-@pytest.mark.functional
 class TestUpsertGroupUpdate(object):
     def test_it_returns_http_404_if_no_authenticated_user(self, app, first_party_group):
         group = {"name": "My Group"}
@@ -210,7 +209,6 @@ class TestUpsertGroupUpdate(object):
         assert res.status_code == 409
 
 
-@pytest.mark.functional
 class TestUpsertGroupCreate(object):
     def test_it_allows_auth_client_with_forwarded_user(
         self, app, auth_client_header, third_party_user

--- a/tests/functional/api/test_annotations.py
+++ b/tests/functional/api/test_annotations.py
@@ -13,7 +13,6 @@ import pytest
 native_str = str
 
 
-@pytest.mark.functional
 class TestGetAnnotation(object):
     def test_it_returns_annotation_if_shared(self, app, annotation):
         """Unauthenticated users may view shared annotations assuming they have group access"""
@@ -50,7 +49,6 @@ class TestGetAnnotation(object):
         assert res.status_code == 404
 
 
-@pytest.mark.functional
 class TestGetAnnotationJSONLD(object):
     def test_it_returns_annotation_if_shared(self, app, annotation):
         """Unauthenticated users may view shared annotations assuming they have group access"""
@@ -159,7 +157,6 @@ class TestPostAnnotation(object):
         assert res.status_code == 200
 
 
-@pytest.mark.functional
 class TestPatchAnnotation(object):
     def test_it_updates_annotation_if_authorized(
         self, app, user_annotation, user_with_token
@@ -211,7 +208,6 @@ class TestPatchAnnotation(object):
         assert res.status_code == 404
 
 
-@pytest.mark.functional
 class TestDeleteAnnotation(object):
     def test_it_deletes_annotation_if_authorized(
         self, app, user_annotation, user_with_token

--- a/tests/functional/api/test_errors.py
+++ b/tests/functional/api/test_errors.py
@@ -17,7 +17,6 @@ from h.models.auth_client import GrantType
 native_str = str
 
 
-@pytest.mark.functional
 class Test400Errors(object):
     """Creating a group can raise all of the client errors we want to test"""
 
@@ -44,7 +43,6 @@ class Test400Errors(object):
         assert stripped == expected
 
 
-@pytest.mark.functional
 class Test404Errors(object):
     # TODO: Some of these 404s should really be 403s
     def test_it_404s_if_authz_fail_with_valid_accept(self, app, append_auth_client):
@@ -94,7 +92,6 @@ class Test404Errors(object):
         )
 
 
-@pytest.mark.functional
 class Test409Errors(object):
     def test_it_409s_on_create_group_if_groupid_is_duplicate(
         self, app, append_auth_client, third_party_user
@@ -113,7 +110,6 @@ class Test409Errors(object):
         )
 
 
-@pytest.mark.functional
 class Test415Errors(object):
     def test_it_415s_if_not_found_with_bad_accept(self, app):
         headers = {}

--- a/tests/functional/api/test_flags.py
+++ b/tests/functional/api/test_flags.py
@@ -13,7 +13,6 @@ import pytest
 native_str = str
 
 
-@pytest.mark.functional
 class TestPutFlag(object):
     def test_it_returns_http_204_if_user_allowed_to_flag_shared_annotation(
         self, app, annotation, user_with_token

--- a/tests/functional/api/test_index.py
+++ b/tests/functional/api/test_index.py
@@ -13,7 +13,6 @@ import pytest
 native_str = str
 
 
-@pytest.mark.functional
 class TestGetIndex(object):
     def test_it_returns_links(self, app):
         res = app.get("/api/")

--- a/tests/functional/api/test_moderation.py
+++ b/tests/functional/api/test_moderation.py
@@ -13,7 +13,6 @@ import pytest
 native_str = str
 
 
-@pytest.mark.functional
 class TestPutHide(object):
     def test_it_returns_http_204_for_group_creator(
         self, app, group_annotation, user_with_token
@@ -67,7 +66,6 @@ class TestPutHide(object):
         assert res.status_code == 404
 
 
-@pytest.mark.functional
 class TestDeleteHide(object):
     def test_it_returns_http_204_for_group_creator(
         self, app, group_annotation, user_with_token

--- a/tests/functional/api/test_profile.py
+++ b/tests/functional/api/test_profile.py
@@ -13,7 +13,6 @@ import pytest
 native_str = str
 
 
-@pytest.mark.functional
 class TestGetProfile(object):
     def test_it_returns_profile_with_single_group_when_not_authd(self, app):
         """
@@ -58,7 +57,6 @@ class TestGetProfile(object):
         assert group_ids == []
 
 
-@pytest.mark.functional
 class TestGetProfileGroups(object):
     def test_it_returns_empty_list_when_not_authed(self, app):
         res = app.get("/api/profile/groups")
@@ -88,7 +86,6 @@ class TestGetProfileGroups(object):
             assert property in res.json[0]
 
 
-@pytest.mark.functional
 class TestPatchProfile(object):
     def test_it_allows_authenticated_user(self, app, user_with_token):
         """PATCH profile will always act on the auth'd user's profile."""

--- a/tests/functional/api/test_users.py
+++ b/tests/functional/api/test_users.py
@@ -17,7 +17,6 @@ from h.models.auth_client import GrantType
 native_str = str
 
 
-@pytest.mark.functional
 class TestCreateUser(object):
     def test_it_returns_http_200_when_successful(
         self, app, auth_client_header, user_payload
@@ -86,7 +85,6 @@ class TestCreateUser(object):
         assert res.status_code == 409
 
 
-@pytest.mark.functional
 class TestUpdateUser(object):
     def test_it_returns_http_200_when_successful(
         self, app, auth_client_header, user, patch_user_payload

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -16,7 +16,6 @@ import pytest
 native_str = str
 
 
-@pytest.mark.functional
 class TestIndexEndpointVersions(object):
     def test_index_sets_version_response_header(self, app):
         """

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -5,8 +5,6 @@ Test the versioning of our API using Accept headers
 
 from __future__ import unicode_literals
 
-import pytest
-
 # String type for request/response headers and metadata in WSGI.
 #
 # Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import pytest
 
 
-@pytest.mark.functional
 class TestAccountSettings(object):
     """Tests for the /account/settings page."""
 

--- a/tests/functional/test_feeds.py
+++ b/tests/functional/test_feeds.py
@@ -5,11 +5,9 @@ from __future__ import unicode_literals
 import pytest
 
 
-@pytest.mark.functional
 def test_atom_feed(app):
     app.get("/stream.atom")
 
 
-@pytest.mark.functional
 def test_rss_feed(app):
     app.get("/stream.rss")

--- a/tests/functional/test_feeds.py
+++ b/tests/functional/test_feeds.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals
 
-import pytest
-
 
 def test_atom_feed(app):
     app.get("/stream.atom")

--- a/tests/functional/test_groups.py
+++ b/tests/functional/test_groups.py
@@ -6,7 +6,6 @@ import pytest
 
 
 @pytest.mark.xfail  # See https://github.com/hypothesis/product-backlog/issues/109
-@pytest.mark.functional
 def test_group_page_includes_referrer_tag(app, db_session, factories, user):
     """
     The group read page should include a referrer tag.
@@ -27,7 +26,6 @@ def test_group_page_includes_referrer_tag(app, db_session, factories, user):
     assert res.html.head.find("meta", attrs={"name": "referrer"}, content="origin")
 
 
-@pytest.mark.functional
 def test_submit_create_group_form_without_xhr_returns_full_html_page(app):
     res = app.get("/groups/new")
     group_form = res.forms["deform"]
@@ -38,7 +36,6 @@ def test_submit_create_group_form_without_xhr_returns_full_html_page(app):
     assert res.text.startswith("<!DOCTYPE html>")
 
 
-@pytest.mark.functional
 def test_submit_create_group_form_with_xhr_returns_partial_html_snippet(app):
     res = app.get("/groups/new")
     group_form = res.forms["deform"]
@@ -49,7 +46,6 @@ def test_submit_create_group_form_with_xhr_returns_partial_html_snippet(app):
     assert res.body.strip(b"\n").startswith(b"<form")
 
 
-@pytest.mark.functional
 def test_submit_create_group_form_with_xhr_returns_plain_text(app):
     res = app.get("/groups/new")
     group_form = res.forms["deform"]

--- a/tests/functional/test_moderation.py
+++ b/tests/functional/test_moderation.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import pytest
 
 
-@pytest.mark.functional
 class TestModeration(object):
     def test_moderator_flag_listing(
         self, app, group, flagged_annotation, moderator_with_token

--- a/tests/functional/test_oauth.py
+++ b/tests/functional/test_oauth.py
@@ -13,7 +13,6 @@ import jwt
 from h.models.auth_client import GrantType
 
 
-@pytest.mark.functional
 class TestOAuth(object):
     def test_getting_an_access_token(self, app, authclient, userid):
         """Test using grant tokens and access tokens."""

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 import pytest
 
 
-@pytest.mark.functional
 def test_search_input_text_is_submitted_as_q_without_javascript(app):
     res = app.get("/search")
     form = res.forms["search-bar"]

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -3,8 +3,6 @@
 
 from __future__ import unicode_literals
 
-import pytest
-
 
 def test_search_input_text_is_submitted_as_q_without_javascript(app):
     res = app.get("/search")

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -77,7 +77,6 @@ class TestAuthToken(object):
         assert result is None
 
     @given(header=st.text())
-    @pytest.mark.fuzz
     def test_returns_none_for_malformed_header_fuzz(self, header, pyramid_request):
         assume(not header.startswith("Bearer "))
         pyramid_request.headers["Authorization"] = header

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -6,7 +6,6 @@ import datetime
 import jwt
 import mock
 
-import pytest
 from hypothesis import strategies as st
 from hypothesis import assume, given
 

--- a/tests/h/search/parser_test.py
+++ b/tests/h/search/parser_test.py
@@ -128,7 +128,6 @@ def test_parse_with_odd_quotes_combinations(query_in, query_out):
 
 @given(st.text())
 @settings(max_examples=30)
-@pytest.mark.fuzz
 def test_parse_always_return_a_multidict(text):
     """Given any string input, output should always be a MultiDict."""
     result = parser.parse(text)
@@ -144,7 +143,6 @@ nonwhitespace_text = st.text(alphabet=nonwhitespace_chars, min_size=1)
 
 @given(kw=st.sampled_from(parser.named_fields), value=nonwhitespace_text)
 @settings(max_examples=30)
-@pytest.mark.fuzz
 def test_parse_with_any_nonwhitespace_text(kw, value):
     result = parser.parse(kw + ":" + value)
     assert result.get(kw) == value


### PR DESCRIPTION
These were unregistered custom pytest marks, and pytest now emits a warning,
which causes our tests to fail, when an unregistered mark is used:

https://github.com/pytest-dev/pytest/pull/4935

Rather than registering the mark simply delete all uses of it. All tests
that're defined using hypothesis automatically have the
`@pytest.mark.hypothesis` mark applied to them so it's not necessary to
try to remember to manually apply a custom mark to every test that uses
hypothesis:

https://hypothesis.readthedocs.io/en/latest/details.html#the-hypothesis-pytest-plugin

And our functional tests are in a separate directory, so trying to manually apply a mark to every one of those also seems unnecessary.