### PR TITLE
Various small installation and devenv improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ lint: python
 	tox -q -e py36-lint
 
 .PHONY: frontend-lint
-frontend-lint:
+frontend-lint: node_modules/.uptodate
 	npm run-script lint
 	npm run-script checkformatting
 
@@ -152,3 +152,7 @@ node_modules/.uptodate: package.json
 .PHONY: python
 python:
 	@./bin/install-python
+
+.PHONY: gulp
+gulp: node_modules/.uptodate
+	$(GULP) $(args)

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,9 @@ help:
 	@echo "                       dependencies, etc)"
 
 .PHONY: services
+services: args?=up -d
 services:
-	docker-compose up -d
+	@tox -q -e docker-compose -- $(args)
 
 .PHONY: dev
 dev: build/manifest.json python
@@ -42,7 +43,7 @@ shell: python
 
 .PHONY: sql
 sql:
-	docker-compose exec postgres psql --pset expanded=auto -U postgres
+	@tox -q -e docker-compose -- exec postgres psql --pset expanded=auto -U postgres
 
 .PHONY: lint
 lint: python

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,10 @@ sql:
 	@tox -q -e docker-compose -- exec postgres psql --pset expanded=auto -U postgres
 
 .PHONY: lint
-lint: python
+lint: backend-lint frontend-lint
+
+.PHONY: backend-lint
+backend-lint: python
 	tox -q -e py36-lint
 
 .PHONY: frontend-lint

--- a/bin/create-testdb
+++ b/bin/create-testdb
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+#
+# Create the "htest" database in Postgres, if it doesn't exist already.
+make services args='exec postgres psql -U postgres -c "CREATE DATABASE htest;"' > /dev/null 2>&1 || true

--- a/docs/developing/code-style.rst
+++ b/docs/developing/code-style.rst
@@ -70,9 +70,10 @@ Front-end Development
 See the `Hypothesis Front-end Toolkit`_ repository for documentation on code
 style and tooling for JavaScript, CSS and HTML.
 
-We use `ESLint <https://eslint.org>`_ for linting front-end code. Use ``gulp
-lint`` to run ESlint locally. You may find it helpful to install an ESLint
-plugin for your editor to get live feedback as you make changes.
+We use `ESLint <https://eslint.org>`_ for linting front-end code.
+Use ``make frontend-lint`` to run ESlint locally. You may find it helpful to
+install an ESLint plugin for your editor to get live feedback as you make
+changes.
 
 .. _Hypothesis Front-end Toolkit: https://github.com/hypothesis/frontend-toolkit
 

--- a/docs/developing/code-style.rst
+++ b/docs/developing/code-style.rst
@@ -45,8 +45,8 @@ Linting
 
 We use `Flake8 <https://pypi.python.org/pypi/flake8>`_ for linting Python code.
 Lint checks are run as part of our continuous integration builds and can be run
-locally using ``make lint``. You may find it helpful to use a flake8 plugin for
-your editor to get live feedback as you make changes.
+locally using ``make backend-lint``. You may find it helpful to use a flake8
+plugin for your editor to get live feedback as you make changes.
 
 Automated code formatting
 `````````````````````````

--- a/docs/developing/index.rst
+++ b/docs/developing/index.rst
@@ -20,3 +20,4 @@ and how to contribute code or documentation to the project.
    making-changes-to-model-code
    debugging-sql-queries
    envvars
+   troubleshooting

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -39,6 +39,7 @@ these prerequisites:
 
 * `pyenv`_.
   Follow the instructions in the pyenv README to install it.
+  The Homebrew method works best on macOS.
 
 Clone the Git repo
 ------------------

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -8,7 +8,7 @@ in a local development environment.
 .. seealso::
 
    * https://github.com/hypothesis/client/ for installing the Hypothesis client
-   * https://github.com/hypothesis/browser-extension. for the browser extension
+   * https://github.com/hypothesis/browser-extension for the browser extension
    * To get "direct" or "in context" links working you need to install Bouncer and Via:\ 
 
      * https://github.com/hypothesis/bouncer

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -31,10 +31,6 @@ each of these prerequisites:
   too old.
   On macOS you should use `Homebrew <https://brew.sh/>`_ to install node.
 
-* `Gulp <https://gulpjs.com/>`_.
-  Once you have npm you can just run ``sudo npm install -g gulp-cli`` to install ``gulp``.
-  On macOS it's recommended to run ``npm install -g gulp-cli`` without the ``sudo``.
-
 * `Docker <https://docs.docker.com/install/>`_.
   Follow the `instructions on the Docker website <https://docs.docker.com/install/>`_
   to install "Docker Engine - Community".

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -7,14 +7,12 @@ in a local development environment.
 
 .. seealso::
 
-   This page documents how to setup a development install of h.
-   For installing the Hypothesis client for development see
-   https://github.com/hypothesis/client/, and for the browser extension
-   see https://github.com/hypothesis/browser-extension.
+   * https://github.com/hypothesis/client/ for installing the Hypothesis client
+   * https://github.com/hypothesis/browser-extension. for the browser extension
+   * To get "direct" or "in context" links working you need to install Bouncer and Via:\ 
 
-   To get "direct" or "in context" links working you need to install Bouncer
-   and Via. See https://github.com/hypothesis/bouncer and
-   https://github.com/hypothesis/via.
+     * https://github.com/hypothesis/bouncer
+     * https://github.com/hypothesis/via
 
 .. seealso::
 

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -65,12 +65,6 @@ Start the services that h requires using Docker Compose:
 
    make services
 
-You'll now have some Docker containers running the PostgreSQL, RabbitMQ, and
-Elasticsearch services. You should be able to see them by running
-``make services args=ps``. You should also be able to visit your Elasticsearch
-service by opening http://localhost:9200/ in a browser, and connect to your
-PostgreSQL by running ``make sql``.
-
 Start the development server
 ----------------------------
 

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -16,6 +16,10 @@ in a local development environment.
    and Via. See https://github.com/hypothesis/bouncer and
    https://github.com/hypothesis/via.
 
+.. seealso::
+
+   :doc:`troubleshooting` if you run into any problems during installation
+
 You will need
 -------------
 
@@ -82,38 +86,9 @@ This will start the server on port 5000 (http://localhost:5000), reload the
 application whenever changes are made to the source code, and restart it should
 it crash for some reason.
 
-Troubleshooting
----------------
-
-Cannot connect to the Docker daemon
-###################################
-
-If you get an error that looks like this when trying to run ``docker``
-commands::
-
- Cannot connect to the Docker daemon. Is the docker daemon running on this host?
- Error: failed to start containers: postgres
-
-it could be because you don't have permission to access the Unix socket that
-the docker daemon is bound to. On some operating systems (e.g. Linux) you need
-to either:
-
-* Take additional steps during Docker installation to give your Unix user
-  access to the Docker daemon's port (consult the installation
-  instructions for your operating system on the Docker website), or
-
-* Prefix all ``docker`` and ``docker-compose`` commands with ``sudo``.
+**That's it!** You've finished setting up your h development environment.
+Run ``make help`` to see all the commands that're available for running the
+tests, linting, code formatting, Python and SQL shells, etc.
 
 .. _Git repo named h: https://github.com/hypothesis/h/
 .. _pyenv: https://github.com/pyenv/pyenv
-
-pyenv errors on macOS
-#####################
-
-``pyenv install`` commands might fail on macOS with error messages such as:
-
-* "symbol(s) not found for architecture x86_64"
-* "ERROR: The Python zlib extension was not compiled. Missing the zlib?"
-
-Read `pyenv's Common Build Problems page <https://github.com/pyenv/pyenv/wiki/common-build-problems>`_
-for the solutions to these.

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -21,8 +21,8 @@ in a local development environment.
 You will need
 -------------
 
-Before installing your local development environment you'll need to install
-each of these prerequisites:
+Before installing your development environment you'll need to install each of
+these prerequisites:
 
 * `Git <https://git-scm.com/>`_
 

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -35,9 +35,9 @@ each of these prerequisites:
   Once you have npm you can just run ``sudo npm install -g gulp-cli`` to install ``gulp``.
   On macOS it's recommended to run ``npm install -g gulp-cli`` without the ``sudo``.
 
-* `Docker CE <https://docs.docker.com/install/>`_ and `Docker Compose <https://docs.docker.com/compose/>`_.
-  Follow the `instructions on the Docker website <https://docs.docker.com/compose/install/>`_
-  to install these.
+* `Docker <https://docs.docker.com/install/>`_.
+  Follow the `instructions on the Docker website <https://docs.docker.com/install/>`_
+  to install "Docker Engine - Community".
 
 * `pyenv`_.
   Follow the instructions in the pyenv README to install it.
@@ -67,10 +67,10 @@ Start the services that h requires using Docker Compose:
    make services
 
 You'll now have some Docker containers running the PostgreSQL, RabbitMQ, and
-Elasticsearch services. You should be able to see them by running ``docker-compose
-ps``. You should also be able to visit your Elasticsearch service by opening
-http://localhost:9200/ in a browser, and connect to your PostgreSQL by
-running ``make sql``.
+Elasticsearch services. You should be able to see them by running
+``make services args=ps``. You should also be able to visit your Elasticsearch
+service by opening http://localhost:9200/ in a browser, and connect to your
+PostgreSQL by running ``make sql``.
 
 Start the development server
 ----------------------------

--- a/docs/developing/testing.rst
+++ b/docs/developing/testing.rst
@@ -3,16 +3,6 @@ Testing
 
 This section covers running and writing tests for the ``h`` codebase.
 
-Create the ``htest`` database
-------------------------------
-
-To be able to run the tests you need to create the ``htest`` database in the
-``postgres`` container:
-
-.. code-block:: shell
-
-   make services args='exec postgres psql -U postgres -c "CREATE DATABASE htest;"'
-
 .. _running-the-tests:
 
 Running the tests, linters and code formatters

--- a/docs/developing/testing.rst
+++ b/docs/developing/testing.rst
@@ -74,7 +74,7 @@ For example:
 
 .. code-block:: shell
 
-    gulp test
+    make gulp args=test
 
 When working on the front-end code, you can run the Karma test runner in
 auto-watch mode which will re-run the tests whenever a change is made to the
@@ -82,14 +82,14 @@ source code. To start the test runner in auto-watch mode, run:
 
 .. code-block:: shell
 
-    gulp test-watch
+    make gulp args=test-watch
 
 To run only a subset of tests for front-end code, use the ``--grep``
 argument or mocha's `.only()`_ modifier.
 
 .. code-block:: shell
 
-    gulp test-watch --grep <pattern>
+    make gulp args=test-watch --grep <pattern>
 
 .. _.only(): http://jaketrent.com/post/run-single-mocha-test/
 

--- a/docs/developing/testing.rst
+++ b/docs/developing/testing.rst
@@ -11,7 +11,7 @@ To be able to run the tests you need to create the ``htest`` database in the
 
 .. code-block:: shell
 
-   docker-compose exec postgres psql -U postgres -c "CREATE DATABASE htest;"
+   make services args='exec postgres psql -U postgres -c "CREATE DATABASE htest;"'
 
 .. _running-the-tests:
 

--- a/docs/developing/troubleshooting.rst
+++ b/docs/developing/troubleshooting.rst
@@ -1,0 +1,32 @@
+Development environment troubleshooting
+=======================================
+
+Cannot connect to the Docker daemon
+-----------------------------------
+
+If you get an error that looks like this when trying to run ``docker``
+commands::
+
+ Cannot connect to the Docker daemon. Is the docker daemon running on this host?
+ Error: failed to start containers: postgres
+
+it could be because you don't have permission to access the Unix socket that
+the docker daemon is bound to. On some operating systems (e.g. Linux) you need
+to either:
+
+* Take additional steps during Docker installation to give your Unix user
+  access to the Docker daemon's port (consult the installation
+  instructions for your operating system on the Docker website), or
+
+* Prefix all ``docker`` and ``docker-compose`` commands with ``sudo``.
+
+pyenv errors on macOS
+---------------------
+
+``pyenv install`` commands might fail on macOS with error messages such as:
+
+* "symbol(s) not found for architecture x86_64"
+* "ERROR: The Python zlib extension was not compiled. Missing the zlib?"
+
+Read `pyenv's Common Build Problems page <https://github.com/pyenv/pyenv/wiki/common-build-problems>`_
+for the solutions to these.

--- a/h/cli/commands/devserver.py
+++ b/h/cli/commands/devserver.py
@@ -103,7 +103,7 @@ def devserver(https, web, ws, worker, assets, beat):
         m.add_process("beat", "hypothesis --dev celery beat")
 
     if assets:
-        m.add_process("assets", "gulp watch")
+        m.add_process("assets", "node_modules/.bin/gulp watch")
 
     m.loop()
 

--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,7 @@ deps =
     dev: ipython
     dev: ipdb
     dev: -r requirements-dev.in
+    docker-compose: docker-compose
 whitelist_externals =
     dev: sh
 changedir =
@@ -112,3 +113,4 @@ commands =
     coverage: -coverage combine
     coverage: coverage report --show-missing
     codecov: codecov
+    docker-compose: docker-compose {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ deps =
     dev: -r requirements-dev.in
     docker-compose: docker-compose
 whitelist_externals =
-    dev: sh
+    {dev,tests,functests}: sh
 changedir =
     {docs,checkdocs}: docs
 commands =
@@ -103,6 +103,7 @@ commands =
     analyze: pylint {posargs:h tests}
     format: black h tests
     checkformatting: black --check h tests
+    {tests,functests}: sh bin/create-testdb
     tests: coverage run -m pytest {posargs:tests/h/}
     functests: pytest {posargs:tests/functional/}
     docs: sphinx-autobuild -BqT -b dirhtml -d {envdir}/doctrees . {envdir}/html


### PR DESCRIPTION
Various devenv installation, usage and docs improvements, that I noticed while testing the new pyenv automation:

* <https://github.com/hypothesis/h/commit/3f62827a82e552cdaadcb7bd15c9021c66f53ea3> Install Docker Compose in tox and use that copy, so you don't have to install it manually. If you do have a system-wide copy of Docker Compose installed, it will still work

* <https://github.com/hypothesis/h/commit/a93afc088d851f29853cc42ae9753a405afe42b7> Similarly, automate installing Gulp in `node_modules` and use that copy. If you do have a system-wide copy of Gulp installed, it will still work.

  In fact we were _already_ installing Gulp in `node_modules` and the make commands were using that copy, but some docs told you to install and use a system-wide copy of node, and the bin/hypothesis command used a system-wide copy.

* <https://github.com/hypothesis/h/commit/98b5236cb8767693e546aa97d141af325afb4cda> Automate creating the `htest` DB

* <https://github.com/hypothesis/h/commit/aa61cd356be1889a854875b2af615e89e7743fed> Add `make backend-lint` like we have `make frontend-lint` and make `make lint` run both

* Some light editing of the install docs page. It's really _very_ simple now: <https://github.com/hypothesis/h/blob/a38288d1f1568ff6ebe699ac547fc44c8f3f1a9a/docs/developing/install.rst>

Where this is going: progress on the devenv, including its install and setup procedure and docs, is going to happen incrementally, bit by bit over time, and everything's going to be applied consistently across all projects. The other projects install docs will be changed to match the format of these new h ones. This PR gets the h install process down to just install four prerequisites and then `git clone`, `make services` and `make dev`. `make services` can be automated away. And this doesn't set envvars or create dev data -- that needs to be automated as well. The end aim is for every app to be just `git clone` and `make dev`, and that will even set all the envvars and create all the data so that they work together. Once it's all that simple then we can create a "master project" that steps you through installing the prerequisites and then installs and runs all of the apps for you, so a single `git clone` and `make dev` will get _all_ of the apps running together locally in one command.