### PR TITLE
Upgrade to Pyramid 1.10.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ mistune==0.8.3
 newrelic==4.10.0.112
 oauthlib==2.0.2
 passlib==1.7.1
-pastedeploy==2.0.1        # via plaster-pastedeploy, pyramid
+pastedeploy==2.0.1        # via plaster-pastedeploy
 peppercorn==0.5           # via deform
 plaster-pastedeploy==0.7  # via pyramid
 plaster==1.0              # via plaster-pastedeploy, pyramid
@@ -53,12 +53,11 @@ pyramid-layout==1.0
 pyramid-mailer==0.15.1
 pyramid-services==0.4
 pyramid-tm==1.1.1
-pyramid==1.9.4
+pyramid==1.10.4
 python-dateutil==2.5.3
 python-editor==1.0.1      # via alembic
 python-slugify==1.1.4
 pytz==2016.6.1            # via celery
-repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.3      # via pyramid-mailer
 sentry-sdk==0.6.2
 six==1.10.0               # via bcrypt, bleach, elasticsearch-dsl, python-dateutil

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,10 @@ filterwarnings =
     #
     ignore:^Use of \.\. or absolute path in a resource path is not allowed and will raise exceptions in a future release\.$:DeprecationWarning:pkg_resources
 
+    # Ignore a Pyramid deprecation warning for now. We will fix our code in a
+    # future commit to not use the pickle serializer, and remove this ignore.
+    ignore:^The default pickle serializer is deprecated as of Pyramid 1\.9 and it will be changed to use pyramid\.session\.JSONSerializer in version 2\.0\. Explicitly set the serializer to avoid future incompatibilities\. See "Upcoming Changes to ISession in Pyramid 2\.0" for more information about this change\.$:DeprecationWarning:pyramid.session
+
     # Ignore WebOb warnings that just say "<method> will be changing in the
     # future" and don't say how it will be changing or what developers can do
     # now to avoid the warning. I don't think these warnings _can_ be avoided
@@ -43,9 +47,6 @@ filterwarnings =
     ignore:^The behavior of AcceptValidHeader\.best_match is currently being maintained for backward compatibility, but it will be deprecated in the future, as it does not conform to the RFC\.$:DeprecationWarning:webob.acceptparse
     ignore:^The behavior of AcceptValidHeader\.__contains__ is currently being maintained for backward compatibility, but it will change in the future to better conform to the RFC\.$:DeprecationWarning:webob.acceptparse
     ignore:^The behavior of AcceptLanguageValidHeader\.__iter__ is currently maintained for backward compatibility, but will change in the future.$:DeprecationWarning:webob.acceptparse
-
-    # Ignore a WebOb warning that Pyramid is triggering.
-    ignore:^The MIMEAccept class has been replaced by webob\.acceptparse\.create_accept_header\. This compatibility shim will be deprecated in a future version of WebOb\.$:DeprecationWarning:webob.acceptparse
 
 [testenv]
 skip_install = true


### PR DESCRIPTION
This means we're now on the most recent version of Pyramid.

Depends on https://github.com/hypothesis/h/pull/5699

Changes
=======

Ignored Pyramid session cookie pickle serialization warning
-----------------------------------------------------------

Pyramid's default session cookie serializer (pickle) now raises a
deprecation warning, and we're supposed to change to the new JSON
serializer:

* https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/sessions.html#upcoming-changes-to-isession-in-pyramid-2-0

Unfortunately there's a bug in Pyramid 1.9's pickle serializer that if
the session cookie fails to deserialize with pickle (e.g. because it's a
JSON serializer session cookie) then Pyramid 1.9 crashes.

This means that if we both upgraded to Pyramid 1.10 and changed to JSON
session cookies in one commit then if there was a problem with Pyramid
1.10 and we had to revert the upgrade, people would then run into this
Pyramid 1.9 bug and experience crashes.

Fortunately the bug has been fixed in Pyramid 1.10. In 1.10 it's
possible to move to JSON session cookies and then, if there's a problem,
go back to pickle session cookies without crashes.

We're therefore going to do this as two separately deployed commits:

1. This commit upgrades us to Pyramid 1.10 but does not yet change to
   JSON session cookies, and therefore has to ignore the pickle session
   cookie deprecation warning. We can revert this commit if we have to,
   without crashes.
2. Once we're sure that we're not going to need to revert to Pyramid 1.9
   we'll deploy a separate commit that changes us to JSON session
   cookies. We can revert that commit if we have to, without problems.


SameSite: Lax session cookie security
-------------------------------------

Pyramid also changed our session cookie to have SameSite: Lax by
default. I don't think we need to do anything as a result of this. See:

https://docs.pylonsproject.org/projects/pyramid/en/latest/whatsnew-1.10.html#feature-additions

Removed ignored WebOb warning
-----------------------------

Pyramid is no longer triggering this WebOb deprecation warning so we no
longer need to ignore the warning in `tox.ini`.

There are still five other pointless WebOb warnings ignored in
`tox.ini`: I didn't check whether these deprecation warnings are still
being raised, I suspect they are, but since they're pointless warnings
(see the comment in `tox.ini`) I think we should continue to ignore them
anyway in case anything else triggers them in future.