### PR TITLE
Upgrade sentry-sdk to the latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ python-slugify==1.1.4
 pytz==2016.6.1            # via celery
 repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.3      # via pyramid-mailer
-sentry-sdk==0.6.2
+sentry-sdk==0.11.2
 six==1.10.0               # via bcrypt, bleach, elasticsearch-dsl, python-dateutil
 sqlalchemy==1.3.6
 statsd==3.2.1


### PR DESCRIPTION
The older version of sentry-sdk seems to cause Pyramid to crash if you upgrade to Pyramid 1.10 with JSON session cookies and then downgrade again to 1.9 and pickle cookies. I didn't investigate further---upgrading sentry-sdk makes the problem go away, and we will need to upgrade it one day anyway.