### PR TITLE
Remove h._compat (1/2)

### DIFF
--- a/h/_compat.py
+++ b/h/_compat.py
@@ -2,7 +2,9 @@
 """Helpers for the Python 2 to Python 3 transition."""
 from __future__ import unicode_literals
 
-import sys
+import configparser
+from io import StringIO
+from urllib import parse as urlparse
 
 __all__ = (
     "PY2",
@@ -17,85 +19,35 @@ __all__ = (
     "StringIO",
 )
 
-PY2 = sys.version_info[0] == 2
+PY2 = False  # We're only using Python 3 now.
 
-if not PY2:
-    text_type = str
-    string_types = (str,)
-    xrange = range
-    unichr = chr
-else:
-    text_type = unicode  # noqa
-    string_types = (str, unicode)  # noqa
-    xrange = xrange
-    unichr = unichr
+text_type = str
+string_types = (str,)
+xrange = range
+unichr = chr
 
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
-
-try:
-    from urllib import parse as urlparse
-
-    url_quote = urlparse.quote
-    url_quote_plus = urlparse.quote_plus
-    url_unquote = urlparse.unquote
-    url_unquote_plus = urlparse.unquote_plus
-except ImportError:
-    import urllib
-    import urlparse
-
-    url_quote = urllib.quote
-    url_quote_plus = urllib.quote_plus
-    url_unquote = urllib.unquote
-    url_unquote_plus = urllib.unquote_plus
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+url_quote = urlparse.quote
+url_quote_plus = urlparse.quote_plus
+url_unquote = urlparse.unquote
+url_unquote_plus = urlparse.unquote_plus
 
 
 # native() function adapted from Pyramid:
 # https://github.com/Pylons/pyramid/blob/a851d05f76edc6bc6bf65269c20eeba7fe726ade/pyramid/compat.py#L78-L95
-if PY2:
+def native(s, encoding="latin-1", errors="strict"):
+    """
+    Return the given string as a Python 3 native string (a unicode string).
 
-    def native(s, encoding="latin-1", errors="strict"):
-        """
-        Return the given string as a Python 2 native string (a byte string).
+    If the given string is a byte string then return it decoded to unicode
+    (using Latin 1 by default).
 
-        If the given string is a unicode string then return it as a byte
-        string (Latin 1 encoded by default).
+    If the given string is already a unicode string then just return it
+    unmodified.
 
-        If the given string is already a byte string (in any encoding) just
-        return it unmodified.
+    Latin 1 encoding is used by default because that's the encoding used
+    for "native" strings in PEP-3333 (the WSGI spec).
 
-        Latin 1 encoding is used by default because that's the encoding used
-        for "native" strings in PEP-3333 (the WSGI spec).
-
-        """
-        if isinstance(s, unicode):  # noqa
-            return s.encode(encoding, errors)
+    """
+    if isinstance(s, str):
         return s
-
-
-else:
-
-    def native(s, encoding="latin-1", errors="strict"):
-        """
-        Return the given string as a Python 3 native string (a unicode string).
-
-        If the given string is a byte string then return it decoded to unicode
-        (using Latin 1 by default).
-
-        If the given string is already a unicode string then just return it
-        unmodified.
-
-        Latin 1 encoding is used by default because that's the encoding used
-        for "native" strings in PEP-3333 (the WSGI spec).
-
-        """
-        if isinstance(s, str):
-            return s
-        return str(s, encoding, errors)
+    return str(s, encoding, errors)

--- a/h/_compat.py
+++ b/h/_compat.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 import configparser
-from io import StringIO
 from urllib import parse as urlparse
 
 __all__ = (
@@ -15,7 +14,6 @@ __all__ = (
     "url_quote_plus",
     "url_unquote",
     "url_unquote_plus",
-    "StringIO",
 )
 
 text_type = str

--- a/h/_compat.py
+++ b/h/_compat.py
@@ -7,7 +7,6 @@ from io import StringIO
 from urllib import parse as urlparse
 
 __all__ = (
-    "PY2",
     "text_type",
     "string_types",
     "configparser",
@@ -18,8 +17,6 @@ __all__ = (
     "url_unquote_plus",
     "StringIO",
 )
-
-PY2 = False  # We're only using Python 3 now.
 
 text_type = str
 string_types = (str,)

--- a/h/_compat.py
+++ b/h/_compat.py
@@ -2,13 +2,11 @@
 """Helpers for the Python 2 to Python 3 transition."""
 from __future__ import unicode_literals
 
-import configparser
 from urllib import parse as urlparse
 
 __all__ = (
     "text_type",
     "string_types",
-    "configparser",
     "urlparse",
     "url_quote",
     "url_quote_plus",

--- a/h/_compat.py
+++ b/h/_compat.py
@@ -2,25 +2,10 @@
 """Helpers for the Python 2 to Python 3 transition."""
 from __future__ import unicode_literals
 
-from urllib import parse as urlparse
-
-__all__ = (
-    "text_type",
-    "string_types",
-    "urlparse",
-    "url_quote",
-    "url_quote_plus",
-    "url_unquote",
-    "url_unquote_plus",
-)
+__all__ = ("text_type", "string_types")
 
 text_type = str
 string_types = (str,)
-
-url_quote = urlparse.quote
-url_quote_plus = urlparse.quote_plus
-url_unquote = urlparse.unquote
-url_unquote_plus = urlparse.unquote_plus
 
 
 # native() function adapted from Pyramid:

--- a/h/_compat.py
+++ b/h/_compat.py
@@ -16,7 +16,6 @@ __all__ = (
 
 text_type = str
 string_types = (str,)
-unichr = chr
 
 url_quote = urlparse.quote
 url_quote_plus = urlparse.quote_plus

--- a/h/_compat.py
+++ b/h/_compat.py
@@ -18,7 +18,6 @@ __all__ = (
 
 text_type = str
 string_types = (str,)
-xrange = range
 unichr = chr
 
 url_quote = urlparse.quote

--- a/h/accounts/util.py
+++ b/h/accounts/util.py
@@ -4,8 +4,7 @@ Helpers for account forms
 from __future__ import unicode_literals
 
 import re
-
-from h._compat import urlparse
+from urllib.parse import urlparse
 
 
 def validate_url(url):
@@ -21,10 +20,10 @@ def validate_url(url):
 
     # Minimal URL validation with urlparse. This is extremely lenient, we might
     # want to use something like https://github.com/kvesteri/validators instead.
-    parsed_url = urlparse.urlparse(url)
+    parsed_url = urlparse(url)
 
     if not parsed_url.scheme:
-        parsed_url = urlparse.urlparse("http://" + url)
+        parsed_url = urlparse("http://" + url)
 
     if not re.match("https?", parsed_url.scheme):
         raise ValueError('Links must have an "http" or "https" prefix')

--- a/h/activity/bucketing.py
+++ b/h/activity/bucketing.py
@@ -5,11 +5,11 @@ from __future__ import unicode_literals
 
 import collections
 import datetime
+from urllib.parse import urlparse
 
 import newrelic.agent
 from pyramid import i18n
 
-from h._compat import urlparse
 from h import links
 from h import presenters
 
@@ -29,7 +29,7 @@ class DocumentBucket:
         presented_document = presenters.DocumentHTMLPresenter(document)
 
         if presented_document.web_uri:
-            parsed = urlparse.urlparse(presented_document.web_uri)
+            parsed = urlparse(presented_document.web_uri)
             self.uri = parsed.geturl()
             self.domain = parsed.netloc
         else:

--- a/h/app.py
+++ b/h/app.py
@@ -4,8 +4,8 @@
 
 from __future__ import unicode_literals
 
-from h._compat import urlparse
 import logging
+from urllib.parse import urlparse
 
 import transaction
 from pyramid.settings import asbool
@@ -98,7 +98,7 @@ def includeme(config):
 
     # Define the global default Content Security Policy
     client_url = settings.get("h.client_url", DEFAULT_CLIENT_URL)
-    client_host = urlparse.urlparse(client_url).netloc
+    client_host = urlparse(client_url).netloc
     settings["csp"] = {
         "font-src": ["'self'", "fonts.gstatic.com", client_host],
         "script-src": ["'self'", client_host, "www.google-analytics.com"],

--- a/h/assets.py
+++ b/h/assets.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import configparser
 import os
 import sys
 
 import json
 from pyramid.settings import asbool, aslist
 from pyramid.static import static_view
-
-from h._compat import configparser
 
 
 class _CachedFile:

--- a/h/cli/commands/normalize_uris.py
+++ b/h/cli/commands/normalize_uris.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from h._compat import xrange
 from collections import namedtuple
 
 import click
@@ -154,7 +153,7 @@ def _fetch_windows(session, column, chunksize=100):
         Window(
             start=updated[min(x + chunksize, count) - 1].updated, end=updated[x].updated
         )
-        for x in xrange(0, count, chunksize)
+        for x in range(0, count, chunksize)
     ]
 
     return windows

--- a/h/feeds/util.py
+++ b/h/feeds/util.py
@@ -1,6 +1,7 @@
 """Utility functions for feed-generating code."""
 from __future__ import unicode_literals
-from h._compat import urlparse
+
+from urllib.parse import urlparse
 
 # See RFC4151 for details of the use and format of the tag date:
 #
@@ -18,7 +19,7 @@ def tag_uri_for_annotation(annotation, annotation_url):
     :rtype: string
 
     """
-    domain = urlparse.urlparse(annotation_url(annotation)).hostname
+    domain = urlparse(annotation_url(annotation)).hostname
     return "tag:{domain},{date}:{id_}".format(
         domain=domain, date=FEED_TAG_DATE, id_=annotation.id
     )

--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import datetime
 from functools import partial
 import json
+from urllib.parse import unquote
 
 try:
     from xml.etree import cElementTree as ElementTree
@@ -12,8 +13,6 @@ except ImportError:
 
 from jinja2 import Markup
 from jinja2.ext import Extension
-
-from h._compat import url_unquote
 
 SVG_NAMESPACE_URI = "http://www.w3.org/2000/svg"
 
@@ -30,7 +29,7 @@ class Filters(Extension):
         environment.filters["to_json"] = to_json
         environment.filters["human_timestamp"] = human_timestamp
         environment.filters["format_number"] = format_number
-        environment.filters["url_unquote"] = url_unquote
+        environment.filters["url_unquote"] = unquote
 
 
 def human_timestamp(timestamp, now=datetime.datetime.utcnow):

--- a/h/links.py
+++ b/h/links.py
@@ -5,8 +5,7 @@ Provides links to different representations of annotations.
 """
 from __future__ import unicode_literals
 
-
-from h._compat import urlparse, url_unquote
+from urllib.parse import urlparse, unquote, urljoin
 
 
 def pretty_link(url):
@@ -16,13 +15,13 @@ def pretty_link(url):
     This strips off 'visual noise' from the URL including common schemes
     (HTTP, HTTPS), domain prefixes ('www.') and query strings.
     """
-    parsed = urlparse.urlparse(url)
+    parsed = urlparse(url)
     if parsed.scheme not in ["http", "https"]:
         return url
     netloc = parsed.netloc
     if netloc.startswith("www."):
         netloc = netloc[4:]
-    return url_unquote(netloc + parsed.path)
+    return unquote(netloc + parsed.path)
 
 
 def html_link(request, annotation):
@@ -41,7 +40,7 @@ def incontext_link(request, annotation):
     if not bouncer_url:
         return None
 
-    link = urlparse.urljoin(bouncer_url, annotation.thread_root_id)
+    link = urljoin(bouncer_url, annotation.thread_root_id)
     uri = annotation.target_uri
     if uri.startswith(("http://", "https://")):
         # We can't use urljoin here, because if it detects the second argument

--- a/h/migrations/versions/58bb601c390f_fill_in_missing_denormalized_document_title.py
+++ b/h/migrations/versions/58bb601c390f_fill_in_missing_denormalized_document_title.py
@@ -93,7 +93,7 @@ def _fetch_windows(session, chunksize=100):
         Window(
             start=updated[min(x + chunksize, count) - 1].updated, end=updated[x].updated
         )
-        for x in xrange(0, count, chunksize)
+        for x in range(0, count, chunksize)
     ]
 
     return windows

--- a/h/migrations/versions/9f5e274b202c_update_all_document_web_uris.py
+++ b/h/migrations/versions/9f5e274b202c_update_all_document_web_uris.py
@@ -10,14 +10,13 @@ from __future__ import unicode_literals
 
 from collections import namedtuple
 import logging
+from urllib.parse import urlparse
 
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import subqueryload
-
-from h._compat import urlparse
 
 
 revision = "9f5e274b202c"
@@ -48,7 +47,7 @@ class Document(Base):
                 uri = document_uri.uri
                 if type_ is not None and document_uri.type != type_:
                     continue
-                if urlparse.urlparse(uri).scheme not in ["http", "https"]:
+                if urlparse(uri).scheme not in ["http", "https"]:
                     continue
                 return document_uri.uri
 

--- a/h/migrations/versions/9f5e274b202c_update_all_document_web_uris.py
+++ b/h/migrations/versions/9f5e274b202c_update_all_document_web_uris.py
@@ -115,7 +115,7 @@ def _fetch_windows(session, chunksize=100):
         Window(
             start=updated[min(x + chunksize, count) - 1].updated, end=updated[x].updated
         )
-        for x in xrange(0, count, chunksize)
+        for x in range(0, count, chunksize)
     ]
 
     return windows

--- a/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
+++ b/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
@@ -9,14 +9,13 @@ Create Date: 2016-09-12 15:31:00.597582
 from __future__ import unicode_literals
 
 from collections import namedtuple
+from urllib.parse import urlparse
 
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import subqueryload
-
-from h._compat import urlparse
 
 
 revision = "a44ef07b085a"
@@ -74,7 +73,7 @@ def downgrade():
 
 def _document_web_uri(document):
     for docuri in document.document_uris:
-        uri = urlparse.urlparse(docuri.uri)
+        uri = urlparse(docuri.uri)
         if uri.scheme in ["http", "https"]:
             return docuri.uri
 

--- a/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
+++ b/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
@@ -92,7 +92,7 @@ def _fetch_windows(session, chunksize=100):
         Window(
             start=updated[min(x + chunksize, count) - 1].updated, end=updated[x].updated
         )
-        for x in xrange(0, count, chunksize)
+        for x in range(0, count, chunksize)
     ]
 
     return windows

--- a/h/migrations/versions/bcdd81e23920_fill_in_missing_annotation_document_id.py
+++ b/h/migrations/versions/bcdd81e23920_fill_in_missing_annotation_document_id.py
@@ -144,7 +144,7 @@ def _fetch_windows(session, chunksize=200):
         Window(
             start=updated[min(x + chunksize, count) - 1].updated, end=updated[x].updated
         )
-        for x in xrange(0, count, chunksize)
+        for x in range(0, count, chunksize)
     ]
 
     return windows

--- a/h/migrations/versions/d536d9a342f3_fill_in_annotation_text_rendered_column.py
+++ b/h/migrations/versions/d536d9a342f3_fill_in_annotation_text_rendered_column.py
@@ -87,7 +87,7 @@ def _fetch_windows(session, chunksize=100):
         Window(
             start=updated[min(x + chunksize, count) - 1].updated, end=updated[x].updated
         )
-        for x in xrange(0, count, chunksize)
+        for x in range(0, count, chunksize)
     ]
 
     return windows

--- a/h/models/document.py
+++ b/h/models/document.py
@@ -4,13 +4,13 @@ from __future__ import unicode_literals
 
 from datetime import datetime
 import logging
+from urllib.parse import urlparse
 
 import sqlalchemy as sa
 import transaction
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.hybrid import hybrid_property
 
-from h._compat import urlparse
 from h.db import Base, mixins
 from h.models.annotation import Annotation
 from h.util.uri import normalize as uri_normalize
@@ -72,7 +72,7 @@ class Document(Base, mixins.Timestamps):
                 uri = document_uri.uri
                 if type_ is not None and document_uri.type != type_:
                     continue
-                if urlparse.urlparse(uri).scheme not in ["http", "https"]:
+                if urlparse(uri).scheme not in ["http", "https"]:
                     continue
                 return document_uri.uri
 

--- a/h/models/group_scope.py
+++ b/h/models/group_scope.py
@@ -2,10 +2,11 @@
 
 from __future__ import unicode_literals
 
+from urllib.parse import urljoin
+
 import sqlalchemy as sa
 from sqlalchemy.ext.hybrid import hybrid_property
 
-from h._compat import urlparse
 from h.db import Base
 from h.util.group_scope import parse_scope_from_url
 
@@ -59,7 +60,7 @@ class GroupScope(Base):
     @property
     def scope(self):
         """Return a URL composed from the origin and path attrs"""
-        return urlparse.urljoin(self._origin, self._path)
+        return urljoin(self._origin, self._path)
 
     @scope.setter
     def scope(self, value):

--- a/h/panels/back_link.py
+++ b/h/panels/back_link.py
@@ -4,9 +4,10 @@
 
 from __future__ import unicode_literals
 
+from urllib.parse import urlparse
+
 from pyramid_layout.panel import panel_config
 
-from h._compat import urlparse
 from h.i18n import TranslationString as _  # noqa
 
 
@@ -16,7 +17,7 @@ def back_link(context, request):
     A link which takes the user back to the previous page on the site.
     """
 
-    referrer_path = urlparse.urlparse(request.referrer or "").path
+    referrer_path = urlparse(request.referrer or "").path
     current_username = request.user.username
 
     if referrer_path == request.route_path(

--- a/h/presenters/document_html.py
+++ b/h/presenters/document_html.py
@@ -2,9 +2,11 @@
 
 from __future__ import unicode_literals
 
+from urllib.parse import urlparse, unquote
+
 import jinja2
 
-from h._compat import text_type, urlparse, url_unquote
+from h._compat import text_type
 
 
 class DocumentHTMLPresenter:
@@ -71,9 +73,9 @@ class DocumentHTMLPresenter:
 
         """
         if self.filename:
-            return jinja2.escape(url_unquote(self.filename))
+            return jinja2.escape(unquote(self.filename))
         else:
-            hostname = urlparse.urlparse(self.uri).hostname
+            hostname = urlparse(self.uri).hostname
 
             # urlparse()'s .hostname is sometimes None.
             hostname = hostname or ""
@@ -145,8 +147,8 @@ class DocumentHTMLPresenter:
         # the front and unquote it for link text.
         lower = title.lower()
         if lower.startswith("http://") or lower.startswith("https://"):
-            parts = urlparse.urlparse(title)
-            return url_unquote(parts.netloc + parts.path)
+            parts = urlparse(title)
+            return unquote(parts.netloc + parts.path)
 
         else:
             return title
@@ -173,9 +175,9 @@ class DocumentHTMLPresenter:
             return jinja2.escape(title)
 
         if self.filename:
-            return jinja2.escape(url_unquote(self.filename))
+            return jinja2.escape(unquote(self.filename))
         else:
-            return jinja2.escape(url_unquote(self.uri))
+            return jinja2.escape(unquote(self.uri))
 
     @property
     def uri(self):

--- a/h/search/util.py
+++ b/h/search/util.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 import re
-from h._compat import urlparse
+from urllib.parse import urlparse
 
 
 def wildcard_uri_is_valid(wildcard_uri):
@@ -23,7 +23,7 @@ def wildcard_uri_is_valid(wildcard_uri):
 
     # Note: according to the URL spec _'s are allowed in the domain so this may be
     # something that needs to be supported at a later date.
-    normalized_uri = urlparse.urlparse(wildcard_uri)
+    normalized_uri = urlparse(wildcard_uri)
     if (
         not normalized_uri.scheme
         or "*" in normalized_uri.netloc

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from h._compat import urlparse
+import urllib.parse
 
 
 def url_in_scope(url, scope_urls):
@@ -37,7 +37,7 @@ def _parse_path(url):
     """Return the path component of a URL string"""
     if url is None:
         return None
-    parsed = urlparse.urlsplit(url)
+    parsed = urllib.parse.urlsplit(url)
     return parsed.path
 
 
@@ -55,7 +55,7 @@ def parse_origin(url):
 
     if url is None:
         return None
-    parsed = urlparse.urlsplit(url)
+    parsed = urllib.parse.urlsplit(url)
     # netloc contains both host and port
-    origin = urlparse.SplitResult(parsed.scheme, parsed.netloc, "", "", "")
+    origin = urllib.parse.SplitResult(parsed.scheme, parsed.netloc, "", "", "")
     return origin.geturl() or None

--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -63,8 +63,15 @@ elsewhere in the Hypothesis application. URI expansion is handled by
 :py:func:`h.storage.expand_uri`.
 """
 import re
-
-from h._compat import url_quote, url_quote_plus, url_unquote, url_unquote_plus, urlparse
+from urllib.parse import (
+    SplitResult,
+    parse_qsl,
+    quote,
+    quote_plus,
+    unquote,
+    unquote_plus,
+    urlsplit,
+)
 
 URL_SCHEMES = set(["http", "https"])
 
@@ -143,7 +150,7 @@ def normalize(uristr):
             break
 
     # Try to extract the scheme
-    uri = urlparse.urlsplit(uristr)
+    uri = urlsplit(uristr)
 
     # If this isn't a URL, we don't perform any normalization
     if uri.scheme.lower() not in URL_SCHEMES:
@@ -159,7 +166,7 @@ def normalize(uristr):
     query = _normalize_query(uri)
     fragment = None
 
-    uri = urlparse.SplitResult(scheme, netloc, path, query, fragment)
+    uri = SplitResult(scheme, netloc, path, query, fragment)
 
     return uri.geturl()
 
@@ -170,8 +177,8 @@ def origin(url):
 
     ``url`` is assumed to be an HTTP(S) URL.
     """
-    url_parts = urlparse.urlsplit(url)
-    return urlparse.SplitResult(url_parts.scheme, url_parts.netloc, "", "", "").geturl()
+    url_parts = urlsplit(url)
+    return SplitResult(url_parts.scheme, url_parts.netloc, "", "", "").geturl()
 
 
 def _normalize_scheme(uri):
@@ -237,14 +244,14 @@ def _normalize_path(uri):
 
 
 def _normalize_pathsegment(segment):
-    return url_quote(url_unquote(segment), safe=UNRESERVED_PATHSEGMENT)
+    return quote(unquote(segment), safe=UNRESERVED_PATHSEGMENT)
 
 
 def _normalize_query(uri):
     query = uri.query
 
     try:
-        items = urlparse.parse_qsl(query, keep_blank_values=True, strict_parsing=True)
+        items = parse_qsl(query, keep_blank_values=True, strict_parsing=True)
     except ValueError:
         # If we can't parse the query string, we better preserve it as it was.
         return query
@@ -271,11 +278,11 @@ def _normalize_queryitems(items):
 
 
 def _normalize_queryname(name):
-    return url_quote_plus(url_unquote_plus(name), safe=UNRESERVED_QUERY_NAME)
+    return quote_plus(unquote_plus(name), safe=UNRESERVED_QUERY_NAME)
 
 
 def _normalize_queryvalue(value):
-    return url_quote_plus(url_unquote_plus(value), safe=UNRESERVED_QUERY_VALUE)
+    return quote_plus(unquote_plus(value), safe=UNRESERVED_QUERY_VALUE)
 
 
 def _blacklisted_query_param(s):

--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -64,14 +64,7 @@ elsewhere in the Hypothesis application. URI expansion is handled by
 """
 import re
 
-from h._compat import (
-    PY2,
-    url_quote,
-    url_quote_plus,
-    url_unquote,
-    url_unquote_plus,
-    urlparse,
-)
+from h._compat import url_quote, url_quote_plus, url_unquote, url_unquote_plus, urlparse
 
 URL_SCHEMES = set(["http", "https"])
 
@@ -143,21 +136,6 @@ def normalize(uristr):
     :rtype: unicode
     """
 
-    # In Python 2 functions in urllib expect a byte string whereas in Python 3
-    # some functions in urllib work with a byte string or unicode but
-    # others (eg. `unquote`) require unicode.
-    #
-    # Hence we work with byte strings internally in Py 2 and unicode internally
-    # in Python 3. In both we always return unicode.
-    if PY2:
-        uristr = uristr.encode("utf-8")
-
-    def decode_result(result):
-        if PY2:
-            return result.decode("utf-8")
-        else:
-            return result
-
     # Strip proxy prefix for proxied URLs
     for scheme in URL_SCHEMES:
         if uristr.startswith(VIA_PREFIX + scheme + ":"):
@@ -169,11 +147,11 @@ def normalize(uristr):
 
     # If this isn't a URL, we don't perform any normalization
     if uri.scheme.lower() not in URL_SCHEMES:
-        return decode_result(uristr)
+        return uristr
 
     # Don't perform normalization on URLs with no hostname.
     if uri.hostname is None:
-        return decode_result(uristr)
+        return uristr
 
     scheme = _normalize_scheme(uri)
     netloc = _normalize_netloc(uri)
@@ -183,7 +161,7 @@ def normalize(uristr):
 
     uri = urlparse.SplitResult(scheme, netloc, path, query, fragment)
 
-    return decode_result(uri.geturl())
+    return uri.geturl()
 
 
 def origin(url):

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 import datetime
 import itertools
+from urllib.parse import urlparse
 
 import colander
 import deform
@@ -30,7 +31,6 @@ from h.accounts.events import LoginEvent
 from h.emails import reset_password
 from h.tasks import mailer
 from h.util.view import json_view
-from h._compat import urlparse
 
 _ = i18n.TranslationString
 
@@ -56,7 +56,7 @@ def bad_csrf_token_html(context, request):
     request.response.status_code = 403
 
     next_path = "/"
-    referer = urlparse.urlparse(request.referer or "")
+    referer = urlparse(request.referer or "")
     if referer.hostname == request.domain:
         next_path = referer.path
 

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -4,7 +4,7 @@
 
 from __future__ import unicode_literals
 
-from h._compat import urlparse
+from urllib.parse import urlparse
 
 from jinja2 import Markup
 from pyramid import httpexceptions
@@ -370,7 +370,7 @@ class UserSearchController(SearchController):
         def domain(user):
             if not user.uri:
                 return None
-            return urlparse.urlparse(user.uri).netloc
+            return urlparse(user.uri).netloc
 
         annotation_count = self._get_total_user_annotations(result, self.request)
         result["stats"] = {"annotation_count": annotation_count}

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import json
 import logging
+from urllib.parse import parse_qs, urlparse
 
 from oauthlib.oauth2 import OAuth2Error
 from pyramid import security
@@ -11,7 +12,6 @@ from pyramid.httpexceptions import HTTPFound, exception_response
 from pyramid.view import view_config, view_defaults
 
 from h import models
-from h._compat import urlparse
 from h.views.api.exceptions import OAuthAuthorizeError, OAuthTokenError
 from h.services.oauth_validator import DEFAULT_SCOPES
 from h.util.datetime import utc_iso8601
@@ -166,8 +166,8 @@ class OAuthAuthorizeController:
             )
 
     def _render_web_message_response(self, redirect_uri):
-        location = urlparse.urlparse(redirect_uri)
-        params = urlparse.parse_qs(location.query)
+        location = urlparse(redirect_uri)
+        params = parse_qs(location.query)
         origin = "{url.scheme}://{url.netloc}".format(url=location)
 
         state = None

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -2,10 +2,8 @@
 
 from __future__ import unicode_literals
 
-from h._compat import xrange
-
-from unittest.mock import Mock
 import datetime
+from unittest.mock import Mock
 
 import pytest
 
@@ -85,7 +83,7 @@ class TestDocumentBucket:
     def test_annotations_count_returns_count_of_annotations(self, db_session, document):
         bucket = bucketing.DocumentBucket(document)
 
-        for _ in xrange(7):
+        for _ in range(7):
             annotation = factories.Annotation()
             bucket.append(annotation)
 
@@ -95,7 +93,7 @@ class TestDocumentBucket:
         bucket = bucketing.DocumentBucket(document)
 
         annotations = []
-        for _ in xrange(7):
+        for _ in range(7):
             annotation = factories.Annotation()
             annotations.append(annotation)
             bucket.append(annotation)
@@ -126,7 +124,7 @@ class TestDocumentBucket:
         bucket_1 = bucketing.DocumentBucket(document)
         bucket_2 = bucketing.DocumentBucket(document)
 
-        for _ in xrange(5):
+        for _ in range(5):
             annotation = factories.Annotation()
             bucket_1.append(annotation)
             bucket_2.append(annotation)

--- a/tests/h/assets_test.py
+++ b/tests/h/assets_test.py
@@ -2,12 +2,12 @@
 
 from __future__ import unicode_literals
 
+from io import StringIO
 from sys import version_info
 from unittest.mock import patch
 
 import pytest
 
-from h._compat import StringIO
 from h.assets import Environment
 
 if version_info.major == 2:

--- a/tests/h/models/user_identity_test.py
+++ b/tests/h/models/user_identity_test.py
@@ -5,7 +5,6 @@ import pytest
 import sqlalchemy.exc
 
 from h import models
-from h._compat import PY2
 
 
 class TestUserIdentity:
@@ -176,11 +175,6 @@ class TestUserIdentity:
         )
 
         expected_repr = "UserIdentity(provider='provider_1', provider_unique_id='1')"
-
-        if PY2:
-            expected_repr = (
-                "UserIdentity(provider=u'provider_1', " "provider_unique_id=u'1')"
-            )
 
         assert repr(user_identity) == expected_repr
 

--- a/tests/h/schemas/base_test.py
+++ b/tests/h/schemas/base_test.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals
 
-from h._compat import PY2
-
 import enum
 from unittest.mock import Mock
 
@@ -25,18 +23,11 @@ class ExampleCSRFSchema(CSRFSchema):
 
 
 class ExampleJSONSchema(JSONSchema):
-    # Use `bytes` for property names in Py 2 so that exception messages about
-    # missing properties have the same content in Py 2 + Py 3.
-    prop_name_type = bytes if PY2 else str
-
     schema = {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",
-        "properties": {
-            prop_name_type("foo"): {"type": "string"},
-            prop_name_type("bar"): {"type": "integer"},
-        },
-        "required": [prop_name_type("foo"), prop_name_type("bar")],
+        "properties": {"foo": {"type": "string"}, "bar": {"type": "integer"}},
+        "required": ["foo", "bar"],
     }
 
 

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-from h._compat import url_quote_plus
+from urllib.parse import quote_plus
 
 import itertools
 import re
@@ -67,7 +67,7 @@ def test_uri_part_tokenizer():
         "stuff",
     ]
 
-    text = url_quote_plus(text)
+    text = quote_plus(text)
     assert re.split(pattern, "http://jump.to/?u=" + text) == [
         "http",
         "",

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals
 
-from h._compat import xrange
-
 from unittest import mock
 
 import pytest
@@ -60,7 +58,7 @@ class TestRenameUserService:
         assert db_session.query(models.User).get(user.id).username == "panda"
 
     def test_rename_deletes_auth_tickets(self, service, user, db_session, factories):
-        ids = [factories.AuthTicket(user=user).id for _ in xrange(3)]
+        ids = [factories.AuthTicket(user=user).id for _ in range(3)]
 
         service.rename(user, "panda")
 

--- a/tests/h/views/api/auth_test.py
+++ b/tests/h/views/api/auth_test.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import datetime
 import json
+import urllib.parse
 
 import pytest
 
@@ -13,7 +14,6 @@ from oauthlib.oauth2 import InvalidRequestFatalError
 from oauthlib.common import Request as OAuthRequest
 from pyramid import httpexceptions
 
-from h._compat import urlparse
 from h.views.api.exceptions import OAuthTokenError
 from h.models.auth_client import ResponseType
 from h.services.auth_token import auth_token_service_factory
@@ -57,9 +57,9 @@ class TestOAuthAuthorizeController:
             view = getattr(controller, view_name)
             view()
 
-        parsed_url = urlparse.urlparse(exc.value.location)
+        parsed_url = urllib.parse.urlparse(exc.value.location)
         assert parsed_url.path == "/login"
-        assert urlparse.parse_qs(parsed_url.query) == {
+        assert urllib.parse.parse_qs(parsed_url.query) == {
             "next": [pyramid_request.url],
             "for_oauth": ["True"],
         }


### PR DESCRIPTION
This is part of https://github.com/hypothesis/h/issues/5714.

This PR is the first chunk of work to replace `h._compat` with direct imports. The changes in this PR are:

1. Remove all the Python 2 branches in `h._compat`
2. Remove `h._compat.PY2` and checks for it
3. Replace all imports of `h._compat` functions with direct imports, except for `text_type`, `string_types` and `native`. Those will come in a follow-up PR.

See individual commit messages for details.