### PR TITLE
Mark community_groups feature flag as pending removal

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -20,7 +20,6 @@ FEATURES = {
     ),
     "overlay_highlighter": "Use the new overlay highlighter?",
     "client_display_names": "Render display names instead of user names in the client",
-    "community_groups": "Turn on community groups in the client and api.",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.
@@ -42,7 +41,8 @@ FEATURES = {
 # 4. Finally, remove the feature from FEATURES_PENDING_REMOVAL.
 #
 FEATURES_PENDING_REMOVAL = {
-    "api_render_user_info": "Return users' extended info in API responses?"
+    "api_render_user_info": "Return users' extended info in API responses?",
+    "community_groups": "Turn on community groups in the client and api.",
 }
 
 


### PR DESCRIPTION
**Do not deploy until 2019-06-28** (_By this time, the browser extension with feature flag checks removed will have been released for a couple of days_)

The client-side checks were removed in https://github.com/hypothesis/client/pull/1195