### PR TITLE
Upgrade to JSON session cookies

### DIFF
--- a/h/session.py
+++ b/h/session.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from pyramid.csrf import SessionCSRFStoragePolicy
-from pyramid.session import SignedCookieSessionFactory
+from pyramid.session import SignedCookieSessionFactory, JSONSerializer
 
 from h.security import derive_key
 
@@ -110,6 +110,7 @@ def includeme(config):
         hashalg="sha512",
         httponly=True,
         timeout=3600,
+        serializer=JSONSerializer(),
     )
     config.set_session_factory(factory)
     config.set_csrf_storage_policy(SessionCSRFStoragePolicy())

--- a/tox.ini
+++ b/tox.ini
@@ -34,10 +34,6 @@ filterwarnings =
     #
     ignore:^Use of \.\. or absolute path in a resource path is not allowed and will raise exceptions in a future release\.$:DeprecationWarning:pkg_resources
 
-    # Ignore a Pyramid deprecation warning for now. We will fix our code in a
-    # future commit to not use the pickle serializer, and remove this ignore.
-    ignore:^The default pickle serializer is deprecated as of Pyramid 1\.9 and it will be changed to use pyramid\.session\.JSONSerializer in version 2\.0\. Explicitly set the serializer to avoid future incompatibilities\. See "Upcoming Changes to ISession in Pyramid 2\.0" for more information about this change\.$:DeprecationWarning:pyramid.session
-
     # Ignore WebOb warnings that just say "<method> will be changing in the
     # future" and don't say how it will be changing or what developers can do
     # now to avoid the warning. I don't think these warnings _can_ be avoided


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h/pull/5685

Pickle session cookies are deprecated in Pyramid.

Any existing pickle-serialized session cookies in production will be
invalidated: Pyramid does not crash but just starts a new, empty JSON
session cookie.

We do not use Pyramid's session cookies for logins (we use
pyramid_authsanity with a separate auth cookie) so existing logins will
not be affected.

If someone loads a form while we still have pickle cookies, then we
deploy this upgrade, then they try to submit the form, they will get an
error because their CSRF token was in their session cookie and the
upgrade invalidated it.

Flash messages could be similarly affected.

That's all we use the session cookie for.