### PR TITLE
Remove third-party `mock` dependency

### DIFF
--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import mock
+from unittest import mock
+
 import pytest
 
 from h import accounts

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
+from unittest.mock import Mock
+
 import colander
 import pytest
-from mock import Mock
 from pyramid.exceptions import BadCSRFToken
 
 from h.accounts import schemas

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -4,9 +4,10 @@ from __future__ import unicode_literals
 
 from h._compat import xrange
 
+from unittest.mock import Mock
 import datetime
+
 import pytest
-from mock import Mock
 
 from h.activity import bucketing
 from tests.common import factories

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from pyramid.httpexceptions import HTTPFound
 from webob.multidict import MultiDict

--- a/tests/h/assets_test.py
+++ b/tests/h/assets_test.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-from sys import version_info
-from h._compat import StringIO
 
-from mock import patch
+from sys import version_info
+from unittest.mock import patch
+
 import pytest
 
+from h._compat import StringIO
 from h.assets import Environment
 
 if version_info.major == 2:

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 import base64
 

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+
 import datetime
+from unittest import mock
 
 import jwt
-import mock
+
 
 from hypothesis import strategies as st
 from hypothesis import assume, given

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -3,9 +3,9 @@
 from __future__ import unicode_literals
 
 from collections import namedtuple
+from unittest import mock
 
 import pytest
-import mock
 import sqlalchemy as sa
 
 from pyramid import security

--- a/tests/h/celery_test.py
+++ b/tests/h/celery_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
 
 from billiard.einfo import ExceptionInfo
 

--- a/tests/h/cli/commands/authclient_test.py
+++ b/tests/h/cli/commands/authclient_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h import models

--- a/tests/h/cli/commands/init_test.py
+++ b/tests/h/cli/commands/init_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h.cli.commands import init as init_cli

--- a/tests/h/cli/commands/normalize_uris_test.py
+++ b/tests/h/cli/commands/normalize_uris_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h import models

--- a/tests/h/cli/commands/search_test.py
+++ b/tests/h/cli/commands/search_test.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import mock
 import os
+from unittest import mock
+
 import pytest
 
 from h.cli.commands import search

--- a/tests/h/cli/commands/shell_test.py
+++ b/tests/h/cli/commands/shell_test.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import sys
+from unittest import mock
 
-import mock
 import pytest
 
 from h.cli.commands import shell

--- a/tests/h/cli/commands/user_test.py
+++ b/tests/h/cli/commands/user_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import mock
+from unittest import mock
+
 import pytest
 from passlib.context import CryptContext
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -8,9 +8,9 @@ from __future__ import unicode_literals
 
 import functools
 import os
+from unittest import mock
 
 import deform
-import mock
 import pytest
 
 import click.testing

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -3,8 +3,8 @@
 from __future__ import unicode_literals
 
 import datetime
+from unittest import mock
 
-import mock
 import pytest
 
 from h.emails.reply_notification import generate

--- a/tests/h/emails/reset_password_test.py
+++ b/tests/h/emails/reset_password_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from h.emails.reset_password import generate
 

--- a/tests/h/eventqueue_test.py
+++ b/tests/h/eventqueue_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 
 from h import eventqueue

--- a/tests/h/events_test.py
+++ b/tests/h/events_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
 
 from h.events import AnnotationEvent, AnnotationTransformEvent
 

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -3,7 +3,7 @@
 """Unit tests for h/atom.py."""
 from __future__ import unicode_literals
 from datetime import datetime
-import mock
+from unittest import mock
 
 from h import models
 from h.feeds import atom

--- a/tests/h/feeds/render_test.py
+++ b/tests/h/feeds/render_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from pyramid.response import Response

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
-import datetime
 
-import mock
+import datetime
+from unittest import mock
 
 from h import models
 from h.feeds import rss

--- a/tests/h/feeds/util_test.py
+++ b/tests/h/feeds/util_test.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
-import datetime
 
-import mock
+import datetime
+from unittest import mock
 
 from h.feeds import util
 

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 
 from h import form

--- a/tests/h/formatters/annotation_user_info_test.py
+++ b/tests/h/formatters/annotation_user_info_test.py
@@ -3,8 +3,8 @@
 from __future__ import unicode_literals
 
 from collections import namedtuple
+from unittest import mock
 
-import mock
 import pytest
 
 from h.formatters.annotation_user_info import AnnotationUserInfoFormatter

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 
 from h.indexer.reindexer import reindex

--- a/tests/h/links_test.py
+++ b/tests/h/links_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 
 from h import models

--- a/tests/h/models/document_test.py
+++ b/tests/h/models/document_test.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import datetime
 
-import mock
+import datetime
+from unittest import mock
+
 import pytest
 import sqlalchemy as sa
 import transaction

--- a/tests/h/models/feature_test.py
+++ b/tests/h/models/feature_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 
 from h.models import Feature

--- a/tests/h/nipsa/subscribers_test.py
+++ b/tests/h/nipsa/subscribers_test.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-from collections import namedtuple
 
-import mock
+from collections import namedtuple
+from unittest import mock
+
 import pytest
 
 from h.nipsa import subscribers

--- a/tests/h/notification/reply_test.py
+++ b/tests/h/notification/reply_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from h.models import Annotation
 from h.models import Document, DocumentMeta

--- a/tests/h/oauth/jwt_grant_test.py
+++ b/tests/h/oauth/jwt_grant_test.py
@@ -5,8 +5,8 @@ from __future__ import unicode_literals
 import json
 from calendar import timegm
 from datetime import datetime, timedelta
+from unittest import mock
 
-import mock
 import pytest
 
 import jwt

--- a/tests/h/oauth/tokens_test.py
+++ b/tests/h/oauth/tokens_test.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+from unittest import mock
 
 import pytest
-import mock
 
 from oauthlib.common import Request as OAuthRequest
 

--- a/tests/h/paginator_test.py
+++ b/tests/h/paginator_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 from webob.multidict import NestedMultiDict
 

--- a/tests/h/panels/back_link_test.py
+++ b/tests/h/panels/back_link_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-from mock import Mock
+from unittest.mock import Mock
+
 import pytest
 
 from h.panels.back_link import back_link

--- a/tests/h/panels/navbar_test.py
+++ b/tests/h/panels/navbar_test.py
@@ -2,8 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
-from mock import PropertyMock
+from unittest import mock
+
 import pytest
 
 from h.panels.navbar import navbar
@@ -59,14 +59,16 @@ class TestNavbar(object):
         assert result["q"] == "tag:question"
 
     def test_it_includes_search_url_when_on_user_search(self, req):
-        type(req.matched_route).name = PropertyMock(return_value="activity.user_search")
+        type(req.matched_route).name = mock.PropertyMock(
+            return_value="activity.user_search"
+        )
         req.matchdict = {"username": "luke"}
 
         result = navbar({}, req)
         assert result["search_url"] == "http://example.com/users/luke"
 
     def test_it_includes_search_url_when_on_group_search(self, req):
-        type(req.matched_route).name = PropertyMock(return_value="group_read")
+        type(req.matched_route).name = mock.PropertyMock(return_value="group_read")
         req.matchdict = {"pubid": "foobar", "slug": "slugbar"}
 
         result = navbar({}, req)

--- a/tests/h/presenters/annotation_base_test.py
+++ b/tests/h/presenters/annotation_base_test.py
@@ -3,8 +3,7 @@
 from __future__ import unicode_literals
 
 import datetime
-
-import mock
+from unittest import mock
 
 from h.presenters.annotation_base import AnnotationBasePresenter
 from h.presenters.annotation_base import utc_iso8601

--- a/tests/h/presenters/annotation_html_test.py
+++ b/tests/h/presenters/annotation_html_test.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+
 import datetime
+from unittest import mock
 
 import pytest
-import mock
 import jinja2
 
 from h.presenters.annotation_html import AnnotationHTMLPresenter

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -3,8 +3,8 @@
 from __future__ import unicode_literals
 
 import datetime
+from unittest import mock
 
-import mock
 import pytest
 
 from pyramid import security

--- a/tests/h/presenters/annotation_jsonld_test.py
+++ b/tests/h/presenters/annotation_jsonld_test.py
@@ -3,8 +3,7 @@
 from __future__ import unicode_literals
 
 import datetime
-
-import mock
+from unittest import mock
 
 from h.presenters.annotation_jsonld import AnnotationJSONLDPresenter
 from h.traversal import AnnotationContext

--- a/tests/h/presenters/annotation_searchindex_test.py
+++ b/tests/h/presenters/annotation_searchindex_test.py
@@ -3,8 +3,8 @@
 from __future__ import unicode_literals
 
 import datetime
+from unittest import mock
 
-import mock
 import pytest
 
 from h.presenters.annotation_searchindex import AnnotationSearchIndexPresenter

--- a/tests/h/presenters/conftest.py
+++ b/tests/h/presenters/conftest.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 

--- a/tests/h/presenters/document_html_test.py
+++ b/tests/h/presenters/document_html_test.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+
 from h._compat import text_type
 
+from unittest import mock
+
 import pytest
-import mock
 import jinja2
 
 from h.presenters.document_html import DocumentHTMLPresenter

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from h.presenters.group_json import GroupJSONPresenter, GroupsJSONPresenter
 from h.services.group_links import GroupLinksService

--- a/tests/h/realtime_test.py
+++ b/tests/h/realtime_test.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+
 from datetime import datetime
+from unittest import mock
 
 import pytest
-import mock
 
 from h import realtime
 

--- a/tests/h/renderers_test.py
+++ b/tests/h/renderers_test.py
@@ -3,8 +3,8 @@
 from __future__ import unicode_literals
 
 from collections import OrderedDict
+from unittest import mock
 
-import mock
 import pytest
 
 from h.renderers import json_sorted_factory

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from mock import Mock, call
+from unittest.mock import Mock, call
 
 from h.routes import includeme
 

--- a/tests/h/schemas/annotation_test.py
+++ b/tests/h/schemas/annotation_test.py
@@ -2,7 +2,8 @@
 from __future__ import unicode_literals
 
 from copy import deepcopy
-import mock
+from unittest import mock
+
 import pytest
 import re
 from webob.multidict import NestedMultiDict, MultiDict

--- a/tests/h/schemas/base_test.py
+++ b/tests/h/schemas/base_test.py
@@ -3,8 +3,10 @@
 from __future__ import unicode_literals
 
 from h._compat import PY2
+
 import enum
-from mock import Mock
+from unittest.mock import Mock
+
 import pytest
 
 import colander

--- a/tests/h/schemas/forms/accounts/login_test.py
+++ b/tests/h/schemas/forms/accounts/login_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
+from unittest.mock import Mock
+
 import colander
 import pytest
-from mock import Mock
 from pyramid.exceptions import BadCSRFToken
 
 from h.schemas.forms.accounts import LoginSchema

--- a/tests/h/schemas/forms/admin/group_test.py
+++ b/tests/h/schemas/forms/admin/group_test.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import colander
 import pytest
-import mock
 
 from h.models.group import (
     GROUP_NAME_MIN_LENGTH,

--- a/tests/h/schemas/validators_test.py
+++ b/tests/h/schemas/validators_test.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import pytest
-from mock import Mock
+from unittest.mock import Mock
 
+import pytest
 import colander
 
 from h.schemas.validators import Email

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -5,8 +5,8 @@ from h._compat import url_quote_plus
 
 import itertools
 import re
+from unittest import mock
 
-import mock
 import pytest
 import elasticsearch
 

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 import h.search.index

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -2,11 +2,11 @@
 from __future__ import unicode_literals
 
 import datetime
+from unittest import mock
 
 import elasticsearch
 import elasticsearch_dsl
 import logging
-import mock
 import pytest
 
 import h.search.index

--- a/tests/h/sentry/helpers/before_send_test.py
+++ b/tests/h/sentry/helpers/before_send_test.py
@@ -2,8 +2,8 @@
 from __future__ import unicode_literals
 
 import logging
+from unittest import mock
 
-import mock
 import pytest
 
 from h.sentry.helpers.before_send import before_send

--- a/tests/h/sentry/helpers/filters_test.py
+++ b/tests/h/sentry/helpers/filters_test.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 import ws4py

--- a/tests/h/services/annotation_delete_test.py
+++ b/tests/h/services/annotation_delete_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from h.events import AnnotationEvent
 from h.services.annotation_delete import annotation_delete_service_factory

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h.interfaces import IGroupService

--- a/tests/h/services/annotation_stats_test.py
+++ b/tests/h/services/annotation_stats_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h.services.annotation_stats import AnnotationStatsService

--- a/tests/h/services/auth_ticket_test.py
+++ b/tests/h/services/auth_ticket_test.py
@@ -3,8 +3,8 @@
 from __future__ import unicode_literals
 
 from datetime import datetime, timedelta
+from unittest import mock
 
-import mock
 import pytest
 
 from h import models

--- a/tests/h/services/delete_group_test.py
+++ b/tests/h/services/delete_group_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h.services.delete_group import (

--- a/tests/h/services/delete_user_test.py
+++ b/tests/h/services/delete_user_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 import sqlalchemy
 
 from h.models import Annotation, Document

--- a/tests/h/services/feature_test.py
+++ b/tests/h/services/feature_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h import models

--- a/tests/h/services/group_create_test.py
+++ b/tests/h/services/group_create_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h.models import Group, User, GroupScope

--- a/tests/h/services/group_list_test.py
+++ b/tests/h/services/group_list_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from h.services.group_list import GroupListService
 from h.services.group_list import group_list_factory

--- a/tests/h/services/group_members_test.py
+++ b/tests/h/services/group_members_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h.models import User, GroupScope

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -3,8 +3,8 @@
 from __future__ import unicode_literals
 
 import datetime
+from unittest import mock
 
-import mock
 import pytest
 
 from h.models import User, Group, GroupScope

--- a/tests/h/services/group_update_test.py
+++ b/tests/h/services/group_update_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from sqlalchemy.exc import SQLAlchemyError
 

--- a/tests/h/services/links_test.py
+++ b/tests/h/services/links_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h.services.links import LinksService, add_annotation_link_generator, links_factory

--- a/tests/h/services/oauth_provider_test.py
+++ b/tests/h/services/oauth_provider_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from oauthlib.common import Request as OAuthRequest

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 
 import datetime
 import uuid
+from unittest import mock
 
-import mock
 import pytest
 
 from oauthlib.common import Request as OAuthRequest

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals
 
 from h._compat import xrange
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h import models

--- a/tests/h/services/settings_test.py
+++ b/tests/h/services/settings_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h.models import Setting

--- a/tests/h/services/user_signup_test.py
+++ b/tests/h/services/user_signup_test.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import datetime
 
-import mock
+import datetime
+from unittest import mock
+
 import pytest
 
 from sqlalchemy.exc import IntegrityError

--- a/tests/h/services/user_unique_test.py
+++ b/tests/h/services/user_unique_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from h.services.user_unique import UserUniqueService, user_unique_factory
 from h.services.user_unique import DuplicateUserError

--- a/tests/h/services/user_update_test.py
+++ b/tests/h/services/user_update_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from sqlalchemy.exc import SQLAlchemyError
 

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
+
+from unittest import mock
+
 import pytest
-import mock
 
 from h import session
 from h.services.group_list import GroupListService

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -3,9 +3,9 @@
 from __future__ import unicode_literals
 
 import copy
+from unittest import mock
 
 import pytest
-import mock
 
 from h.models.annotation import Annotation
 from h.models.document import Document, DocumentURI

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 from gevent.queue import Queue
 from pyramid import security

--- a/tests/h/streamer/streamer_test.py
+++ b/tests/h/streamer/streamer_test.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import mock
-from mock import call
+
+from unittest import mock
 import pytest
 
 from h.streamer import messages
@@ -90,7 +90,7 @@ def test_process_work_queue_calls_close_after_commit(session):
 
     streamer.process_work_queue({}, queue, session_factory=lambda _: session)
 
-    assert session.method_calls[-2:] == [call.commit(), call.close()]
+    assert session.method_calls[-2:] == [mock.call.commit(), mock.call.close()]
 
 
 def test_process_work_queue_calls_close_after_rollback(session):
@@ -101,7 +101,7 @@ def test_process_work_queue_calls_close_after_rollback(session):
 
     streamer.process_work_queue({}, queue, session_factory=lambda _: session)
 
-    assert session.method_calls[-2:] == [call.rollback(), call.close()]
+    assert session.method_calls[-2:] == [mock.call.rollback(), mock.call.close()]
 
 
 @pytest.fixture

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -2,8 +2,8 @@
 
 from __future__ import unicode_literals
 from collections import namedtuple
+from unittest import mock
 
-import mock
 import pytest
 from gevent.queue import Queue
 from jsonschema import ValidationError

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h import subscribers

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h.tasks import indexer

--- a/tests/h/tasks/mailer_test.py
+++ b/tests/h/tasks/mailer_test.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-from smtplib import SMTPServerDisconnected
 
-import mock
+from smtplib import SMTPServerDisconnected
+from unittest import mock
+
 import pytest
 
 from h.tasks import mailer

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 from pyramid import security
 from pyramid.authorization import ACLAuthorizationPolicy
 

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -2,10 +2,11 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pyramid.authorization
 import pyramid.security
 import pytest
-import mock
 
 import h.auth
 from h.models import AuthClient

--- a/tests/h/util/db_test.py
+++ b/tests/h/util/db_test.py
@@ -3,8 +3,8 @@
 from __future__ import unicode_literals
 
 import random
+from unittest import mock
 
-import mock
 import pytest
 
 from h.util.db import lru_cache_in_transaction, on_transaction_end

--- a/tests/h/util/metrics_test.py
+++ b/tests/h/util/metrics_test.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 from webob.multidict import MultiDict
 
 from h.util import metrics

--- a/tests/h/util/view_test.py
+++ b/tests/h/util/view_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest.mock import Mock
+
 import pytest
-from mock import Mock
 
 from h.util.view import handle_exception, json_view
 

--- a/tests/h/viewpredicates_test.py
+++ b/tests/h/viewpredicates_test.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
 
 from h.viewpredicates import FeaturePredicate
 

--- a/tests/h/views/account_signup_test.py
+++ b/tests/h/views/account_signup_test.py
@@ -2,7 +2,9 @@
 # pylint: disable=no-self-use
 
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 
 from pyramid import httpexceptions

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -2,7 +2,9 @@
 # pylint: disable=no-self-use
 
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 import colander
 

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -2,9 +2,9 @@
 from __future__ import unicode_literals
 
 import datetime
+from unittest import mock
 
 import pytest
-import mock
 from pyramid import httpexceptions
 from webob.multidict import MultiDict
 

--- a/tests/h/views/admin/admins_test.py
+++ b/tests/h/views/admin/admins_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 from pyramid import httpexceptions
 

--- a/tests/h/views/admin/badge_test.py
+++ b/tests/h/views/admin/badge_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 from pyramid import httpexceptions
 

--- a/tests/h/views/admin/features_test.py
+++ b/tests/h/views/admin/features_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h import models

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from h.models import Organization
 from h.views.admin import groups

--- a/tests/h/views/admin/index_test.py
+++ b/tests/h/views/admin/index_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-
 from __future__ import unicode_literals
+
 from h.views.admin import index
 
 

--- a/tests/h/views/admin/oauthclients_test.py
+++ b/tests/h/views/admin/oauthclients_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-from mock import create_autospec, Mock
+from unittest.mock import create_autospec, Mock
+
 import pytest
 
 from h.models.auth_client import AuthClient, GrantType, ResponseType

--- a/tests/h/views/admin/organizations_test.py
+++ b/tests/h/views/admin/organizations_test.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
-from mock import Mock
+from unittest.mock import Mock
+
 import pytest
 
 from h.models import Organization

--- a/tests/h/views/admin/staff_test.py
+++ b/tests/h/views/admin/staff_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 from pyramid import httpexceptions
 

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -2,8 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
-from mock import MagicMock
+from unittest import mock
+
 from pyramid import httpexceptions
 import pytest
 
@@ -198,7 +198,7 @@ def test_users_delete_user_not_found_error(user_service, pyramid_request):
 
 def test_users_delete_deletes_user(user_service, delete_user_service, pyramid_request):
     pyramid_request.params = {"userid": "acct:bob@example.com"}
-    user = MagicMock()
+    user = mock.MagicMock()
 
     user_service.fetch.return_value = user
 

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 from webob.multidict import NestedMultiDict, MultiDict
 

--- a/tests/h/views/api/auth_test.py
+++ b/tests/h/views/api/auth_test.py
@@ -2,10 +2,11 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import datetime
 import json
 
-import mock
 import pytest
 
 from oauthlib.oauth2 import InvalidRequestFatalError

--- a/tests/h/views/api/config_test.py
+++ b/tests/h/views/api/config_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 
 from h.views.api import config as api_config

--- a/tests/h/views/api/decorators/client_errors_test.py
+++ b/tests/h/views/api/decorators/client_errors_test.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 
 from pyramid.response import Response

--- a/tests/h/views/api/decorators/response_test.py
+++ b/tests/h/views/api/decorators/response_test.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 
 from pyramid.response import Response

--- a/tests/h/views/api/errors_test.py
+++ b/tests/h/views/api/errors_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-from mock import Mock
+from unittest.mock import Mock
+
 from pyramid.httpexceptions import HTTPExpectationFailed, HTTPNotFound
 
 from h.views.api import errors as views

--- a/tests/h/views/api/flags_test.py
+++ b/tests/h/views/api/flags_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from pyramid.httpexceptions import HTTPNoContent

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from pyramid.httpexceptions import (

--- a/tests/h/views/api/helpers/cors_test.py
+++ b/tests/h/views/api/helpers/cors_test.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import mock
+
+from unittest import mock
+
 import pytest
 
 from pyramid.request import Request

--- a/tests/h/views/api/helpers/links_test.py
+++ b/tests/h/views/api/helpers/links_test.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from h.views.api.helpers import links
 from h.views.api.helpers.angular import AngularRouteTemplater

--- a/tests/h/views/api/index_test.py
+++ b/tests/h/views/api/index_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from pyramid.config import Configurator
 

--- a/tests/h/views/api/moderation_test.py
+++ b/tests/h/views/api/moderation_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from pyramid.httpexceptions import HTTPNoContent

--- a/tests/h/views/api/profile_test.py
+++ b/tests/h/views/api/profile_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from pyramid.httpexceptions import HTTPBadRequest

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 from pyramid.httpexceptions import HTTPConflict
 
 from h.views.api.exceptions import PayloadError

--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
+from unittest import mock
+
 import pytest
-import mock
 
 from pyramid import httpexceptions
 from webob.multidict import MultiDict

--- a/tests/h/views/errors_test.py
+++ b/tests/h/views/errors_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from mock import Mock
+from unittest.mock import Mock
 
 from h.views.errors import notfound, error, json_error
 

--- a/tests/h/views/feeds_test.py
+++ b/tests/h/views/feeds_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h.views.feeds import stream_atom, stream_rss

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+
+from unittest import mock
+
 import deform
-import mock
 import pytest
 from pyramid.httpexceptions import HTTPMovedPermanently
 

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 from pyramid import httpexceptions
 import pytest
 

--- a/tests/h/views/notification_test.py
+++ b/tests/h/views/notification_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 
 from h.models import Subscriptions

--- a/tests/h/views/organizations_test.py
+++ b/tests/h/views/organizations_test.py
@@ -2,9 +2,9 @@
 
 from __future__ import unicode_literals
 
-from h.views import organizations
+from unittest import mock
 
-import mock
+from h.views import organizations
 
 
 class TestOrganizationLogo(object):

--- a/tests/h/views/status_test.py
+++ b/tests/h/views/status_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
+
 import pytest
 from pyramid.httpexceptions import HTTPInternalServerError
 

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,6 @@ deps =
     tests: coverage
     {tests,functests,docstrings,checkdocstrings,analyze}: pytest
     {tests,functests,docstrings,checkdocstrings,analyze}: factory-boy
-    {tests,docstrings,checkdocstrings,analyze}: mock
     {tests,docstrings,checkdocstrings,analyze}: hypothesis
     lint: flake8
     lint: flake8-future-import


### PR DESCRIPTION
This PR removes the third-party `mock` dependency for `h` tests.

WIP because I'd like pointers in how to test this.

Fixes https://github.com/hypothesis/h/issues/5720