### PR TITLE
Upgrade to Pyramid 1.8.6 and WebOb 1.8.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ gevent==1.3.5
 greenlet==0.4.13
 gunicorn==19.9.0
 hkdf==0.0.3
+hupper==1.8.1             # via pyramid
 iso8601==0.1.11           # via colander, deform
 itsdangerous==0.24
 jinja2==2.10.1            # via pyramid-jinja2
@@ -50,7 +51,7 @@ pyramid-layout==1.0
 pyramid-mailer==0.15.1
 pyramid-services==0.4
 pyramid-tm==1.1.1
-pyramid==1.7.6
+pyramid==1.8.6
 python-dateutil==2.5.3
 python-editor==1.0.1      # via alembic
 python-slugify==1.1.4
@@ -69,7 +70,7 @@ urllib3==1.24.2           # via elasticsearch, sentry-sdk
 venusian==1.0
 vine==1.3.0               # via amqp, celery
 webencodings==0.5.1       # via bleach
-webob==1.6.1              # via pyramid
+webob==1.8.5              # via pyramid
 ws4py==0.4.2
 wsaccel==0.6.2
 zope.deprecation==4.1.2   # via deform, pyramid, pyramid-jinja2

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -84,7 +84,7 @@ class TestIndexEndpointVersions(object):
 
     def test_index_200s_with_invalid_accept_header_value(self, app):
         """
-        Set a generally-invalid Accept header and we should always get a 406.
+        Set a generally-invalid Accept header and we should get a 200.
         """
         headers = {"Accept": str("nonsensical")}
 

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -82,7 +82,7 @@ class TestIndexEndpointVersions(object):
 
         assert res.status_code == 406
 
-    def test_index_406s_with_invalid_accept_header_value(self, app):
+    def test_index_200s_with_invalid_accept_header_value(self, app):
         """
         Set a generally-invalid Accept header and we should always get a 406.
         """
@@ -90,7 +90,11 @@ class TestIndexEndpointVersions(object):
 
         res = app.get("/api/", headers=headers, expect_errors=True)
 
-        assert res.status_code == 406
+        assert res.status_code == 200
+        assert "links" in res.json
+        assert (
+            res.headers["Hypothesis-Media-Type"] == "application/vnd.hypothesis.v1+json"
+        )
 
     def test_index_adds_v1_response_header(self, app):
         """

--- a/tests/h/views/api/decorators/client_errors_test.py
+++ b/tests/h/views/api/decorators/client_errors_test.py
@@ -5,7 +5,7 @@ import pytest
 
 from pyramid.response import Response
 from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound, HTTPNotAcceptable
-from webob.acceptparse import MIMEAccept, MIMENilAccept
+from webob.acceptparse import create_accept_header
 
 from h.views.api.decorators.client_errors import (
     unauthorized_to_not_found,
@@ -84,7 +84,7 @@ class TestValidateMediaTypes(object):
         self, pyramid_request, testview
     ):
         # At least one of these is valid
-        pyramid_request.accept = MIMEAccept("application/json, foo/bar")
+        pyramid_request.accept = create_accept_header("application/json, foo/bar")
         fake_context = mock.Mock()
         validate_media_types(testview)(fake_context, pyramid_request)
 
@@ -95,7 +95,9 @@ class TestValidateMediaTypes(object):
         self, pyramid_request, testview
     ):
         # None of these is valid
-        pyramid_request.accept = MIMEAccept("application/something+json, foo/bar")
+        pyramid_request.accept = create_accept_header(
+            "application/something+json, foo/bar"
+        )
         fake_context = mock.Mock()
         validate_media_types(testview)(fake_context, pyramid_request)
 
@@ -106,7 +108,7 @@ class TestValidateMediaTypes(object):
     def pyramid_request(self, pyramid_request):
         # Set an empty accept on the request, imitating what pyramid does
         # in real life if no Accept header is set on the incoming request
-        pyramid_request.accept = MIMENilAccept()
+        pyramid_request.accept = create_accept_header(None)
         return pyramid_request
 
 

--- a/tests/h/views/api/decorators/response_test.py
+++ b/tests/h/views/api/decorators/response_test.py
@@ -4,7 +4,7 @@ import mock
 import pytest
 
 from pyramid.response import Response
-from webob.acceptparse import MIMENilAccept, MIMEAccept
+from webob.acceptparse import create_accept_header
 
 from h.views.api.decorators.response import version_media_type_header
 
@@ -43,7 +43,7 @@ class TestVersionMediaTypeHeader(object):
     def test_it_sets_response_header_based_on_value_of_accept(
         self, pyramid_request, testview, accept, expected_header
     ):
-        pyramid_request.accept = MIMEAccept(accept)
+        pyramid_request.accept = create_accept_header(accept)
 
         res = version_media_type_header(testview)(None, pyramid_request)
 
@@ -59,5 +59,5 @@ def testview():
 def pyramid_request(pyramid_request):
     # Set an empty accept on the request, imitating what pyramid does
     # in real life if no Accept header is set on the incoming request
-    pyramid_request.accept = MIMENilAccept()
+    pyramid_request.accept = create_accept_header(None)
     return pyramid_request

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -127,7 +127,7 @@ class TestStreamUserRedirect(object):
         with pytest.raises(httpexceptions.HTTPFound) as exc:
             main.stream_user_redirect(pyramid_request)
 
-        assert exc.value.location == "http://example.com/user/acct%3Abob"
+        assert exc.value.location == "http://example.com/user/acct:bob"
 
     @pytest.fixture
     def routes(self, pyramid_config):

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,19 @@ filterwarnings =
     #
     ignore:^Use of \.\. or absolute path in a resource path is not allowed and will raise exceptions in a future release\.$:DeprecationWarning:pkg_resources
 
+    # Ignore WebOb warnings that just say "<method> will be changing in the
+    # future" and don't say how it will be changing or what developers can do
+    # now to avoid the warning. I don't think these warnings _can_ be avoided
+    # currently.
+    ignore:^The behavior of \.best_match for the Accept classes is currently being maintained for backward compatibility, but the method will be deprecated in the future, as its behavior is not specified in \(and currently does not conform to\) RFC 7231\.$:DeprecationWarning:webob.acceptparse
+    ignore:^The behavior of \.__contains__ for the Accept classes is currently being maintained for backward compatibility, but it will change in the future to better conform to the RFC\.$:DeprecationWarning:webob.acceptparse
+    ignore:^The behavior of AcceptValidHeader\.best_match is currently being maintained for backward compatibility, but it will be deprecated in the future, as it does not conform to the RFC\.$:DeprecationWarning:webob.acceptparse
+    ignore:^The behavior of AcceptValidHeader\.__contains__ is currently being maintained for backward compatibility, but it will change in the future to better conform to the RFC\.$:DeprecationWarning:webob.acceptparse
+    ignore:^The behavior of AcceptLanguageValidHeader\.__iter__ is currently maintained for backward compatibility, but will change in the future.$:DeprecationWarning:webob.acceptparse
+
+    # Ignore a WebOb warning that Pyramid is triggering.
+    ignore:^The MIMEAccept class has been replaced by webob\.acceptparse\.create_accept_header\. This compatibility shim will be deprecated in a future version of WebOb\.$:DeprecationWarning:webob.acceptparse
+
 [testenv]
 skip_install = true
 sitepackages = {env:SITE_PACKAGES:false}


### PR DESCRIPTION
WebOb 1.8.5 (which is the latest version of WebOb) is required by the Pyramid 1.8.6 upgrade.

Pyramid 1.8.6 is the latest version of Pyramid that does not cause much additional breakage to our app, in addition to what the WebOb upgrade breaks (what is fixed in this PR).

After this PR there'll be further PRs to upgrade to Pyramid 1.9 and 1.10, fixing the things those Pyramid versions break.

I'm doing this in separate PRs so I can fix the breakage cause by WebOb 1.8 in this PR, and then fix the breakage caused by Pyramid 1.9 and 1.10 in separate PRs later, and we can do less risky deploys.

* WebOb 1.8.5 breaks a few of our tests because its [Accept-header parsing API has changed](https://docs.pylonsproject.org/projects/webob/en/stable/changes.html#backwards-incompatibilities). This is test breakage only, our code isn't broken. This is fixed in https://github.com/hypothesis/h/pull/5674/commits/9e12648d9370633d2b18a98148f690d0e34a974d

  For how the new WebOb Accept-parsing API works see <https://docs.pylonsproject.org/projects/webob/en/stable/reference.html#accept-headers> and <https://docs.pylonsproject.org/projects/webob/en/stable/api/webob.html#module-webob.acceptparse>.

* The new WebOb Accept-parsing code also triggers a bunch of silly warnings. These are being triggered by Pyramid, not us. They're ignored in https://github.com/hypothesis/h/pull/5674/commits/d3eb558560167feb291c2016ed9506d52457ebf3

* Pyramid changes triggered by the new WebOb Accept-parsing changed the behaviour of our API when given an invalid Accept header. I just updated the test to match the changed behavior. Detailed explanation in the commit message: https://github.com/hypothesis/h/pull/5674/commits/caf85ab17480dbbcbbb71b4b8ff28aa21ff9e376

* Pyramid 1.8 contains a small change to string escaping in `route_url()` that required a small test fix: https://github.com/hypothesis/h/pull/5674/commits/caf85ab17480dbbcbbb71b4b8ff28aa21ff9e376