### PR TITLE
Whitelist Hypothesis-Client-Version header in CORS requests

### DIFF
--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -21,7 +21,12 @@ from h.views.api import API_VERSIONS, API_VERSION_DEFAULT
 #: headers set during standard request processing are discarded if an exception
 #: occurs and an exception view is invoked to generate the response instead.
 cors_policy = cors.policy(
-    allow_headers=("Authorization", "Content-Type", "X-Client-Id"),
+    allow_headers=(
+        "Authorization",
+        "Content-Type",
+        "Hypothesis-Client-Version",
+        "X-Client-Id",
+    ),
     allow_methods=("HEAD", "GET", "PATCH", "POST", "PUT", "DELETE"),
 )
 


### PR DESCRIPTION
Add "Hypothesis-Client-Version" to the list of headers that browser-based h
API clients are allowed to send in requests.

This header is set by recent versions of the Hypothesis client and is
needed to enable hosting custom builds of the client on domains other
than the one that h is hosted on.

In concrete terms, this causes the [`Access-Control-Allow-Headers` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) in CORS preflight responses to include this header name.