### PR TITLE
Only rate limit external requests

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -8,12 +8,6 @@ events {
 }
 
 http {
-  # Forward user's real ip in Cloudflare header.
-  # Avoid multiple proxy layers by using CF-Connecting-IP
-  # instead of X-Forwarded-For. 
-  set_real_ip_from 0.0.0.0/0;
-  real_ip_header CF-Connecting-IP;
-
   client_max_body_size 20m;
   sendfile on;
   server_tokens off;
@@ -24,9 +18,11 @@ http {
   access_log off;
 
   # If there is an auth token, rate limit based on that,
-  # otherwise rate limit per ip.
+  # else if there is a cloudflare ip header rate limit based on that,
+  # otherwise assume it's from an internal service and do not 
+  # rate limit at all.
   map $http_authorization $limit_per_user {
-    "" $binary_remote_addr;
+    "" $http_cf_connecting_ip;
     default $http_authorization;
   }
 


### PR DESCRIPTION
External requests are defined as having a Cloudflare connecting ip
header or an authorization header.

Previous behavior:
if authorization header, rate limit based on that
else if cloudflare connecting ip header, rate limit based on that
else, rate limit based on x-forwarded-for ip.

Current behavior:
if authorization header, rate limit based on that
else if cloudflare connecting ip header, rate limit based on that
else, assume that this is an internal service-service request
and do not rate limit at all.

This is a fix for https://github.com/hypothesis/h/issues/5649.