### PR TITLE
Add new API service: `GET /api/users/{userid}`

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -20,6 +20,7 @@ AUTH_CLIENT_API_WHITELIST = [
     ("api.group_upsert", "PUT"),
     ("api.group_member", "POST"),
     ("api.users", "POST"),
+    ("api.user_read", "GET"),
     ("api.user", "PATCH"),
 ]
 

--- a/h/routes.py
+++ b/h/routes.py
@@ -167,6 +167,13 @@ def includeme(config):
     config.add_route("api.search", "/api/search")
     config.add_route("api.users", "/api/users", factory="h.traversal.UserRoot")
     config.add_route(
+        "api.user_read",
+        "/api/users/{userid}",
+        request_method="GET",
+        factory="h.traversal.UserUserIDRoot",
+        traverse="/{userid}",
+    )
+    config.add_route(
         "api.user",
         "/api/users/{username}",
         factory="h.traversal.UserRoot",

--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -10,10 +10,12 @@ from h.traversal.roots import ProfileRoot
 from h.traversal.roots import GroupRoot
 from h.traversal.roots import GroupUpsertRoot
 from h.traversal.roots import UserRoot
+from h.traversal.roots import UserUserIDRoot
 from h.traversal.contexts import AnnotationContext
 from h.traversal.contexts import OrganizationContext
 from h.traversal.contexts import GroupContext
 from h.traversal.contexts import GroupUpsertContext
+from h.traversal.contexts import UserContext
 
 __all__ = (
     "Root",
@@ -25,8 +27,10 @@ __all__ = (
     "GroupUpsertRoot",
     "ProfileRoot",
     "UserRoot",
+    "UserUserIDRoot",
     "AnnotationContext",
     "OrganizationContext",
     "GroupContext",
     "GroupUpsertContext",
+    "UserContext",
 )

--- a/h/traversal/contexts.py
+++ b/h/traversal/contexts.py
@@ -180,3 +180,31 @@ class GroupUpsertContext(object):
         if self.group is not None:
             return self.group.__acl__()
         return [(Allow, role.User, "upsert")]
+
+
+class UserContext(object):
+    """
+    Context for user-centered views
+
+    .. todo:: Most views still traverse using ``username`` and work directly
+       with User models (:class:`h.models.User`). This context should be
+       expanded as we continue to move over to a more resource-based approach.
+    """
+
+    def __init__(self, user):
+        self.user = user
+
+    def __acl__(self):
+        """
+        Set the "read" permission for AuthClients that have a matching authority
+        to the user. This supercedes the ACL in :class:`h.models.User`.
+
+        .. todo:: This ACL should be expanded (as needed) as more views make use of
+        a context versus a model directly.
+        """
+        acl = []
+
+        user_authority_principal = f"client_authority:{self.user.authority}"
+        acl.append((Allow, user_authority_principal, "read"))
+
+        return acl

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -250,7 +250,7 @@ class ProfileRoot(object):
 
 class UserRoot(object):
     """
-    Root factory for routes whose context is an :py:class:`h.traversal.UserContext`.
+    Root factory for routes which traverse Users by ``username``
 
     FIXME: This class should return UserContext objects, not User objects.
 
@@ -270,3 +270,25 @@ class UserRoot(object):
             raise KeyError()
 
         return user
+
+
+class UserUserIDRoot(object):
+    """
+    Root factory for routes whose context is a :class:`h.traversal.UserContext`.
+
+    .. todo:: This should be the main Root for User objects
+    """
+
+    __acl__ = [(Allow, role.AuthClient, "create")]
+
+    def __init__(self, request):
+        self.request = request
+        self.user_svc = self.request.find_service(name="user")
+
+    def __getitem__(self, userid):
+        user = self.user_svc.fetch(userid)
+
+        if not user:
+            raise KeyError()
+
+        return contexts.UserContext(user)

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -15,6 +15,24 @@ from h.services.user_unique import DuplicateUserError
 
 @api_config(
     versions=["v1", "v2"],
+    route_name="api.user_read",
+    request_method="GET",
+    link_name="user.read",
+    description="Fetch a user",
+    permission="read",
+)
+def read(context, request):
+    """
+    Fetch a user.
+
+    This API endpoint allows authorized clients (those able to provide a valid
+    Client ID and Client Secret) to read users in their authority.
+    """
+    return TrustedUserJSONPresenter(context.user).asdict()
+
+
+@api_config(
+    versions=["v1", "v2"],
     route_name="api.users",
     request_method="POST",
     link_name="user.create",

--- a/tests/functional/api/test_users.py
+++ b/tests/functional/api/test_users.py
@@ -17,6 +17,23 @@ from h.models.auth_client import GrantType
 native_str = str
 
 
+class TestReadUser(object):
+    def test_it_returns_http_404_if_auth_client_missing(self, app, user):
+        url = "/api/users/{userid}".format(userid=user.userid)
+
+        res = app.get(url, expect_errors=True)
+
+        assert res.status_code == 404
+
+    def test_it_returns_user_when_successful(self, app, auth_client_header, user):
+        url = "/api/users/{userid}".format(userid=user.userid)
+
+        res = app.get(url, headers=auth_client_header)
+
+        assert res.json_body["email"] == user.email
+        assert res.json_body["display_name"] == user.display_name
+
+
 class TestCreateUser(object):
     def test_it_returns_http_200_when_successful(
         self, app, auth_client_header, user_payload

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -162,6 +162,13 @@ def test_includeme():
         call("api.search", "/api/search"),
         call("api.users", "/api/users", factory="h.traversal.UserRoot"),
         call(
+            "api.user_read",
+            "/api/users/{userid}",
+            request_method="GET",
+            factory="h.traversal.UserUserIDRoot",
+            traverse="/{userid}",
+        ),
+        call(
             "api.user",
             "/api/users/{username}",
             factory="h.traversal.UserRoot",

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -12,7 +12,26 @@ from h.schemas import ValidationError
 from h.services.user_signup import UserSignupService
 from h.services.user_update import UserUpdateService
 from h.services.user_unique import UserUniqueService, DuplicateUserError
-from h.views.api.users import create, update
+from h.traversal import UserContext
+from h.views.api.users import read, create, update
+
+
+class TestRead(object):
+    def test_it_presents_user(self, pyramid_request, context, TrustedUserJSONPresenter):
+        read(context, pyramid_request)
+
+        TrustedUserJSONPresenter.assert_called_once_with(context.user)
+        TrustedUserJSONPresenter.return_value.asdict.assert_called_once_with()
+
+    def test_it_returns_presented_user(
+        self, pyramid_request, context, TrustedUserJSONPresenter
+    ):
+        result = read(context, pyramid_request)
+        assert result == TrustedUserJSONPresenter.return_value.asdict.return_value
+
+    @pytest.fixture
+    def context(self, user):
+        return mock.create_autospec(UserContext, instance=True, user=user)
 
 
 @pytest.mark.usefixtures("client_authority", "user_signup_service", "user_unique_svc")


### PR DESCRIPTION
This PR adds a new API service for fetching a single user. This endpoint requires `AuthClient` credentials at present. It will only return users that are within a given `AuthClient`'s `authority`.

This ended up being a slightly more fiddly task than I expected as I ended up adding new `Root` and `Context` classes to support traversing by `userid` instead of `username` and returning a context instead of a model. This allows the `ACL` to be managed at the `Context` level, which satisfies our current coding conventions. It also avoids having ambiguous URLs for these user resources (i.e. authority is hidden in another header). In this approach, every user (across authorities) has a unique URI.

If this flies, I'll handle docs in a separate PR for brevity's sake.

Part of https://github.com/hypothesis/h/issues/5671