### PR TITLE
Add `group.read_members` API endpoint route and view

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -153,6 +153,12 @@ def includeme(config):
     config.add_route("api.profile_groups", "/api/profile/groups")
     config.add_route("api.debug_token", "/api/debug-token")
     config.add_route(
+        "api.group_members",
+        "/api/groups/{pubid}/members",
+        factory="h.traversal.GroupRoot",
+        traverse="/{pubid}",
+    )
+    config.add_route(
         "api.group_member",
         "/api/groups/{pubid}/members/{userid}",
         factory="h.traversal.GroupRoot",

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -13,7 +13,7 @@ from pyramid.httpexceptions import (
 from h.auth.util import client_authority
 from h.views.api.exceptions import PayloadError
 from h.i18n import TranslationString as _  # noqa: N813
-from h.presenters import GroupJSONPresenter, GroupsJSONPresenter
+from h.presenters import GroupJSONPresenter, GroupsJSONPresenter, UserJSONPresenter
 from h.schemas.api.group import CreateGroupAPISchema, UpdateGroupAPISchema
 from h.traversal import GroupContext
 from h.views.api.config import api_config
@@ -191,6 +191,19 @@ def upsert(context, request):
     return GroupJSONPresenter(GroupContext(group, request)).asdict(
         expand=["organization", "scopes"]
     )
+
+
+@api_config(
+    versions=["v1", "v2"],
+    route_name="api.group_members",
+    request_method="GET",
+    link_name="group.members.read",
+    description="Fetch all members of a group",
+    permission="member_read",
+)
+def read_members(group, request):
+    """Fetch the members of a group."""
+    return [UserJSONPresenter(user).asdict() for user in group.members]
 
 
 @api_config(

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -148,6 +148,12 @@ def test_includeme():
         call("api.profile_groups", "/api/profile/groups"),
         call("api.debug_token", "/api/debug-token"),
         call(
+            "api.group_members",
+            "/api/groups/{pubid}/members",
+            factory="h.traversal.GroupRoot",
+            traverse="/{pubid}",
+        ),
+        call(
             "api.group_member",
             "/api/groups/{pubid}/members/{userid}",
             factory="h.traversal.GroupRoot",

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -491,6 +491,22 @@ class TestUpsertGroup(object):
         return context_factory
 
 
+class TestReadMembers(object):
+    def test_it_returns_formatted_users_from_group(
+        self, factories, pyramid_request, UserJSONPresenter
+    ):
+        group = factories.Group.build()
+        group.members = [
+            factories.User.build(),
+            factories.User.build(),
+            factories.User.build(),
+        ]
+
+        views.read_members(group, pyramid_request)
+
+        assert UserJSONPresenter.call_count == len(group.members)
+
+
 @pytest.mark.usefixtures("group_members_service", "user_service")
 class TestAddMember(object):
     def test_it_adds_user_from_request_params_to_group(
@@ -623,6 +639,11 @@ def GroupJSONPresenter(patch):
 @pytest.fixture
 def GroupsJSONPresenter(patch):
     return patch("h.views.api.groups.GroupsJSONPresenter")
+
+
+@pytest.fixture
+def UserJSONPresenter(patch):
+    return patch("h.views.api.groups.UserJSONPresenter")
 
 
 @pytest.fixture


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/1009

This PR adds a simple, one-line view and route to provide an API endpoint for retrieving the members of a group. At present, users are not sorted. That can be done as we see fit...