### PR TITLE
Fix ptweens and other Pyramid scripts

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,7 @@ passenv =
     {tests,functests}: PYTEST_ADDOPTS
     functests: BROKER_URL
     codecov: CI TRAVIS*
+setenv = dev: PYTHONPATH = .
 deps =
     tests: coverage
     {tests,functests,docstrings,checkdocstrings,analyze}: pytest


### PR DESCRIPTION
You can run Pyramid's ptweens and other scripts like this:

    tox -qe py36-dev ptweens conf/development-app.ini

But it will fail because it can't import h. Add the directory containing
the h package to the dev env's PYTHONPATH to fix this.