### PR TITLE
Use Prettier to format JS code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,8 @@
 {
   "extends": "hypothesis",
   "rules": {
-    "arrow-parens": ["error", "as-needed", { "requireForBlockBody": true }],
-    "arrow-spacing": "error",
+    "indent": "off",
     "no-var": "error",
-    "keyword-spacing": "error",
     "prefer-arrow-callback": "error",
     "prefer-const": ["error", { "destructuring": "all" }],
     "space-before-blocks": "error"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,7 @@ matrix:
       language: node_js
       node_js: 'node'
       script:
-        gulp lint
-        npm run-script checkformatting
+        make frontend-lint
 
     # Lint backend code
     - env: ACTION=backend-lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ matrix:
       node_js: 'node'
       script:
         gulp lint
+        npm run-script checkformatting
 
     # Lint backend code
     - env: ACTION=backend-lint

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ lint:
 
 .PHONY: frontend-lint
 frontend-lint:
-	$(GULP) lint
+	npm run-script lint
 	npm run-script checkformatting
 
 .PHONY: analyze

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,11 @@ sql:
 lint:
 	tox -q -e py36-lint
 
+.PHONY: frontend-lint
+frontend-lint:
+	$(GULP) lint
+	npm run-script checkformatting
+
 .PHONY: analyze
 analyze:
 	tox -qq -e py36-analyze

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -289,14 +289,3 @@ gulp.task('test', function(callback) {
 gulp.task('test-watch', function(callback) {
   runKarma('./h/static/scripts/karma.config.js', {}, callback);
 });
-
-gulp.task('lint', function() {
-  // Adapted from usage example at https://www.npmjs.com/package/gulp-eslint
-  // `gulp-eslint` is loaded lazily so that it is not required during Docker image builds
-  var eslint = require('gulp-eslint');
-  return gulp
-    .src(['gulpfile.js', 'h/static/scripts/**/*.js'])
-    .pipe(eslint())
-    .pipe(eslint.format())
-    .pipe(eslint.failAfterError());
-});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,13 +59,15 @@ var vendorNoParseModules = ['jquery', 'unorm'];
 gulp.task('build-vendor-js', function() {
   var finished = [];
   Object.keys(vendorBundles).forEach(function(name) {
-    finished.push(createBundle({
-      name: name,
-      require: vendorBundles[name],
-      minify: IS_PRODUCTION_BUILD,
-      path: SCRIPT_DIR,
-      noParse: vendorNoParseModules,
-    }));
+    finished.push(
+      createBundle({
+        name: name,
+        require: vendorBundles[name],
+        minify: IS_PRODUCTION_BUILD,
+        path: SCRIPT_DIR,
+        noParse: vendorNoParseModules,
+      })
+    );
   });
   return Promise.all(finished);
 });
@@ -77,37 +79,50 @@ var bundleBaseConfig = {
   noParse: vendorNoParseModules,
 };
 
-var bundles = [{
-  // Public-facing website
-  name: 'site',
-  entry: './h/static/scripts/site',
-},{
-  // Admin areas of the site
-  name: 'admin-site',
-  entry: './h/static/scripts/admin-site',
-},{
-  // Header script inserted inline at the top of the page
-  name: 'header',
-  entry: './h/static/scripts/header',
-},{
-  // Helper script for the OAuth post-authorization page.
-  name: 'post-auth',
-  entry: './h/static/scripts/post-auth',
-}];
+var bundles = [
+  {
+    // Public-facing website
+    name: 'site',
+    entry: './h/static/scripts/site',
+  },
+  {
+    // Admin areas of the site
+    name: 'admin-site',
+    entry: './h/static/scripts/admin-site',
+  },
+  {
+    // Header script inserted inline at the top of the page
+    name: 'header',
+    entry: './h/static/scripts/header',
+  },
+  {
+    // Helper script for the OAuth post-authorization page.
+    name: 'post-auth',
+    entry: './h/static/scripts/post-auth',
+  },
+];
 
 var bundleConfigs = bundles.map(function(config) {
   return Object.assign({}, bundleBaseConfig, config);
 });
 
-gulp.task('build-js', gulp.series(['build-vendor-js'], function() {
-  return Promise.all(bundleConfigs.map(function(config) {
-    return createBundle(config);
-  }));
-}));
+gulp.task(
+  'build-js',
+  gulp.series(['build-vendor-js'], function() {
+    return Promise.all(
+      bundleConfigs.map(function(config) {
+        return createBundle(config);
+      })
+    );
+  })
+);
 
-gulp.task('watch-js', gulp.series(['build-vendor-js'], function() {
-  return bundleConfigs.map(config => createBundle(config, { watch: true }));
-}));
+gulp.task(
+  'watch-js',
+  gulp.series(['build-vendor-js'], function() {
+    return bundleConfigs.map(config => createBundle(config, { watch: true }));
+  })
+);
 
 // Rewrite font URLs to look for fonts in 'build/fonts' instead of
 // 'build/styles/fonts'
@@ -126,7 +141,8 @@ gulp.task('build-vendor-css', function() {
     url: rewriteCSSURL,
   });
 
-  return gulp.src(vendorCSSFiles)
+  return gulp
+    .src(vendorCSSFiles)
     .pipe(newer(STYLE_DIR))
     .pipe(postcss([cssURLRewriter]))
     .pipe(gulp.dest(STYLE_DIR));
@@ -148,18 +164,26 @@ function buildStyleBundle(entryFile, options) {
   });
 }
 
-gulp.task('build-css', gulp.series(['build-vendor-css'], function() {
-  return Promise.all(styleBundleEntryFiles.map(buildStyleBundle));
-}));
+gulp.task(
+  'build-css',
+  gulp.series(['build-vendor-css'], function() {
+    return Promise.all(styleBundleEntryFiles.map(buildStyleBundle));
+  })
+);
 
 gulp.task('watch-css', function() {
-  gulp.watch('h/static/styles/**/*.scss', { ignoreInitial: false }, gulp.series('build-css'));
+  gulp.watch(
+    'h/static/styles/**/*.scss',
+    { ignoreInitial: false },
+    gulp.series('build-css')
+  );
 });
 
 var fontFiles = 'h/static/styles/vendor/fonts/*.woff';
 
 gulp.task('build-fonts', function() {
-  return gulp.src(fontFiles)
+  return gulp
+    .src(fontFiles)
     .pipe(changed(FONTS_DIR))
     .pipe(gulp.dest(FONTS_DIR));
 });
@@ -174,7 +198,8 @@ gulp.task('build-images', function() {
     return IS_PRODUCTION_BUILD && file.path.match(/\.svg$/);
   };
 
-  return gulp.src(imageFiles)
+  return gulp
+    .src(imageFiles)
     .pipe(changed(IMAGES_DIR))
     .pipe(gulpIf(shouldMinifySVG, svgmin()))
     .pipe(gulp.dest(IMAGES_DIR));
@@ -191,26 +216,47 @@ var MANIFEST_SOURCE_FILES = 'build/@(fonts|images|scripts|styles)/**/*.*';
  * URLs containing cache-busting query string parameters.
  */
 function generateManifest() {
-  return gulp.src(MANIFEST_SOURCE_FILES)
-    .pipe(manifest({name: 'manifest.json'}))
-    .pipe(through.obj(function(file, enc, callback) {
-      log.info('Updated asset manifest');
-      this.push(file);
-      callback();
-    }))
+  return gulp
+    .src(MANIFEST_SOURCE_FILES)
+    .pipe(manifest({ name: 'manifest.json' }))
+    .pipe(
+      through.obj(function(file, enc, callback) {
+        log.info('Updated asset manifest');
+        this.push(file);
+        callback();
+      })
+    )
     .pipe(gulp.dest('build/'));
 }
 
 gulp.task('watch-manifest', function() {
-  gulp.watch(MANIFEST_SOURCE_FILES, batch(function(events, done) {
-    endOfStream(generateManifest(), function() {
-      done();
-    });
-  }));
+  gulp.watch(
+    MANIFEST_SOURCE_FILES,
+    batch(function(events, done) {
+      endOfStream(generateManifest(), function() {
+        done();
+      });
+    })
+  );
 });
 
-gulp.task('build', gulp.series(['build-js', 'build-css', 'build-fonts', 'build-images'], generateManifest));
-gulp.task('watch', gulp.parallel(['watch-js', 'watch-css', 'watch-fonts', 'watch-images', 'watch-manifest']));
+gulp.task(
+  'build',
+  gulp.series(
+    ['build-js', 'build-css', 'build-fonts', 'build-images'],
+    generateManifest
+  )
+);
+gulp.task(
+  'watch',
+  gulp.parallel([
+    'watch-js',
+    'watch-css',
+    'watch-fonts',
+    'watch-images',
+    'watch-manifest',
+  ])
+);
 
 function runKarma(baseConfig, opts, done) {
   // See https://github.com/karma-runner/karma-mocha#configuration
@@ -223,13 +269,21 @@ function runKarma(baseConfig, opts, done) {
   };
 
   var karma = require('karma');
-  new karma.Server(Object.assign({}, {
-    configFile: path.resolve(__dirname, baseConfig),
-  }, cliOpts, opts), done).start();
+  new karma.Server(
+    Object.assign(
+      {},
+      {
+        configFile: path.resolve(__dirname, baseConfig),
+      },
+      cliOpts,
+      opts
+    ),
+    done
+  ).start();
 }
 
 gulp.task('test', function(callback) {
-  runKarma('./h/static/scripts/karma.config.js', {singleRun:true}, callback);
+  runKarma('./h/static/scripts/karma.config.js', { singleRun: true }, callback);
 });
 
 gulp.task('test-watch', function(callback) {
@@ -240,7 +294,8 @@ gulp.task('lint', function() {
   // Adapted from usage example at https://www.npmjs.com/package/gulp-eslint
   // `gulp-eslint` is loaded lazily so that it is not required during Docker image builds
   var eslint = require('gulp-eslint');
-  return gulp.src(['gulpfile.js', 'h/static/scripts/**/*.js'])
+  return gulp
+    .src(['gulpfile.js', 'h/static/scripts/**/*.js'])
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError());

--- a/h/static/scripts/admin-site.js
+++ b/h/static/scripts/admin-site.js
@@ -15,9 +15,12 @@ const upgradeElements = require('./base/upgrade-elements');
 // Additional controllers for admin site.
 const AdminUsersController = require('./controllers/admin-users-controller');
 
-const controllers = Object.assign({}, {
-  '.js-users-delete-form': AdminUsersController,
-}, sharedControllers);
+const controllers = Object.assign(
+  {},
+  {
+    '.js-users-delete-form': AdminUsersController,
+  },
+  sharedControllers
+);
 upgradeElements(document.body, controllers);
 window.envFlags.ready();
-

--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -34,9 +34,10 @@ class Controller {
    *        specific to that type of controller.
    */
   constructor(element, options = {}) {
-
     if (!element) {
-      throw new Error('Controllers require an element passed to the constructor');
+      throw new Error(
+        'Controllers require an element passed to the constructor'
+      );
     } else if (!element.controllers) {
       element.controllers = [this];
     } else {

--- a/h/static/scripts/base/environment-flags.js
+++ b/h/static/scripts/base/environment-flags.js
@@ -17,9 +17,9 @@
  */
 class EnvironmentFlags {
   /**
-    * @param {Element} element - DOM element which environment flags will be added
-    *                  to.
-    */
+   * @param {Element} element - DOM element which environment flags will be added
+   *                  to.
+   */
   constructor(element) {
     this._element = element;
   }
@@ -79,8 +79,10 @@ class EnvironmentFlags {
     }, JS_LOAD_TIMEOUT);
 
     // Process flag overrides specified in URL
-    const flags = envFlagsFromUrl(url || this._element.ownerDocument.location.href);
-    flags.forEach((flag) => {
+    const flags = envFlagsFromUrl(
+      url || this._element.ownerDocument.location.href
+    );
+    flags.forEach(flag => {
       if (flag.indexOf('no-') === 0) {
         this.set(flag.slice(3), false);
       } else {

--- a/h/static/scripts/base/raven.js
+++ b/h/static/scripts/base/raven.js
@@ -18,7 +18,7 @@ function init(config) {
   }).install();
 
   if (config.userid) {
-    Raven.setUserContext({id: config.userid});
+    Raven.setUserContext({ id: config.userid });
   }
 
   installUnhandledPromiseErrorHandler();
@@ -67,7 +67,7 @@ function report(error, when, context) {
  * automatically, in which case this code can simply be removed.
  */
 function installUnhandledPromiseErrorHandler() {
-  window.addEventListener('unhandledrejection', (event) => {
+  window.addEventListener('unhandledrejection', event => {
     if (event.reason) {
       report(event.reason, 'Unhandled Promise rejection');
     }

--- a/h/static/scripts/base/settings.js
+++ b/h/static/scripts/base/settings.js
@@ -18,11 +18,10 @@ function settings(document, settingsClass) {
   if (!settingsClass) {
     settingsClass = 'js-hypothesis-settings';
   }
-  const settingsElements =
-    document.querySelectorAll('script.' + settingsClass);
+  const settingsElements = document.querySelectorAll('script.' + settingsClass);
 
   const config = {};
-  for (let i=0; i < settingsElements.length; i++) {
+  for (let i = 0; i < settingsElements.length; i++) {
     Object.assign(config, JSON.parse(settingsElements[i].textContent));
   }
   return config;

--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -6,7 +6,7 @@
 function markReady(element) {
   const HIDE_CLASS = 'is-hidden-when-loading';
   const hideOnLoad = Array.from(element.querySelectorAll('.' + HIDE_CLASS));
-  hideOnLoad.forEach((el) => {
+  hideOnLoad.forEach(el => {
     el.classList.remove(HIDE_CLASS);
   });
   element.classList.remove(HIDE_CLASS);
@@ -23,7 +23,7 @@ let upgradedElements = [];
  * document.
  */
 function removeControllers(root) {
-  upgradedElements = upgradedElements.filter((el) => {
+  upgradedElements = upgradedElements.filter(el => {
     if (root.contains(el)) {
       el.controllers.forEach(ctrl => ctrl.beforeRemove());
       el.controllers = [];
@@ -65,9 +65,9 @@ function upgradeElements(root, controllers) {
     return newElement;
   }
 
-  Object.keys(controllers).forEach((selector) => {
+  Object.keys(controllers).forEach(selector => {
     const elements = Array.from(root.querySelectorAll(selector));
-    elements.forEach((el) => {
+    elements.forEach(el => {
       const ControllerClass = controllers[selector];
       try {
         new ControllerClass(el, {
@@ -76,7 +76,13 @@ function upgradeElements(root, controllers) {
         upgradedElements.push(el);
         markReady(el);
       } catch (err) {
-        console.error('Failed to upgrade element %s with controller', el, ControllerClass, ':', err.toString());
+        console.error(
+          'Failed to upgrade element %s with controller',
+          el,
+          ControllerClass,
+          ':',
+          err.toString()
+        );
 
         // Re-raise error so that Raven can capture and report it
         throw err;

--- a/h/static/scripts/controllers/admin-users-controller.js
+++ b/h/static/scripts/controllers/admin-users-controller.js
@@ -8,10 +8,12 @@ class AdminUsersController extends Controller {
 
     const window_ = options.window || window;
     function confirmFormSubmit() {
-      return window_.confirm('This will permanently delete all the user\'s data. Are you sure?');
+      return window_.confirm(
+        "This will permanently delete all the user's data. Are you sure?"
+      );
     }
 
-    this.on('submit', (event) => {
+    this.on('submit', event => {
       if (!confirmFormSubmit()) {
         event.preventDefault();
       }

--- a/h/static/scripts/controllers/authorize-form-controller.js
+++ b/h/static/scripts/controllers/authorize-form-controller.js
@@ -44,10 +44,13 @@ class AuthorizeFormController extends Controller {
 
       // Since this message contains no private data, just set the origin to
       // '*' (any).
-      window.opener.postMessage({
-        type: 'authorization_canceled',
-        state,
-      }, '*');
+      window.opener.postMessage(
+        {
+          type: 'authorization_canceled',
+          state,
+        },
+        '*'
+      );
     }
   }
 

--- a/h/static/scripts/controllers/autosuggest-dropdown-controller.js
+++ b/h/static/scripts/controllers/autosuggest-dropdown-controller.js
@@ -12,7 +12,6 @@ const DOWN = 40;
  * Controller for adding autosuggest control to a piece of the page
  */
 class AutosuggestDropdownController extends Controller {
-
   /*
    * @typedef {Object} ConfigOptions
    * @property {Function} renderListItem - called with every item in the list
@@ -39,19 +38,24 @@ class AutosuggestDropdownController extends Controller {
    *
    */
   constructor(inputElement, configOptions) {
-
     super(inputElement, configOptions);
 
     if (!configOptions.renderListItem) {
-      throw new Error('Missing renderListItem callback in AutosuggestDropdownController constructor');
+      throw new Error(
+        'Missing renderListItem callback in AutosuggestDropdownController constructor'
+      );
     }
 
     if (!configOptions.listFilter) {
-      throw new Error('Missing listFilter function in AutosuggestDropdownController constructor');
+      throw new Error(
+        'Missing listFilter function in AutosuggestDropdownController constructor'
+      );
     }
 
     if (!configOptions.onSelect) {
-      throw new Error('Missing onSelect callback in AutosuggestDropdownController constructor');
+      throw new Error(
+        'Missing onSelect callback in AutosuggestDropdownController constructor'
+      );
     }
 
     // set up our element class attribute enum values
@@ -59,11 +63,16 @@ class AutosuggestDropdownController extends Controller {
     // classes, but we have them if we wanted to give something for a default
     // styling.
     if (configOptions.classNames) {
-      this.options.classNames.container = configOptions.classNames.container || 'autosuggest__container';
-      this.options.classNames.list = configOptions.classNames.list || 'autosuggest__list';
-      this.options.classNames.item = configOptions.classNames.item || 'autosuggest__list-item';
-      this.options.classNames.activeItem = configOptions.classNames.activeItem || 'autosuggest__list-item--active';
-      this.options.classNames.header = configOptions.classNames.header || 'autosuggest__header';
+      this.options.classNames.container =
+        configOptions.classNames.container || 'autosuggest__container';
+      this.options.classNames.list =
+        configOptions.classNames.list || 'autosuggest__list';
+      this.options.classNames.item =
+        configOptions.classNames.item || 'autosuggest__list-item';
+      this.options.classNames.activeItem =
+        configOptions.classNames.activeItem || 'autosuggest__list-item--active';
+      this.options.classNames.header =
+        configOptions.classNames.header || 'autosuggest__header';
     }
 
     // renaming simply to make it more obvious what
@@ -85,17 +94,14 @@ class AutosuggestDropdownController extends Controller {
 
     this._setList(configOptions.list);
 
-
     // Public API
     this.setHeader = this._setHeader;
   }
 
   update(newState, prevState) {
-
     // if our prev state is empty then
     // we assume that this is the first update/render call
     if (!('visible' in prevState)) {
-
       // create the elements that make up the component
       this._renderContentContainers();
       this._addTopLevelEventListeners();
@@ -103,14 +109,17 @@ class AutosuggestDropdownController extends Controller {
 
     if (newState.visible !== prevState.visible) {
       // updates the dom to change the class which actually updates visibilty
-      setElementState(this._suggestionContainer, { open: newState.visible});
+      setElementState(this._suggestionContainer, { open: newState.visible });
     }
 
     if (newState.header !== prevState.header) {
       this._header.innerHTML = newState.header;
     }
 
-    const listChanged = updateHelper.listIsDifferent(newState.list, prevState.list);
+    const listChanged = updateHelper.listIsDifferent(
+      newState.list,
+      prevState.list
+    );
 
     if (listChanged) {
       this._renderListItems();
@@ -119,14 +128,16 @@ class AutosuggestDropdownController extends Controller {
     // list change detection is needed to persist the
     // currently active elements over to the new list
     if (newState.activeId !== prevState.activeId || listChanged) {
-
       const currentActive = this._getActiveListItemElement();
 
       if (prevState.activeId && currentActive) {
         currentActive.classList.remove(this.options.classNames.activeItem);
       }
 
-      if (newState.activeId && newState.list.find(item => item.__suggestionId === newState.activeId)) {
+      if (
+        newState.activeId &&
+        newState.list.find(item => item.__suggestionId === newState.activeId)
+      ) {
         this._listContainer
           .querySelector(`[data-suggestion-id="${newState.activeId}"]`)
           .classList.add(this.options.classNames.activeItem);
@@ -153,19 +164,20 @@ class AutosuggestDropdownController extends Controller {
    * @param  {Array} list The new list.
    */
   _setList(list) {
-
     if (!Array.isArray(list)) {
       throw new TypeError('setList requires an array first argument');
     }
 
     this.setState({
-      rootList: list.map((item) => {
+      rootList: list.map(item => {
         return Object.assign({}, item, {
           // create an id that lets us direction map
           // selection to arbitrary item in list.
           // This allows lists to pass more than just the required
           // `name` property to know more about what the list item is
-          __suggestionId: Math.random().toString(36).substr(2, 5),
+          __suggestionId: Math.random()
+            .toString(36)
+            .substr(2, 5),
         });
       }),
     });
@@ -183,7 +195,8 @@ class AutosuggestDropdownController extends Controller {
    */
   _filterListFromInput() {
     this.setState({
-      list: this.options.listFilter(this.state.rootList, this._input.value) || [],
+      list:
+        this.options.listFilter(this.state.rootList, this._input.value) || [],
     });
   }
 
@@ -203,10 +216,12 @@ class AutosuggestDropdownController extends Controller {
    *  This is process to actually make a selection
    */
   _selectCurrentActiveItem() {
-
     const currentActive = this._getActiveListItemElement();
-    const suggestionId = currentActive && currentActive.getAttribute('data-suggestion-id');
-    const selection = this.state.list.filter((item) => { return item.__suggestionId === suggestionId;})[0];
+    const suggestionId =
+      currentActive && currentActive.getAttribute('data-suggestion-id');
+    const selection = this.state.list.filter(item => {
+      return item.__suggestionId === suggestionId;
+    })[0];
 
     if (selection) {
       this.options.onSelect(selection);
@@ -225,11 +240,10 @@ class AutosuggestDropdownController extends Controller {
    * @param  {Event} event    event used to pull the list item being targeted
    */
   _toggleItemHoverState(hovering, event) {
-
     const currentActive = this._getActiveListItemElement();
     const target = event.currentTarget;
 
-    if ( hovering && currentActive && currentActive.contains(target)) {
+    if (hovering && currentActive && currentActive.contains(target)) {
       return;
     }
 
@@ -247,7 +261,6 @@ class AutosuggestDropdownController extends Controller {
    * @param  {bool} show should we update the state to be visible or not
    */
   _toggleSuggestionsVisibility(show) {
-
     // keeps the internal state synced with visibility
     this.setState({
       visible: !!show,
@@ -258,7 +271,9 @@ class AutosuggestDropdownController extends Controller {
    * @returns {HTMLElement}  the active list item element
    */
   _getActiveListItemElement() {
-    return this._listContainer.querySelector('.' + this.options.classNames.activeItem);
+    return this._listContainer.querySelector(
+      '.' + this.options.classNames.activeItem
+    );
   }
 
   /**
@@ -268,21 +283,19 @@ class AutosuggestDropdownController extends Controller {
    * @param  {bool} down is the user navigating down the list?
    */
   _keyboardSelectionChange(down) {
-
     const currentActive = this._getActiveListItemElement();
     let nextActive;
 
     // we have a starting point, navigate on siblings of current
     if (currentActive) {
-
       if (down) {
         nextActive = currentActive.nextSibling;
       } else {
         nextActive = currentActive.previousSibling;
       }
 
-    // we have no starting point, let's navigate based on
-    // the directional expectation of what the first item would be
+      // we have no starting point, let's navigate based on
+      // the directional expectation of what the first item would be
     } else if (down) {
       nextActive = this._listContainer.firstChild;
     } else {
@@ -290,7 +303,9 @@ class AutosuggestDropdownController extends Controller {
     }
 
     this.setState({
-      activeId: nextActive ?  nextActive.getAttribute('data-suggestion-id') : null,
+      activeId: nextActive
+        ? nextActive.getAttribute('data-suggestion-id')
+        : null,
     });
   }
 
@@ -299,11 +314,9 @@ class AutosuggestDropdownController extends Controller {
    *  the suggestion box and content containers.
    */
   _renderContentContainers() {
-
     // container of all suggestion elements
     this._suggestionContainer = document.createElement('div');
     this._suggestionContainer.classList.add(this.options.classNames.container);
-
 
     // child elements that will be populated by consumer
     this._header = document.createElement('h4');
@@ -321,7 +334,10 @@ class AutosuggestDropdownController extends Controller {
     if (HTMLElement.prototype.insertAdjacentElement) {
       this._input.insertAdjacentElement('afterend', this._suggestionContainer);
     } else {
-      this._input.parentNode.insertBefore(this._suggestionContainer, this._input.nextSibling);
+      this._input.parentNode.insertBefore(
+        this._suggestionContainer,
+        this._input.nextSibling
+      );
     }
   }
 
@@ -335,7 +351,7 @@ class AutosuggestDropdownController extends Controller {
 
     this._listContainer.innerHTML = '';
 
-    this.state.list.forEach((listItem) => {
+    this.state.list.forEach(listItem => {
       const li = document.createElement('li');
       li.setAttribute('role', 'option');
       li.classList.add(this.options.classNames.item);
@@ -344,14 +360,20 @@ class AutosuggestDropdownController extends Controller {
       // this should use some sort of event delegation if
       // we find we want to expand this to lists with *a lot* of items in it
       // But for now this binding has no real affect on small list perf
-      li.addEventListener('mouseenter', this._toggleItemHoverState.bind(this, /*hovering*/true));
-      li.addEventListener('mouseleave', this._toggleItemHoverState.bind(this, /*hovering*/false));
-      li.addEventListener('mousedown', (event) => {
+      li.addEventListener(
+        'mouseenter',
+        this._toggleItemHoverState.bind(this, /*hovering*/ true)
+      );
+      li.addEventListener(
+        'mouseleave',
+        this._toggleItemHoverState.bind(this, /*hovering*/ false)
+      );
+      li.addEventListener('mousedown', event => {
         // for situations like mobile, hovering might not be
         // the first event to set the active state for an element
         // so we will mimic that on mouse down and let selection happen
         // at the top level event
-        this._toggleItemHoverState(/*hovering*/true, event);
+        this._toggleItemHoverState(/*hovering*/ true, event);
         this._selectCurrentActiveItem();
       });
 
@@ -366,12 +388,10 @@ class AutosuggestDropdownController extends Controller {
    *  level scope, we are going to set them here.
    */
   _addTopLevelEventListeners() {
-
     // we need to use mousedown instead of click
     // so we can beat the blur event which can
     // change visibility/target of the active event
-    document.addEventListener('mousedown', (event) => {
-
+    document.addEventListener('mousedown', event => {
       const target = event.target;
 
       // when clicking the input itself or if we are
@@ -383,7 +403,6 @@ class AutosuggestDropdownController extends Controller {
 
       // see if inside interaction areas
       if (this._suggestionContainer.contains(target)) {
-
         event.preventDefault();
         event.stopPropagation();
       }
@@ -396,52 +415,56 @@ class AutosuggestDropdownController extends Controller {
     // Note, keydown needed here to properly prevent the default
     // nature of navigating keystrokes - like DOWN ARROW at the end of an
     // input takes the cursor to the beginning of the input value.
-    this._input.addEventListener('keydown', (event) => {
+    this._input.addEventListener(
+      'keydown',
+      event => {
+        const key = event.keyCode;
 
-      const key = event.keyCode;
-
-      // only consume the ENTER event if
-      // we have an active item
-      if (key === ENTER && !this._getActiveListItemElement()) {
-        return;
-      }
-
-      // these keys are going to be consumed and not propagated
-      if ([ENTER, UP, DOWN].indexOf(key) > -1) {
-
-        if (key === ENTER) {
-          this._selectCurrentActiveItem();
-        } else {
-          this._keyboardSelectionChange(/*down*/key === DOWN);
+        // only consume the ENTER event if
+        // we have an active item
+        if (key === ENTER && !this._getActiveListItemElement()) {
+          return;
         }
 
-        event.preventDefault();
-        event.stopPropagation();
-        event.stopImmediatePropagation();
-      }
+        // these keys are going to be consumed and not propagated
+        if ([ENTER, UP, DOWN].indexOf(key) > -1) {
+          if (key === ENTER) {
+            this._selectCurrentActiveItem();
+          } else {
+            this._keyboardSelectionChange(/*down*/ key === DOWN);
+          }
 
-      // capture phase needed to beat any other listener that could
-      // stop propagation after inspecting input value
-    }, /*useCapturePhase*/ true);
+          event.preventDefault();
+          event.stopPropagation();
+          event.stopImmediatePropagation();
+        }
 
-    this._input.addEventListener('keyup', (event) => {
+        // capture phase needed to beat any other listener that could
+        // stop propagation after inspecting input value
+      },
+      /*useCapturePhase*/ true
+    );
 
-      if ([ENTER, UP, DOWN].indexOf(event.keyCode) === -1) {
-        this._filterAndToggleVisibility();
-      }
+    this._input.addEventListener(
+      'keyup',
+      event => {
+        if ([ENTER, UP, DOWN].indexOf(event.keyCode) === -1) {
+          this._filterAndToggleVisibility();
+        }
 
-      // capture phase needed to beat any other listener that could
-      // stop propagation after inspecting input value
-    }, /*useCapturePhase*/ true);
+        // capture phase needed to beat any other listener that could
+        // stop propagation after inspecting input value
+      },
+      /*useCapturePhase*/ true
+    );
 
     this._input.addEventListener('focus', () => {
       this._filterAndToggleVisibility();
     });
 
     this._input.addEventListener('blur', () => {
-      this._toggleSuggestionsVisibility(/*show*/false);
+      this._toggleSuggestionsVisibility(/*show*/ false);
     });
-
   }
 }
 

--- a/h/static/scripts/controllers/character-limit-controller.js
+++ b/h/static/scripts/controllers/character-limit-controller.js
@@ -18,8 +18,8 @@ class CharacterLimitController extends Controller {
     const maxlength = parseInt(input.dataset.maxlength);
     const counter = this.refs.characterLimitCounter;
     counter.textContent = input.value.length + '/' + maxlength;
-    setElementState(counter, {tooLong: input.value.length > maxlength});
-    setElementState(this.refs.characterLimitCounter, {ready: true});
+    setElementState(counter, { tooLong: input.value.length > maxlength });
+    setElementState(this.refs.characterLimitCounter, { ready: true });
   }
 }
 

--- a/h/static/scripts/controllers/confirm-submit-controller.js
+++ b/h/static/scripts/controllers/confirm-submit-controller.js
@@ -14,14 +14,18 @@ class ConfirmSubmitController extends Controller {
 
     const window_ = options.window || window;
 
-    element.addEventListener('click', (event) => {
-      if (!window_.confirm(element.dataset.confirmMessage)) {
-        event.preventDefault();
-        event.stopPropagation();
-        event.stopImmediatePropagation();
-        return;
-      }
-    }, /*capture*/ true);
+    element.addEventListener(
+      'click',
+      event => {
+        if (!window_.confirm(element.dataset.confirmMessage)) {
+          event.preventDefault();
+          event.stopPropagation();
+          event.stopImmediatePropagation();
+          return;
+        }
+      },
+      /*capture*/ true
+    );
   }
 }
 

--- a/h/static/scripts/controllers/copy-button-controller.js
+++ b/h/static/scripts/controllers/copy-button-controller.js
@@ -20,29 +20,26 @@ class CopyButtonController extends Controller {
     this.refs.input.readOnly = !isProbablyMobileSafari(userAgent);
 
     this.refs.button.onclick = () => {
-
       // Method for selecting <input> text taken from 'select' package.
       // See https://github.com/zenorocha/select/issues/1 and
       // http://stackoverflow.com/questions/3272089
       this.refs.input.focus();
       this.refs.input.setSelectionRange(0, this.refs.input.value.length);
 
-      const notificationText = document.execCommand('copy') ?
-        'Link copied to clipboard!' :
-        'Copying link failed';
+      const notificationText = document.execCommand('copy')
+        ? 'Link copied to clipboard!'
+        : 'Copying link failed';
 
       const NOTIFICATION_TEXT_TIMEOUT = 1000;
       const originalValue = this.refs.input.value;
       this.refs.input.value = notificationText;
-      window.setTimeout(
-        () => {
-          this.refs.input.value = originalValue;
-          // Copying can leave the <input> focused but its value text not
-          // selected, and since it's already focused clicking on it to focus
-          // it doesn't trigger the auto select all on focus. So we unfocus it.
-          this.refs.input.blur();
-        },
-        NOTIFICATION_TEXT_TIMEOUT);
+      window.setTimeout(() => {
+        this.refs.input.value = originalValue;
+        // Copying can leave the <input> focused but its value text not
+        // selected, and since it's already focused clicking on it to focus
+        // it doesn't trigger the auto select all on focus. So we unfocus it.
+        this.refs.input.blur();
+      }, NOTIFICATION_TEXT_TIMEOUT);
     };
   }
 }

--- a/h/static/scripts/controllers/create-group-form-controller.js
+++ b/h/static/scripts/controllers/create-group-form-controller.js
@@ -15,7 +15,7 @@ function CreateGroupFormController(element) {
   self._groupNameInput.addEventListener('input', groupNameChanged);
   groupNameChanged();
 
-  this._infoLink.addEventListener('click', (event) => {
+  this._infoLink.addEventListener('click', event => {
     event.preventDefault();
     self._infoLink.classList.add('is-hidden');
     self._infoText.classList.remove('is-hidden');

--- a/h/static/scripts/controllers/dropdown-menu-controller.js
+++ b/h/static/scripts/controllers/dropdown-menu-controller.js
@@ -12,7 +12,7 @@ class DropdownMenuController extends Controller {
 
     const toggleEl = this.refs.dropdownMenuToggle;
 
-    const handleClickOutside = (event) => {
+    const handleClickOutside = event => {
       if (!this.refs.dropdownMenuContent.contains(event.target)) {
         // When clicking outside the menu on the toggle element, stop the event
         // so that it does not re-trigger the menu
@@ -21,27 +21,36 @@ class DropdownMenuController extends Controller {
           event.preventDefault();
         }
 
-        this.setState({open: false});
+        this.setState({ open: false });
 
-        element.ownerDocument.removeEventListener('click', handleClickOutside,
-          true /* capture */);
+        element.ownerDocument.removeEventListener(
+          'click',
+          handleClickOutside,
+          true /* capture */
+        );
       }
     };
 
-    toggleEl.addEventListener('click', (event) => {
+    toggleEl.addEventListener('click', event => {
       event.preventDefault();
       event.stopPropagation();
 
-      this.setState({open: true});
+      this.setState({ open: true });
 
-      element.ownerDocument.addEventListener('click', handleClickOutside,
-        true /* capture */);
+      element.ownerDocument.addEventListener(
+        'click',
+        handleClickOutside,
+        true /* capture */
+      );
     });
   }
 
   update(state) {
-    setElementState(this.refs.dropdownMenuContent, {open: state.open});
-    this.refs.dropdownMenuToggle.setAttribute('aria-expanded', state.open.toString());
+    setElementState(this.refs.dropdownMenuContent, { open: state.open });
+    this.refs.dropdownMenuToggle.setAttribute(
+      'aria-expanded',
+      state.open.toString()
+    );
   }
 }
 

--- a/h/static/scripts/controllers/form-cancel-controller.js
+++ b/h/static/scripts/controllers/form-cancel-controller.js
@@ -15,7 +15,7 @@ class FormCancelController extends Controller {
 
     const window_ = options.window || window;
 
-    element.addEventListener('click', (event) => {
+    element.addEventListener('click', event => {
       event.preventDefault();
       window_.close();
     });

--- a/h/static/scripts/controllers/form-controller.js
+++ b/h/static/scripts/controllers/form-controller.js
@@ -44,52 +44,57 @@ class FormController extends Controller {
   constructor(element, options) {
     super(element, options);
 
-    setElementState(this.refs.cancelBtn, {hidden: false});
-    this.refs.cancelBtn.addEventListener('click', (event) => {
+    setElementState(this.refs.cancelBtn, { hidden: false });
+    this.refs.cancelBtn.addEventListener('click', event => {
       event.preventDefault();
       this.cancel();
     });
 
     // List of groups of controls that constitute each form field
-    this._fields = Array.from(element.querySelectorAll('.js-form-input'))
-      .map((el) => {
+    this._fields = Array.from(element.querySelectorAll('.js-form-input')).map(
+      el => {
         const parts = findRefs(el);
         return {
           container: el,
           input: parts.formInput,
           label: parts.label,
         };
-      });
-
-    this.on('focus', (event) => {
-      const field = this._fields.find(field => field.input === event.target);
-      if (!field) {
-        return;
       }
+    );
 
-      this.setState({
-        editingFields: this._editSet(field),
-        focusedField: field,
-      });
-    }, true /* capture - focus does not bubble */);
+    this.on(
+      'focus',
+      event => {
+        const field = this._fields.find(field => field.input === event.target);
+        if (!field) {
+          return;
+        }
 
-    this.on('change', (event) => {
+        this.setState({
+          editingFields: this._editSet(field),
+          focusedField: field,
+        });
+      },
+      true /* capture - focus does not bubble */
+    );
+
+    this.on('change', event => {
       if (shouldAutosubmit(event.target.type)) {
         this.submit();
       }
     });
 
-    this.on('input', (event) => {
+    this.on('input', event => {
       // Some but not all browsers deliver an `input` event for radio/checkbox
       // inputs. Since we auto-submit when such inputs change, don't mark the
       // field as dirty.
       if (shouldAutosubmit(event.target.type)) {
         return;
       }
-      this.setState({dirty: true});
+      this.setState({ dirty: true });
     });
 
-    this.on('keydown', (event) => {
+    this.on('keydown', event => {
       event.stopPropagation();
       if (event.key === 'Escape') {
         this.cancel();
@@ -97,13 +102,13 @@ class FormController extends Controller {
     });
 
     // Ignore clicks outside of the active field when editing
-    this.refs.formBackdrop.addEventListener('mousedown', (event) => {
+    this.refs.formBackdrop.addEventListener('mousedown', event => {
       event.preventDefault();
       event.stopPropagation();
     });
 
     // Setup AJAX handling for forms
-    this.on('submit', (event) => {
+    this.on('submit', event => {
       event.preventDefault();
       this.submit();
     });
@@ -139,13 +144,15 @@ class FormController extends Controller {
       );
     }
 
-    if (state.editingFields.length > 0 &&
-        state.editingFields !== prevState.editingFields) {
+    if (
+      state.editingFields.length > 0 &&
+      state.editingFields !== prevState.editingFields
+    ) {
       this._trapFocus();
     }
 
     const isEditing = state.editingFields.length > 0;
-    setElementState(this.element, {editing: isEditing});
+    setElementState(this.element, { editing: isEditing });
     setElementState(this.refs.formActions, {
       hidden: !isEditing || shouldAutosubmit(state.editingFields[0].input.type),
       saving: state.saving,
@@ -166,12 +173,13 @@ class FormController extends Controller {
    * @param {Object} state - The internal state of the form
    */
   _updateFields(state) {
-    this._fields.forEach((field) => {
+    this._fields.forEach(field => {
       setElementState(field.container, {
         editing: state.editingFields.includes(field),
         focused: field === state.focusedField,
-        hidden: isHiddenField(field.container) &&
-                !state.editingFields.includes(field),
+        hidden:
+          isHiddenField(field.container) &&
+          !state.editingFields.includes(field),
       });
 
       // Update labels
@@ -212,42 +220,45 @@ class FormController extends Controller {
       activeInputId = this.state.editingFields[0].input.id;
     }
 
-    this.setState({saving: true});
+    this.setState({ saving: true });
 
-    return submitForm(this.element).then((response) => {
-      this.options.reload(response.form);
-    }).catch((err) => {
-      if (err.form) {
-        // The server processed the request but rejected the submission.
-        // Display the returned form which will contain any validation error
-        // messages.
-        const newFormEl = this.options.reload(err.form);
-        const newFormCtrl = newFormEl.controllers.find(ctrl =>
-          ctrl instanceof FormController);
+    return submitForm(this.element)
+      .then(response => {
+        this.options.reload(response.form);
+      })
+      .catch(err => {
+        if (err.form) {
+          // The server processed the request but rejected the submission.
+          // Display the returned form which will contain any validation error
+          // messages.
+          const newFormEl = this.options.reload(err.form);
+          const newFormCtrl = newFormEl.controllers.find(
+            ctrl => ctrl instanceof FormController
+          );
 
-        // Resume editing the field where validation failed
-        const newInput = document.getElementById(activeInputId);
-        if (newInput) {
-          newInput.focus();
+          // Resume editing the field where validation failed
+          const newInput = document.getElementById(activeInputId);
+          if (newInput) {
+            newInput.focus();
+          }
+
+          newFormCtrl.setState({
+            // Mark the field in the replaced form as dirty since it has unsaved
+            // changes
+            dirty: newInput !== null,
+            // If editing is canceled, revert back to the _original_ version of
+            // the form, not the version with validation errors from the server.
+            originalForm,
+          });
+        } else {
+          // If there was an error processing the request or the server could
+          // not be reached, display a helpful error
+          this.setState({
+            submitError: err.reason || 'There was a problem saving changes.',
+            saving: false,
+          });
         }
-
-        newFormCtrl.setState({
-          // Mark the field in the replaced form as dirty since it has unsaved
-          // changes
-          dirty: newInput !== null,
-          // If editing is canceled, revert back to the _original_ version of
-          // the form, not the version with validation errors from the server.
-          originalForm,
-        });
-      } else {
-        // If there was an error processing the request or the server could
-        // not be reached, display a helpful error
-        this.setState({
-          submitError: err.reason || 'There was a problem saving changes.',
-          saving: false,
-        });
-      }
-    });
+      });
   }
 
   /**
@@ -255,7 +266,9 @@ class FormController extends Controller {
    * depending upon the field which is currently focused.
    */
   _focusGroup() {
-    const fieldContainers = this.state.editingFields.map(field => field.container);
+    const fieldContainers = this.state.editingFields.map(
+      field => field.container
+    );
     if (fieldContainers.length === 0) {
       return null;
     }
@@ -267,21 +280,24 @@ class FormController extends Controller {
    * Trap focus within the set of form fields currently being edited.
    */
   _trapFocus() {
-    this._releaseFocus = modalFocus.trap(this._focusGroup(), (newFocusedElement) => {
-      // Keep focus in the current field when it has unsaved changes,
-      // otherwise let the user focus another field in the form or move focus
-      // outside the form entirely.
-      if (this.state.dirty) {
-        return this.state.editingFields[0].input;
-      }
+    this._releaseFocus = modalFocus.trap(
+      this._focusGroup(),
+      newFocusedElement => {
+        // Keep focus in the current field when it has unsaved changes,
+        // otherwise let the user focus another field in the form or move focus
+        // outside the form entirely.
+        if (this.state.dirty) {
+          return this.state.editingFields[0].input;
+        }
 
-      // If the user tabs out of the form, clear the editing state
-      if (!this.element.contains(newFocusedElement)) {
-        this.setState({editingFields: []});
-      }
+        // If the user tabs out of the form, clear the editing state
+        if (!this.element.contains(newFocusedElement)) {
+          this.setState({ editingFields: [] });
+        }
 
-      return null;
-    });
+        return null;
+      }
+    );
   }
 
   /**

--- a/h/static/scripts/controllers/form-select-onfocus-controller.js
+++ b/h/static/scripts/controllers/form-select-onfocus-controller.js
@@ -11,7 +11,7 @@ class FormSelectOnFocusController extends Controller {
       element.select();
     }
 
-    element.addEventListener('focus', (event) => {
+    element.addEventListener('focus', event => {
       event.target.select();
     });
   }

--- a/h/static/scripts/controllers/input-autofocus-controller.js
+++ b/h/static/scripts/controllers/input-autofocus-controller.js
@@ -3,8 +3,9 @@
 const Controller = require('../base/controller');
 
 function isWordChar(event) {
-  return event.key.match(/^\w$/) && !event.ctrlKey && !event.altKey &&
-                                    !event.metaKey;
+  return (
+    event.key.match(/^\w$/) && !event.ctrlKey && !event.altKey && !event.metaKey
+  );
 }
 
 /**
@@ -19,7 +20,7 @@ class InputAutofocusController extends Controller {
   constructor(element) {
     super(element);
 
-    this._onKeyDown = (event) => {
+    this._onKeyDown = event => {
       if (document.activeElement === document.body) {
         if (isWordChar(event) || event.key === 'Backspace') {
           element.focus();

--- a/h/static/scripts/controllers/list-input-controller.js
+++ b/h/static/scripts/controllers/list-input-controller.js
@@ -22,7 +22,7 @@ class ListInputController extends Controller {
     });
 
     // Handle 'Remove' button.
-    element.addEventListener('click', (event) => {
+    element.addEventListener('click', event => {
       const btn = event.target.closest('button');
       if (btn.getAttribute('data-ref') === 'removeItemButton') {
         const parentItem = event.target.closest('li');

--- a/h/static/scripts/controllers/lozenge-controller.js
+++ b/h/static/scripts/controllers/lozenge-controller.js
@@ -17,7 +17,6 @@ const { setElementState } = require('../util/dom');
  * });
  */
 class LozengeController extends Controller {
-
   constructor(element, options) {
     super(element, options);
 
@@ -32,14 +31,16 @@ class LozengeController extends Controller {
     let facetValue = options.content;
 
     if (searchTextParser.hasKnownNamedQueryTerm(options.content)) {
-      const queryTerm = searchTextParser.getLozengeFacetNameAndValue(options.content);
+      const queryTerm = searchTextParser.getLozengeFacetNameAndValue(
+        options.content
+      );
       facetName = queryTerm.facetName;
       facetValue = queryTerm.facetValue;
     }
 
     element.classList.add('js-lozenge');
 
-    this.refs.deleteButton.addEventListener('click', (event) => {
+    this.refs.deleteButton.addEventListener('click', event => {
       event.preventDefault();
       options.deleteCallback();
     });
@@ -52,7 +53,7 @@ class LozengeController extends Controller {
   }
 
   update(state) {
-    setElementState(this.element, {disabled: state.disabled});
+    setElementState(this.element, { disabled: state.disabled });
     let facetName = state.facetName;
     if (facetName) {
       facetName += ':';

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -9,12 +9,10 @@ const SearchTextParser = require('../util/search-text-parser');
 const { cloneTemplate } = require('../util/dom');
 const stringUtil = require('../util/string');
 
-
 const FACET_TYPE = 'FACET';
 const TAG_TYPE = 'TAG';
 const GROUP_TYPE = 'GROUP';
 const MAX_SUGGESTIONS = 5;
-
 
 /**
  * Normalize a string for use in comparisons of user input with a suggestion.
@@ -44,7 +42,6 @@ class SearchBarController extends Controller {
      *  lists of all suggestion values.
      */
     this._suggestionsMap = (() => {
-
       const explanationList = [
         {
           matchOn: 'user',
@@ -67,7 +64,9 @@ class SearchBarController extends Controller {
           title: 'group:',
           explanation: 'show annotations associated with a group',
         },
-      ].map((item) => { return Object.assign(item, { type: FACET_TYPE}); });
+      ].map(item => {
+        return Object.assign(item, { type: FACET_TYPE });
+      });
 
       // tagSuggestions are made available by the scoped template data.
       // see search.html.jinja2 for definition
@@ -82,7 +81,7 @@ class SearchBarController extends Controller {
         }
       }
 
-      const tagsList = ((tagSuggestions) || []).map((item) => {
+      const tagsList = (tagSuggestions || []).map(item => {
         return Object.assign(item, {
           type: TAG_TYPE,
           title: item.tag, // make safe
@@ -93,18 +92,23 @@ class SearchBarController extends Controller {
 
       // groupSuggestions are made available by the scoped template data.
       // see search.html.jinja2 for definition
-      const groupSuggestionJSON = document.querySelector('.js-group-suggestions');
+      const groupSuggestionJSON = document.querySelector(
+        '.js-group-suggestions'
+      );
       let groupSuggestions = [];
 
       if (groupSuggestionJSON) {
         try {
           groupSuggestions = JSON.parse(groupSuggestionJSON.innerHTML.trim());
         } catch (e) {
-          console.error('Could not parse .js-group-suggestions JSON content', e);
+          console.error(
+            'Could not parse .js-group-suggestions JSON content',
+            e
+          );
         }
       }
 
-      const groupsList = ((groupSuggestions) || []).map((item) => {
+      const groupsList = (groupSuggestions || []).map(item => {
         return Object.assign(item, {
           type: GROUP_TYPE,
           title: item.name, // make safe
@@ -122,7 +126,6 @@ class SearchBarController extends Controller {
       return this._input.value.trim();
     };
 
-
     /**
      * given a lozenge set for a group, like "group:value", match the value
      *  against our group suggestions list to find a match on either pubid
@@ -138,7 +141,7 @@ class SearchBarController extends Controller {
      *      input: {String}    // like group:pid1234
      *    }
      */
-    const getInputAndDisplayValsForGroup = (groupLoz) => {
+    const getInputAndDisplayValsForGroup = groupLoz => {
       let groupVal = groupLoz.substr(groupLoz.indexOf(':') + 1).trim();
       let inputVal = groupVal.trim();
       let displayVal = groupVal;
@@ -146,12 +149,14 @@ class SearchBarController extends Controller {
         return str.indexOf(' ') > -1 ? `"${str}"` : str;
       };
 
-
       // remove quotes from value
-      if (groupVal[0] === '"' || groupVal[0] === '\'') {
+      if (groupVal[0] === '"' || groupVal[0] === "'") {
         groupVal = groupVal.substr(1);
       }
-      if (groupVal[groupVal.length - 1] === '"' || groupVal[groupVal.length - 1] === '\'') {
+      if (
+        groupVal[groupVal.length - 1] === '"' ||
+        groupVal[groupVal.length - 1] === "'"
+      ) {
         groupVal = groupVal.slice(0, -1);
       }
 
@@ -163,16 +168,20 @@ class SearchBarController extends Controller {
       // them equal to us. Since that is very unlikely to occur for one user's group
       // set, the convenience of being defensive about bad input/urls is more valuable
       // than the risk of overlap.
-      const matchByPubid = this._suggestionsMap.find((item) => {
-        return item.type === GROUP_TYPE && item.pubid.toLowerCase() === matchVal;
+      const matchByPubid = this._suggestionsMap.find(item => {
+        return (
+          item.type === GROUP_TYPE && item.pubid.toLowerCase() === matchVal
+        );
       });
 
       if (matchByPubid) {
         inputVal = matchByPubid.pubid;
         displayVal = wrapQuotesIfNeeded(matchByPubid.name);
       } else {
-        const matchByName = this._suggestionsMap.find((item) => {
-          return item.type === GROUP_TYPE && item.matchOn.toLowerCase() === matchVal;
+        const matchByName = this._suggestionsMap.find(item => {
+          return (
+            item.type === GROUP_TYPE && item.matchOn.toLowerCase() === matchVal
+          );
         });
         if (matchByName) {
           inputVal = matchByName.pubid;
@@ -210,7 +219,9 @@ class SearchBarController extends Controller {
 
     /** Return the controllers for all of the displayed lozenges. */
     const lozenges = () => {
-      const lozElements = Array.from(this.element.querySelectorAll('.js-lozenge'));
+      const lozElements = Array.from(
+        this.element.querySelectorAll('.js-lozenge')
+      );
       return lozElements.map(el => el.controllers[0]);
     };
 
@@ -226,7 +237,7 @@ class SearchBarController extends Controller {
      */
     const updateHiddenInput = () => {
       let newValue = '';
-      lozenges().forEach((loz) => {
+      lozenges().forEach(loz => {
         let inputValue = loz.inputValue();
         if (inputValue.indexOf('group:') === 0) {
           inputValue = getInputAndDisplayValsForGroup(inputValue).input;
@@ -243,21 +254,24 @@ class SearchBarController extends Controller {
      *
      * @param {string} content The search term
      */
-    const addLozenge = (content) => {
-
+    const addLozenge = content => {
       const lozengeEl = cloneTemplate(this.options.lozengeTemplate);
       const currentLozenges = this.element.querySelectorAll('.lozenge');
       if (currentLozenges.length > 0) {
-        this._lozengeContainer.insertBefore(lozengeEl,
-          currentLozenges[currentLozenges.length-1].nextSibling);
+        this._lozengeContainer.insertBefore(
+          lozengeEl,
+          currentLozenges[currentLozenges.length - 1].nextSibling
+        );
       } else {
-        this._lozengeContainer.insertBefore(lozengeEl,
-          this._lozengeContainer.firstChild);
+        this._lozengeContainer.insertBefore(
+          lozengeEl,
+          this._lozengeContainer.firstChild
+        );
       }
 
       const deleteCallback = () => {
         lozengeEl.remove();
-        lozenges().forEach(ctrl => ctrl.setState({disabled: true}));
+        lozenges().forEach(ctrl => ctrl.setState({ disabled: true }));
         updateHiddenInput();
         this.refs.searchBarForm.submit();
       };
@@ -281,8 +295,10 @@ class SearchBarController extends Controller {
      * so they are hooked up with the proper event handling
      */
     const lozengifyInput = () => {
-
-      const {lozengeValues, incompleteInputValue} = SearchTextParser.getLozengeValues(this._input.value);
+      const {
+        lozengeValues,
+        incompleteInputValue,
+      } = SearchTextParser.getLozengeValues(this._input.value);
 
       lozengeValues.forEach(addLozenge);
       this._input.value = incompleteInputValue;
@@ -290,8 +306,7 @@ class SearchBarController extends Controller {
       updateHiddenInput();
     };
 
-
-    const onInputKeyDown = (event) => {
+    const onInputKeyDown = event => {
       const SPACE_KEY_CODE = 32;
 
       if (event.keyCode === SPACE_KEY_CODE) {
@@ -305,12 +320,9 @@ class SearchBarController extends Controller {
       }
     };
 
-
     this._hiddenInput = insertHiddenInput(this.refs.searchBarForm);
 
-
-    this._suggestionsHandler = new AutosuggestDropdownController( this._input, {
-
+    this._suggestionsHandler = new AutosuggestDropdownController(this._input, {
       list: this._suggestionsMap,
 
       header: 'Narrow your search:',
@@ -323,21 +335,26 @@ class SearchBarController extends Controller {
         activeItem: 'js-search-bar-dropdown-menu-item--active',
       },
 
-      renderListItem: (listItem) => {
-        let itemContents = `<span class="search-bar__dropdown-menu-title"> ${escapeHtml(listItem.title)} </span>`;
+      renderListItem: listItem => {
+        let itemContents = `<span class="search-bar__dropdown-menu-title"> ${escapeHtml(
+          listItem.title
+        )} </span>`;
         if (listItem.type === GROUP_TYPE && listItem.relationship) {
-          itemContents += `<span class="search-bar__dropdown-menu-relationship"> ${escapeHtml(listItem.relationship)} </span>`;
+          itemContents += `<span class="search-bar__dropdown-menu-relationship"> ${escapeHtml(
+            listItem.relationship
+          )} </span>`;
         }
-        
+
         if (listItem.explanation) {
-          itemContents += `<span class="search-bar__dropdown-menu-explanation"> ${listItem.explanation} </span>`;
+          itemContents += `<span class="search-bar__dropdown-menu-explanation"> ${
+            listItem.explanation
+          } </span>`;
         }
 
         return itemContents;
       },
 
       listFilter: (list, currentInput) => {
-
         currentInput = (currentInput || '').trim();
 
         let typeFilter = FACET_TYPE;
@@ -354,7 +371,7 @@ class SearchBarController extends Controller {
           inputFilter = inputFilter.substr(inputFilter.indexOf(':') + 1);
 
           // remove the initial quote for comparisons if it exists
-          if (inputFilter[0] === '\'' || inputFilter[0] === '"') {
+          if (inputFilter[0] === "'" || inputFilter[0] === '"') {
             inputFilter = inputFilter.substr(1);
           }
         }
@@ -365,47 +382,52 @@ class SearchBarController extends Controller {
           });
         }
 
-        return list.filter((item) => {
-          return item.type === typeFilter && item.matchOn.toLowerCase().indexOf(inputFilter.toLowerCase()) >= 0;
-        }).sort((a,b) => {
+        return list
+          .filter(item => {
+            return (
+              item.type === typeFilter &&
+              item.matchOn.toLowerCase().indexOf(inputFilter.toLowerCase()) >= 0
+            );
+          })
+          .sort((a, b) => {
+            // this sort functions intention is to
+            // sort partial matches as lower index match
+            // value first. Then let natural sort of the
+            // original list take effect if they have equal
+            // index values or there is no current input value
 
-          // this sort functions intention is to
-          // sort partial matches as lower index match
-          // value first. Then let natural sort of the
-          // original list take effect if they have equal
-          // index values or there is no current input value
+            if (inputFilter) {
+              const aIndex = a.matchOn.indexOf(inputFilter);
+              const bIndex = b.matchOn.indexOf(inputFilter);
 
-          if (inputFilter) {
-            const aIndex = a.matchOn.indexOf(inputFilter);
-            const bIndex = b.matchOn.indexOf(inputFilter);
-
-            // match score
-            if (aIndex > bIndex) {
-              return 1;
-            } else if (aIndex < bIndex) {
-              return -1;
+              // match score
+              if (aIndex > bIndex) {
+                return 1;
+              } else if (aIndex < bIndex) {
+                return -1;
+              }
             }
-          }
 
-
-          // If we are filtering on tags, we need to arrange
-          // by popularity
-          if (typeFilter === TAG_TYPE) {
-            if (a.usageCount > b.usageCount) {
-              return -1;
-            } else if (a.usageCount < b.usageCount) {
-              return 1;
+            // If we are filtering on tags, we need to arrange
+            // by popularity
+            if (typeFilter === TAG_TYPE) {
+              if (a.usageCount > b.usageCount) {
+                return -1;
+              } else if (a.usageCount < b.usageCount) {
+                return 1;
+              }
             }
-          }
 
-          return 0;
-
-        }).slice(0, MAX_SUGGESTIONS);
+            return 0;
+          })
+          .slice(0, MAX_SUGGESTIONS);
       },
 
-      onSelect: (itemSelected) => {
-
-        if (itemSelected.type === TAG_TYPE || itemSelected.type === GROUP_TYPE) {
+      onSelect: itemSelected => {
+        if (
+          itemSelected.type === TAG_TYPE ||
+          itemSelected.type === GROUP_TYPE
+        ) {
           const prefix = itemSelected.type === TAG_TYPE ? 'tag:' : 'group:';
 
           let valSelection = itemSelected.title;
@@ -427,7 +449,6 @@ class SearchBarController extends Controller {
         }
         updateHiddenInput();
       },
-
     });
 
     this._input.addEventListener('keydown', onInputKeyDown);
@@ -436,7 +457,6 @@ class SearchBarController extends Controller {
   }
 
   update(newState, prevState) {
-
     if (!this._suggestionsHandler) {
       return;
     }
@@ -450,7 +470,6 @@ class SearchBarController extends Controller {
         this._suggestionsHandler.setHeader('Narrow your search:');
       }
     }
-
   }
 }
 

--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -26,7 +26,7 @@ class SearchBucketController extends Controller {
 
     this.scrollTo = this.options.scrollTo || scrollIntoView;
 
-    this.refs.header.addEventListener('click', (event) => {
+    this.refs.header.addEventListener('click', event => {
       if (this.refs.domainLink.contains(event.target)) {
         return;
       }
@@ -34,18 +34,18 @@ class SearchBucketController extends Controller {
       event.stopPropagation();
       event.preventDefault();
 
-      this.setState({expanded: !this.state.expanded});
+      this.setState({ expanded: !this.state.expanded });
     });
 
-    this.refs.title.addEventListener('click', (event) => {
+    this.refs.title.addEventListener('click', event => {
       event.stopPropagation();
       event.preventDefault();
 
-      this.setState({expanded: !this.state.expanded});
+      this.setState({ expanded: !this.state.expanded });
     });
 
     this.refs.collapseView.addEventListener('click', () => {
-      this.setState({expanded: !this.state.expanded});
+      this.setState({ expanded: !this.state.expanded });
     });
 
     const envFlags = this.options.envFlags || window.envFlags;
@@ -56,8 +56,8 @@ class SearchBucketController extends Controller {
   }
 
   update(state, prevState) {
-    setElementState(this.refs.content, {expanded: state.expanded});
-    setElementState(this.element, {expanded: state.expanded});
+    setElementState(this.refs.content, { expanded: state.expanded });
+    setElementState(this.element, { expanded: state.expanded });
 
     this.refs.title.setAttribute('aria-expanded', state.expanded.toString());
 

--- a/h/static/scripts/controllers/share-widget-controller.js
+++ b/h/static/scripts/controllers/share-widget-controller.js
@@ -11,12 +11,12 @@ const CLIPBOARD_INPUT_SELECTOR = '.js-share-widget-clipboard';
 const PRIVATE_MSG_SELECTOR = '.js-share-widget-msg-private';
 const GROUP_MSG_SELECTOR = '.js-share-widget-msg-group';
 
-const ARROW_PADDING_RIGHT =  16;
-const ARROW_PADDING_BOTTOM =  5;
+const ARROW_PADDING_RIGHT = 16;
+const ARROW_PADDING_BOTTOM = 5;
 
 let shareWidgetAttached = false;
 
-const getOffset = (el) => {
+const getOffset = el => {
   el = el.getBoundingClientRect();
   return {
     // adjust for top left of the document
@@ -27,11 +27,8 @@ const getOffset = (el) => {
   };
 };
 
-
 class ShareWidget {
-
   constructor(containerElement) {
-
     // we only attach one to the dom since it's a global listener
     if (shareWidgetAttached) {
       return;
@@ -46,8 +43,7 @@ class ShareWidget {
     // on initialize we need to reset container visbility
     this.hide();
 
-    this._handler = (event) => {
-
+    this._handler = event => {
       const target = event.target;
 
       // do nothing if we are clicking inside of the widget
@@ -58,7 +54,6 @@ class ShareWidget {
       const trigger = target.closest(TRIGGER_SELECTOR);
 
       if (trigger) {
-
         const config = JSON.parse(trigger.getAttribute(CONFIG_ATTR));
 
         // if we click the same trigger twice we expect
@@ -78,7 +73,6 @@ class ShareWidget {
         event.stopPropagation();
         event.stopImmediatePropagation();
         return;
-
       }
 
       // hide the widget if the click was not handled by
@@ -105,14 +99,17 @@ class ShareWidget {
    *   with the correct information per card.
    */
   _renderWidgetTemplate(config) {
-
     // copy to clipboard input
     this._widget.querySelector(CLIPBOARD_INPUT_SELECTOR).value = config.url;
 
     // social links
-    Array.from(this._widget.querySelectorAll(TARGET_HREF_SELECTOR)).forEach((target) => {
-      target.href = target.getAttribute(TARGET_HREF_ATTR).replace('{href}', encodeURI(config.url));
-    });
+    Array.from(this._widget.querySelectorAll(TARGET_HREF_SELECTOR)).forEach(
+      target => {
+        target.href = target
+          .getAttribute(TARGET_HREF_ATTR)
+          .replace('{href}', encodeURI(config.url));
+      }
+    );
 
     // scope access dialog
     const privateMessage = this._widget.querySelector(PRIVATE_MSG_SELECTOR);
@@ -128,7 +125,6 @@ class ShareWidget {
     }
   }
 
-
   /**
    * Given a node, update the template, repostion the widget properly,
    *  and make it visible.
@@ -138,7 +134,6 @@ class ShareWidget {
    * @param  {ConfigOptions} config Passed through to rendering/interpolation
    */
   showForNode(node, config) {
-
     if (!node || !config) {
       throw new Error('showForNode did not recieve both arguments');
     }
@@ -146,11 +141,17 @@ class ShareWidget {
     this._renderWidgetTemplate(config);
 
     // offsets affecting height need to be updated after variable replacement
-    const widgetOffsets =  getOffset(this._widget);
+    const widgetOffsets = getOffset(this._widget);
     const nodeOffset = getOffset(node);
 
-    this._widget.style.top = (nodeOffset.top - widgetOffsets.height - ARROW_PADDING_BOTTOM) + 'px';
-    this._widget.style.left = ((ARROW_PADDING_RIGHT + nodeOffset.left + (nodeOffset.width / 2)) - widgetOffsets.width) + 'px';
+    this._widget.style.top =
+      nodeOffset.top - widgetOffsets.height - ARROW_PADDING_BOTTOM + 'px';
+    this._widget.style.left =
+      ARROW_PADDING_RIGHT +
+      nodeOffset.left +
+      nodeOffset.width / 2 -
+      widgetOffsets.width +
+      'px';
 
     this._container.style.visibility = 'visible';
 
@@ -161,7 +162,6 @@ class ShareWidget {
     this._container.style.visibility = 'hidden';
     this._widgetVisible = false;
   }
-
 
   /**
    * Utility to clean up the listeners applied. Otherwise the subsequent
@@ -180,7 +180,6 @@ class ShareWidget {
  * the libraries api
  */
 class ShareWidgetController extends Controller {
-
   constructor(element, options = {}) {
     super(element, options);
 

--- a/h/static/scripts/controllers/tooltip-controller.js
+++ b/h/static/scripts/controllers/tooltip-controller.js
@@ -25,20 +25,21 @@ class TooltipController extends Controller {
     // focus.
     // See http://www.codediesel.com/javascript/making-mouseover-event-work-on-an-ipad/
     el.addEventListener('mouseover', () => {
-      this.setState({target: el});
+      this.setState({ target: el });
     });
 
     el.addEventListener('mouseout', () => {
-      this.setState({target: null});
+      this.setState({ target: null });
     });
 
     this._tooltipEl = el.ownerDocument.createElement('div');
-    this._tooltipEl.innerHTML = '<span class="tooltip-label js-tooltip-label"></span>';
+    this._tooltipEl.innerHTML =
+      '<span class="tooltip-label js-tooltip-label"></span>';
     this._tooltipEl.className = 'tooltip';
     el.appendChild(this._tooltipEl);
     this._labelEl = this._tooltipEl.querySelector('.js-tooltip-label');
 
-    this.setState({target: null});
+    this.setState({ target: null });
   }
 
   update(state) {

--- a/h/static/scripts/header.js
+++ b/h/static/scripts/header.js
@@ -11,10 +11,17 @@ window.envFlags = new EnvironmentFlags(document.documentElement);
 window.envFlags.init();
 
 // Set up the Google Analytics command queue if we have a tracking ID.
-const gaTrackingId = document.querySelector('meta[name="google-analytics-tracking-id"]');
+const gaTrackingId = document.querySelector(
+  'meta[name="google-analytics-tracking-id"]'
+);
 if (gaTrackingId) {
   /* eslint-disable */
-  window.ga = window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+  window.ga =
+    window.ga ||
+    function() {
+      (ga.q = ga.q || []).push(arguments);
+    };
+  ga.l = +new Date();
   ga('create', gaTrackingId.content, 'auto');
   ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');

--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -2,18 +2,12 @@
 
 module.exports = function(config) {
   config.set({
-
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: './',
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: [
-      'browserify',
-      'mocha',
-      'chai',
-      'sinon',
-    ],
+    frameworks: ['browserify', 'mocha', 'chai', 'sinon'],
 
     // list of files / patterns to load in the browser
     files: [
@@ -26,12 +20,16 @@ module.exports = function(config) {
       // Karma watching is disabled for these files because they are
       // bundled with karma-browserify which handles watching itself via
       // watchify
-      { pattern: 'tests/**/*-test.js', watched: false, included: true, served: true },
+      {
+        pattern: 'tests/**/*-test.js',
+        watched: false,
+        included: true,
+        served: true,
+      },
     ],
 
     // list of files to exclude
-    exclude: [
-    ],
+    exclude: [],
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
@@ -44,9 +42,12 @@ module.exports = function(config) {
     browserify: {
       debug: true,
       transform: [
-        ['babelify', {
-          plugins: ['mockable-imports'],
-        }],
+        [
+          'babelify',
+          {
+            plugins: ['mockable-imports'],
+          },
+        ],
       ],
     },
 

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -21,7 +21,7 @@ require('element-dataset')();
 
 // Element.prototype.remove. Required by IE 10/11
 if (!Element.prototype.remove) {
-  Element.prototype.remove = function () {
+  Element.prototype.remove = function() {
     if (this.parentNode) {
       this.parentNode.removeChild(this);
     }

--- a/h/static/scripts/post-auth.js
+++ b/h/static/scripts/post-auth.js
@@ -46,7 +46,10 @@ function sendAuthResponse() {
       clientWindow.dispatchEvent(event);
       window.close();
     } catch (err) {
-      console.error('The "web_message" response mode is not supported in IE', err);
+      console.error(
+        'The "web_message" response mode is not supported in IE',
+        err
+      );
     }
     return;
   }
@@ -56,4 +59,3 @@ function sendAuthResponse() {
 }
 
 sendAuthResponse();
-

--- a/h/static/scripts/tests/base/controller-test.js
+++ b/h/static/scripts/tests/base/controller-test.js
@@ -29,20 +29,24 @@ describe('Controller', () => {
   });
 
   it('exposes elements with "data-ref" attributes on the `refs` property', () => {
-    assert.deepEqual(ctrl.refs, {test: ctrl.element.children[0]});
+    assert.deepEqual(ctrl.refs, { test: ctrl.element.children[0] });
   });
 
   describe('#setState', () => {
     it('calls update() with new and previous state', () => {
-      ctrl.setState({open: true});
+      ctrl.setState({ open: true });
       ctrl.update = sinon.stub();
-      ctrl.setState({open: true, saving: true});
-      assert.calledWith(ctrl.update, {
-        open: true,
-        saving: true,
-      }, {
-        open: true,
-      });
+      ctrl.setState({ open: true, saving: true });
+      assert.calledWith(
+        ctrl.update,
+        {
+          open: true,
+          saving: true,
+        },
+        {
+          open: true,
+        }
+      );
     });
   });
 });

--- a/h/static/scripts/tests/base/environment-flags-test.js
+++ b/h/static/scripts/tests/base/environment-flags-test.js
@@ -37,7 +37,7 @@ describe('EnvironmentFlags', () => {
     });
 
     it('should add "env-touch" flag if touch events are available', () => {
-      el.ontouchstart = function () {};
+      el.ontouchstart = function() {};
       flags.init();
       assert.isTrue(el.classList.contains('env-touch'));
     });

--- a/h/static/scripts/tests/base/raven-test.js
+++ b/h/static/scripts/tests/base/raven-test.js
@@ -31,9 +31,13 @@ describe('raven', () => {
         release: 'release',
         userid: 'acct:foobar@hypothes.is',
       });
-      assert.calledWith(fakeRavenJS.config, 'dsn', sinon.match({
-        release: 'release',
-      }));
+      assert.calledWith(
+        fakeRavenJS.config,
+        'dsn',
+        sinon.match({
+          release: 'release',
+        })
+      );
     });
 
     it('sets the user context when a userid is specified', () => {
@@ -42,9 +46,12 @@ describe('raven', () => {
         release: 'release',
         userid: 'acct:foobar@hypothes.is',
       });
-      assert.calledWith(fakeRavenJS.setUserContext, sinon.match({
-        id: 'acct:foobar@hypothes.is',
-      }));
+      assert.calledWith(
+        fakeRavenJS.setUserContext,
+        sinon.match({
+          id: 'acct:foobar@hypothes.is',
+        })
+      );
     });
 
     it('does not set the user context when a userid is not specified', () => {
@@ -62,18 +69,25 @@ describe('raven', () => {
         release: 'release',
       });
       const event = document.createEvent('Event');
-      event.initEvent('unhandledrejection', true /* bubbles */, true /* cancelable */);
+      event.initEvent(
+        'unhandledrejection',
+        true /* bubbles */,
+        true /* cancelable */
+      );
       event.reason = new Error('Some error');
       window.dispatchEvent(event);
 
-      assert.calledWith(fakeRavenJS.captureException, event.reason,
-        sinon.match.any);
+      assert.calledWith(
+        fakeRavenJS.captureException,
+        event.reason,
+        sinon.match.any
+      );
     });
   });
 
   describe('.report()', () => {
     it('extracts the message property from Error-like objects', () => {
-      raven.report({message: 'An error'}, 'context');
+      raven.report({ message: 'An error' }, 'context');
       assert.calledWith(fakeRavenJS.captureException, 'An error', {
         extra: {
           when: 'context',

--- a/h/static/scripts/tests/base/settings-test.js
+++ b/h/static/scripts/tests/base/settings-test.js
@@ -13,7 +13,7 @@ function createJSONScriptTag(obj, className) {
 
 function removeJSONScriptTags() {
   const elements = document.querySelectorAll('.js-settings-test');
-  for (let i=0; i < elements.length; i++) {
+  for (let i = 0; i < elements.length; i++) {
     elements[i].parentNode.removeChild(elements[i]);
   }
 }
@@ -22,21 +22,23 @@ describe('settings', () => {
   afterEach(removeJSONScriptTags);
 
   it('reads config from .js-hypothesis-settings <script> tags', () => {
-    document.body.appendChild(createJSONScriptTag({key:'value'},
-      'js-hypothesis-settings'));
-    assert.deepEqual(settings(document), {key:'value'});
+    document.body.appendChild(
+      createJSONScriptTag({ key: 'value' }, 'js-hypothesis-settings')
+    );
+    assert.deepEqual(settings(document), { key: 'value' });
   });
 
   it('reads config from <script> tags with the specified class name', () => {
-    document.body.appendChild(createJSONScriptTag({foo:'bar'},
-      'js-custom-settings'));
+    document.body.appendChild(
+      createJSONScriptTag({ foo: 'bar' }, 'js-custom-settings')
+    );
     assert.deepEqual(settings(document), {});
-    assert.deepEqual(settings(document, 'js-custom-settings'), {foo:'bar'});
+    assert.deepEqual(settings(document, 'js-custom-settings'), { foo: 'bar' });
   });
 
   it('merges settings from all config <script> tags', () => {
-    document.body.appendChild(createJSONScriptTag({a: 1}, 'settings'));
-    document.body.appendChild(createJSONScriptTag({b: 2}, 'settings'));
-    assert.deepEqual(settings(document, 'settings'), {a: 1, b: 2});
+    document.body.appendChild(createJSONScriptTag({ a: 1 }, 'settings'));
+    document.body.appendChild(createJSONScriptTag({ b: 2 }, 'settings'));
+    assert.deepEqual(settings(document, 'settings'), { a: 1, b: 2 });
   });
 });

--- a/h/static/scripts/tests/base/upgrade-elements-test.js
+++ b/h/static/scripts/tests/base/upgrade-elements-test.js
@@ -14,7 +14,7 @@ describe('upgradeElements', () => {
     const root = document.createElement('div');
     root.innerHTML = '<div class="js-test"></div>';
 
-    upgradeElements(root, {'.js-test': TestController});
+    upgradeElements(root, { '.js-test': TestController });
 
     assert.instanceOf(root.children[0].controllers[0], TestController);
   });
@@ -23,18 +23,19 @@ describe('upgradeElements', () => {
     const root = document.createElement('div');
     root.innerHTML = '<div class="js-test is-hidden-when-loading"></div>';
 
-    upgradeElements(root, {'.js-test': TestController});
+    upgradeElements(root, { '.js-test': TestController });
 
     assert.equal(root.querySelectorAll('.is-hidden-when-loading').length, 0);
   });
 
   it('should unhide child elements hidden until upgrade', () => {
     const root = document.createElement('div');
-    root.innerHTML = '<div class="js-test">' +
-                     '<span class="is-hidden-when-loading"></span>' +
-                     '</div>';
+    root.innerHTML =
+      '<div class="js-test">' +
+      '<span class="is-hidden-when-loading"></span>' +
+      '</div>';
 
-    upgradeElements(root, {'.js-test': TestController});
+    upgradeElements(root, { '.js-test': TestController });
 
     assert.equal(root.querySelectorAll('.is-hidden-when-loading').length, 0);
   });
@@ -45,11 +46,11 @@ describe('upgradeElements', () => {
     function setupAndReload() {
       const root = document.createElement('div');
       root.innerHTML = '<div class="js-test">Original content</div>';
-      upgradeElements(root, {'.js-test': TestController});
+      upgradeElements(root, { '.js-test': TestController });
 
       const reloadFn = root.children[0].controllers[0].options.reload;
       const reloadResult = reloadFn(newContent);
-      return {root: root, reloadResult: reloadResult};
+      return { root: root, reloadResult: reloadResult };
     }
 
     it('replaces element markup', () => {
@@ -72,7 +73,7 @@ describe('upgradeElements', () => {
     it('calls #beforeRemove on the original controllers', () => {
       const root = document.createElement('div');
       root.innerHTML = '<div class="js-test">Original content</div>';
-      upgradeElements(root, {'.js-test': TestController});
+      upgradeElements(root, { '.js-test': TestController });
       const ctrl = root.children[0].controllers[0];
       ctrl.beforeRemove = sinon.stub();
       const reloadFn = ctrl.options.reload;

--- a/h/static/scripts/tests/bootstrap.js
+++ b/h/static/scripts/tests/bootstrap.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Expose the sinon assertions.
-sinon.assert.expose(assert, {prefix: null});
+sinon.assert.expose(assert, { prefix: null });

--- a/h/static/scripts/tests/controllers/admin-users-controller-test.js
+++ b/h/static/scripts/tests/controllers/admin-users-controller-test.js
@@ -3,7 +3,7 @@
 const AdminUsersController = require('../../controllers/admin-users-controller');
 
 function submitEvent() {
-  return new Event('submit', {bubbles: true, cancelable: true});
+  return new Event('submit', { bubbles: true, cancelable: true });
 }
 
 describe('AdminUsersController', () => {
@@ -23,8 +23,8 @@ describe('AdminUsersController', () => {
 
   it('it submits the form when confirm returns true', () => {
     const event = submitEvent();
-    const fakeWindow = {confirm: sinon.stub().returns(true)};
-    new AdminUsersController(root, {window: fakeWindow});
+    const fakeWindow = { confirm: sinon.stub().returns(true) };
+    new AdminUsersController(root, { window: fakeWindow });
 
     form.dispatchEvent(event);
 
@@ -33,8 +33,8 @@ describe('AdminUsersController', () => {
 
   it('it cancels the form submission when confirm returns false', () => {
     const event = submitEvent();
-    const fakeWindow = {confirm: sinon.stub().returns(false)};
-    new AdminUsersController(root, {window: fakeWindow});
+    const fakeWindow = { confirm: sinon.stub().returns(false) };
+    new AdminUsersController(root, { window: fakeWindow });
 
     form.dispatchEvent(event);
 

--- a/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
+++ b/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
@@ -3,46 +3,42 @@
 const syn = require('syn');
 const unroll = require('../util').unroll;
 
-
 const AutosuggestDropdownController = require('../../controllers/autosuggest-dropdown-controller');
-
 
 // syn's move functionality does not fire
 // mouseenter and mouseleave events.
 const mouseMove = (() => {
-
   let _lastMovePos;
 
-  return (posObj) => {
-
+  return posObj => {
     if (_lastMovePos) {
-      const prevEl = document.elementFromPoint(_lastMovePos.pageX, _lastMovePos.pageY);
-      const leaveEvent = document.createEvent( 'Events' );
-      leaveEvent.initEvent( 'mouseleave', true, false );
-      prevEl.dispatchEvent( leaveEvent );
+      const prevEl = document.elementFromPoint(
+        _lastMovePos.pageX,
+        _lastMovePos.pageY
+      );
+      const leaveEvent = document.createEvent('Events');
+      leaveEvent.initEvent('mouseleave', true, false);
+      prevEl.dispatchEvent(leaveEvent);
     }
 
     _lastMovePos = posObj;
 
     const el = document.elementFromPoint(posObj.pageX, posObj.pageY);
-    const enterEevent = document.createEvent( 'Events' );
-    enterEevent.initEvent( 'mouseenter', true, false );
-    el.dispatchEvent( enterEevent );
+    const enterEevent = document.createEvent('Events');
+    enterEevent.initEvent('mouseenter', true, false);
+    el.dispatchEvent(enterEevent);
   };
 })();
-
 
 function center(element) {
   const rect = element.getBoundingClientRect();
   return {
-    pageX: rect.left + (rect.width / 2),
-    pageY: rect.top + (rect.height / 2),
+    pageX: rect.left + rect.width / 2,
+    pageY: rect.top + rect.height / 2,
   };
 }
 
-
 describe('AutosuggestDropdownController', () => {
-
   describe('provides suggestions', () => {
     let container;
     let input;
@@ -65,7 +61,8 @@ describe('AutosuggestDropdownController', () => {
         },
         {
           title: 'group:',
-          explanation: 'show annotations created in a group you are a member of',
+          explanation:
+            'show annotations created in a group you are a member of',
         },
       ],
 
@@ -79,24 +76,22 @@ describe('AutosuggestDropdownController', () => {
         activeItem: 'an-active-item',
       },
 
-      renderListItem: (listItem) => {
-
+      renderListItem: listItem => {
         let itemContents = `<span class="a-title"> ${listItem.title} </span>`;
 
         if (listItem.explanation) {
-          itemContents += `<span class="an-explanation"> ${listItem.explanation} </span>`;
+          itemContents += `<span class="an-explanation"> ${
+            listItem.explanation
+          } </span>`;
         }
 
         return itemContents;
       },
 
       listFilter: function(list, currentInput) {
-
-
         currentInput = (currentInput || '').trim();
 
-        return list.filter((item) => {
-
+        return list.filter(item => {
           if (!currentInput) {
             return item;
           }
@@ -108,13 +103,19 @@ describe('AutosuggestDropdownController', () => {
     };
 
     const isSuggestionContainerVisible = () => {
-      const suggestionContainer = container.querySelector('.' + defaultConfig.classNames.container);
+      const suggestionContainer = container.querySelector(
+        '.' + defaultConfig.classNames.container
+      );
       return suggestionContainer.classList.contains('is-open');
     };
 
     const getListItems = () => {
-      const suggestionContainer = container.querySelector('.' + defaultConfig.classNames.container);
-      return suggestionContainer.querySelectorAll('.' + defaultConfig.classNames.item);
+      const suggestionContainer = container.querySelector(
+        '.' + defaultConfig.classNames.container
+      );
+      return suggestionContainer.querySelectorAll(
+        '.' + defaultConfig.classNames.item
+      );
     };
 
     const getCurrentActiveElements = () => {
@@ -144,57 +145,68 @@ describe('AutosuggestDropdownController', () => {
       }
     });
 
-
     it('should initialize the controller with correct dom', () => {
-
       assert.isTrue(form.childNodes.length === 1, 'baseline');
 
       new AutosuggestDropdownController(input, defaultConfig);
 
-      assert.isFalse(form.childNodes.length === 1, 'initializing should add container to dom');
+      assert.isFalse(
+        form.childNodes.length === 1,
+        'initializing should add container to dom'
+      );
 
-      const suggestionContainer = container.querySelector('.' + defaultConfig.classNames.container);
+      const suggestionContainer = container.querySelector(
+        '.' + defaultConfig.classNames.container
+      );
 
       assert.isOk(suggestionContainer);
-      assert.isOk(suggestionContainer.querySelector('.' + defaultConfig.classNames.header));
-      assert.isOk(suggestionContainer.querySelector('.' + defaultConfig.classNames.list));
+      assert.isOk(
+        suggestionContainer.querySelector('.' + defaultConfig.classNames.header)
+      );
+      assert.isOk(
+        suggestionContainer.querySelector('.' + defaultConfig.classNames.list)
+      );
       assert.lengthOf(getListItems(), 4);
 
-      assert.lengthOf(suggestionContainer.querySelectorAll('.a-title'), 4, 'reflects our rendering');
-      assert.lengthOf(suggestionContainer.querySelectorAll('.an-explanation'), 4, 'reflects our rendering');
-
+      assert.lengthOf(
+        suggestionContainer.querySelectorAll('.a-title'),
+        4,
+        'reflects our rendering'
+      );
+      assert.lengthOf(
+        suggestionContainer.querySelectorAll('.an-explanation'),
+        4,
+        'reflects our rendering'
+      );
     });
 
-
-    it('opens and closes based on focus status', (done) => {
-
+    it('opens and closes based on focus status', done => {
       new AutosuggestDropdownController(input, defaultConfig);
 
       assert.isFalse(isSuggestionContainerVisible(), 'basline is hidden');
 
-      syn
-        .click(input, () => {
+      syn.click(input, () => {
+        assert.isTrue(isSuggestionContainerVisible(), 'focus should show');
 
-          assert.isTrue(isSuggestionContainerVisible(), 'focus should show');
-
-          syn
-            .click(document.body, () => {
-              assert.isFalse(isSuggestionContainerVisible(), 'blur should hide');
-              done();
-            });
+        syn.click(document.body, () => {
+          assert.isFalse(isSuggestionContainerVisible(), 'blur should hide');
+          done();
         });
+      });
     });
 
-
-    it('changes suggestion container and item visibility on matching input', (done) => {
-
+    it('changes suggestion container and item visibility on matching input', done => {
       const reduceSpy = sinon.spy(defaultConfig, 'listFilter');
 
       assert.equal(reduceSpy.callCount, 0);
 
       new AutosuggestDropdownController(input, defaultConfig);
 
-      assert.equal(reduceSpy.callCount, 1, 'gets initial reduced list on initialize');
+      assert.equal(
+        reduceSpy.callCount,
+        1,
+        'gets initial reduced list on initialize'
+      );
 
       assert.lengthOf(getListItems(), 4);
 
@@ -204,29 +216,24 @@ describe('AutosuggestDropdownController', () => {
           assert.isTrue(isSuggestionContainerVisible(), 'focus show');
         })
         .type('u', () => {
-
           assert.lengthOf(getListItems(), 3);
           assert.equal(reduceSpy.callCount, 3, 'reduces on input');
         })
         .type('r', () => {
-
           assert.lengthOf(getListItems(), 1);
           assert.equal(reduceSpy.callCount, 4, 'reduces on input');
 
           assert.isTrue(isSuggestionContainerVisible(), 'still showing');
         })
         .type('x', () => {
-
           assert.lengthOf(getListItems(), 0);
           assert.equal(reduceSpy.callCount, 5, 'reduces on input');
 
           assert.isFalse(isSuggestionContainerVisible(), 'no match hide');
-
         })
 
         // backspace
         .type('\b', () => {
-
           assert.lengthOf(getListItems(), 1);
           assert.equal(reduceSpy.callCount, 6, 'reduces on input');
 
@@ -234,41 +241,39 @@ describe('AutosuggestDropdownController', () => {
 
           done();
         });
-
     });
 
-    it('allows click selection', (done) => {
+    it('allows click selection', done => {
       const onSelectSpy = sinon.spy(defaultConfig, 'onSelect');
 
       assert.equal(onSelectSpy.callCount, 0);
 
       new AutosuggestDropdownController(input, defaultConfig);
 
-      syn
-        .click(input)
-        .type('t', () => {
+      syn.click(input).type('t', () => {
+        const items = getListItems();
 
-          const items = getListItems();
+        assert.lengthOf(items, 1);
 
-          assert.lengthOf(items, 1);
+        assert.isTrue(isSuggestionContainerVisible(), 'pre select show');
 
-          assert.isTrue(isSuggestionContainerVisible(), 'pre select show');
+        syn.click(items[0], () => {
+          assert.equal(onSelectSpy.callCount, 1);
 
-          syn
-            .click(items[0], () => {
+          const selectedItem = onSelectSpy.args[0][0];
 
-              assert.equal(onSelectSpy.callCount, 1);
+          assert.propertyVal(selectedItem, 'title', 'tag:');
+          assert.propertyVal(
+            selectedItem,
+            'explanation',
+            'search for annotations with a tag'
+          );
 
-              const selectedItem = onSelectSpy.args[0][0];
+          assert.isFalse(isSuggestionContainerVisible(), 'post select hide');
 
-              assert.propertyVal(selectedItem, 'title', 'tag:');
-              assert.propertyVal(selectedItem, 'explanation', 'search for annotations with a tag');
-
-              assert.isFalse(isSuggestionContainerVisible(), 'post select hide');
-
-              done();
-            });
+          done();
         });
+      });
     });
 
     const navigationExpectations = [
@@ -280,135 +285,172 @@ describe('AutosuggestDropdownController', () => {
       { travel: '[down][down][down][down][down]', selectedIndex: -1 },
       { travel: '[up][up][up][up]', selectedIndex: 0 },
       { travel: '[up][up][up][up][up]', selectedIndex: -1 },
-      { travel: '[up][down][up][down][down][down][down][up]', selectedIndex: 1 },
+      {
+        travel: '[up][down][up][down][down][down][down][up]',
+        selectedIndex: 1,
+      },
     ];
 
-    unroll('allows keyboard navigation', (done, fixture) => {
+    unroll(
+      'allows keyboard navigation',
+      (done, fixture) => {
+        new AutosuggestDropdownController(input, defaultConfig);
 
-      new AutosuggestDropdownController(input, defaultConfig);
+        const list = container.querySelector(
+          '.' + defaultConfig.classNames.list
+        );
 
-      const list = container.querySelector('.' + defaultConfig.classNames.list);
-
-      syn
-        .click(input)
-        .type(fixture.travel, () => {
+        syn.click(input).type(fixture.travel, () => {
           const active = getCurrentActiveElements();
           if (fixture.selectedIndex === -1) {
             assert.lengthOf(active, 0);
           } else {
-            assert.isTrue(list.childNodes[fixture.selectedIndex].classList.contains(defaultConfig.classNames.activeItem));
+            assert.isTrue(
+              list.childNodes[fixture.selectedIndex].classList.contains(
+                defaultConfig.classNames.activeItem
+              )
+            );
             assert.lengthOf(active, 1);
           }
           done();
         });
-    }, navigationExpectations);
+      },
+      navigationExpectations
+    );
 
-
-    it('persists active navigation through list filter', (done) => {
+    it('persists active navigation through list filter', done => {
       new AutosuggestDropdownController(input, defaultConfig);
 
       const list = container.querySelector('.' + defaultConfig.classNames.list);
       syn
         .click(input)
         .type('[down][down]', () => {
-          assert.isTrue(list.childNodes[1].classList.contains(defaultConfig.classNames.activeItem));
-          assert.equal(list.childNodes[1].querySelector('.a-title').textContent.trim(),
-            defaultConfig.list[1].title);
+          assert.isTrue(
+            list.childNodes[1].classList.contains(
+              defaultConfig.classNames.activeItem
+            )
+          );
+          assert.equal(
+            list.childNodes[1].querySelector('.a-title').textContent.trim(),
+            defaultConfig.list[1].title
+          );
         })
         .type('t', () => {
-
-          assert.isTrue(list.childNodes[0].classList.contains(defaultConfig.classNames.activeItem));
-          assert.equal(list.childNodes[0].querySelector('.a-title').textContent.trim(),
-            defaultConfig.list[1].title);
+          assert.isTrue(
+            list.childNodes[0].classList.contains(
+              defaultConfig.classNames.activeItem
+            )
+          );
+          assert.equal(
+            list.childNodes[0].querySelector('.a-title').textContent.trim(),
+            defaultConfig.list[1].title
+          );
           done();
         });
     });
 
-    it('allows keyboard selection', (done) => {
+    it('allows keyboard selection', done => {
       const onSelectSpy = sinon.spy(defaultConfig, 'onSelect');
 
       assert.equal(onSelectSpy.callCount, 0);
 
       new AutosuggestDropdownController(input, defaultConfig);
 
-      syn
-        .click(input)
-        .type('[down][down][enter]', () => {
+      syn.click(input).type('[down][down][enter]', () => {
+        assert.equal(onSelectSpy.callCount, 1);
 
-          assert.equal(onSelectSpy.callCount, 1);
+        const selectedItem = onSelectSpy.args[0][0];
 
-          const selectedItem = onSelectSpy.args[0][0];
+        assert.propertyVal(selectedItem, 'title', 'tag:');
+        assert.propertyVal(
+          selectedItem,
+          'explanation',
+          'search for annotations with a tag'
+        );
 
-          assert.propertyVal(selectedItem, 'title', 'tag:');
-          assert.propertyVal(selectedItem, 'explanation', 'search for annotations with a tag');
+        assert.isFalse(
+          form.onsubmit.called,
+          'should not submit the form on enter'
+        );
 
-          assert.isFalse(form.onsubmit.called, 'should not submit the form on enter');
-
-          done();
-        });
+        done();
+      });
     });
 
-    it('can hover items', (done) => {
+    it('can hover items', done => {
+      new AutosuggestDropdownController(input, defaultConfig);
 
+      const list = container.querySelector('.' + defaultConfig.classNames.list);
+
+      syn.click(input, () => {
+        mouseMove(center(list.childNodes[1]));
+
+        assert.lengthOf(getCurrentActiveElements(), 1);
+        assert.isTrue(
+          list.childNodes[1].classList.contains(
+            defaultConfig.classNames.activeItem
+          )
+        );
+
+        mouseMove(center(list.childNodes[2]));
+
+        assert.lengthOf(getCurrentActiveElements(), 1);
+        assert.isTrue(
+          list.childNodes[2].classList.contains(
+            defaultConfig.classNames.activeItem
+          )
+        );
+
+        mouseMove(center(input));
+        assert.lengthOf(getCurrentActiveElements(), 0);
+
+        done();
+      });
+    });
+
+    it('correctly sets active elements when swapping between keyboard and mouse setting', done => {
       new AutosuggestDropdownController(input, defaultConfig);
 
       const list = container.querySelector('.' + defaultConfig.classNames.list);
 
       syn
         .click(input, () => {
-
-          mouseMove(center(list.childNodes[1]));
-
-          assert.lengthOf(getCurrentActiveElements(), 1);
-          assert.isTrue(list.childNodes[1].classList.contains(defaultConfig.classNames.activeItem));
-
-
           mouseMove(center(list.childNodes[2]));
 
           assert.lengthOf(getCurrentActiveElements(), 1);
-          assert.isTrue(list.childNodes[2].classList.contains(defaultConfig.classNames.activeItem));
-
-          mouseMove(center(input));
-          assert.lengthOf(getCurrentActiveElements(), 0);
-
-          done();
-
-        });
-
-    });
-
-    it('correctly sets active elements when swapping between keyboard and mouse setting', (done) => {
-
-      new AutosuggestDropdownController(input, defaultConfig);
-
-      const list = container.querySelector('.' + defaultConfig.classNames.list);
-
-      syn
-        .click(input, () => {
-
-          mouseMove(center(list.childNodes[2]));
-
-          assert.lengthOf(getCurrentActiveElements(), 1);
-          assert.isTrue(list.childNodes[2].classList.contains(defaultConfig.classNames.activeItem));
-
+          assert.isTrue(
+            list.childNodes[2].classList.contains(
+              defaultConfig.classNames.activeItem
+            )
+          );
         })
         .type('[down]', () => {
           assert.lengthOf(getCurrentActiveElements(), 1);
-          assert.isTrue(list.childNodes[3].classList.contains(defaultConfig.classNames.activeItem));
+          assert.isTrue(
+            list.childNodes[3].classList.contains(
+              defaultConfig.classNames.activeItem
+            )
+          );
         })
         .type('[up][up][up]', () => {
           assert.lengthOf(getCurrentActiveElements(), 1);
-          assert.isTrue(list.childNodes[0].classList.contains(defaultConfig.classNames.activeItem));
-
+          assert.isTrue(
+            list.childNodes[0].classList.contains(
+              defaultConfig.classNames.activeItem
+            )
+          );
 
           mouseMove(center(list.childNodes[2]));
 
           assert.lengthOf(getCurrentActiveElements(), 1);
-          assert.isTrue(list.childNodes[2].classList.contains(defaultConfig.classNames.activeItem));
+          assert.isTrue(
+            list.childNodes[2].classList.contains(
+              defaultConfig.classNames.activeItem
+            )
+          );
 
           done();
         });
     });
-
   });
 });

--- a/h/static/scripts/tests/controllers/character-limit-controller-test.js
+++ b/h/static/scripts/tests/controllers/character-limit-controller-test.js
@@ -4,7 +4,6 @@ const CharacterLimitController = require('../../controllers/character-limit-cont
 const util = require('./util');
 
 describe('CharacterLimitController', () => {
-
   let ctrl;
 
   afterEach(() => {
@@ -22,7 +21,10 @@ describe('CharacterLimitController', () => {
     maxlength = maxlength || 250;
 
     let template = '<div class="js-character-limit">';
-    template += '<textarea data-ref="characterLimitInput" data-maxlength="' + maxlength + '">';
+    template +=
+      '<textarea data-ref="characterLimitInput" data-maxlength="' +
+      maxlength +
+      '">';
     if (value) {
       template += value;
     }
@@ -104,22 +106,19 @@ describe('CharacterLimitController', () => {
   it('does not add error class when no pre-rendered text', () => {
     const counterEl = component(null, 5).counterEl;
 
-    assert.equal(counterEl.classList.contains('is-too-long'),
-                 false);
+    assert.equal(counterEl.classList.contains('is-too-long'), false);
   });
 
   it('does not add error class when pre-rendered text short enough', () => {
     const counterEl = component('foo', 5).counterEl;
 
-    assert.equal(counterEl.classList.contains('is-too-long'),
-                 false);
+    assert.equal(counterEl.classList.contains('is-too-long'), false);
   });
 
   it('adds an error class to the counter when pre-rendered value too long', () => {
     const counterEl = component('Too long', 5).counterEl;
 
-    assert.equal(counterEl.classList.contains('is-too-long'),
-                 true);
+    assert.equal(counterEl.classList.contains('is-too-long'), true);
   });
 
   it('adds an error class to the counter when too much text entered', () => {
@@ -130,8 +129,7 @@ describe('CharacterLimitController', () => {
     textarea.value = 'too long';
     textarea.dispatchEvent(new Event('input'));
 
-    assert.equal(counterEl.classList.contains('is-too-long'),
-                 true);
+    assert.equal(counterEl.classList.contains('is-too-long'), true);
   });
 
   it('removes error class from counter when text reduced', () => {
@@ -142,7 +140,6 @@ describe('CharacterLimitController', () => {
     textarea.value = 'short';
     textarea.dispatchEvent(new Event('input'));
 
-    assert.equal(counterEl.classList.contains('is-too-long'),
-                 false);
+    assert.equal(counterEl.classList.contains('is-too-long'), false);
   });
 });

--- a/h/static/scripts/tests/controllers/confirm-submit-controller-test.js
+++ b/h/static/scripts/tests/controllers/confirm-submit-controller-test.js
@@ -4,7 +4,6 @@ const ConfirmSubmitController = require('../../controllers/confirm-submit-contro
 const util = require('./util');
 
 describe('ConfirmSubmitController', () => {
-
   let ctrl;
 
   afterEach(() => {
@@ -20,7 +19,8 @@ describe('ConfirmSubmitController', () => {
    *
    */
   function component(windowConfirmReturnValue) {
-    const confirmMessage = "Are you sure you want to leave the group 'Test Group'?";
+    const confirmMessage =
+      "Are you sure you want to leave the group 'Test Group'?";
     const template = `<button type="submit"
       class="js-confirm-submit"
       data-confirm-message="${confirmMessage}">
@@ -30,10 +30,9 @@ describe('ConfirmSubmitController', () => {
       confirm: sinon.stub().returns(windowConfirmReturnValue),
     };
 
-    ctrl = util.setupComponent(document,
-                               template,
-                               ConfirmSubmitController,
-                               {window: fakeWindow});
+    ctrl = util.setupComponent(document, template, ConfirmSubmitController, {
+      window: fakeWindow,
+    });
 
     return {
       ctrl: ctrl,
@@ -51,7 +50,7 @@ describe('ConfirmSubmitController', () => {
   }
 
   it('shows a confirm dialog using the text from the data-confirm-message attribute', () => {
-    const {ctrl, fakeWindow, confirmMessage} = component(true);
+    const { ctrl, fakeWindow, confirmMessage } = component(true);
 
     ctrl.element.dispatchEvent(new Event('click'));
 

--- a/h/static/scripts/tests/controllers/copy-button-controller-test.js
+++ b/h/static/scripts/tests/controllers/copy-button-controller-test.js
@@ -16,7 +16,7 @@ describe('CopyButtonController', () => {
   beforeEach(() => {
     copySuccess = false;
     copiedText = '';
-    sinon.stub(document, 'execCommand', (command) => {
+    sinon.stub(document, 'execCommand', command => {
       if (command === 'copy') {
         copiedText = document.getSelection().toString();
         return copySuccess;
@@ -54,7 +54,8 @@ describe('CopyButtonController', () => {
   });
 
   it('leaves the input field read-write on Mobile Safari', () => {
-    const mobileSafariUserAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_0 like Mac OS X) AppleWebKit/602.1.38 (KHTML, like Gecko) Version/10.0 Mobile/14A5297c Safari/602.1';
+    const mobileSafariUserAgent =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 10_0 like Mac OS X) AppleWebKit/602.1.38 (KHTML, like Gecko) Version/10.0 Mobile/14A5297c Safari/602.1';
     ctrl = setupComponent(document, template, CopyButtonController, {
       userAgent: mobileSafariUserAgent,
     });

--- a/h/static/scripts/tests/controllers/create-group-form-controller-test.js
+++ b/h/static/scripts/tests/controllers/create-group-form-controller-test.js
@@ -20,10 +20,11 @@ describe('CreateGroupFormController', () => {
   let template;
 
   before(() => {
-    template = '<input type="text" class="js-group-name-input">' +
-               '<input type="submit" class="js-create-group-create-btn">' +
-               '<a href="" class="js-group-info-link">Tell me more!</a>' +
-               '<div class="js-group-info-text is-hidden">More!</div>';
+    template =
+      '<input type="text" class="js-group-name-input">' +
+      '<input type="submit" class="js-create-group-create-btn">' +
+      '<a href="" class="js-group-info-link">Tell me more!</a>' +
+      '<div class="js-group-info-text is-hidden">More!</div>';
   });
 
   beforeEach(() => {

--- a/h/static/scripts/tests/controllers/form-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-controller-test.js
@@ -15,7 +15,7 @@ const FormController = require('../../controllers/form-controller');
  */
 function dataAttrs(data) {
   const dataAttrs = [];
-  Object.keys(data || {}).forEach((key) => {
+  Object.keys(data || {}).forEach(key => {
     dataAttrs.push(`data-${hyphenate(key)}="${data[key]}"`);
   });
   return dataAttrs.join(' ');
@@ -29,7 +29,9 @@ function fieldTemplate(field) {
 
   return `<div class="js-form-input" data-ref="${field.fieldRef}" ${dataAttr}>
     <label data-ref="label ${field.labelRef}">Label</label>
-    <input id="deformField" data-ref="formInput ${field.ref}" ${typeAttr} value="${field.value}">
+    <input id="deformField" data-ref="formInput ${
+      field.ref
+    }" ${typeAttr} value="${field.value}">
   </div>`;
 }
 
@@ -50,16 +52,20 @@ function formTemplate(fields) {
 `;
 }
 
-const FORM_TEMPLATE = formTemplate([{
-  ref: 'firstInput',
-  value: 'original value',
-},{
-  ref: 'secondInput',
-  value: 'original value 2',
-},{
-  ref: 'checkboxInput',
-  type: 'checkbox',
-}]);
+const FORM_TEMPLATE = formTemplate([
+  {
+    ref: 'firstInput',
+    value: 'original value',
+  },
+  {
+    ref: 'secondInput',
+    value: 'original value 2',
+  },
+  {
+    ref: 'checkboxInput',
+    type: 'checkbox',
+  },
+]);
 
 const UPDATED_FORM = FORM_TEMPLATE.replace('js-form', 'js-form is-updated');
 
@@ -86,7 +92,7 @@ describe('FormController', () => {
     // spy on calls to it and update `ctrl` to the new controller instance
     // when the form is reloaded
     const reloadFn = ctrl.options.reload;
-    reloadSpy = sinon.spy((html) => {
+    reloadSpy = sinon.spy(html => {
       const newElement = reloadFn(html);
       ctrl = newElement.controllers[0];
       return newElement;
@@ -146,14 +152,16 @@ describe('FormController', () => {
 
   it('reverts the form when "Escape" key is pressed', () => {
     startEditing();
-    const event = new Event('keydown', {bubbles: true});
+    const event = new Event('keydown', { bubbles: true });
     event.key = 'Escape';
     ctrl.refs.firstInput.dispatchEvent(event);
     assert.equal(ctrl.refs.firstInput.value, 'original value');
   });
 
   it('submits the form when "Save" is clicked', () => {
-    fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+    fakeSubmitForm.returns(
+      Promise.resolve({ status: 200, form: UPDATED_FORM })
+    );
     ctrl.refs.testSaveBtn.click();
     assert.calledWith(fakeSubmitForm, ctrl.element);
 
@@ -164,14 +172,18 @@ describe('FormController', () => {
 
   context('when form is successfully submitted', () => {
     it('updates form with new rendered version from server', () => {
-      fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+      fakeSubmitForm.returns(
+        Promise.resolve({ status: 200, form: UPDATED_FORM })
+      );
       return submitForm().then(() => {
         assert.isTrue(ctrl.element.classList.contains('is-updated'));
       });
     });
 
     it('stops editing the form', () => {
-      fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+      fakeSubmitForm.returns(
+        Promise.resolve({ status: 200, form: UPDATED_FORM })
+      );
       return submitForm().then(() => {
         assert.isFalse(isEditing());
       });
@@ -181,7 +193,9 @@ describe('FormController', () => {
   context('when validation fails', () => {
     it('updates form with rendered version from server', () => {
       startEditing();
-      fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
+      fakeSubmitForm.returns(
+        Promise.reject({ status: 400, form: UPDATED_FORM })
+      );
       return submitForm().then(() => {
         assert.isTrue(ctrl.element.classList.contains('is-updated'));
       });
@@ -189,7 +203,9 @@ describe('FormController', () => {
 
     it('marks updated form as dirty', () => {
       startEditing();
-      fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
+      fakeSubmitForm.returns(
+        Promise.reject({ status: 400, form: UPDATED_FORM })
+      );
       return submitForm().then(() => {
         assert.isTrue(ctrl.state.dirty);
       });
@@ -197,7 +213,9 @@ describe('FormController', () => {
 
     it('continues editing current field', () => {
       startEditing();
-      fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
+      fakeSubmitForm.returns(
+        Promise.reject({ status: 400, form: UPDATED_FORM })
+      );
       return submitForm().then(() => {
         assert.isTrue(isEditing());
       });
@@ -205,7 +223,9 @@ describe('FormController', () => {
 
     it('focuses the matching input field in the re-rendered form', () => {
       startEditing();
-      fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
+      fakeSubmitForm.returns(
+        Promise.reject({ status: 400, form: UPDATED_FORM })
+      );
 
       // Simulate the user saving the form by clicking the 'Save' button, which
       // changes the focus from the input field to the button
@@ -219,7 +239,9 @@ describe('FormController', () => {
   });
 
   it('enters the "saving" state while the form is being submitted', () => {
-    fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+    fakeSubmitForm.returns(
+      Promise.resolve({ status: 200, form: UPDATED_FORM })
+    );
     const saved = submitForm();
     assert.isTrue(isSaving());
     return saved.then(() => {
@@ -228,7 +250,9 @@ describe('FormController', () => {
   });
 
   it('displays an error if form submission fails without returning a new form', () => {
-    fakeSubmitForm.returns(Promise.reject({status: 501, reason: 'Internal Server Error'}));
+    fakeSubmitForm.returns(
+      Promise.reject({ status: 501, reason: 'Internal Server Error' })
+    );
     return submitForm().then(() => {
       assert.equal(submitError(), 'Internal Server Error');
     });
@@ -243,7 +267,7 @@ describe('FormController', () => {
 
   it('ignores clicks outside the field being edited', () => {
     startEditing();
-    const event = new Event('mousedown', {cancelable: true});
+    const event = new Event('mousedown', { cancelable: true });
     ctrl.refs.formBackdrop.dispatchEvent(event);
     assert.isTrue(event.defaultPrevented);
   });
@@ -251,7 +275,7 @@ describe('FormController', () => {
   it('sets form state to dirty if user modifies active field', () => {
     startEditing();
 
-    ctrl.refs.firstInput.dispatchEvent(new Event('input', {bubbles: true}));
+    ctrl.refs.firstInput.dispatchEvent(new Event('input', { bubbles: true }));
 
     assert.isTrue(ctrl.state.dirty);
   });
@@ -272,7 +296,7 @@ describe('FormController', () => {
 
     it('keeps focus in previous input if it has unsaved changes', () => {
       startEditing();
-      ctrl.setState({dirty: true});
+      ctrl.setState({ dirty: true });
 
       // Simulate user/browser attempting to switch to another field
       ctrl.refs.secondInput.focus();
@@ -304,7 +328,7 @@ describe('FormController', () => {
 
     it('keeps current field focused if it has unsaved changes', () => {
       startEditing();
-      ctrl.setState({dirty: true});
+      ctrl.setState({ dirty: true });
 
       // Simulate user/browser attempting to switch focus to an element outside
       // the form
@@ -316,9 +340,13 @@ describe('FormController', () => {
 
   context('when a checkbox is toggled', () => {
     beforeEach(() => {
-      fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+      fakeSubmitForm.returns(
+        Promise.resolve({ status: 200, form: UPDATED_FORM })
+      );
       ctrl.refs.checkboxInput.focus();
-      ctrl.refs.checkboxInput.dispatchEvent(new Event('change', {bubbles: true}));
+      ctrl.refs.checkboxInput.dispatchEvent(
+        new Event('change', { bubbles: true })
+      );
     });
 
     afterEach(() => {
@@ -340,19 +368,24 @@ describe('FormController', () => {
       // Setup a form like the 'Change Email' which has a field that is initially
       // visible plus additional fields that are shown once the form is being
       // edited
-      initForm(formTemplate([{
-        fieldRef: 'emailContainer',
-        ref: 'emailInput',
-        value: 'jim@smith.com',
-      },{
-        fieldRef: 'passwordContainer',
-        ref: 'passwordInput',
-        value: '',
-        type: 'password',
-        data: {
-          hideUntilActive: true,
-        },
-      }]));
+      initForm(
+        formTemplate([
+          {
+            fieldRef: 'emailContainer',
+            ref: 'emailInput',
+            value: 'jim@smith.com',
+          },
+          {
+            fieldRef: 'passwordContainer',
+            ref: 'passwordInput',
+            value: '',
+            type: 'password',
+            data: {
+              hideUntilActive: true,
+            },
+          },
+        ])
+      );
     });
 
     function isConfirmFieldHidden() {
@@ -380,13 +413,18 @@ describe('FormController', () => {
     });
 
     it('shows all fields in an editing state when any is focused', () => {
-      const containers = [ctrl.refs.emailContainer, ctrl.refs.passwordContainer];
+      const containers = [
+        ctrl.refs.emailContainer,
+        ctrl.refs.passwordContainer,
+      ];
       const inputs = [ctrl.refs.emailInput, ctrl.refs.passwordInput];
 
-      inputs.forEach((input) => {
+      inputs.forEach(input => {
         input.focus();
 
-        const editing = containers.filter(el => el.classList.contains('is-editing'));
+        const editing = containers.filter(el =>
+          el.classList.contains('is-editing')
+        );
         assert.equal(editing.length, 2);
       });
     });
@@ -394,15 +432,19 @@ describe('FormController', () => {
 
   describe('fields with inactive and active labels', () => {
     beforeEach(() => {
-      initForm(formTemplate([{
-        labelRef: 'passwordLabel',
-        ref: 'passwordInput',
-        type: 'password',
-        data: {
-          activeLabel: 'Current password',
-          inactiveLabel: 'Password',
-        },
-      }]));
+      initForm(
+        formTemplate([
+          {
+            labelRef: 'passwordLabel',
+            ref: 'passwordInput',
+            type: 'password',
+            data: {
+              activeLabel: 'Current password',
+              inactiveLabel: 'Password',
+            },
+          },
+        ])
+      );
     });
 
     it('uses the inactive label for fields when the form is inactive', () => {
@@ -417,15 +459,18 @@ describe('FormController', () => {
 
   describe('password fields', () => {
     beforeEach(() => {
-      initForm(formTemplate([{
-        ref: 'password',
-        type: 'password',
-      }]));
+      initForm(
+        formTemplate([
+          {
+            ref: 'password',
+            type: 'password',
+          },
+        ])
+      );
     });
 
     it('adds a placeholder to inactive password fields', () => {
-      assert.equal(ctrl.refs.password.getAttribute('placeholder'),
-        '••••••••');
+      assert.equal(ctrl.refs.password.getAttribute('placeholder'), '••••••••');
     });
 
     it('clears the placeholder when the password field is focused', () => {

--- a/h/static/scripts/tests/controllers/form-input-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-input-controller-test.js
@@ -18,7 +18,10 @@ describe('FormInputController', () => {
   });
 
   it('sets `hasError` state of controller if rendered with "is-error" class', () => {
-    const errorTemplate = template.replace('js-form-input', 'js-form-input is-error');
+    const errorTemplate = template.replace(
+      'js-form-input',
+      'js-form-input is-error'
+    );
     const ctrl = setupComponent(document, errorTemplate, FormInputController);
     assert.equal(ctrl.state.hasError, true);
   });

--- a/h/static/scripts/tests/controllers/form-select-onfocus-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-select-onfocus-controller-test.js
@@ -16,8 +16,9 @@ describe('FormSelectOnFocusController', () => {
 
   beforeEach(() => {
     root = document.createElement('div');
-    root.innerHTML = '<form id="js-users-delete-form">' +
-                     '<input type="text" class="js-select-onfocus" value="some-test-value">';
+    root.innerHTML =
+      '<form id="js-users-delete-form">' +
+      '<input type="text" class="js-select-onfocus" value="some-test-value">';
     document.body.appendChild(root);
   });
 

--- a/h/static/scripts/tests/controllers/input-autofocus-controller-test.js
+++ b/h/static/scripts/tests/controllers/input-autofocus-controller-test.js
@@ -11,7 +11,7 @@ const { setupComponent } = require('./util');
  */
 function sendKey(key, opts = {}) {
   // Note: PhantomJS 2.x does not support the KeyboardEvent constructor
-  const event = new Event('keydown', {bubbles: true});
+  const event = new Event('keydown', { bubbles: true });
   event.key = key;
   Object.assign(event, opts);
   document.activeElement.dispatchEvent(event);
@@ -63,9 +63,9 @@ describe('InputAutofocusController', () => {
     });
 
     it('should not focus the input if a letter key is pressed with a modifier', () => {
-      sendKey('a', {ctrlKey: true});
-      sendKey('b', {altKey: true});
-      sendKey('c', {metaKey: true});
+      sendKey('a', { ctrlKey: true });
+      sendKey('b', { altKey: true });
+      sendKey('c', { metaKey: true });
       assert.notEqual(document.activeElement, ctrl.element);
     });
   });

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -15,8 +15,10 @@ const SearchBarController = require('../../controllers/search-bar-controller');
  * @param {SearchBarController} ctrl
  * @return {string[]}
  */
-const getLozengeValues = (ctrl) => {
-  return Array.from(ctrl.refs.searchBarLozenges.querySelectorAll('.lozenge')).map((el) => {
+const getLozengeValues = ctrl => {
+  return Array.from(
+    ctrl.refs.searchBarLozenges.querySelectorAll('.lozenge')
+  ).map(el => {
     const facetName = el.querySelector('.lozenge__facet-name').textContent;
     const facetValue = el.querySelector('.lozenge__facet-value').textContent;
     return facetName + facetValue;
@@ -53,7 +55,9 @@ describe('SearchBarController', () => {
     `;
 
     const getItemTitles = function() {
-      return Array.from(dropdown.querySelectorAll('.search-bar__dropdown-menu-title')).map((node) => {
+      return Array.from(
+        dropdown.querySelectorAll('.search-bar__dropdown-menu-title')
+      ).map(node => {
         return node.textContent.trim();
       });
     };
@@ -181,21 +185,19 @@ describe('SearchBarController', () => {
     beforeEach(setup);
     afterEach(teardown);
 
-    it('uses autosuggestion for initial facets', (done) => {
-
+    it('uses autosuggestion for initial facets', done => {
       assert.isFalse(dropdown.classList.contains('is-open'));
 
-      syn
-        .click(input, () => {
-          assert.isTrue(dropdown.classList.contains('is-open'));
+      syn.click(input, () => {
+        assert.isTrue(dropdown.classList.contains('is-open'));
 
-          assert.deepEqual(getItemTitles(), ['user:', 'tag:', 'url:', 'group:']);
+        assert.deepEqual(getItemTitles(), ['user:', 'tag:', 'url:', 'group:']);
 
-          done();
-        });
+        done();
+      });
     });
 
-    it('it filters and updates input with autosuggested facet selection', (done) => {
+    it('it filters and updates input with autosuggested facet selection', done => {
       syn
         .click(input, () => {
           assert.notOk(input.value, 'baseline no value in input');
@@ -206,8 +208,7 @@ describe('SearchBarController', () => {
         });
     });
 
-
-    it('allows submitting the form dropdown is open but has no selected value', (done) => {
+    it('allows submitting the form dropdown is open but has no selected value', done => {
       const form = testEl.querySelector('form');
       const submit = sinon.stub(form, 'submit');
 
@@ -217,14 +218,16 @@ describe('SearchBarController', () => {
           assert.isTrue(dropdown.classList.contains('is-open'));
         })
         .type('[enter]', () => {
-          assert.equal(testEl.querySelector('input[type=hidden]').value, 'test');
+          assert.equal(
+            testEl.querySelector('input[type=hidden]').value,
+            'test'
+          );
           assert.isTrue(submit.calledOnce);
           done();
         });
     });
 
     describe('it allows group value suggestions', () => {
-
       beforeEach(() => {
         // we need to setup the env vars before invoking controller
         teardown();
@@ -234,86 +237,136 @@ describe('SearchBarController', () => {
         sinon.stub(testEl.querySelector('form'), 'submit');
       });
 
-      unroll('shows group suggestions', (done, fixture) => {
-        syn
-          .click(input)
-          .type(fixture.text, () => {
-            assert.isTrue(dropdown.classList.contains('is-open'));
+      unroll(
+        'shows group suggestions',
+        (done, fixture) => {
+          syn
+            .click(input)
+            .type(fixture.text, () => {
+              assert.isTrue(dropdown.classList.contains('is-open'));
 
-            const titles = getItemTitles();
+              const titles = getItemTitles();
 
-            assert.lengthOf(titles, 5, 'we should be enforcing the 5 item max');
-          })
-          .type('[backspace][backspace][backspace][backspace][backspace][backspace]', () => {
-            assert.deepEqual(getItemTitles(), [ 'user:', 'tag:', 'url:', 'group:' ], 'group suggestions go away as facet is removed');
-            done();
-          });
-      },[
-        {text: 'group:'},
-        {text: 'Group:'},
-        {text: 'GROUP:'},
-      ]);
+              assert.lengthOf(
+                titles,
+                5,
+                'we should be enforcing the 5 item max'
+              );
+            })
+            .type(
+              '[backspace][backspace][backspace][backspace][backspace][backspace]',
+              () => {
+                assert.deepEqual(
+                  getItemTitles(),
+                  ['user:', 'tag:', 'url:', 'group:'],
+                  'group suggestions go away as facet is removed'
+                );
+                done();
+              }
+            );
+        },
+        [{ text: 'group:' }, { text: 'Group:' }, { text: 'GROUP:' }]
+      );
 
-      it('orders groups by earliest value match first', (done) => {
+      it('orders groups by earliest value match first', done => {
         syn
           .click(input)
           .type('group:', () => {
-            assert.deepEqual(getItemTitles(), [ 'aaac', 'aaab', 'aaaa', 'aaae', 'aaad' ], 'default ordering based on original order with no input');
+            assert.deepEqual(
+              getItemTitles(),
+              ['aaac', 'aaab', 'aaaa', 'aaae', 'aaad'],
+              'default ordering based on original order with no input'
+            );
           })
           .type('aad', () => {
-            assert.deepEqual(getItemTitles(), [ 'aadf', 'aaad'], 'sorting by indexof score with some input');
+            assert.deepEqual(
+              getItemTitles(),
+              ['aadf', 'aaad'],
+              'sorting by indexof score with some input'
+            );
             done();
           });
       });
 
-      it('supports multi word matching', (done) => {
+      it('supports multi word matching', done => {
         syn
           .click(input)
           .type('group:"mul', () => {
-            assert.deepEqual(getItemTitles(), [ 'multi word' ], 'supports matching on a double quote initial input');
+            assert.deepEqual(
+              getItemTitles(),
+              ['multi word'],
+              'supports matching on a double quote initial input'
+            );
           })
-          .type('[backspace][backspace][backspace][backspace]\'mul', () => {
-            assert.deepEqual(getItemTitles(), [ 'multi word' ], 'supports matching on a single quote initial input');
+          .type("[backspace][backspace][backspace][backspace]'mul", () => {
+            assert.deepEqual(
+              getItemTitles(),
+              ['multi word'],
+              'supports matching on a single quote initial input'
+            );
             done();
           });
       });
 
-      it('handles filtering matches with unicode', (done) => {
-        syn
-          .click(input)
-          .type('group:éf', () => {
-            assert.deepEqual(getItemTitles(), [ 'effort' ], 'matches éffort with unicode value');
-            done();
-          });
+      it('handles filtering matches with unicode', done => {
+        syn.click(input).type('group:éf', () => {
+          assert.deepEqual(
+            getItemTitles(),
+            ['effort'],
+            'matches éffort with unicode value'
+          );
+          done();
+        });
       });
 
-      it('sets input and display friendly name value', (done) => {
+      it('sets input and display friendly name value', done => {
         syn
           .click(input)
           .type('group:"mul[down][enter]', () => {
-            assert.equal(testEl.querySelector('input[type=hidden]').value.trim(), 'group:pid8', 'pubid should be added to the hidden input');
-            assert.deepEqual(getLozengeValues(ctrl), ['group:"multi word"'], 'adds and wraps multi word with quotes');
+            assert.equal(
+              testEl.querySelector('input[type=hidden]').value.trim(),
+              'group:pid8',
+              'pubid should be added to the hidden input'
+            );
+            assert.deepEqual(
+              getLozengeValues(ctrl),
+              ['group:"multi word"'],
+              'adds and wraps multi word with quotes'
+            );
           })
           .type('group:a[down][enter]', () => {
-            assert.equal(testEl.querySelector('input[type=hidden]').value.trim(), 'group:pid8 group:pid1', 'pubid should be added to the hidden input');
-            assert.deepEqual(getLozengeValues(ctrl), ['group:"multi word"', 'group:aaac'], 'adds single word as is to lozenge');
+            assert.equal(
+              testEl.querySelector('input[type=hidden]').value.trim(),
+              'group:pid8 group:pid1',
+              'pubid should be added to the hidden input'
+            );
+            assert.deepEqual(
+              getLozengeValues(ctrl),
+              ['group:"multi word"', 'group:aaac'],
+              'adds single word as is to lozenge'
+            );
             done();
           });
       });
 
-      it('matches escaped values', (done) => {
-        syn
-          .click(input)
-          .type('group:<[down][enter]', () => {
-            assert.equal(testEl.querySelector('input[type=hidden]').value.trim(), 'group:pid10', 'pubid should be added to the hidden input');
-            assert.deepEqual(getLozengeValues(ctrl), ['group:"<*>Haskell fans<*>"'], 'adds and wraps multi word with quotes');
-            done();
-          });
+      it('matches escaped values', done => {
+        syn.click(input).type('group:<[down][enter]', () => {
+          assert.equal(
+            testEl.querySelector('input[type=hidden]').value.trim(),
+            'group:pid10',
+            'pubid should be added to the hidden input'
+          );
+          assert.deepEqual(
+            getLozengeValues(ctrl),
+            ['group:"<*>Haskell fans<*>"'],
+            'adds and wraps multi word with quotes'
+          );
+          done();
+        });
       });
     });
 
     describe('it allows tag value suggestions', () => {
-
       beforeEach(() => {
         // we need to setup the env vars before invoking controller
         teardown();
@@ -323,62 +376,91 @@ describe('SearchBarController', () => {
         sinon.stub(testEl.querySelector('form'), 'submit');
       });
 
-      unroll('shows tag suggestions', (done, fixture) => {
-        syn
-          .click(input)
-          .type(fixture.text, () => {
-            assert.isTrue(dropdown.classList.contains('is-open'));
+      unroll(
+        'shows tag suggestions',
+        (done, fixture) => {
+          syn
+            .click(input)
+            .type(fixture.text, () => {
+              assert.isTrue(dropdown.classList.contains('is-open'));
 
-            const titles = getItemTitles();
+              const titles = getItemTitles();
 
-            assert.lengthOf(titles, 5, 'we should be enforcing the 5 item max');
-          })
-          .type('[backspace][backspace][backspace][backspace]', () => {
-            assert.deepEqual(getItemTitles(), [ 'user:', 'tag:', 'url:', 'group:' ], 'tags go away as facet is removed');
-            done();
-          });
-      },[
-        {text: 'tag:'},
-        {text: 'Tag:'},
-        {text: 'TAG:'},
-      ]);
+              assert.lengthOf(
+                titles,
+                5,
+                'we should be enforcing the 5 item max'
+              );
+            })
+            .type('[backspace][backspace][backspace][backspace]', () => {
+              assert.deepEqual(
+                getItemTitles(),
+                ['user:', 'tag:', 'url:', 'group:'],
+                'tags go away as facet is removed'
+              );
+              done();
+            });
+        },
+        [{ text: 'tag:' }, { text: 'Tag:' }, { text: 'TAG:' }]
+      );
 
-      it('orders tags by priority and indexOf score', (done) => {
+      it('orders tags by priority and indexOf score', done => {
         syn
           .click(input)
           .type('tag:', () => {
-            assert.deepEqual(getItemTitles(), [ 'aaac', 'aaad', 'aadf', 'aaag', 'aaaa' ], 'default ordering based on priority');
+            assert.deepEqual(
+              getItemTitles(),
+              ['aaac', 'aaad', 'aadf', 'aaag', 'aaaa'],
+              'default ordering based on priority'
+            );
           })
           .type('aad', () => {
-            assert.deepEqual(getItemTitles(), [ 'aadf', 'aaad'], 'sorting by indexof score with equal priority');
+            assert.deepEqual(
+              getItemTitles(),
+              ['aadf', 'aaad'],
+              'sorting by indexof score with equal priority'
+            );
             done();
           });
       });
 
-      it('matches on multi word searches', (done) => {
+      it('matches on multi word searches', done => {
         syn
           .click(input)
           .type('tag:"mul', () => {
-            assert.deepEqual(getItemTitles(), [ 'multi word' ], 'supports matching on a double quote initial input');
+            assert.deepEqual(
+              getItemTitles(),
+              ['multi word'],
+              'supports matching on a double quote initial input'
+            );
           })
-          .type('[backspace][backspace][backspace][backspace]\'mul', () => {
-            assert.deepEqual(getItemTitles(), [ 'multi word' ], 'supports matching on a single quote initial input');
+          .type("[backspace][backspace][backspace][backspace]'mul", () => {
+            assert.deepEqual(
+              getItemTitles(),
+              ['multi word'],
+              'supports matching on a single quote initial input'
+            );
           })
           .type('[down][enter][enter]', () => {
-            assert.equal(testEl.querySelector('input[type=hidden]').value.trim(), 'tag:"multi word"', 'selecting a multi word tag should wrap with quotes');
+            assert.equal(
+              testEl.querySelector('input[type=hidden]').value.trim(),
+              'tag:"multi word"',
+              'selecting a multi word tag should wrap with quotes'
+            );
             done();
           });
       });
 
-      it('handles filtering matches with unicode', (done) => {
-        syn
-          .click(input)
-          .type('tag:éf', () => {
-            assert.deepEqual(getItemTitles(), [ 'effort' ], 'matches éffort with unicode value');
-            done();
-          });
+      it('handles filtering matches with unicode', done => {
+        syn.click(input).type('tag:éf', () => {
+          assert.deepEqual(
+            getItemTitles(),
+            ['effort'],
+            'matches éffort with unicode value'
+          );
+          done();
+        });
       });
-
     });
   });
 
@@ -430,67 +512,72 @@ describe('SearchBarController', () => {
     }
 
     it('should create lozenges for existing query terms in the input on page load', () => {
-      const {ctrl} = component('foo');
+      const { ctrl } = component('foo');
 
       assert.deepEqual(getLozengeValues(ctrl), ['foo']);
     });
 
     it('inserts a hidden input on init', () => {
-      const {hiddenInput} = component();
+      const { hiddenInput } = component();
 
       assert.notEqual(hiddenInput, null);
     });
 
     it('removes the name="q" attribute from the input on init', () => {
-      const {input} = component();
+      const { input } = component();
 
       assert.isFalse(input.hasAttribute('name'));
     });
 
     it('adds the name="q" attribute to the hidden input on init', () => {
-      const {hiddenInput} = component();
+      const { hiddenInput } = component();
 
       assert.equal(hiddenInput.getAttribute('name'), 'q');
     });
 
     it('leaves the hidden input empty on init if the visible input is empty', () => {
-      const {hiddenInput} = component();
+      const { hiddenInput } = component();
 
       assert.equal(hiddenInput.value, '');
     });
 
     it('copies lozengifiable text from the input into the hidden input on init', () => {
-      const {hiddenInput} = component('these are my tag:lozenges');
+      const { hiddenInput } = component('these are my tag:lozenges');
 
       assert.equal(hiddenInput.value, 'these are my tag:lozenges');
     });
 
     it('copies unlozengifiable text from the input into the hidden input on init', () => {
-      const {hiddenInput} = component("group:'unclosed quotes");
+      const { hiddenInput } = component("group:'unclosed quotes");
 
       assert.equal(hiddenInput.value, "group:'unclosed quotes");
     });
 
     it('copies lozengifiable and unlozengifiable text from the input into the hidden input on init', () => {
-      const {hiddenInput} = component("these are my tag:lozenges group:'unclosed quotes");
+      const { hiddenInput } = component(
+        "these are my tag:lozenges group:'unclosed quotes"
+      );
 
-      assert.equal(hiddenInput.value, "these are my tag:lozenges group:'unclosed quotes");
+      assert.equal(
+        hiddenInput.value,
+        "these are my tag:lozenges group:'unclosed quotes"
+      );
     });
 
     it('updates the value of the hidden input as text is typed into the visible input', () => {
-      const {input, hiddenInput} = component('initial text');
+      const { input, hiddenInput } = component('initial text');
 
-      input.value = 'new text';  // This is just "new text" and not
-                                 // "initial text new text" because the
-                                 // "initial text" will have been moved into
-                                 // lozenges.
+      input.value = 'new text'; // This is just "new text" and not
+      // "initial text new text" because the
+      // "initial text" will have been moved into
+      // lozenges.
       input.dispatchEvent(new Event('input'));
 
       assert.equal(hiddenInput.value, 'initial text new text');
     });
 
     it('updates the value of the hidden input as unlozengifiable text is typed into the visible input', () => {
-      const {input, hiddenInput} = component("group:'unclosed quotes");
+      const { input, hiddenInput } = component("group:'unclosed quotes");
 
       input.value = "group:'unclosed quotes still unclosed";
       input.dispatchEvent(new Event('input'));
@@ -499,7 +586,7 @@ describe('SearchBarController', () => {
     });
 
     it('updates the value of the hidden input when a lozenge is deleted', () => {
-      const {ctrl, hiddenInput} = component('foo bar');
+      const { ctrl, hiddenInput } = component('foo bar');
 
       const lozenge = getLozenges(ctrl)[0];
       lozenge.controllers[0].options.deleteCallback();
@@ -508,14 +595,14 @@ describe('SearchBarController', () => {
     });
 
     it('should not create a lozenge for incomplete query strings in the input on page load', () => {
-      const {ctrl, input} = component("'bar");
+      const { ctrl, input } = component("'bar");
 
       assert.equal(getLozenges(ctrl).length, 0);
       assert.equal(input.value, "'bar");
     });
 
-    it('should create a lozenge when the user presses space and there are no incomplete query strings in the input', (done) => {
-      const {ctrl, input} = component('foo');
+    it('should create a lozenge when the user presses space and there are no incomplete query strings in the input', done => {
+      const { ctrl, input } = component('foo');
 
       syn
         .click(input)
@@ -526,20 +613,20 @@ describe('SearchBarController', () => {
         });
     });
 
-    it('should create a lozenge when the user completes a previously incomplete query string and then presses the space key', (done) => {
-      const {ctrl, input} = component("'bar gar'");
+    it('should create a lozenge when the user completes a previously incomplete query string and then presses the space key', done => {
+      const { ctrl, input } = component("'bar gar'");
 
       syn
         .click(input)
-        .type(' gar\'')
+        .type(" gar'")
         .type('[space]', () => {
           assert.deepEqual(getLozengeValues(ctrl), ["'bar gar'"]);
           done();
         });
     });
 
-    it('should not create a lozenge when the user does not completes a previously incomplete query string and presses the space key', (done) => {
-      const {ctrl, input} = component("'bar");
+    it('should not create a lozenge when the user does not completes a previously incomplete query string and presses the space key', done => {
+      const { ctrl, input } = component("'bar");
 
       syn
         .click(input)
@@ -554,14 +641,15 @@ describe('SearchBarController', () => {
     });
 
     describe('mapping initial input value to proper group lozenge and input values', () => {
-
       let groupsScript;
 
       beforeEach(() => {
-        const suggestions = [{
-          name: 'abc 123',
-          pubid: 'pid124',
-        }];
+        const suggestions = [
+          {
+            name: 'abc 123',
+            pubid: 'pid124',
+          },
+        ];
 
         groupsScript = document.createElement('script');
         groupsScript.innerHTML = JSON.stringify(suggestions);
@@ -574,8 +662,7 @@ describe('SearchBarController', () => {
       });
 
       it('should map an initial group name to proper group pubid input value', () => {
-
-        const {input, hiddenInput} = component("group:'abc 123'");
+        const { input, hiddenInput } = component("group:'abc 123'");
 
         assert.deepEqual(getLozengeValues(ctrl), ['group:"abc 123"']);
         assert.equal(input.value, '');
@@ -583,16 +670,14 @@ describe('SearchBarController', () => {
       });
 
       it('should map an initial group pubid to proper group name lozenge value', () => {
-
-        const {input, hiddenInput} = component('group:pid124');
+        const { input, hiddenInput } = component('group:pid124');
 
         assert.deepEqual(getLozengeValues(ctrl), ['group:"abc 123"']);
         assert.equal(input.value, '');
         assert.equal(hiddenInput.value, 'group:pid124');
       });
 
-
-      it('places lozenges as first elements in container', (done) => {
+      it('places lozenges as first elements in container', done => {
         const template = `
             <div>
               <form data-ref="searchBarForm">
@@ -603,7 +688,11 @@ describe('SearchBarController', () => {
             </div>
           `.trim();
 
-        const ctrl = util.setupComponent(document, template, SearchBarController);
+        const ctrl = util.setupComponent(
+          document,
+          template,
+          SearchBarController
+        );
 
         // Stub the submit method so it doesn't actually do a full page reload.
         ctrl.refs.searchBarForm.submit = sinon.stub();
@@ -613,21 +702,25 @@ describe('SearchBarController', () => {
 
         let currentChildrenCount = container.children.length;
 
-        syn
-          .click(input)
-          .type('foo[space]', () => {
+        syn.click(input).type('foo[space]', () => {
+          currentChildrenCount += 1;
 
-            currentChildrenCount += 1;
+          assert.lengthOf(
+            container.children,
+            currentChildrenCount,
+            'lozenge add should be added as a child'
+          );
 
-            assert.lengthOf(container.children, currentChildrenCount, 'lozenge add should be added as a child');
+          assert.ok(
+            container.children[0].classList.contains('lozenge'),
+            'should be set as first child'
+          );
 
-            assert.ok(container.children[0].classList.contains('lozenge'), 'should be set as first child');
-
-            done();
-          });
+          done();
+        });
       });
 
-      it('places lozenges after any initial lozenges', (done) => {
+      it('places lozenges after any initial lozenges', done => {
         const template = `
             <div>
               <form data-ref="searchBarForm">
@@ -638,7 +731,11 @@ describe('SearchBarController', () => {
             </div>
           `.trim();
 
-        const ctrl = util.setupComponent(document, template, SearchBarController);
+        const ctrl = util.setupComponent(
+          document,
+          template,
+          SearchBarController
+        );
 
         // Stub the submit method so it doesn't actually do a full page reload.
         ctrl.refs.searchBarForm.submit = sinon.stub();
@@ -646,7 +743,7 @@ describe('SearchBarController', () => {
         const container = ctrl.element.querySelector('.search-bar__lozenges');
 
         const lozengeEl = cloneTemplate(lozengeTemplateEl);
-        new LozengeController(lozengeEl, {content: 'seeded'});
+        new LozengeController(lozengeEl, { content: 'seeded' });
 
         container.insertBefore(lozengeEl, container.firstChild);
 
@@ -654,23 +751,19 @@ describe('SearchBarController', () => {
 
         let currentChildrenCount = container.children.length;
 
-        syn
-          .click(input)
-          .type('foo[space]', () => {
+        syn.click(input).type('foo[space]', () => {
+          currentChildrenCount += 1;
 
-            currentChildrenCount += 1;
+          assert.lengthOf(container.children, currentChildrenCount);
 
-            assert.lengthOf(container.children, currentChildrenCount);
+          assert.ok(container.children[0].classList.contains('lozenge'));
+          assert.ok(container.children[1].classList.contains('lozenge'));
 
-            assert.ok(container.children[0].classList.contains('lozenge'));
-            assert.ok(container.children[1].classList.contains('lozenge'));
+          assert.deepEqual(getLozengeValues(ctrl), ['seeded', 'foo']);
 
-            assert.deepEqual(getLozengeValues(ctrl), ['seeded', 'foo']);
-
-            done();
-          });
+          done();
+        });
       });
-
     });
   });
 });

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -14,7 +14,7 @@ const TEMPLATE = `<div class="js-search-bucket">
 `;
 
 class FakeEnvFlags {
-  constructor (flags = []) {
+  constructor(flags = []) {
     this.flags = flags;
   }
 
@@ -46,7 +46,7 @@ describe('SearchBucketController', () => {
   });
 
   it('does not expand when domain link is clicked', () => {
-    ctrl.refs.domainLink.dispatchEvent(new Event('click', {bubbles: true}));
+    ctrl.refs.domainLink.dispatchEvent(new Event('click', { bubbles: true }));
     assert.isFalse(ctrl.refs.content.classList.contains('is-expanded'));
   });
 

--- a/h/static/scripts/tests/controllers/share-widget-controller-test.js
+++ b/h/static/scripts/tests/controllers/share-widget-controller-test.js
@@ -5,7 +5,6 @@ const syn = require('syn');
 const ShareWidgetController = require('../../controllers/share-widget-controller');
 
 describe('ShareWidgetController', () => {
-
   // this is pseudo duplicating you see in share_widget.html.jinja2
   // but it only has the needed pieces to perform the functions we test
   const widgetTemplate = `
@@ -60,22 +59,32 @@ describe('ShareWidgetController', () => {
   };
 
   const widgetIsVisble = () => {
-    return container.querySelector('.js-share-widget').style.visibility === 'visible';
+    return (
+      container.querySelector('.js-share-widget').style.visibility === 'visible'
+    );
   };
 
-  const urlsReflectUpdate = (interpolatedValue) => {
-    return Array.from(container.querySelectorAll('[share-target-href]')).every((anchor) => {
-      const tmpl = anchor.getAttribute('share-target-href');
-      return tmpl.replace('{href}', interpolatedValue) === anchor.href;
-    });
+  const urlsReflectUpdate = interpolatedValue => {
+    return Array.from(container.querySelectorAll('[share-target-href]')).every(
+      anchor => {
+        const tmpl = anchor.getAttribute('share-target-href');
+        return tmpl.replace('{href}', interpolatedValue) === anchor.href;
+      }
+    );
   };
 
   const privateMessageVisible = () => {
-    return container.querySelector('.js-share-widget-msg-private').style.display === 'block';
+    return (
+      container.querySelector('.js-share-widget-msg-private').style.display ===
+      'block'
+    );
   };
 
   const groupMessageVisible = () => {
-    return container.querySelector('.js-share-widget-msg-group').style.display === 'block';
+    return (
+      container.querySelector('.js-share-widget-msg-group').style.display ===
+      'block'
+    );
   };
 
   beforeEach(() => {
@@ -84,8 +93,9 @@ describe('ShareWidgetController', () => {
 
     document.body.appendChild(container);
 
-    ctrl = new ShareWidgetController(document.querySelector('.js-share-widget'));
-
+    ctrl = new ShareWidgetController(
+      document.querySelector('.js-share-widget')
+    );
   });
 
   afterEach(() => {
@@ -93,8 +103,7 @@ describe('ShareWidgetController', () => {
     ctrl.beforeRemove();
   });
 
-  it('shows/hides widget on clicking', (done) => {
-
+  it('shows/hides widget on clicking', done => {
     assert.isFalse(widgetIsVisble(), 'not visible by default');
 
     const btns = getTriggers();
@@ -104,22 +113,33 @@ describe('ShareWidgetController', () => {
         assert.isTrue(widgetIsVisble(), 'visible after clicking trigger');
       })
       .click(document.body, () => {
-        assert.isFalse(widgetIsVisble(), 'hidden after clicking another trigger while it is open');
+        assert.isFalse(
+          widgetIsVisble(),
+          'hidden after clicking another trigger while it is open'
+        );
       })
       .click(btns[3].querySelector('b'), () => {
-        assert.isTrue(widgetIsVisble(), 'opens when clicking elements inside of trigger');
+        assert.isTrue(
+          widgetIsVisble(),
+          'opens when clicking elements inside of trigger'
+        );
       })
       .click(btns[2], () => {
-        assert.isTrue(widgetIsVisble(), 'keeps trigger open when clicking another trigger while another dialog is open');
+        assert.isTrue(
+          widgetIsVisble(),
+          'keeps trigger open when clicking another trigger while another dialog is open'
+        );
       })
       .click(btns[2], () => {
-        assert.isFalse(widgetIsVisble(), 'close widget when clicking on the currently open trigger again');
+        assert.isFalse(
+          widgetIsVisble(),
+          'close widget when clicking on the currently open trigger again'
+        );
         done();
       });
   });
 
-  it('displays correctly for current share link', (done) => {
-
+  it('displays correctly for current share link', done => {
     const btns = getTriggers();
 
     syn
@@ -145,5 +165,4 @@ describe('ShareWidgetController', () => {
         done();
       });
   });
-
 });

--- a/h/static/scripts/tests/controllers/tooltip-controller-test.js
+++ b/h/static/scripts/tests/controllers/tooltip-controller-test.js
@@ -9,8 +9,9 @@ describe('TooltipController', () => {
   let tooltipEl;
 
   before(() => {
-    template = '<div class="form-input__hint-icon js-tooltip"' +
-     'aria-label="Test"></div>';
+    template =
+      '<div class="form-input__hint-icon js-tooltip"' +
+      'aria-label="Test"></div>';
   });
 
   beforeEach(() => {
@@ -22,7 +23,6 @@ describe('TooltipController', () => {
 
     tooltipEl = testEl.querySelector('.tooltip');
   });
-
 
   it('appears when the target is hovered', () => {
     targetEl.dispatchEvent(new Event('mouseover'));

--- a/h/static/scripts/tests/promise-util.js
+++ b/h/static/scripts/tests/promise-util.js
@@ -8,11 +8,13 @@
  * as expected in tests.
  */
 function toResult(promise) {
-  return promise.then((result) => {
-    return { result: result };
-  }).catch((err) => {
-    return { error: err };
-  });
+  return promise
+    .then(result => {
+      return { result: result };
+    })
+    .catch(err => {
+      return { error: err };
+    });
 }
 
 module.exports = {

--- a/h/static/scripts/tests/util.js
+++ b/h/static/scripts/tests/util.js
@@ -30,18 +30,20 @@
  * @param {Array<T>} fixtures - Array of fixture objects.
  */
 function unroll(description, testFn, fixtures) {
-  fixtures.forEach((fixture) => {
+  fixtures.forEach(fixture => {
     const caseDescription = Object.keys(fixture).reduce((desc, key) => {
       return desc.replace('#' + key, String(fixture[key]));
     }, description);
-    it(caseDescription, (done) => {
+    it(caseDescription, done => {
       if (testFn.length === 1) {
         // Test case does not accept a 'done' callback argument, so we either
         // call done() immediately if it returns a non-Promiselike object
         // or when the Promise resolves otherwise
         const result = testFn(fixture);
         if (typeof result === 'object' && result.then) {
-          result.then(() => { done(); }, done);
+          result.then(() => {
+            done();
+          }, done);
         } else {
           done();
         }

--- a/h/static/scripts/tests/util/dom-test.js
+++ b/h/static/scripts/tests/util/dom-test.js
@@ -68,7 +68,9 @@ describe('util/dom', () => {
     });
 
     it('clones the first child of the template when <template> is not supported', () => {
-      const template = createDOM('<fake-template><div id="child"></div></fake-template>');
+      const template = createDOM(
+        '<fake-template><div id="child"></div></fake-template>'
+      );
       const clone = domUtil.cloneTemplate(template);
       assert.deepEqual(clone.outerHTML, '<div id="child"></div>');
     });

--- a/h/static/scripts/tests/util/modal-focus-test.js
+++ b/h/static/scripts/tests/util/modal-focus-test.js
@@ -11,7 +11,7 @@ describe('util/modal-focus', () => {
   let releaseFocus;
 
   beforeEach(() => {
-    insideEls = [1,2,3].map(() => document.createElement('input'));
+    insideEls = [1, 2, 3].map(() => document.createElement('input'));
     insideEls.forEach(el => document.body.appendChild(el));
 
     outsideEl = document.createElement('input');

--- a/h/static/scripts/tests/util/search-text-parser-test.js
+++ b/h/static/scripts/tests/util/search-text-parser-test.js
@@ -4,37 +4,45 @@ const searchTextParser = require('../../util/search-text-parser');
 const unroll = require('../util').unroll;
 
 describe('SearchTextParser', () => {
-  unroll('should create a lozenge #input', (fixture) => {
-    assert.isTrue(searchTextParser.shouldLozengify(fixture.input));
-  },[
-    {input: 'foo'},
-    {input: '    foo    '},
-    {input: '"foo bar"'},
-    {input: '\'foo bar\''},
-    {input: 'foo:"bar"'},
-    {input: 'foo:\'bar\''},
-    {input: 'foo:\'bar1 bar2\''},
-    {input: 'foo:"bar1 bar2"'},
-    {input: 'foo:'},
-    {input: '\'foo\':'},
-    {input: '"foo":'},
-    {input: 'foo"bar:'},
-    {input: 'foo\'bar:'},
-    {input: '\'foo\'bar:'},
-    {input: '"foo"bar:'},
-    {input: 'foo\'bar'},
-    {input: 'foo"bar'},
-  ]);
+  unroll(
+    'should create a lozenge #input',
+    fixture => {
+      assert.isTrue(searchTextParser.shouldLozengify(fixture.input));
+    },
+    [
+      { input: 'foo' },
+      { input: '    foo    ' },
+      { input: '"foo bar"' },
+      { input: "'foo bar'" },
+      { input: 'foo:"bar"' },
+      { input: "foo:'bar'" },
+      { input: "foo:'bar1 bar2'" },
+      { input: 'foo:"bar1 bar2"' },
+      { input: 'foo:' },
+      { input: "'foo':" },
+      { input: '"foo":' },
+      { input: 'foo"bar:' },
+      { input: "foo'bar:" },
+      { input: "'foo'bar:" },
+      { input: '"foo"bar:' },
+      { input: "foo'bar" },
+      { input: 'foo"bar' },
+    ]
+  );
 
-  unroll('should not create a lozenge for', (fixture) => {
-    assert.isFalse(searchTextParser.shouldLozengify(fixture.input));
-  },[
-    {input: 'foo\''},
-    {input: 'foo\"'},
-    {input: '\'foo'},
-    {input: '\"foo'},
-    {input: ''},
-    {input: 'foo:\'bar'},
-    {input: 'foo:\"bar'},
-  ]);
+  unroll(
+    'should not create a lozenge for',
+    fixture => {
+      assert.isFalse(searchTextParser.shouldLozengify(fixture.input));
+    },
+    [
+      { input: "foo'" },
+      { input: 'foo"' },
+      { input: "'foo" },
+      { input: '"foo' },
+      { input: '' },
+      { input: "foo:'bar" },
+      { input: 'foo:"bar' },
+    ]
+  );
 });

--- a/h/static/scripts/tests/util/string-test.js
+++ b/h/static/scripts/tests/util/string-test.js
@@ -20,7 +20,6 @@ describe('util/string', () => {
   });
 
   describe('stringUtil helpers', () => {
-
     it('removes hungarian marks', () => {
       const text = 'Fürge rőt róka túlszökik zsíros étkű kutyán';
       const decoded = stringUtil.fold(stringUtil.normalize(text));
@@ -62,12 +61,13 @@ describe('util/string', () => {
     });
 
     it('removes all marks', () => {
-      const text = '̀ ́ ̂ ̃ ̄ ̅ ̆ ̇ ̈ ̉ ̊ ̋ ̌ ̍ ̎ ̏ ̐ ̑ ̒ ̓ ̔ ̕ ̖ ̗ ̘ ̙ ̚ ̛ ̜ ̝ ̞ ̟ ̠ ̡ ̢ ̣ ̤ ̥ ̦ ̧ ̨ ̩ ̪ ̫ ̬ ̭ ̮ ̯ ̰ ̱ ̲ ̳ ̴ ̵ ̶ ̷ ̸ ̹ ̺ ̻ ̼ ̽ ̾ ̿ ̀ ́ ͂ ̓ ̈́ ͅ ͠ ͡"';
+      const text =
+        '̀ ́ ̂ ̃ ̄ ̅ ̆ ̇ ̈ ̉ ̊ ̋ ̌ ̍ ̎ ̏ ̐ ̑ ̒ ̓ ̔ ̕ ̖ ̗ ̘ ̙ ̚ ̛ ̜ ̝ ̞ ̟ ̠ ̡ ̢ ̣ ̤ ̥ ̦ ̧ ̨ ̩ ̪ ̫ ̬ ̭ ̮ ̯ ̰ ̱ ̲ ̳ ̴ ̵ ̶ ̷ ̸ ̹ ̺ ̻ ̼ ̽ ̾ ̿ ̀ ́ ͂ ̓ ̈́ ͅ ͠ ͡"';
       const decoded = stringUtil.fold(stringUtil.normalize(text));
-      const expected = '                                                                       "';
+      const expected =
+        '                                                                       "';
 
       assert.equal(decoded, expected);
     });
-
   });
 });

--- a/h/static/scripts/tests/util/submit-form-test.js
+++ b/h/static/scripts/tests/util/submit-form-test.js
@@ -24,66 +24,79 @@ describe('submitForm', () => {
     return form;
   }
 
-  unroll('submits the form data', (testCase) => {
-    const form = document.createElement('form');
-    form.method = 'POST';
-    form.innerHTML = '<input name="field" value="value">';
+  unroll(
+    'submits the form data',
+    testCase => {
+      const form = document.createElement('form');
+      form.method = 'POST';
+      form.innerHTML = '<input name="field" value="value">';
 
-    if (typeof testCase.action === 'string') {
-      form.setAttribute('action', testCase.action);
-    }
-    mockResponse('<form><!-- updated form !--></form>', testCase.expectedSubmitUrl);
+      if (typeof testCase.action === 'string') {
+        form.setAttribute('action', testCase.action);
+      }
+      mockResponse(
+        '<form><!-- updated form !--></form>',
+        testCase.expectedSubmitUrl
+      );
 
-    return submitForm(form, fetchMock.fetchMock).then(() => {
-      const [,requestInit] = fetchMock.lastCall(testCase.expectedSubmitUrl);
-      assert.instanceOf(requestInit.body, FormData);
-    });
-  }, [{
-    action: FORM_URL,
-    expectedSubmitUrl: FORM_URL,
-  },{
-    // Setting "action" to an empty string is technically disallowed according
-    // to https://w3c.github.io/html/sec-forms.html#element-attrdef-form-action
-    // but in practice browsers treat it mostly the same way as a missing
-    // "action" attr.
-    action: '',
-    expectedSubmitUrl: document.location.href,
-  },{
-    // Omit "action" attr.
-    action: null,
-    expectedSubmitUrl: document.location.href,
-  }]);
+      return submitForm(form, fetchMock.fetchMock).then(() => {
+        const [, requestInit] = fetchMock.lastCall(testCase.expectedSubmitUrl);
+        assert.instanceOf(requestInit.body, FormData);
+      });
+    },
+    [
+      {
+        action: FORM_URL,
+        expectedSubmitUrl: FORM_URL,
+      },
+      {
+        // Setting "action" to an empty string is technically disallowed according
+        // to https://w3c.github.io/html/sec-forms.html#element-attrdef-form-action
+        // but in practice browsers treat it mostly the same way as a missing
+        // "action" attr.
+        action: '',
+        expectedSubmitUrl: document.location.href,
+      },
+      {
+        // Omit "action" attr.
+        action: null,
+        expectedSubmitUrl: document.location.href,
+      },
+    ]
+  );
 
   it('returns the markup for the updated form if validation succeeds', () => {
     const form = createForm();
     const responseBody = '<form><!-- updated form !--></form>';
     mockResponse(responseBody);
 
-    return submitForm(form, fetchMock.fetchMock).then((response) => {
+    return submitForm(form, fetchMock.fetchMock).then(response => {
       assert.equal(response.form, responseBody);
     });
   });
 
   it('rejects with the updated form markup if validation fails', () => {
     const form = createForm();
-    mockResponse({status: 400, body: 'response'});
+    mockResponse({ status: 400, body: 'response' });
 
     const done = submitForm(form, fetchMock.fetchMock);
 
-    return done.catch((err) => {
-      assert.match(err, sinon.match({status: 400, form: 'response'}));
+    return done.catch(err => {
+      assert.match(err, sinon.match({ status: 400, form: 'response' }));
     });
   });
 
   it('rejects with an error message if submission fails', () => {
     const form = createForm();
-    mockResponse({status: 500, statusText: 'Internal Server Error'});
+    mockResponse({ status: 500, statusText: 'Internal Server Error' });
 
     const done = submitForm(form, fetchMock.fetchMock);
 
-    return done.catch((err) => {
-      assert.match(err, sinon.match({status: 500, reason: 'Internal Server Error'}));
+    return done.catch(err => {
+      assert.match(
+        err,
+        sinon.match({ status: 500, reason: 'Internal Server Error' })
+      );
     });
   });
-
 });

--- a/h/static/scripts/util/dom.js
+++ b/h/static/scripts/util/dom.js
@@ -17,7 +17,7 @@ const hyphenate = stringUtil.hyphenate;
  *                 is true or removed otherwise.
  */
 function setElementState(el, state) {
-  Object.keys(state).forEach((key) => {
+  Object.keys(state).forEach(key => {
     const stateClass = 'is-' + hyphenate(key);
     if (state[key]) {
       el.classList.add(stateClass);
@@ -38,12 +38,12 @@ function findRefs(el) {
   const map = {};
 
   const descendantsWithRef = el.querySelectorAll('[data-ref]');
-  for (let i=0; i < descendantsWithRef.length; i++) {
+  for (let i = 0; i < descendantsWithRef.length; i++) {
     // Use `Element#getAttribute` rather than `Element#dataset` to support IE 10
     // and avoid https://bugs.webkit.org/show_bug.cgi?id=161454
     const refEl = descendantsWithRef[i];
     const refs = (refEl.getAttribute('data-ref') || '').split(' ');
-    refs.forEach((ref) => {
+    refs.forEach(ref => {
       map[ref] = refEl;
     });
   }
@@ -60,7 +60,7 @@ function findRefs(el) {
  * @param {Node} node
  */
 function firstElementChild(node) {
-  for (let i=0; i < node.childNodes.length; i++) {
+  for (let i = 0; i < node.childNodes.length; i++) {
     if (node.childNodes[i].nodeType === Node.ELEMENT_NODE) {
       return node.childNodes[i];
     }

--- a/h/static/scripts/util/modal-focus.js
+++ b/h/static/scripts/util/modal-focus.js
@@ -33,7 +33,7 @@ function trap(elements, callback) {
   //
   // Instead we watch the 'focus' event on the document itself.
 
-  const onFocusChange = (event) => {
+  const onFocusChange = event => {
     if (elements.some(el => el.contains(event.target))) {
       // Focus remains within modal group
       return;
@@ -55,7 +55,11 @@ function trap(elements, callback) {
   const releaseFn = () => {
     if (currentReleaseFn === releaseFn) {
       currentReleaseFn = null;
-      document.removeEventListener('focus', onFocusChange, true /* useCapture */);
+      document.removeEventListener(
+        'focus',
+        onFocusChange,
+        true /* useCapture */
+      );
     }
   };
   currentReleaseFn = releaseFn;

--- a/h/static/scripts/util/search-text-parser.js
+++ b/h/static/scripts/util/search-text-parser.js
@@ -21,19 +21,31 @@ function canLozengify(phrase) {
     return false;
   }
   // if a phrase starts with a double quote, it has to have a closing double quote
-  if (phrase.indexOf('"') === 0 && (phrase.indexOf('"', 1) > phrase.length - 1 || phrase.indexOf('"', 1) < 0)) {
+  if (
+    phrase.indexOf('"') === 0 &&
+    (phrase.indexOf('"', 1) > phrase.length - 1 || phrase.indexOf('"', 1) < 0)
+  ) {
     return false;
   }
   // if a phrase starts with a single quote, it has to have a closing double quote
-  if (phrase.indexOf("'") === 0 && (phrase.indexOf("'", 1) > phrase.length - 1 || phrase.indexOf("'", 1) < 0)) {
+  if (
+    phrase.indexOf("'") === 0 &&
+    (phrase.indexOf("'", 1) > phrase.length - 1 || phrase.indexOf("'", 1) < 0)
+  ) {
     return false;
   }
   // if phrase ends with a double quote it has to start with one
-  if (phrase.indexOf('"', 1) === phrase.length - 1 && phrase.indexOf('"') !== 0) {
+  if (
+    phrase.indexOf('"', 1) === phrase.length - 1 &&
+    phrase.indexOf('"') !== 0
+  ) {
     return false;
   }
   // if phrase ends with a single quote it has to start with one
-  if (phrase.indexOf("'", 1) === phrase.length - 1 && phrase.indexOf("'") !== 0) {
+  if (
+    phrase.indexOf("'", 1) === phrase.length - 1 &&
+    phrase.indexOf("'") !== 0
+  ) {
     return false;
   }
   return true;
@@ -63,11 +75,13 @@ function shouldLozengify(phrase) {
     if (!canLozengify(queryTerm.facetName)) {
       return false;
     }
-    if (queryTerm.facetValue.length > 0 && !canLozengify(queryTerm.facetValue)) {
+    if (
+      queryTerm.facetValue.length > 0 &&
+      !canLozengify(queryTerm.facetValue)
+    ) {
       return false;
     }
-  }
-  else if (!canLozengify(phrase)) {
+  } else if (!canLozengify(phrase)) {
     return false;
   }
   return true;
@@ -93,7 +107,7 @@ function getLozengeValues(queryString) {
   let inputTerms = '';
   let quoted;
   const queryTerms = [];
-  queryString.split(' ').forEach((term) => {
+  queryString.split(' ').forEach(term => {
     if (quoted) {
       inputTerms = inputTerms + ' ' + term;
       if (shouldLozengify(inputTerms)) {
@@ -131,11 +145,7 @@ function getLozengeValues(queryString) {
  * hasKnownNamedQueryTerm('user:foo')
  */
 function hasKnownNamedQueryTerm(queryTerm) {
-  const knownNamedQueryTerms = ['user',
-    'uri',
-    'url',
-    'group',
-    'tag'];
+  const knownNamedQueryTerms = ['user', 'uri', 'url', 'group', 'tag'];
 
   const facetName = getLozengeFacetNameAndValue(queryTerm).facetName;
 
@@ -173,10 +183,10 @@ function getLozengeFacetNameAndValue(queryTerm) {
   if (queryTerm.indexOf(':') >= 0) {
     i = queryTerm.indexOf(':');
 
-    lozengeFacetNameAndValue.facetName =
-      queryTerm.slice(0, i).trim();
-    lozengeFacetNameAndValue.facetValue =
-      queryTerm.slice(i+1, queryTerm.length).trim();
+    lozengeFacetNameAndValue.facetName = queryTerm.slice(0, i).trim();
+    lozengeFacetNameAndValue.facetValue = queryTerm
+      .slice(i + 1, queryTerm.length)
+      .trim();
 
     return lozengeFacetNameAndValue;
   }

--- a/h/static/scripts/util/string.js
+++ b/h/static/scripts/util/string.js
@@ -18,8 +18,8 @@ function unhyphenate(name) {
   if (idx === -1) {
     return name;
   } else {
-    const ch = (name[idx+1] || '').toUpperCase();
-    return unhyphenate(name.slice(0,idx) + ch + name.slice(idx+2));
+    const ch = (name[idx + 1] || '').toUpperCase();
+    return unhyphenate(name.slice(0, idx) + ch + name.slice(idx + 2));
   }
 }
 

--- a/h/static/scripts/util/submit-form.js
+++ b/h/static/scripts/util/submit-form.js
@@ -67,25 +67,28 @@ function submitForm(formEl, fetch = window.fetch) {
     headers: {
       'X-Requested-With': 'XMLHttpRequest',
     },
-  }).then((response_) => {
-    response = response_;
-    return response.text();
-  }).then((body) => {
-    const { status } = response;
-    switch (status) {
-    case 200:
-      return {status, form: body};
-    case 400:
-      throw new FormSubmitError('Form validation failed', {
-        status, form: body,
-      });
-    default:
-      throw new FormSubmitError('Form submission failed', {
-        status,
-        reason: response.statusText,
-      });
-    }
-  });
+  })
+    .then(response_ => {
+      response = response_;
+      return response.text();
+    })
+    .then(body => {
+      const { status } = response;
+      switch (status) {
+        case 200:
+          return { status, form: body };
+        case 400:
+          throw new FormSubmitError('Form validation failed', {
+            status,
+            form: body,
+          });
+        default:
+          throw new FormSubmitError('Form submission failed', {
+            status,
+            reason: response.statusText,
+          });
+      }
+    });
 }
 
 module.exports = submitForm;

--- a/h/static/scripts/util/update-helpers.js
+++ b/h/static/scripts/util/update-helpers.js
@@ -1,7 +1,6 @@
 'use strict';
 
 module.exports = {
-
   /**
    * compare two list arrays and decide if they have changed
    *
@@ -11,7 +10,6 @@ module.exports = {
    *   arrays seem like they have changed. True if they have changed
    */
   listIsDifferent: function(listA, listB) {
-
     if (!(Array.isArray(listA) && Array.isArray(listB))) {
       return true;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1779,15 +1779,6 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
-    "bufferstreams": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.1.tgz",
-      "integrity": "sha1-AWE3MGCsWYjv+ZBYcxEU9uGV1R4=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.2"
-      }
-    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -4741,17 +4732,6 @@
       "requires": {
         "gulp-util": "^3.0.0",
         "through2": "^2.0.0"
-      }
-    },
-    "gulp-eslint": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-3.0.1.tgz",
-      "integrity": "sha1-BOV+PhjGl0JnwSz2hV3HF9SjE70=",
-      "dev": true,
-      "requires": {
-        "bufferstreams": "^1.1.1",
-        "eslint": "^3.0.0",
-        "gulp-util": "^3.0.6"
       }
     },
     "gulp-if": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3107,7 +3107,7 @@
     },
     "esprima": {
       "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "resolved": "http://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
     },
     "esprima-fb": {
@@ -3881,7 +3881,6 @@
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4063,8 +4062,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4142,8 +4140,7 @@
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -8336,6 +8333,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "prettier": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
+      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+      "dev": true
     },
     "pretty-hrtime": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "gulp build",
     "checkformatting": "prettier --check *.js {h,scripts}/**/*.js",
-    "format": "prettier --list-different --write *.js {h,scripts}/**/*.js"
+    "format": "prettier --list-different --write *.js {h,scripts}/**/*.js",
+    "lint": "eslint h/static/scripts"
   },
   "dependencies": {
     "autoprefixer": "^6.0.3",
@@ -58,7 +59,6 @@
     "eslint": "^3.9.1",
     "eslint-config-hypothesis": "^1.0.0",
     "fetch-mock": "^5.1.5",
-    "gulp-eslint": "^3.0.1",
     "karma": "^3.0.0",
     "karma-browserify": "^5.3.0",
     "karma-chai": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "description": "The Internet, peer reviewed.",
   "scripts": {
-    "build": "gulp build"
+    "build": "gulp build",
+    "checkformatting": "prettier --check *.js {h,scripts}/**/*.js",
+    "format": "prettier --list-different --write *.js {h,scripts}/**/*.js"
   },
   "dependencies": {
     "autoprefixer": "^6.0.3",
@@ -65,6 +67,7 @@
     "karma-phantomjs-launcher": "^1.0.1",
     "karma-sinon": "^1.0.5",
     "mocha": "^5.2.0",
+    "prettier": "1.17.0",
     "sinon": "^1.17.3",
     "syn": "^0.2.2",
     "websocket": "^1.0.22"

--- a/scripts/gulp/create-style-bundle.js
+++ b/scripts/gulp/create-style-bundle.js
@@ -26,33 +26,35 @@ function compileSass(options) {
   var postcssPlugins = [autoprefixer];
 
   if (options.urlRewriter) {
-    postcssPlugins.push(postcssURL({
-      url: options.urlRewriter,
-    }));
+    postcssPlugins.push(
+      postcssURL({
+        url: options.urlRewriter,
+      })
+    );
   }
 
   var sassBuild = new Promise((resolve, reject) => {
-    sass.render({
-      file: options.input,
-      importer: options.onImport,
-      includePaths: [
-        path.dirname(options.input),
-        'node_modules',
-      ],
-      outputStyle: options.minify ? 'compressed' : 'expanded',
-      sourceMap: sourcemapPath,
-    }, (err, result) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(result);
+    sass.render(
+      {
+        file: options.input,
+        importer: options.onImport,
+        includePaths: [path.dirname(options.input), 'node_modules'],
+        outputStyle: options.minify ? 'compressed' : 'expanded',
+        sourceMap: sourcemapPath,
+      },
+      (err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
       }
-    });
+    );
   });
 
-  return sassBuild.then(result => {
-    return postcss(postcssPlugins)
-      .process(result.css, {
+  return sassBuild
+    .then(result => {
+      return postcss(postcssPlugins).process(result.css, {
         from: options.output,
         to: options.output,
         map: {
@@ -60,13 +62,15 @@ function compileSass(options) {
           prev: result.map.toString(),
         },
       });
-  }).then(result => {
-    fs.writeFileSync(options.output, result.css);
-    fs.writeFileSync(sourcemapPath, result.map.toString());
-  }).catch(srcErr => {
-    // Rewrite error so that the message property contains the file path
-    throw new Error(`SASS build error in ${srcErr.file}: ${srcErr.message}`);
-  });
+    })
+    .then(result => {
+      fs.writeFileSync(options.output, result.css);
+      fs.writeFileSync(sourcemapPath, result.map.toString());
+    })
+    .catch(srcErr => {
+      // Rewrite error so that the message property contains the file path
+      throw new Error(`SASS build error in ${srcErr.file}: ${srcErr.message}`);
+    });
 }
 
 module.exports = compileSass;

--- a/scripts/gulp/manifest.js
+++ b/scripts/gulp/manifest.js
@@ -14,24 +14,27 @@ var VinylFile = require('vinyl');
  * manifest mapping input paths (eg. "scripts/foo.js")
  * to URLs with cache-busting query parameters (eg. "scripts/foo.js?af95bd").
  */
-module.exports = function (opts) {
+module.exports = function(opts) {
   var manifest = {};
 
-  return through.obj(function (file, enc, callback) {
-    var hash = crypto.createHash('sha1');
-    hash.update(file.contents);
+  return through.obj(
+    function(file, enc, callback) {
+      var hash = crypto.createHash('sha1');
+      hash.update(file.contents);
 
-    var hashSuffix = hash.digest('hex').slice(0, 6);
-    var relPath = path.relative('build/', file.path);
-    manifest[relPath] = relPath + '?' + hashSuffix;
+      var hashSuffix = hash.digest('hex').slice(0, 6);
+      var relPath = path.relative('build/', file.path);
+      manifest[relPath] = relPath + '?' + hashSuffix;
 
-    callback();
-  }, function (callback) {
-    var manifestFile = new VinylFile({
-      path: opts.name,
-      contents: Buffer.from(JSON.stringify(manifest, null, 2), 'utf-8'),
-    });
-    this.push(manifestFile);
-    callback();
-  });
+      callback();
+    },
+    function(callback) {
+      var manifestFile = new VinylFile({
+        path: opts.name,
+        contents: Buffer.from(JSON.stringify(manifest, null, 2), 'utf-8'),
+      });
+      this.push(manifestFile);
+      callback();
+    }
+  );
 };


### PR DESCRIPTION
This PR adds commands to format JS code in h using Prettier, runs it on all JS files in the repo and adds a step to the Travis build to check that formatting is correct.

This brings the style of JS code in h into line with our other repos.

As part of this PR, I have made the h repo consistent with lms in adding a `make frontend-lint` command which runs both ESLint and Prettier and any other checks that we find useful in future.