### PR TITLE
Remove pyramid_debugtoolbar

### DIFF
--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -18,9 +18,6 @@ secret_key: notverysecretafterall
 
 sqlalchemy.url: postgresql://postgres@localhost/postgres
 
-;http://docs.pylonsproject.org/projects/pyramid-debugtoolbar/en/latest/#settings
-debugtoolbar.show_on_exc_only: True
-
 [server:main]
 use: egg:gunicorn
 host: localhost

--- a/h/app.py
+++ b/h/app.py
@@ -136,7 +136,3 @@ def includeme(config):
     config.include("h.links")
     config.include("h.nipsa")
     config.include("h.notification")
-
-    # Debugging assistance
-    if asbool(config.registry.settings.get("h.debug")):
-        config.include("pyramid_debugtoolbar")

--- a/h/util/view.py
+++ b/h/util/view.py
@@ -21,11 +21,6 @@ def handle_exception(request, exception):
     """
     request.response.status_int = 500
 
-    # In debug mode we should just reraise, so that the exception is caught by
-    # the debug toolbar.
-    if request.debug:
-        raise
-
 
 def json_view(**settings):
     """A view configuration decorator with JSON defaults."""

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,4 @@
 -r requirements.txt
 
 honcho
-pyramid_debugtoolbar
 pip-tools

--- a/tests/h/util/view_test.py
+++ b/tests/h/util/view_test.py
@@ -15,20 +15,8 @@ class TestHandleException(object):
 
         assert pyramid_request.response.status_int == 500
 
-    def test_reraises_in_debug_mode(self, pyramid_request):
-        pyramid_request.debug = True
-        dummy_exc = ValueError("dummy")
-
-        try:
-            raise dummy_exc
-        except:
-            with pytest.raises(ValueError) as exc:
-                handle_exception(pyramid_request, Mock())
-            assert exc.value == dummy_exc
-
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.debug = False
         return pyramid_request
 
     @pytest.fixture


### PR DESCRIPTION
This causes error pages to look and behave differently in dev than in
prod, which often gets in the way of debugging and testing things.

I don't find the debugtoolbar particularly useful for debugging
either---I prefer to see logging and tracebacks in my terminal and to
use pdb.