### PR TITLE
Apply custom Content-Security-Policy header to client sidebar app

### DIFF
--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -186,6 +186,16 @@ def normalize(uristr):
     return decode_result(uri.geturl())
 
 
+def origin(url):
+    """
+    Return a copy of ``url`` with the path, query string and fragment removed.
+
+    ``url`` is assumed to be an HTTP(S) URL.
+    """
+    url_parts = urlparse.urlsplit(url)
+    return urlparse.SplitResult(url_parts.scheme, url_parts.netloc, "", "", "").geturl()
+
+
 def _normalize_scheme(uri):
     scheme = uri.scheme
 

--- a/tests/h/util/uri_test.py
+++ b/tests/h/util/uri_test.py
@@ -162,3 +162,16 @@ def test_normalize(url_in, url_out):
 @pytest.mark.parametrize("url,_", TEST_URLS)
 def test_normalize_returns_unicode(url, _):
     assert isinstance(uri.normalize(url), text_type)
+
+
+@pytest.mark.parametrize(
+    "url_in,url_out",
+    [
+        ("https://example.com", "https://example.com"),
+        ("https://example.com/foo?bar=baz#frag", "https://example.com"),
+        ("http://localhost:3000/foo", "http://localhost:3000"),
+        ("HTTP://LOCALHOST:3000/foo", "http://LOCALHOST:3000"),
+    ],
+)
+def test_origin(url_in, url_out):
+    assert uri.origin(url_in) == url_out

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -35,6 +35,15 @@ class TestSidebarApp(object):
 
         assert ctx["embed_url"] == "/embed.js"
 
+    def test_it_sets_custom_content_security_policy_header(self, pyramid_request):
+        client.sidebar_app(pyramid_request)
+        csp_header = pyramid_request.response.headers["Content-Security-Policy"]
+
+        assert (
+            csp_header
+            == "script-src 'self' https://cdn.hypothes.is https://www.google-analytics.com; style-src https://cdn.hypothes.is"
+        )
+
 
 @pytest.mark.usefixtures("routes", "pyramid_settings")
 class TestEmbedRedirect(object):


### PR DESCRIPTION
Add a custom CSP header to the Hypothesis client's sidebar app HTML page
(https://hypothes.is/app.html) to ensure that only scripts and styles
from expected locations are loaded.

This should help to protect against problems caused by browser
extensions which inject custom scripts or styles into the page. This
includes both problems for the user, eg. a script that monkey-patches
the environment and breaks our app, but also causes problems for us in
the form of spurious error reports to Sentry (for example, [this error caused by Privacy Badger](https://sentry.io/organizations/hypothesis/issues/1189790854/?project=69811&query=is%3Aunresolved), and there are many other suspicious reports)

Note that this won't prevent the execution of scripts executed directly
using Chrome/Firefox extension APIs, but those execute in an isolated JS
world and so are less likely to cause problems.

This CSP header would also be useful if applied to the h routes that
serve the client as a top level page (`/a/{annotation_id}` and `/stream`) but
the initial commit only enables it for the sidebar.

There is room to extend the CSP here to cover other types of resources:
fonts, images etc. This initial version only covers the two main types
of resource.