### PR TITLE
Return 406 not 415 for Accept header mismatches

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -35,7 +35,7 @@ info:
     ```
 
     If an `Accept` header is set with an unrecognized media type, the API will
-    return an HTTP 415 (Unsupported Media Type) error.
+    return an HTTP 406 (Not Acceptable) error.
 
     Responses to API requests include a header indicating which API version was used
     to handle the request, e.g.:
@@ -94,7 +94,7 @@ info:
     | 403         | Unauthorized  | v1 of the API only returns 404s, to avoid leaking resource existence |
     | 404         | Not Found     | Resource not found or permission failure    |
     | 409         | Conflict      | Resource could not be created because of a conflict—resource already exists |
-    | 415         | Unsupported Media Type | The request's `Accept` header designates an unrecognized media type |
+    | 406         | Not Acceptable | The request's `Accept` header designates an unacceptable media type |
     | 500         | Server Error  | An error occurred with our API |
 
 servers:
@@ -196,8 +196,8 @@ components:
         application/*json:
           schema:
             $ref: './schemas/errors.yaml#/Error'
-    UnsupportedMediaType:
-      description: Unsupported Media Type
+    NotAcceptable:
+      description: Not Acceptable
       content:
         application/*json:
           schema:

--- a/docs/_extra/api-reference/hypothesis-v2.yaml
+++ b/docs/_extra/api-reference/hypothesis-v2.yaml
@@ -37,7 +37,7 @@ info:
     ```
 
     If an `Accept` header is set with an unrecognized media type, the API will
-    return an HTTP 415 (Unsupported Media Type) error.
+    return an HTTP 406 (Not Acceptable) error.
 
     Responses to API requests include a header indicating which API version was used
     to handle the request, e.g.:
@@ -96,7 +96,7 @@ info:
     | 403         | Unauthorized  | v1 of the API only returns 404s, to avoid leaking resource existence |
     | 404         | Not Found     | Resource not found or permission failure    |
     | 409         | Conflict      | Resource could not be created because of a conflict—resource already exists |
-    | 415         | Unsupported Media Type | The request's `Accept` header designates an unrecognized media type |
+    | 406         | Not Acceptable | The request's `Accept` header designates an unacceptable media type |
     | 500         | Server Error  | An error occurred with our API |
 
 servers:
@@ -198,8 +198,8 @@ components:
         application/*json:
           schema:
             $ref: './schemas/errors.yaml#/Error'
-    UnsupportedMediaType:
-      description: Unsupported Media Type
+    NotAcceptable:
+      description: Not Acceptable
       content:
         application/*json:
           schema:

--- a/h/views/api/decorators/client_errors.py
+++ b/h/views/api/decorators/client_errors.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals
 
-from pyramid.httpexceptions import HTTPNotFound, HTTPUnsupportedMediaType
+from pyramid.httpexceptions import HTTPNotFound, HTTPNotAcceptable
 
 from h.views.api.helpers.media_types import valid_media_types
 
@@ -32,15 +32,15 @@ def normalize_not_found(wrapped):
 
 
 def validate_media_types(wrapped):
-    """View decorator to convert certain 4xx errors to 415s"""
+    """View decorator to convert certain 4xx errors to 406s"""
 
     def wrapper(context, request):
         # If Accept has been set
         if request.accept:
             # At least one of the media types in Accept must be known to the app
             if not any([t in valid_media_types() for t in request.accept]):
-                # If no Accept media types are known, convert to a 415 error
-                context = HTTPUnsupportedMediaType("Unsupported media type")
+                # If no Accept media types are known, convert to a 406 error
+                context = HTTPNotAcceptable("Not acceptable")
         response = wrapped(context, request)
         return response
 

--- a/tests/functional/api/test_errors.py
+++ b/tests/functional/api/test_errors.py
@@ -110,22 +110,22 @@ class Test409Errors(object):
         )
 
 
-class Test415Errors(object):
-    def test_it_415s_if_not_found_with_bad_accept(self, app):
+class Test406Errors(object):
+    def test_it_406s_if_not_found_with_bad_accept(self, app):
         headers = {}
         headers[native_str("Accept")] = native_str("application/totally_random")
         res = app.get("/api/not_a_thing", headers=headers, expect_errors=True)
 
-        assert res.status_code == 415
-        assert res.json["reason"] == "Unsupported media type"
+        assert res.status_code == 406
+        assert res.json["reason"] == "Not acceptable"
 
-    def test_it_415s_if_path_extant_but_bad_accept(self, app):
+    def test_it_406s_if_path_extant_but_bad_accept(self, app):
         headers = {}
         headers[native_str("Accept")] = native_str("application/totally_random")
         res = app.get("/api/groups", headers=headers, expect_errors=True)
 
-        assert res.status_code == 415
-        assert res.json["reason"] == "Unsupported media type"
+        assert res.status_code == 406
+        assert res.json["reason"] == "Not acceptable"
 
 
 @pytest.fixture

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -71,26 +71,26 @@ class TestIndexEndpointVersions(object):
         assert res.status_code == 200
         assert "links" in res.json
 
-    def test_index_415s_with_invalid_version_header(self, app):
+    def test_index_406s_with_invalid_version_header(self, app):
         """
-        Set a v3 Accept header and we should get a 415 response.
+        Set a v3 Accept header and we should get a 406 response.
         (For now because the version doesn't exist yet)
         """
         headers = {"Accept": str("application/vnd.hypothesis.v3+json")}
 
         res = app.get("/api/", headers=headers, expect_errors=True)
 
-        assert res.status_code == 415
+        assert res.status_code == 406
 
-    def test_index_415s_with_invalid_accept_header_value(self, app):
+    def test_index_406s_with_invalid_accept_header_value(self, app):
         """
-        Set a generally-invalid Accept header and we should always get a 415.
+        Set a generally-invalid Accept header and we should always get a 406.
         """
         headers = {"Accept": str("nonsensical")}
 
         res = app.get("/api/", headers=headers, expect_errors=True)
 
-        assert res.status_code == 415
+        assert res.status_code == 406
 
     def test_index_adds_v1_response_header(self, app):
         """

--- a/tests/h/views/api/decorators/client_errors_test.py
+++ b/tests/h/views/api/decorators/client_errors_test.py
@@ -4,7 +4,7 @@ import mock
 import pytest
 
 from pyramid.response import Response
-from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound, HTTPUnsupportedMediaType
+from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound, HTTPNotAcceptable
 from webob.acceptparse import MIMEAccept, MIMENilAccept
 
 from h.views.api.decorators.client_errors import (
@@ -91,7 +91,7 @@ class TestValidateMediaTypes(object):
         context, _ = testview.call_args[0]
         assert context == fake_context
 
-    def test_it_replaces_context_with_415_if_accept_set_and_invalid(
+    def test_it_replaces_context_with_406_if_accept_set_and_invalid(
         self, pyramid_request, testview
     ):
         # None of these is valid
@@ -100,7 +100,7 @@ class TestValidateMediaTypes(object):
         validate_media_types(testview)(fake_context, pyramid_request)
 
         context, _ = testview.call_args[0]
-        assert isinstance(context, HTTPUnsupportedMediaType)
+        assert isinstance(context, HTTPNotAcceptable)
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
Return HTTP 406 not 415 when an API's Accept header is invalid/malformed
or just doesn't match any of the content types that we support.

This affects both v1 and 2 of our API.

HTTP 415 Unsupported Media Type isn't appropriate for Accept header
problems:

> 415 UNSUPPORTED MEDIA TYPE
>
> The origin server is refusing to service the request because the
> payload is in a format not supported by this method on the target
> resource.
>
> The format problem might be due to the request's indicated
> Content-Type or Content-Encoding, or as a result of inspecting the
> data directly.

Source: https://httpstatuses.com/415

So 415 has to do with the Content-Type, Content-Encoding, or contents of
the _request's_ body. Not to do with the type of response that the
request is requesting in its Accept header.

The right status to use for an Accept header problem is 406:

> 406 NOT ACCEPTABLE
>
> The target resource does not have a current representation that would
> be acceptable to the user agent, according to the proactive
> negotiation header fields received in the request, and the server is
> unwilling to supply a default representation.

Source: https://httpstatuses.com/406

Also see RFC 7231, where the HTTP Accept header is specified:

> 5.3 Content Negotiation
>
> ...
>
> 5.3.2 Accept
>
> ...
>
> If the header field is present in a request and none of the available
> representations for the response have a media type that is listed as
> acceptable, the origin server can either honor the header field by
> sending a 406 (Not Acceptable) response or disregard the header field
> by treating the response as if it is not subject to content
> negotiation.

Source: https://tools.ietf.org/html/rfc7231#section-5.3.2