### PR TITLE
Break up `UserJSONPresenter`

### DIFF
--- a/h/presenters/__init__.py
+++ b/h/presenters/__init__.py
@@ -16,7 +16,7 @@ from h.presenters.document_json import DocumentJSONPresenter
 from h.presenters.document_searchindex import DocumentSearchIndexPresenter
 from h.presenters.group_json import GroupJSONPresenter
 from h.presenters.group_json import GroupsJSONPresenter
-from h.presenters.user_json import UserJSONPresenter
+from h.presenters.user_json import UserJSONPresenter, TrustedUserJSONPresenter
 
 __all__ = (
     "AnnotationHTMLPresenter",
@@ -29,4 +29,5 @@ __all__ = (
     "GroupJSONPresenter",
     "GroupsJSONPresenter",
     "UserJSONPresenter",
+    "TrustedUserJSONPresenter",
 )

--- a/h/presenters/user_json.py
+++ b/h/presenters/user_json.py
@@ -4,15 +4,10 @@ from __future__ import unicode_literals
 
 
 class UserJSONPresenter(object):
-    """
-    Present a user in the JSON format returned by API requests.
+    """Present a user.
 
-    Note that this presenter as of now returns some information
-    that should not be publicly available, like the users email
-    address. This is fine for now because it is only used in
-    places where the caller has access to this. We would need
-    to refactor this as soon as we use this presenter for a
-    public API.
+    Format a user's data in JSON for use in API services. Only include
+    properties that are public-facing.
     """
 
     def __init__(self, user):
@@ -21,8 +16,23 @@ class UserJSONPresenter(object):
     def asdict(self):
         return {
             "authority": self.user.authority,
-            "email": self.user.email,
             "userid": self.user.userid,
             "username": self.user.username,
             "display_name": self.user.display_name,
         }
+
+
+class TrustedUserJSONPresenter(object):
+    """Present a user to a trusted consumer.
+
+    Format a user's data in JSON for use in API services, including any
+    sensitive/private properties.
+    """
+
+    def __init__(self, user):
+        self.user = user
+
+    def asdict(self):
+        user_presented = UserJSONPresenter(self.user).asdict()
+        user_presented["email"] = self.user.email
+        return user_presented

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -7,7 +7,7 @@ from pyramid.httpexceptions import HTTPConflict
 from h.auth.util import client_authority
 from h.views.api.exceptions import PayloadError
 from h.views.api.config import api_config
-from h.presenters import UserJSONPresenter
+from h.presenters import TrustedUserJSONPresenter
 from h.schemas.api.user import CreateUserAPISchema, UpdateUserAPISchema
 from h.schemas import ValidationError
 from h.services.user_unique import DuplicateUserError
@@ -60,7 +60,7 @@ def create(request):
 
     user_signup_service = request.find_service(name="user_signup")
     user = user_signup_service.signup(require_activation=False, **appstruct)
-    presenter = UserJSONPresenter(user)
+    presenter = TrustedUserJSONPresenter(user)
     return presenter.asdict()
 
 
@@ -85,7 +85,7 @@ def update(user, request):
     user_update_service = request.find_service(name="user_update")
     user = user_update_service.update(user, **appstruct)
 
-    presenter = UserJSONPresenter(user)
+    presenter = TrustedUserJSONPresenter(user)
     return presenter.asdict()
 
 

--- a/tests/h/presenters/user_json_test.py
+++ b/tests/h/presenters/user_json_test.py
@@ -2,23 +2,41 @@
 
 from __future__ import unicode_literals
 
-from h.presenters.user_json import UserJSONPresenter
+import pytest
+
+from h.presenters.user_json import UserJSONPresenter, TrustedUserJSONPresenter
 
 
 class TestUserJSONPresenter(object):
-    def test_asdict(self, factories):
-        user = factories.User(
-            authority="example.org",
-            email="jack@doe.com",
-            username="jack",
-            display_name="Jack Doe",
-        )
+    def test_asdict(self, user):
         presenter = UserJSONPresenter(user)
 
         assert presenter.asdict() == {
-            "authority": "example.org",
-            "email": "jack@doe.com",
-            "userid": "acct:jack@example.org",
-            "username": "jack",
-            "display_name": "Jack Doe",
+            "authority": user.authority,
+            "userid": user.userid,
+            "username": user.username,
+            "display_name": user.display_name,
         }
+
+
+class TestTrustedUserJSONPresenter(object):
+    def test_asdict(self, user):
+        presenter = TrustedUserJSONPresenter(user)
+
+        assert presenter.asdict() == {
+            "authority": user.authority,
+            "userid": user.userid,
+            "username": user.username,
+            "display_name": user.display_name,
+            "email": user.email,
+        }
+
+
+@pytest.fixture
+def user(factories):
+    return factories.User(
+        authority="example.org",
+        email="jack@doe.com",
+        username="jack",
+        display_name="Jack Doe",
+    )

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -32,20 +32,20 @@ class TestCreate(object):
         )
 
     def test_it_presents_user(
-        self, pyramid_request, valid_payload, user, UserJSONPresenter
+        self, pyramid_request, valid_payload, user, TrustedUserJSONPresenter
     ):
         pyramid_request.json_body = valid_payload
         create(pyramid_request)
 
-        UserJSONPresenter.assert_called_once_with(user)
+        TrustedUserJSONPresenter.assert_called_once_with(user)
 
     def test_it_returns_presented_user(
-        self, pyramid_request, valid_payload, UserJSONPresenter
+        self, pyramid_request, valid_payload, TrustedUserJSONPresenter
     ):
         pyramid_request.json_body = valid_payload
         result = create(pyramid_request)
 
-        assert result == UserJSONPresenter.return_value.asdict()
+        assert result == TrustedUserJSONPresenter.return_value.asdict()
 
     def test_it_validates_the_input(
         self, pyramid_request, valid_payload, CreateUserAPISchema
@@ -135,7 +135,7 @@ class TestCreate(object):
     "user",
     "user_update_svc",
     "UpdateUserAPISchema",
-    "UserJSONPresenter",
+    "TrustedUserJSONPresenter",
 )
 class TestUpdate(object):
     def test_it_validates_request_payload(
@@ -163,19 +163,19 @@ class TestUpdate(object):
         user_update_svc.update.assert_called_once_with(user, **appstruct)
 
     def test_it_presents_updated_user_returned_from_service(
-        self, pyramid_request, user, UserJSONPresenter, user_update_svc
+        self, pyramid_request, user, TrustedUserJSONPresenter, user_update_svc
     ):
         user_update_svc.update.return_value = user
         update(user, pyramid_request)
 
-        UserJSONPresenter.assert_called_once_with(user)
+        TrustedUserJSONPresenter.assert_called_once_with(user)
 
     def test_it_returns_presented_user(
-        self, pyramid_request, valid_payload, UserJSONPresenter
+        self, pyramid_request, valid_payload, TrustedUserJSONPresenter
     ):
         result = update(user, pyramid_request)
 
-        assert result == UserJSONPresenter.return_value.asdict()
+        assert result == TrustedUserJSONPresenter.return_value.asdict()
 
     def test_raises_when_schema_validation_fails(
         self, user, pyramid_request, valid_payload, UpdateUserAPISchema
@@ -268,8 +268,8 @@ def UpdateUserAPISchema(patch):
 
 
 @pytest.fixture
-def UserJSONPresenter(patch):
-    return patch("h.views.api.users.UserJSONPresenter")
+def TrustedUserJSONPresenter(patch):
+    return patch("h.views.api.users.TrustedUserJSONPresenter")
 
 
 @pytest.fixture


### PR DESCRIPTION
There was a note that the existing `UserJSONPresenter` included private/sensitive fields (specifically email for now) and should, in the future, be refactored if we needed to return user data to less-privileged consumers. That time is now, as we need an endpoint to return all users in a given group.

This PR splits the user presenter into two classes: `UserJSONPresenter` (public fields only) and `TrustedUserJSONPresenter` (adds private fields). It also adjusts the existing user API endpoints (which are for privileged users) to use the `TrustedUserJSONPresenter`. The upcoming new endpoint will use `UserJSONPresenter`.

Note: I'm happy to change the name of this class if `Trusted` seems out of line. I just couldn't think of anything better.

Part of https://github.com/hypothesis/product-backlog/issues/1009