### PR TITLE
Remove several Python 2-specific code blocks

### DIFF
--- a/h/_compat.py
+++ b/h/_compat.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import sys
 
 __all__ = (
-    "PY2",
     "text_type",
     "string_types",
     "configparser",

--- a/h/assets.py
+++ b/h/assets.py
@@ -131,14 +131,7 @@ def _add_cors_header(wrapped):
 def _load_bundles(fp):
     """Read an asset bundle config from a file object."""
     parser = configparser.ConfigParser()
-
-    # readfp() changed to read_file() in Python 3.2.
-    # FIXME: Remove this once we no longer support Python 2.
-    if sys.version_info.major == 3 and sys.version_info.minor >= 2:
-        parser.read_file(fp)
-    else:
-        parser.readfp(fp)
-
+    parser.read_file(fp)
     return {k: aslist(v) for k, v in parser.items("bundles")}
 
 

--- a/h/assets.py
+++ b/h/assets.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import os
-import sys
 
 import json
 from pyramid.settings import asbool, aslist

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -295,13 +295,7 @@ class AuthClientPolicy:
     @staticmethod
     def _forwarded_userid(request):
         """Return forwarded userid or None"""
-        userid = request.headers.get("X-Forwarded-User", None)
-        if userid is not None:
-            # In Python 2 request header values are byte strings, so we need to
-            # decode them to get unicode.
-            # FIXME: Remove this once we've moved to Python 3.
-            userid = pyramid.compat.text_(userid)
-        return userid
+        return request.headers.get("X-Forwarded-User", None)
 
 
 @interface.implementer(interfaces.IAuthenticationPolicy)

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-import pyramid.compat
 from pyramid import interfaces
 from pyramid.authentication import BasicAuthAuthenticationPolicy
 from pyramid.authentication import CallbackAuthenticationPolicy

--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -65,7 +65,6 @@ elsewhere in the Hypothesis application. URI expansion is handled by
 import re
 
 from h._compat import (
-    PY2,
     url_quote,
     url_quote_plus,
     url_unquote,
@@ -143,21 +142,6 @@ def normalize(uristr):
     :rtype: unicode
     """
 
-    # In Python 2 functions in urllib expect a byte string whereas in Python 3
-    # some functions in urllib work with a byte string or unicode but
-    # others (eg. `unquote`) require unicode.
-    #
-    # Hence we work with byte strings internally in Py 2 and unicode internally
-    # in Python 3. In both we always return unicode.
-    if PY2:
-        uristr = uristr.encode("utf-8")
-
-    def decode_result(result):
-        if PY2:
-            return result.decode("utf-8")
-        else:
-            return result
-
     # Strip proxy prefix for proxied URLs
     for scheme in URL_SCHEMES:
         if uristr.startswith(VIA_PREFIX + scheme + ":"):
@@ -169,11 +153,11 @@ def normalize(uristr):
 
     # If this isn't a URL, we don't perform any normalization
     if uri.scheme.lower() not in URL_SCHEMES:
-        return decode_result(uristr)
+        return uristr
 
     # Don't perform normalization on URLs with no hostname.
     if uri.hostname is None:
-        return decode_result(uristr)
+        return uristr
 
     scheme = _normalize_scheme(uri)
     netloc = _normalize_netloc(uri)
@@ -183,7 +167,7 @@ def normalize(uristr):
 
     uri = urlparse.SplitResult(scheme, netloc, path, query, fragment)
 
-    return decode_result(uri.geturl())
+    return uri.geturl()
 
 
 def origin(url):

--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -64,13 +64,7 @@ elsewhere in the Hypothesis application. URI expansion is handled by
 """
 import re
 
-from h._compat import (
-    url_quote,
-    url_quote_plus,
-    url_unquote,
-    url_unquote_plus,
-    urlparse,
-)
+from h._compat import url_quote, url_quote_plus, url_unquote, url_unquote_plus, urlparse
 
 URL_SCHEMES = set(["http", "https"])
 

--- a/tests/h/models/user_identity_test.py
+++ b/tests/h/models/user_identity_test.py
@@ -5,7 +5,6 @@ import pytest
 import sqlalchemy.exc
 
 from h import models
-from h._compat import PY2
 
 
 class TestUserIdentity:
@@ -176,11 +175,6 @@ class TestUserIdentity:
         )
 
         expected_repr = "UserIdentity(provider='provider_1', provider_unique_id='1')"
-
-        if PY2:
-            expected_repr = (
-                "UserIdentity(provider=u'provider_1', " "provider_unique_id=u'1')"
-            )
 
         assert repr(user_identity) == expected_repr
 

--- a/tests/h/paginator_test.py
+++ b/tests/h/paginator_test.py
@@ -243,17 +243,6 @@ class TestPaginateQuery:
         """Return a mock view callable for paginate_query() to wrap."""
         view_callable = mock.Mock(return_value=query, spec_set=["__call__", "__name__"])
         view_callable.__name__ = "mock_view_callable"
-
-        # functools.wraps(wrapped) expects wrapped.__name__ to be a unicode
-        # string in Python 3, but to be a byte string in Python 2, otherwise
-        # it raises TypeError: __name__ must be set to a string object.
-        #
-        # str is the unicode type in Python 3 but is the byte string type in
-        # Python 2, so it does what we need either way.
-        #
-        # TODO: Remove this once we no longer need to support Python 2.
-        view_callable.__name__ = str(view_callable.__name__)
-
         return view_callable
 
     @pytest.fixture

--- a/tests/h/schemas/annotation_test.py
+++ b/tests/h/schemas/annotation_test.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from unittest import mock
 
 import pytest
-import re
 from webob.multidict import NestedMultiDict, MultiDict
 
 from h.search.query import LIMIT_DEFAULT, LIMIT_MAX, OFFSET_MAX

--- a/tests/h/schemas/annotation_test.py
+++ b/tests/h/schemas/annotation_test.py
@@ -183,10 +183,7 @@ class TestCreateUpdateAnnotationSchema:
         with pytest.raises(ValidationError) as exc:
             validate(pyramid_request, input_data)
 
-        # Strip "u" literal prefixes that get added in front of property names in
-        # certain error messages in Python 2.
         actual_msg = str(exc.value)
-        actual_msg = re.sub(r"u'([^']+)'", "'\\1'", actual_msg)
         assert actual_msg == error_message
 
     @pytest.mark.parametrize(

--- a/tests/h/schemas/base_test.py
+++ b/tests/h/schemas/base_test.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals
 
-from h._compat import PY2
-
 import enum
 from unittest.mock import Mock
 
@@ -25,18 +23,14 @@ class ExampleCSRFSchema(CSRFSchema):
 
 
 class ExampleJSONSchema(JSONSchema):
-    # Use `bytes` for property names in Py 2 so that exception messages about
-    # missing properties have the same content in Py 2 + Py 3.
-    prop_name_type = bytes if PY2 else str
-
     schema = {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",
         "properties": {
-            prop_name_type("foo"): {"type": "string"},
-            prop_name_type("bar"): {"type": "integer"},
+            "foo": {"type": "string"},
+            "bar": {"type": "integer"},
         },
-        "required": [prop_name_type("foo"), prop_name_type("bar")],
+        "required": ["foo", "bar"],
     }
 
 

--- a/tests/h/schemas/base_test.py
+++ b/tests/h/schemas/base_test.py
@@ -26,10 +26,7 @@ class ExampleJSONSchema(JSONSchema):
     schema = {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",
-        "properties": {
-            "foo": {"type": "string"},
-            "bar": {"type": "integer"},
-        },
+        "properties": {"foo": {"type": "string"}, "bar": {"type": "integer"}},
         "required": ["foo", "bar"],
     }
 


### PR DESCRIPTION
Remove several code blocks that had comments saying they should be
removed when Python 2 is no longer supported, as well as code blocks
guarded by `if PY2` checks.