### PR TITLE
Always use Python commands from pyenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,9 @@ requires =
   tox-pip-extensions
   tox-pyenv
 tox_pip_extensions_ext_venv_update = true
+# Exclusively use Python commands from pyenv's copies of Python, don't fall
+# back to tox's default non-pyenv command search strategy.
+tox_pyenv_fallback = false
 
 [pytest]
 filterwarnings =


### PR DESCRIPTION
Always use pyenv's copies of Python commands (like `python`, `pip`,
etc). Don't fall back on tox's default command search strategy if
`pyenv which` fails to find the command.

This ensures that tox is always working in pyenv and can't somehow accidentally use or modify a non-pyenv copy of Python.

See https://github.com/samstav/tox-pyenv#notes