### PR TITLE
Remove `h._compat.{configparser, stringio}` imports

### DIFF
--- a/h/_compat.py
+++ b/h/_compat.py
@@ -14,7 +14,6 @@ __all__ = (
     "url_quote_plus",
     "url_unquote",
     "url_unquote_plus",
-    "StringIO",
 )
 
 PY2 = sys.version_info[0] == 2
@@ -50,11 +49,6 @@ except ImportError:
     url_quote_plus = urllib.quote_plus
     url_unquote = urllib.unquote
     url_unquote_plus = urllib.unquote_plus
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 
 # native() function adapted from Pyramid:

--- a/h/_compat.py
+++ b/h/_compat.py
@@ -8,7 +8,6 @@ __all__ = (
     "PY2",
     "text_type",
     "string_types",
-    "configparser",
     "urlparse",
     "url_quote",
     "url_quote_plus",
@@ -28,11 +27,6 @@ else:
     string_types = (str, unicode)  # noqa
     xrange = xrange
     unichr = unichr
-
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
 
 try:
     from urllib import parse as urlparse

--- a/h/assets.py
+++ b/h/assets.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
+import configparser
 import os
 import sys
 
 import json
 from pyramid.settings import asbool, aslist
 from pyramid.static import static_view
-
-from h._compat import configparser
 
 
 class _CachedFile:

--- a/tests/h/assets_test.py
+++ b/tests/h/assets_test.py
@@ -2,12 +2,12 @@
 
 from __future__ import unicode_literals
 
+from io import StringIO
 from sys import version_info
 from unittest.mock import patch
 
 import pytest
 
-from h._compat import StringIO
 from h.assets import Environment
 
 if version_info.major == 2:


### PR DESCRIPTION
These can now be replaced with direct imports from the standard library.