### PR TITLE
Remove unused CSRF token from session model

### DIFF
--- a/h/session.py
+++ b/h/session.py
@@ -8,7 +8,6 @@ from h.security import derive_key
 
 def model(request):
     session = {}
-    session["csrf"] = request.session.get_csrf_token()
     session["userid"] = request.authenticated_userid
     session["groups"] = _current_groups(request, request.default_authority)
     session["features"] = request.feature.all()


### PR DESCRIPTION
This doesn't work in Pyramid 1.9, and it's also no longer used by our
client.

Logging in and out still work without it, as does creating, leaving and
joining groups (client's groups menu updates in real time).