### PR TITLE
Upgrade Pyramid to 1.9.4

### DIFF
--- a/h/schemas/base.py
+++ b/h/schemas/base.py
@@ -9,14 +9,14 @@ import copy
 import colander
 import deform
 import jsonschema
-from pyramid.session import check_csrf_token
+from pyramid.csrf import check_csrf_token, get_csrf_token
 from pyramid import httpexceptions
 
 
 @colander.deferred
 def deferred_csrf_token(node, kw):
     request = kw.get("request")
-    return request.session.get_csrf_token()
+    return get_csrf_token(request)
 
 
 class ValidationError(httpexceptions.HTTPBadRequest):

--- a/h/session.py
+++ b/h/session.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+
+from pyramid.csrf import SessionCSRFStoragePolicy
 from pyramid.session import SignedCookieSessionFactory
 
 from h.security import derive_key
@@ -110,3 +112,4 @@ def includeme(config):
         timeout=3600,
     )
     config.set_session_factory(factory)
+    config.set_csrf_storage_policy(SessionCSRFStoragePolicy())

--- a/h/templates/admin/admins.html.jinja2
+++ b/h/templates/admin/admins.html.jinja2
@@ -15,7 +15,7 @@
     </div>
     <div class="panel-body">
       <form method="POST" class="form-inline">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <div class="form-group">
           <label for="add">Username</label>
           <input type="text" class="form-control" name="add">
@@ -37,7 +37,7 @@
       <form
         method="POST"
         action="{{ request.route_url('admin.admins') }}">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <ul>
           {% for user in admin_users %}
             <li>

--- a/h/templates/admin/badge.html.jinja2
+++ b/h/templates/admin/badge.html.jinja2
@@ -26,7 +26,7 @@
     </div>
     <div class="panel-body">
       <form method="POST" class="form-inline">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <div class="form-group">
           <label for="add">URI</label>
           <input type="text" class="form-control" name="add">
@@ -45,7 +45,7 @@
       <form
         method="POST"
         action="{{ request.route_url('admin.badge') }}">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <ul>
           {% for uri in uris %}
             <li>

--- a/h/templates/admin/cohorts.html.jinja2
+++ b/h/templates/admin/cohorts.html.jinja2
@@ -14,7 +14,7 @@
     </div>
     <div class="panel-body">
       <form method="POST" class="form-inline">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <div class="form-group">
           <label for="add">Feature cohort name</label>
           <input type="text" class="form-control" name="add">

--- a/h/templates/admin/cohorts_edit.html.jinja2
+++ b/h/templates/admin/cohorts_edit.html.jinja2
@@ -19,7 +19,7 @@
       <form method="POST"
             class="form-inline"
             action="{{ request.route_url('admin.cohorts_edit', id=cohort.id) }}">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <input type="hidden" name="cohort" value="{{ cohort.id }}">
         <div class="form-group">
           <label for="add">Username</label>
@@ -42,7 +42,7 @@
     <div class="panel-body">
       {% if members %}
         <form method="POST" action="{{ request.route_url('admin.cohorts_edit', id=cohort.id) }}">
-          <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+          <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
           <input type="hidden" name="cohort" value="{{ cohort.id }}">
           <ul>
             {% for user in members %}

--- a/h/templates/admin/features.html.jinja2
+++ b/h/templates/admin/features.html.jinja2
@@ -17,7 +17,7 @@
       <input
         type="hidden"
         name="csrf_token"
-        value="{{ request.session.get_csrf_token() }}">
+        value="{{ get_csrf_token() }}">
       <table class="table table-striped">
         <thead>
           <tr>

--- a/h/templates/admin/mailer.html.jinja2
+++ b/h/templates/admin/mailer.html.jinja2
@@ -18,7 +18,7 @@
     </div>
     <div class="panel-body">
       <form method="POST" action="{{ request.route_path('admin.mailer_test') }}" class="form-inline">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <div class="form-group">
           <label for="recipient">Recipient</label>
           <input type="text" class="form-control" name="recipient">

--- a/h/templates/admin/nipsa.html.jinja2
+++ b/h/templates/admin/nipsa.html.jinja2
@@ -17,7 +17,7 @@
     </div>
     <div class="panel-body">
       <form method="POST" class="form-inline">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <div class="form-group">
           <label for="add">Username</label>
           <input type="text" class="form-control" name="add">
@@ -40,7 +40,7 @@
       <form
         method="POST"
         action="{{ request.route_url('admin.nipsa') }}">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <ul>
           {% for userid in userids %}
             <li>

--- a/h/templates/admin/staff.html.jinja2
+++ b/h/templates/admin/staff.html.jinja2
@@ -15,7 +15,7 @@
     </div>
     <div class="panel-body">
       <form method="POST" class="form-inline">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <div class="form-group">
           <label for="add">Username</label>
           <input type="text" class="form-control" name="add">
@@ -37,7 +37,7 @@
       <form
         method="POST"
         action="{{ request.route_url('admin.staff') }}">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <ul>
           {% for user in staff %}
             <li>

--- a/h/templates/admin/users.html.jinja2
+++ b/h/templates/admin/users.html.jinja2
@@ -41,7 +41,7 @@
                       method="POST">
                   <input type="hidden"
                          name="csrf_token"
-                         value="{{ request.session.get_csrf_token() }}">
+                         value="{{ get_csrf_token() }}">
                   <input type="hidden"
                          name="userid"
                          value="{{user.userid}}">
@@ -70,7 +70,7 @@
       <h3>Please-be-careful Zone</h3>
 
       <form method="POST" action="{{request.route_path('admin.users_rename')}}" class="form-inline">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <input type="hidden" name="userid" value="{{user.userid}}">
         <input type="text" name="new_username" placeholder="New Username" pattern="^[A-Za-z0-9._]+$">
         <button class="btn" type="submit">Change username</button>
@@ -81,7 +81,7 @@
       <form method="POST"
             action="{{request.route_path('admin.users_delete')}}"
             class="form-inline js-users-delete-form">
-        <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <input type="hidden" name="userid" value="{{user.userid}}">
 
         {% if user_meta['annotations_count'] > 100 %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,8 +38,10 @@ mistune==0.8.3
 newrelic==4.10.0.112
 oauthlib==2.0.2
 passlib==1.7.1
-pastedeploy==1.5.2        # via pyramid
+pastedeploy==2.0.1        # via plaster-pastedeploy, pyramid
 peppercorn==0.5           # via deform
+plaster-pastedeploy==0.7  # via pyramid
+plaster==1.0              # via plaster-pastedeploy, pyramid
 psycogreen==1.0.1
 psycopg2==2.7.3.2
 pycparser==2.14           # via cffi
@@ -51,7 +53,7 @@ pyramid-layout==1.0
 pyramid-mailer==0.15.1
 pyramid-services==0.4
 pyramid-tm==1.1.1
-pyramid==1.8.6
+pyramid==1.9.4
 python-dateutil==2.5.3
 python-editor==1.0.1      # via alembic
 python-slugify==1.1.4
@@ -78,4 +80,4 @@ zope.interface==4.3.2
 zope.sqlalchemy==1.1
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.1.0        # via pyramid, repoze.sendmail, zope.deprecation, zope.interface, zope.sqlalchemy
+# setuptools==41.2.0        # via plaster, pyramid, repoze.sendmail, zope.deprecation, zope.interface, zope.sqlalchemy

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -9,6 +9,9 @@ from h.accounts import schemas
 from h.services.user_password import UserPasswordService
 
 
+pytestmark = pytest.mark.usefixtures("pyramid_config")
+
+
 class TestUnblacklistedUsername(object):
     def test(self, dummy_node):
         blacklist = set(["admin", "root", "postmaster"])

--- a/tests/h/schemas/base_test.py
+++ b/tests/h/schemas/base_test.py
@@ -8,10 +8,14 @@ from mock import Mock
 import pytest
 
 import colander
+from pyramid import csrf
 from pyramid.exceptions import BadCSRFToken
 
 from h.schemas import ValidationError
 from h.schemas.base import enum_type, CSRFSchema, JSONSchema
+
+
+pytestmark = pytest.mark.usefixtures("pyramid_config")
 
 
 class ExampleCSRFSchema(CSRFSchema):
@@ -42,7 +46,7 @@ class TestCSRFSchema(object):
             schema.deserialize({})
 
     def test_ok_with_good_csrf(self, pyramid_request):
-        csrf_token = pyramid_request.session.get_csrf_token()
+        csrf_token = csrf.get_csrf_token(pyramid_request)
         pyramid_request.POST["csrf_token"] = csrf_token
         schema = ExampleCSRFSchema().bind(request=pyramid_request)
 

--- a/tests/h/schemas/forms/accounts/edit_profile_test.py
+++ b/tests/h/schemas/forms/accounts/edit_profile_test.py
@@ -6,6 +6,9 @@ import pytest
 from h.schemas.forms.accounts import EditProfileSchema
 
 
+pytestmark = pytest.mark.usefixtures("pyramid_config")
+
+
 class TestEditProfileSchema(object):
     def test_accepts_valid_input(self, pyramid_csrf_request):
         schema = EditProfileSchema().bind(request=pyramid_csrf_request)

--- a/tests/h/schemas/forms/accounts/forgot_password_test.py
+++ b/tests/h/schemas/forms/accounts/forgot_password_test.py
@@ -6,6 +6,9 @@ import pytest
 from h.schemas.forms.accounts import ForgotPasswordSchema
 
 
+pytestmark = pytest.mark.usefixtures("pyramid_config")
+
+
 @pytest.mark.usefixtures("user_model")
 class TestForgotPasswordSchema(object):
     def test_it_is_invalid_with_no_user(self, pyramid_csrf_request, user_model):

--- a/tests/h/schemas/forms/accounts/reset_password_test.py
+++ b/tests/h/schemas/forms/accounts/reset_password_test.py
@@ -7,6 +7,9 @@ from itsdangerous import BadData, SignatureExpired
 from h.schemas.forms.accounts import ResetPasswordSchema
 
 
+pytestmark = pytest.mark.usefixtures("pyramid_config")
+
+
 @pytest.mark.usefixtures("user_model")
 class TestResetPasswordSchema(object):
     def test_it_is_invalid_with_password_too_short(self, pyramid_csrf_request):

--- a/tests/h/schemas/forms/admin/organization_test.py
+++ b/tests/h/schemas/forms/admin/organization_test.py
@@ -9,6 +9,9 @@ from h.schemas.forms.admin.organization import (
 )
 
 
+pytestmark = pytest.mark.usefixtures("pyramid_config")
+
+
 class TestOrganizationSchema(object):
     def test_it_allows_valid_data(self, org_data, bound_schema):
         bound_schema.deserialize(org_data)

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -285,7 +285,7 @@ class FakeRequest(object):
 
         self.feature = fake_feature
         self.route_url = mock.Mock(return_value="/group/a")
-        self.session = mock.Mock(get_csrf_token=lambda: "__CSRF__")
+        self.session = mock.Mock()
 
         self._group_list_service = mock.create_autospec(
             GroupListService, spec_set=True, instance=True

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -769,6 +769,7 @@ class TestNotificationsController(object):
         pyramid_config.add_route("account_notifications", "/p/notifications")
 
 
+@pytest.mark.usefixtures("pyramid_config")
 class TestEditProfileController(object):
     def test_get_reads_user_properties(self, pyramid_request):
         pyramid_request.user = mock.Mock()


### PR DESCRIPTION
I had to make some minor changes to our CSRF-related code and tests, to
adapt to a change in Pyramid's CSRF support.

What changed in Pyramid
-----------------------

The way CSRF support used to work in Pyramid was:

1. You had to enable a session factory with
   `config.set_session_factory()` (h uses Pyramid's builtin
   `SignedCookieSessionFactory`)

2. You called `request.session.get_csrf_token()` to get a CSRF token for
   the request (creating a new one if the request doesn't already have
   one)

3. Since Pyramid passes `request` to templates you could call `{{
   request.session.get_csrf_token() }}` in a template, for example to
   render a CSRF token into a hidden form field, or pass it to some
   JavaScript code for use in an XHR request

4. You could call `pyramid.session.check_csrf_token(request)` to check a
   request's CSRF token manually (either returned `True` or raised
   `HTTPBadRequest`)

5. Since Pyramid 1.7 you could also do `@view_config(...,
   require_csrf=True)` to have Pyramid check a request's CSRF token
   automatically before calling a view. h uses this for lots of views.

Source: https://docs.pylonsproject.org/projects/pyramid/en/1.8-branch/narr/sessions.html#preventing-cross-site-request-forgery-attacks

What's changed in Pyramid 1.9 is:

* As well as setting a session factory, you now also need to set a CSRF
  storage policy by calling
  `config.set_csrf_storage_policy(SomeCSRFStoragePolicy)` and Pyramid
  now comes with a couple of builtin storage policies, including a
  `SessionCSRFStoragePolicy` that stores the CSRF tokens in the session
  (in the signed session cookie, in h's case)

* `request.session.get_csrf_token()` moved to
  `pyramid.csrf.get_csrf_token(request)`

* Accessing the request token from templates is now just `{{
  get_csrf_token() }}` rather than `{{ request.session.get_csrf_token() }}`

* `pyramid.session.check_csrf_token(request)` moved to
  `pyramid.csrf.check_csrf_token(request)`

* `@view_config(..., require_csrf=True)` remains the same

Sources:

* https://docs.pylonsproject.org/projects/pyramid/en/latest/whatsnew-1.9.html#major-feature-additions
* https://docs.pylonsproject.org/projects/pyramid/en/1.9-branch/narr/security.html#preventing-cross-site-request-forgery-attacks

What I had to change in h
-------------------------

* Added a call to `set_csrf_storage_policy(SessionCSRFStoragePolicy()`,
  otherwise Pyramid crashes because no CSRF storage policy is enabled

* Call `pyramid.csrf.get_csrf_token()` instead of
  `request.session.get_csrf_token()`

* In templates call `{{ get_csrf_token() }}` instead of
  `{{ request.session.get_csrf_token() }}`

* I added `pytestmark = pytest.mark.usefixtures("pyramid_config")` to a
  few test modules. This enables the `pyramid_config` fixture for all
  tests in those modules. Otherwise Pyramid crashes when those tests
  run, because no CSRF storage policy is set.

Problems
--------

I've left one call to `pyramid_request.session.get_csrf_token()` in
`tests/h/conftest.py`. This method actually still exists and is not
deprecated, and Pyramid's new `SessionCSRFStoragePolicy` calls it. The
changelog says that code "should" change to
`pyramid.csrf.get_csrf_token()` because
`pyramid_request.session.get_csrf_token()` might go away one day.
Updating this test fixture is difficult because it introduces a circular
fixture dependency involving the `pyramid_config` and
`pyramid_csrf_request` fixtures that I couldn't find a good resolution
to. Some tricky test fixture refactoring, or some kind of escape hatch,
would be required. I'm proposing to leave this as is for now.

If you're eagle-eyed you might also see that there's some mock
`pyramid_request.session` objects in the tests that still contain a
mock `get_csrf_token()` method. These mock methods are actually still
needed: Pyramid itself still calls them.