### PR TITLE
Add documentation for `GET /api/users/{user}` endpoint

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -1024,6 +1024,30 @@ paths:
   # ---------------------------------------------------------------------------
   # Operations on single User Resources
   # ---------------------------------------------------------------------------
+  /users/{user}:
+    # ----------------------------------------------------------
+    # GET users/{user} -- Fetch a user by `userid`
+    # ----------------------------------------------------------
+    get:
+      tags:
+        - users
+      summary: Fetch a user
+      description: |
+        Fetch a single user. This endpoint is only accessible to
+        requests authenticated with `AuthClient` credentials and is restricted
+        to users within the associated authority.
+      security:
+        - AuthClient: []
+      parameters:
+        - $ref: '#/components/parameters/UserID'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserFull'
+
   /users/{username}:
     patch:
       tags:

--- a/docs/_extra/api-reference/hypothesis-v2.yaml
+++ b/docs/_extra/api-reference/hypothesis-v2.yaml
@@ -1026,6 +1026,30 @@ paths:
   # ---------------------------------------------------------------------------
   # Operations on single User Resources
   # ---------------------------------------------------------------------------
+  /users/{user}:
+    # ----------------------------------------------------------
+    # GET users/{user} -- Fetch a user by `userid`
+    # ----------------------------------------------------------
+    get:
+      tags:
+        - users
+      summary: Fetch a user
+      description: |
+        Fetch a single user. This endpoint is only accessible to
+        requests authenticated with `AuthClient` credentials and is restricted
+        to users within the associated authority.
+      security:
+        - AuthClient: []
+      parameters:
+        - $ref: '#/components/parameters/UserID'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserFull'
+
   /users/{username}:
     patch:
       tags:


### PR DESCRIPTION
Depends on #5672 

This PR adds v1 and v2 docs for the fetch-user endpoint:

![image](https://user-images.githubusercontent.com/439947/62960695-15413700-bdb0-11e9-8b14-865459e853dd.png)

Fixes #5671 