### PR TITLE
Fix math rendering regression in the client

### DIFF
--- a/h/views/client.py
+++ b/h/views/client.py
@@ -94,10 +94,15 @@ def sidebar_app(request, extra=None):
     # The `'self'` script-src is needed because app.html references the `/embed.js`
     # route from h.
     client_origin = origin(_client_url(request))
-    ga_origin = "https://www.google-analytics.com"
+    script_src = f"'self' {client_origin} https://www.google-analytics.com"
+
+    # nb. Inline styles are currently allowed for the client because LaTeX
+    # math rendering using KaTeX relies on them.
+    style_src = f"{client_origin} 'unsafe-inline'"
+
     request.response.headers[
         "Content-Security-Policy"
-    ] = f"script-src 'self' {client_origin} {ga_origin}; style-src {client_origin}"
+    ] = f"script-src {script_src}; style-src {style_src}"
 
     return ctx
 

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -41,7 +41,7 @@ class TestSidebarApp(object):
 
         assert (
             csp_header
-            == "script-src 'self' https://cdn.hypothes.is https://www.google-analytics.com; style-src https://cdn.hypothes.is"
+            == "script-src 'self' https://cdn.hypothes.is https://www.google-analytics.com; style-src https://cdn.hypothes.is 'unsafe-inline'"
         )
 
 


### PR DESCRIPTION
Rendering of annotations containing LaTeX content such as:

```
$$\int_\gamma \|\gamma' \|$$
```

Produced incorrect output because the inline styles in the HTML
generated by KaTeX were blocked by the Content-Security-Policy header
recently added to https://hypothes.is/app.html.

Until the client's math rendering can be re-worked to avoid needing this,
re-enable support for inline styles. Note that inline _scripts_ are
still blocked.

Support issue: https://hypothes-is.slack.com/archives/C2BLQDKHA/p1568118710003600