### PR TITLE
Revert nginx ratelimit changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN apk add --no-cache \
     libffi \
     libpq \
     nginx \
-    git \
-    nginx-mod-http-geoip
+    git
 
 # Create the hypothesis user, group, home directory and package directory.
 RUN addgroup -S hypothesis && adduser -S -G hypothesis -h /var/lib/hypothesis hypothesis

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,12 +3,9 @@ worker_processes auto;
 pid /var/lib/hypothesis/nginx.pid;
 error_log /dev/stderr;
 
-load_module "modules/ngx_http_geoip_module.so";
-
 events {
   worker_connections 4096;
 }
-
 
 http {
   # Forward user's real ip in Cloudflare header.
@@ -16,11 +13,6 @@ http {
   # instead of X-Forwarded-For. 
   set_real_ip_from 0.0.0.0/0;
   real_ip_header CF-Connecting-IP;
-
-  geo $whitelist_ip {
-      default $binary_remote_addr;
-      10.0.0.0/8 "";
-  }
 
   client_max_body_size 20m;
   sendfile on;
@@ -34,7 +26,7 @@ http {
   # If there is an auth token, rate limit based on that,
   # otherwise rate limit per ip.
   map $http_authorization $limit_per_user {
-    "" $whitelist_ip;
+    "" $binary_remote_addr;
     default $http_authorization;
   }
 
@@ -44,7 +36,7 @@ http {
   limit_req_zone $limit_per_user zone=badge_user_1rps_limit:1m rate=1r/s;
   limit_req_zone $limit_per_user zone=assets_user_1rps_limit:1m rate=1r/s;
   limit_req_zone $limit_per_user zone=create_ann_user_1rps_limit:1m rate=1r/s;
-  limit_req_zone $limit_per_user zone=user_10rps_limit:1m rate=10r/s;
+  limit_req_zone $limit_per_user zone=user_1rps_limit:1m rate=1r/s;
   limit_req_status 429;
 
   # We set fail_timeout=0 so that the upstream isn't marked as down if a single
@@ -132,7 +124,7 @@ http {
       }
 
       location /api {
-        limit_req zone=user_10rps_limit burst=44 nodelay;
+        limit_req zone=user_1rps_limit burst=44 nodelay;
         error_page 429 @api_error_429;
 
         proxy_pass http://web;
@@ -140,7 +132,7 @@ http {
 
       # An overall rate limit was chosen to allow reasonable usage while
       # preventing a single user from causing service disruption.
-      limit_req zone=user_10rps_limit burst=44 nodelay;
+      limit_req zone=user_1rps_limit burst=44 nodelay;
     }
   }
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -20,7 +20,6 @@ http {
   geo $whitelist_ip {
       default $binary_remote_addr;
       10.0.0.0/8 "";
-      172.16.0.0/12 "";
   }
 
   client_max_body_size 20m;


### PR DESCRIPTION
Revert these Dockerfile and nginx config changes because they caused a prod deployment failure. See https://hypothes-is.slack.com/archives/C4K6M7P5E/p1567167045048900

@hmstepanek reported getting alerted about rate limiting errors and health checks on new instances failed to pass due to (very roughly) ~50% of requests failing with 4xx errors.

Failed deployment log: https://jenkins.hypothes.is/job/deployment/2521/console

This reverts #5690 and #5692. CC @dmfine and @hmstepanek for when you're online later.