### PR TITLE
Filter out TransientErrors from Sentry reporting

### DIFF
--- a/h/sentry/helpers/before_send.py
+++ b/h/sentry/helpers/before_send.py
@@ -31,6 +31,7 @@ def before_send(event_dict, hint_dict):
     filter_functions = [
         filters.filter_ws4py_error_logging,
         filters.filter_ws4py_handshake_error,
+        filters.filter_transient_error,
     ]
 
     # If every filter returns True then do report the event to Sentry.

--- a/h/sentry/helpers/filters.py
+++ b/h/sentry/helpers/filters.py
@@ -9,6 +9,7 @@ filter returns ``False`` for a given event then the event is not reported.
 """
 from __future__ import unicode_literals
 
+import transaction
 import ws4py.exc
 
 
@@ -28,4 +29,16 @@ def filter_ws4py_handshake_error(event):
     if isinstance(event.exception, ws4py.exc.HandshakeError):
         if str(event.exception) == "Header HTTP_UPGRADE is not defined":
             return False
+    return True
+
+
+def filter_transient_error(event):
+    """
+    Filter out `transaction.interfaces.TransientError`.
+
+    Concurrent database write errors are raised as TransientErrors
+    and the request is retried by pyramid_tm.
+    """
+    if isinstance(event.exception, transaction.interfaces.TransientError):
+        return False
     return True

--- a/tests/h/sentry/helpers/filters_test.py
+++ b/tests/h/sentry/helpers/filters_test.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
+import transaction
 import ws4py
 
 from h.sentry.helpers import filters
@@ -38,6 +39,20 @@ class TestFilterWS4PYHandshakeError(object):
 
     def test_it_doesnt_filter_exception_events(self, unexpected_exception_event):
         assert filters.filter_ws4py_handshake_error(unexpected_exception_event) is True
+
+
+class TestFilterTransientError(object):
+    def test_it_filters_TransientError_events(self):
+        event = exception_event(
+            transaction.interfaces.TransientError("concurrent document creation")
+        )
+        assert filters.filter_transient_error(event) is False
+
+    def test_it_doesnt_filter_other_logger_events(self, unexpected_logger_event):
+        assert filters.filter_transient_error(unexpected_logger_event) is True
+
+    def test_it_doesnt_filter_exception_events(self, unexpected_exception_event):
+        assert filters.filter_transient_error(unexpected_exception_event) is True
 
 
 @pytest.fixture


### PR DESCRIPTION
Currently, TransientErrors in H are used to signal pyramid_tm to
retry ConcurrentUpdateErrors. That means these errors are still getting
reported to Sentry even though they are being retried and the request
was ultimately successful. Filter these out so that they don't cause
noise in Sentry.

This is a fix for https://github.com/hypothesis/h/issues/5495.