### PR TITLE
Fix horizontal margins of annotation quotes

### DIFF
--- a/h/static/styles/components/_annotation-card.scss
+++ b/h/static/styles/components/_annotation-card.scss
@@ -135,6 +135,8 @@
   letter-spacing: 0.1px;
   border-left: 3px solid $grey-3;
   margin-bottom: 10px;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .annotation-card__text {


### PR DESCRIPTION
Our CSS reset used to contain a rule which set the margin of blockquotes to 0. When the CSS reset was updated to be based on a current version of normalize.css in ca2e34df87f35b7a25ffc3125a38db972dade82c this rule was removed, as modern browsers all have a consistent horizontal margin of 40px for block quotes.

To get the previous visual result we therefore need to override the horizontal margin in the CSS class for the annotation quote.

**Before:**

<img width="679" alt="Screenshot 2019-07-26 15 30 13" src="https://user-images.githubusercontent.com/2458/61959358-23731300-afbb-11e9-856b-8bbc73fa2bc6.png">

**After:**

<img width="668" alt="Screenshot 2019-07-26 15 30 34" src="https://user-images.githubusercontent.com/2458/61959337-19e9ab00-afbb-11e9-999e-de698880b2fc.png">

The issue doesn't affect the client because it still has the "old" version of the CSS reset.
