### PR TITLE
Add `member_read` permission to Group ACL

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -244,6 +244,9 @@ class Group(Base, mixins.Timestamps):
         authority_principal = "client_authority:{}".format(self.authority)
 
         # auth_clients that have the same authority as the target group
+        # may read the members within it
+        terms.append((security.Allow, authority_principal, "member_read"))
+        # auth_clients that have the same authority as the target group
         # may add members to it
         terms.append((security.Allow, authority_principal, "member_add"))
         # auth_clients that have the same authority as this group

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -243,6 +243,24 @@ def test_non_public_group():
 
 
 class TestGroupACL(object):
+    def test_auth_client_with_matching_authority_may_read_members(
+        self, group, authz_policy
+    ):
+        group.authority = "weewhack.com"
+
+        assert authz_policy.permits(
+            group, ["flip", "client_authority:weewhack.com"], "member_read"
+        )
+
+    def test_auth_client_without_matching_authority_may_not_read_members(
+        self, group, authz_policy
+    ):
+        group.authority = "weewhack.com"
+
+        assert not authz_policy.permits(
+            group, ["flip", "client_authority:2weewhack.com"], "member_read"
+        )
+
     def test_auth_client_with_matching_authority_may_add_members(
         self, group, authz_policy
     ):


### PR DESCRIPTION
This teeny PR adds a permission I'll need later to develop a fetch-members-in-a-group API endpoint. For now, since users are sensitive, I'm locking this down to trusted auth clients.

Part of https://github.com/hypothesis/product-backlog/issues/1009