### PR TITLE
Add documentation for `GET /groups/{id}/members`

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -258,17 +258,17 @@ components:
       $ref: './schemas/profile.yaml#/Profile'
     User:
       $ref: './schemas/user.yaml#/User'
+    UserFull:
+      $ref: './schemas/user.yaml#/UserFull'
     UserCreate:
       $ref: './schemas/user-new.yaml#/User'
     UserUpdate:
       $ref: './schemas/user-update.yaml#/User'
 
-
 # -----------------------------------------------------------------------------
 # API OPERATIONS
 # -----------------------------------------------------------------------------
 paths:
-
   # ---------------------------------------------------------------------------
   # Service Root
   # ---------------------------------------------------------------------------
@@ -876,8 +876,35 @@ paths:
   # ---------------------------------------------------------------------------
   # Operations on Group Membership
   # ---------------------------------------------------------------------------
-  /groups/{id}/members/{user}:
 
+  # ---------------------------------------------------------------------------
+  # GET groups/{id}/members - Get group members
+  # ---------------------------------------------------------------------------
+  /groups/{id}/members:
+    get:
+      tags:
+        - groups
+      summary: Get group members
+      description: >
+        Fetch a list of all members (users) in a group. Returned user resource only
+        contains public-facing user data. Authenticated user must have read access
+        to the group. Does not require authentication for reading members of
+        public groups. Returned members are unsorted.
+      security:
+        - AuthClient: []
+        - ApiKey: []
+        - {} # Unauthenticated OK for public groups
+      responses:
+        '200':
+          description: Success
+          content:
+            application/*json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+
+  /groups/{id}/members/{user}:
     # ----------------------------------------------------------
     # POST groups/{id}/members/{user} - Add user to group
     # ----------------------------------------------------------
@@ -1000,7 +1027,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/UserFull'
 
   # ---------------------------------------------------------------------------
   # Operations on single User Resources
@@ -1031,4 +1058,4 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/UserFull'

--- a/docs/_extra/api-reference/hypothesis-v2.yaml
+++ b/docs/_extra/api-reference/hypothesis-v2.yaml
@@ -260,6 +260,8 @@ components:
       $ref: './schemas/profile.yaml#/Profile'
     User:
       $ref: './schemas/user.yaml#/User'
+    UserFull:
+      $ref: './schemas/user.yaml#/UserFull'
     UserCreate:
       $ref: './schemas/user-new.yaml#/User'
     UserUpdate:
@@ -878,6 +880,34 @@ paths:
   # ---------------------------------------------------------------------------
   # Operations on Group Membership
   # ---------------------------------------------------------------------------
+
+  # ---------------------------------------------------------------------------
+  # GET groups/{id}/members - Get group members
+  # ---------------------------------------------------------------------------
+  /groups/{id}/members:
+    get:
+      tags:
+        - groups
+      summary: Get group members
+      description: >
+        Fetch a list of all members (users) in a group. Returned user resource only
+        contains public-facing user data. Authenticated user must have read access
+        to the group. Does not require authentication for reading members of
+        public groups. Returned members are unsorted.
+      security:
+        - AuthClient: []
+        - ApiKey: []
+        - {} # Unauthenticated OK for public groups
+      responses:
+        '200':
+          description: Success
+          content:
+            application/*json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+
   /groups/{id}/members/{user}:
 
     # ----------------------------------------------------------

--- a/docs/_extra/api-reference/schemas/user.yaml
+++ b/docs/_extra/api-reference/schemas/user.yaml
@@ -1,4 +1,26 @@
 User:
+  type: object
+  properties:
+    authority:
+      type: string
+    username:
+      type: string
+      minLength: 3
+      maxLength: 30
+      pattern: ^[A-Za-z0-9._]+$
+    userid:
+      type: string
+      pattern: ^acct:.+$
+    display_name:
+      type: string
+      maxLength: 30
+  required:
+    - authority
+    - username
+    - userid
+    - display_name
+
+UserFull:
   allOf:
     - $ref: './user-new.yaml#/User'
     - type: object


### PR DESCRIPTION

<img width="1697" alt="Screen Shot 2019-05-28 at 9 50 10 AM" src="https://user-images.githubusercontent.com/439947/58483441-4f465980-812e-11e9-8c06-299b288a4548.png">

This PR adds documentation for the new API endpoint for fetching members of a group.

Identical documentation has been added for both v1 and v2 of the API.

In addition, User schemas have been futzed with a bit to account for the difference between a fully-represented user resource (trusted) and a more compact, public-facing user resource.

Fixes https://github.com/hypothesis/product-backlog/issues/1009