### PR TITLE
Preserve SVG viewBox when minifying SVGs for production

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -195,10 +195,23 @@ gulp.task('build-images', function() {
     return IS_PRODUCTION_BUILD && file.path.match(/\.svg$/);
   };
 
+  // See https://github.com/ben-eb/gulp-svgmin#plugins
+  var svgminConfig = {
+    plugins: [
+      {
+        // svgo removes `viewBox` by default, which breaks scaled rendering of
+        // the SVG.
+        //
+        // See https://github.com/svg/svgo/issues/1128
+        removeViewBox: false,
+      },
+    ],
+  };
+
   return gulp
     .src(imageFiles)
     .pipe(changed(IMAGES_DIR))
-    .pipe(gulpIf(shouldMinifySVG, svgmin()))
+    .pipe(gulpIf(shouldMinifySVG, svgmin(svgminConfig)))
     .pipe(gulp.dest(IMAGES_DIR));
 });
 


### PR DESCRIPTION
By default svgo (our SVG minifier) removes the `viewBox` attribute of the `<svg>` element, which breaks
scaling of the SVG content when rendering.

This caused various icons on the site to render at an incorrect scale.
In some cases this was not very noticeable because the natural size of
the content was close to the scaled size. In other cases the icon failed
to appear at all.

To see the difference, compare:

```
rm build/images/icons/*
NODE_ENV=production gulp build-images
cat build/images/icons/groups.svg
```

Before and after this patch is applied.

I'm unclear if this issue appeared in production when svgo was last updated, which happened in 2762912541f8dda875e71875fedf10fbfbd404bf, or whether it has in fact existed for a much longer period of time, since the behavior is not new in svgo.

Other projects will need to be checked for the same issue.

Fixes #5656

Background reading on how SVG scaling works: https://css-tricks.com/scale-svg/