### PR TITLE
Automate running `make services`

### DIFF
--- a/bin/wait-for-port
+++ b/bin/wait-for-port
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+#
+# Wait for the given host and port to start responding.
+#
+# Repeatedly try to contact the given host and port over TCP until it responds,
+# then exit with status 0.
+#
+# If the host:port does not respond after 10 seconds of trying then exit with
+# status 1.
+#
+# Usage
+# =====
+#
+#     bin/wait-for-port localhost 5432
+set -e
+
+if [ $# -ne 2 ]; then
+    echo "Wrong number of command line arguments."
+    echo "Usage:"
+    echo ""
+    echo "    $0 <HOST> <PORT>"
+    echo ""
+    echo "Example:"
+    echo ""
+    echo "    $0 localhost 5432"
+    exit 1
+fi
+
+n=0
+while [ "$n" -lt 100 ]; do
+    n=$(( n + 1 ))
+    nc -z "$1" "$2" && exit 0
+    sleep 0.1
+done
+
+exit 1

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -56,15 +56,6 @@ installation process:
 
    cd h
 
-Run the services with Docker Compose
-------------------------------------
-
-Start the services that h requires using Docker Compose:
-
-.. code-block:: shell
-
-   make services
-
 Start the development server
 ----------------------------
 


### PR DESCRIPTION
Make commands like `make dev`, `make test`, `make sql`, etc
automatically call `make services` to start the services if they haven't
already been started.

This just makes things a little more convenient as you can just run
`make whatever` without having to remember to run `make services` first.

It also makes setup instructions across our apps simpler: now none of
them require you to run a `make services` command.

This does make all of these commands a little slower to start up as they
now all run `docker-compose up -d` first. I think that's fine: the
Makefile commands are supposed to be the automatic and convenient
commands and as such they can't always be the fastest. People are
welcome to run the underlying commands directly if they want, which will
be faster.

A `bin/wait-for-port` script had to be added to achieve this. This is
because `docker-compose up -d` actually exits before the services have
started up, which creates a race condition: if the dev server (for
example) gets going before Postgres does then h will crash on startup
when it fails to connect to Postgres.

By having `make services` call `bin/wait-for-port` it waits until the
services are actually responding before starting the dev server, tests,
shell, or whatever.