### PR TITLE
Upgrade to pyramid_tm 2 and pyramid_retry

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -47,9 +47,8 @@ def includeme(config):
     # important that responsibility for caching user lookups is left to the
     # UserService and not duplicated here.
     #
-    # This prevents retried requests (those that raise
-    # `transaction.interfaces.TransientError`) gaining access to a stale
-    # `User` instance.
+    # This prevents requests that are retried by pyramid_retry gaining access
+    # to a stale `User` instance.
     config.add_request_method(get_user, name="user", property=True)
 
     config.include(".schemas")

--- a/h/app.py
+++ b/h/app.py
@@ -82,15 +82,13 @@ def includeme(config):
     # retrieving services bound to the request.
     config.include("pyramid_services")
 
-    # Configure the transaction manager to support retrying retryable
-    # exceptions, and generate a new transaction manager for each request.
     config.add_settings(
         {
-            "tm.attempts": 3,
             "tm.manager_hook": lambda request: transaction.TransactionManager(),
             "tm.annotate_user": False,
         }
     )
+    config.include("pyramid_retry")
     config.include("pyramid_tm")
 
     # Define the global default Content Security Policy

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -110,6 +110,20 @@ def _session(request):
         if changes:
             msg = "closing a session with uncommitted changes %s"
             log.warning(msg, changes, extra={"stack": True, "changes": changes})
+
+        elif len(session.transaction._connections) > 1:
+            # There are no uncommitted changes but there do appear to be
+            # unclosed database connections.
+            log.warning(
+                "closing an unclosed DB session (no uncommitted changes)",
+                extra={"stack": True},
+            )
+
+        # Close any unclosed DB connections.
+        # This is done outside of either of the `if` statements above just in
+        # case: it's okay to call `session.close()` even if the session does
+        # not need to be closed, so just call it unconditionally so that
+        # there's no chance of leaking any unclosed DB connections.
         session.close()
 
     return session

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -106,24 +106,23 @@ def _session(request):
     # See: https://github.com/Pylons/pyramid_tm/issues/40
     @request.add_finished_callback
     def close_the_sqlalchemy_session(request):
-        changes = tracker.uncommitted_changes() if tracker else []
-        if changes:
-            msg = "closing a session with uncommitted changes %s"
-            log.warning(msg, changes, extra={"stack": True, "changes": changes})
-
-        elif len(session.transaction._connections) > 1:
-            # There are no uncommitted changes but there do appear to be
-            # unclosed database connections.
-            log.warning(
-                "closing an unclosed DB session (no uncommitted changes)",
-                extra={"stack": True},
-            )
-
+        if len(session.transaction._connections) > 1:
+            # There appear to still be open DB connections belonging to this
+            # request. This shouldn't happen.
+            changes = tracker.uncommitted_changes() if tracker else []
+            if changes:
+                msg = "closing a session with uncommitted changes %s"
+                log.warning(msg, changes, extra={"stack": True, "changes": changes})
+            else:
+                log.warning(
+                    "closing an unclosed DB session (no uncommitted changes)",
+                    extra={"stack": True},
+                )
         # Close any unclosed DB connections.
-        # This is done outside of either of the `if` statements above just in
-        # case: it's okay to call `session.close()` even if the session does
-        # not need to be closed, so just call it unconditionally so that
-        # there's no chance of leaking any unclosed DB connections.
+        # This is done outside of the `if` statement above just in case: it's
+        # okay to call `session.close()` even if the session does not need to
+        # be closed, so just call it unconditionally so that there's no chance
+        # of leaking any unclosed DB connections.
         session.close()
 
     return session

--- a/h/migrations/script.py.mako
+++ b/h/migrations/script.py.mako
@@ -1,9 +1,5 @@
 <%text># -*- coding: utf-8 -*-</%text>
 """${message}"""
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-
 from alembic import op
 ${imports if imports else ""}
 

--- a/h/models/document.py
+++ b/h/models/document.py
@@ -4,8 +4,8 @@ from datetime import datetime
 import logging
 from urllib.parse import urlparse
 
+from pyramid_retry import mark_error_retryable
 import sqlalchemy as sa
-import transaction
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.hybrid import hybrid_property
 
@@ -16,8 +16,11 @@ from h.util.uri import normalize as uri_normalize
 log = logging.getLogger(__name__)
 
 
-class ConcurrentUpdateError(transaction.interfaces.TransientError):
+class ConcurrentUpdateError(Exception):
     """Raised when concurrent updates to document data conflict."""
+
+
+mark_error_retryable(ConcurrentUpdateError)
 
 
 class Document(Base, mixins.Timestamps):

--- a/h/sentry/__init__.py
+++ b/h/sentry/__init__.py
@@ -31,3 +31,5 @@ def includeme(config):
         send_default_pii=True,
         before_send=_before_send,
     )
+
+    config.scan("h.sentry.subscribers")

--- a/h/sentry/helpers/before_send.py
+++ b/h/sentry/helpers/before_send.py
@@ -29,6 +29,7 @@ def before_send(event_dict, hint_dict):
     filter_functions = [
         filters.filter_ws4py_error_logging,
         filters.filter_ws4py_handshake_error,
+        filters.filter_retryable_error,
     ]
 
     # If every filter returns True then do report the event to Sentry.

--- a/h/sentry/helpers/filters.py
+++ b/h/sentry/helpers/filters.py
@@ -7,6 +7,10 @@ returns ``True`` if the event should be reported to Sentry or ``False`` to
 filter it out. Every filter function gets called for every event and if any one
 filter returns ``False`` for a given event then the event is not reported.
 """
+from __future__ import unicode_literals
+
+from pyramid.threadlocal import get_current_request
+from pyramid_retry import is_error_retryable
 import ws4py.exc
 
 
@@ -26,4 +30,41 @@ def filter_ws4py_handshake_error(event):
     if isinstance(event.exception, ws4py.exc.HandshakeError):
         if str(event.exception) == "Header HTTP_UPGRADE is not defined":
             return False
+    return True
+
+
+def filter_retryable_error(event):
+    """
+    Filter exceptions from requests that are going to be retried.
+
+    If a request raises a retryable error, so pyramid_retry automatically
+    retries that request, and a subsequent retry succeeds and we end up sending
+    a successful response back to the client, then we don't want to report
+    anything to Sentry.
+
+    See:
+
+    https://docs.pylonsproject.org/projects/pyramid-retry/en/latest/api.html#pyramid_retry.is_error_retryable
+    """
+    request = get_current_request()
+
+    if request is None:
+        # get_current_request() returns None if we're outside of Pyramid's
+        # request context. This happens when sentry-sdk's Pyramid integration
+        # catches an exception that Pyramid is going to raise to the WSGI
+        # server (Gunicorn, in our case).
+        # Always allow these uncaught exceptions to be reported to Sentry:
+        return True
+
+    if is_error_retryable(request, event.exception):
+        # Don't report the exception to Sentry if the request is going to be
+        # re-tried.
+        #
+        # Note: is_error_retryable() returns *False* if the error is marked as
+        # retryable but the request is on its last attempt and is not going to
+        # be re-tried again, so if a request fails with a retryable exception
+        # on its last attempt (and we send back an error response to the
+        # client) that exception will still be reported.
+        return False
+
     return True

--- a/h/sentry/helpers/filters.py
+++ b/h/sentry/helpers/filters.py
@@ -7,8 +7,6 @@ returns ``True`` if the event should be reported to Sentry or ``False`` to
 filter it out. Every filter function gets called for every event and if any one
 filter returns ``False`` for a given event then the event is not reported.
 """
-from __future__ import unicode_literals
-
 from pyramid.threadlocal import get_current_request
 from pyramid_retry import is_error_retryable
 import ws4py.exc

--- a/h/sentry/subscribers.py
+++ b/h/sentry/subscribers.py
@@ -40,9 +40,9 @@ def add_retryable_error_to_sentry_context(event):
     """
     attempt = event.environ.get("retry.attempt")
     attempts = event.environ.get("retry.attempts")
-    exception = event.request.exception
+    exception = event.exception
 
-    if attempt is None or attempts is None or exception is None:
+    if attempt is None or attempts is None:
         return
 
     # The first attempt is numbered 0. Let's make it more human.

--- a/h/sentry/subscribers.py
+++ b/h/sentry/subscribers.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import traceback
 
 from pyramid.events import subscriber

--- a/h/sentry/subscribers.py
+++ b/h/sentry/subscribers.py
@@ -1,0 +1,70 @@
+from __future__ import unicode_literals
+
+import traceback
+
+from pyramid.events import subscriber
+from pyramid_retry import IBeforeRetry
+import sentry_sdk
+
+
+@subscriber(IBeforeRetry)
+def add_retryable_error_to_sentry_context(event):
+    """
+    Add information about a retryable error to the Sentry context.
+
+    If a request raises a retryable error then, if we're not already on this
+    request's last retry attempt, pyramid_retry calls this IBeforeRetry
+    subscriber function before it retries the request.
+
+    This function adds some information to the Sentry context about the
+    retryable error that was raised by the failed attempt at the request.
+
+    If a future retry of this request raises a non-retryable error, or if we
+    use up the maximum number of retry attempts, so that we ultimately end up
+    sending an error response back to the client, then the information that
+    this function adds to the Sentry context will be included in the event that
+    is ultimately reported to Sentry.
+
+    This makes debugging errors easier because you can see information about
+    previous failed attempts at the request, as well as the usual information
+    about the last exception that was raised by the final attempt.
+
+    If a future retry of this request succeeds and we ultimately end up sending
+    a successful response back to the client then nothing will be reported to
+    Sentry.
+
+    See:
+
+    * https://docs.pylonsproject.org/projects/pyramid-retry/en/latest/#receiving-retry-notifications
+    * https://docs.sentry.io/platforms/python/#extra-context
+    """
+    attempt = event.environ.get("retry.attempt")
+    attempts = event.environ.get("retry.attempts")
+    exception = event.request.exception
+
+    if attempt is None or attempts is None or exception is None:
+        return
+
+    # The first attempt is numbered 0. Let's make it more human.
+    attempt = attempt + 1
+
+    traceback_str = "".join(
+        traceback.format_exception(type(exception), exception, exception.__traceback__)
+    )
+
+    # Sentry event variables are limited to 512 characters long, otherwise they
+    # get truncated: https://docs.sentry.io/development/sdk-dev/data-handling/
+    # We don't want the end of our stack trace to get truncated because the end
+    # of a stack trace is the most useful part of it, so truncate the start
+    # ourselves instead.
+    if len(traceback_str) > 512:
+        traceback_str = "..." + traceback_str[-509:]
+
+    with sentry_sdk.configure_scope() as scope:
+        scope.set_extra(
+            f"Exception from attempt {attempt}/{attempts}",
+            repr(exception) or str(exception),
+        )
+        scope.set_extra(
+            f"End of traceback from attempt {attempt}/{attempts}", traceback_str
+        )

--- a/requirements.in
+++ b/requirements.in
@@ -34,6 +34,7 @@ pyramid_layout
 pyramid-jinja2
 pyramid-services
 pyramid_mailer
+pyramid_retry
 pyramid_tm
 python-dateutil
 python-slugify < 1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ pyramid-layout==1.0
 pyramid-mailer==0.15.1
 pyramid-retry==2.0
 pyramid-services==0.4
-pyramid-tm==2.2.1
+pyramid-tm==2.3
 pyramid==1.10.4
 python-dateutil==2.5.3
 python-editor==1.0.1      # via alembic
@@ -80,4 +80,4 @@ zope.interface==4.3.2
 zope.sqlalchemy==1.1
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via plaster, pyramid, repoze.sendmail, zope.deprecation, zope.interface, zope.sqlalchemy
+# setuptools==41.4.0        # via plaster, pyramid, repoze.sendmail, zope.deprecation, zope.interface, zope.sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,8 +51,9 @@ pyramid-authsanity==1.0.0
 pyramid-jinja2==2.6.2
 pyramid-layout==1.0
 pyramid-mailer==0.15.1
+pyramid-retry==2.0
 pyramid-services==0.4
-pyramid-tm==1.1.1
+pyramid-tm==2.2.1
 pyramid==1.10.4
 python-dateutil==2.5.3
 python-editor==1.0.1      # via alembic

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ pyramid-authsanity==1.0.0
 pyramid-jinja2==2.6.2
 pyramid-layout==1.0
 pyramid-mailer==0.15.1
-pyramid-retry==2.0
+pyramid-retry==2.1
 pyramid-services==0.4
 pyramid-tm==2.3
 pyramid==1.10.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,15 +7,7 @@ ignore = \
     E121,E123,E126,E226,E24,E704,W503 \
 
     # "whitespace before ':'" conflicts with the Black code formatter.
-    E203 \
-
-    # flake8-future-import's "__future__ import “*” missing' rules. We run a
-    # separate flake8 command to run these rules because we want them to ignore
-    # certain files, so disable them for our general flake8 command.
-    #
-    # This also disables flake8-future-import's '__future__ import “*” present'
-    # rules. These will become useful once we've moved to Python 3.
-    FI
+    E203
 
 [isort]
 include_trailing_comma = True

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -17,6 +17,7 @@ TEST_SETTINGS = {
     "es.index": ELASTICSEARCH_INDEX,
     "h.app_url": "http://example.com",
     "h.authority": "example.com",
+    "h.sentry_dsn_frontend": "TEST_SENTRY_DSN_FRONTEND",
     "pyramid.debug_all": False,
     "secret_key": "notasecret",
     "sqlalchemy.url": os.environ.get(

--- a/tests/h/models/document_test.py
+++ b/tests/h/models/document_test.py
@@ -5,10 +5,10 @@ from unittest import mock
 
 import pytest
 import sqlalchemy as sa
-import transaction
 
 from h import models
 from h.models import document
+from h.models.document import ConcurrentUpdateError
 
 
 class TestDocumentFindByURIs:
@@ -130,7 +130,7 @@ class TestDocumentFindOrCreateByURIs:
 
         monkeypatch.setattr(db_session, "flush", err)
 
-        with pytest.raises(transaction.interfaces.TransientError):
+        with pytest.raises(ConcurrentUpdateError):
             with db_session.no_autoflush:  # prevent premature IntegrityError
                 document.Document.find_or_create_by_uris(
                     db_session,
@@ -458,7 +458,7 @@ class TestCreateOrUpdateDocumentURI:
 
         monkeypatch.setattr(db_session, "flush", err)
 
-        with pytest.raises(transaction.interfaces.TransientError):
+        with pytest.raises(ConcurrentUpdateError):
             with db_session.no_autoflush:  # prevent premature IntegrityError
                 document.create_or_update_document_uri(
                     session=db_session,
@@ -655,7 +655,7 @@ class TestCreateOrUpdateDocumentMeta:
 
         monkeypatch.setattr(db_session, "flush", err)
 
-        with pytest.raises(transaction.interfaces.TransientError):
+        with pytest.raises(ConcurrentUpdateError):
             with db_session.no_autoflush:  # prevent premature IntegrityError
                 document.create_or_update_document_meta(
                     session=db_session,
@@ -744,7 +744,7 @@ class TestMergeDocuments:
 
         monkeypatch.setattr(db_session, "flush", err)
 
-        with pytest.raises(transaction.interfaces.TransientError):
+        with pytest.raises(ConcurrentUpdateError):
             document.merge_documents(db_session, merge_data)
 
     @pytest.fixture

--- a/tests/h/sentry/helpers/filters_test.py
+++ b/tests/h/sentry/helpers/filters_test.py
@@ -50,10 +50,13 @@ class TestFilterRetryableError:
 
         is_error_retryable.assert_called_once_with(pyramid_request, event.exception)
 
-    def test_it_doesnt_filter_uncaught_errors(self, event, get_current_request):
+    def test_it_doesnt_filter_uncaught_errors(
+        self, event, get_current_request, is_error_retryable
+    ):
         get_current_request.return_value = None
 
         assert filters.filter_retryable_error(event) is True
+        is_error_retryable.assert_not_called()
 
     def test_it_filters_retryable_errors(self, event, is_error_retryable):
         is_error_retryable.return_value = True

--- a/tests/h/sentry/helpers/filters_test.py
+++ b/tests/h/sentry/helpers/filters_test.py
@@ -39,6 +39,46 @@ class TestFilterWS4PYHandshakeError:
         assert filters.filter_ws4py_handshake_error(unexpected_exception_event) is True
 
 
+class TestFilterRetryableError:
+    def test_it_doesnt_filter_non_retryable_errors(self, event):
+        assert filters.filter_retryable_error(event) is True
+
+    def test_it_checks_whether_the_error_is_retryable(
+        self, event, is_error_retryable, pyramid_request
+    ):
+        filters.filter_retryable_error(event)
+
+        is_error_retryable.assert_called_once_with(pyramid_request, event.exception)
+
+    def test_it_doesnt_filter_uncaught_errors(self, event, get_current_request):
+        get_current_request.return_value = None
+
+        assert filters.filter_retryable_error(event) is True
+
+    def test_it_filters_retryable_errors(self, event, is_error_retryable):
+        is_error_retryable.return_value = True
+
+        assert filters.filter_retryable_error(event) is False
+
+    @pytest.fixture
+    def event(self):
+        event = mock.create_autospec(Event, instance=True, spec_set=True)
+        event.exception = RuntimeError("Something went wrong")
+        return event
+
+    @pytest.fixture(autouse=True)
+    def get_current_request(self, patch, pyramid_request):
+        get_current_request = patch("h.sentry.helpers.filters.get_current_request")
+        get_current_request.return_value = pyramid_request
+        return get_current_request
+
+    @pytest.fixture(autouse=True)
+    def is_error_retryable(self, patch):
+        is_error_retryable = patch("h.sentry.helpers.filters.is_error_retryable")
+        is_error_retryable.return_value = False
+        return is_error_retryable
+
+
 @pytest.fixture
 def unexpected_logger_event():
     """Return an unexpected logger event that no filter should stop."""

--- a/tests/h/sentry/subscribers_test.py
+++ b/tests/h/sentry/subscribers_test.py
@@ -1,0 +1,94 @@
+from __future__ import unicode_literals
+
+from unittest import mock
+
+from pyramid_retry import BeforeRetry
+import pytest
+
+from h.sentry.subscribers import add_retryable_error_to_sentry_context
+
+
+class TestAddRetryableErrorToSentryContext:
+    def test_it_adds_the_retryable_error_to_the_sentry_context(
+        self, event, matchers, scope
+    ):
+        add_retryable_error_to_sentry_context(event)
+
+        assert scope.set_extra.call_args_list == [
+            mock.call(
+                "Exception from attempt 1/3", "RuntimeError('Something went wrong',)"
+            ),
+            mock.call(
+                "End of traceback from attempt 1/3",
+                matchers.Regex(
+                    r"^Traceback \(most recent call last\):\n"
+                    r'  File "/.*/tests/h/sentry/subscribers_test\.py", line \d\d, in exception\n'
+                    r'    raise RuntimeError\("Something went wrong"\)\n'
+                    r"RuntimeError: Something went wrong\n$"
+                ),
+            ),
+        ]
+
+    def test_it_truncates_long_tracebacks(self, event, scope, traceback):
+        traceback.format_exception.return_value = ["a" * 300 + "\n", "b" * 300 + "\n"]
+
+        add_retryable_error_to_sentry_context(event)
+
+        traceback_str = scope.set_extra.call_args[0][1]
+        assert traceback_str.startswith("...aaa")
+        assert traceback_str.endswith("bbb\n")
+        assert len(traceback_str) == 512
+
+    def test_it_doesnt_crash_if_theres_no_retry_environ(self, event):
+        # I don't think this ever happens (as long as you have pyramid_retry
+        # installed) but lets be defensive and make sure it doesn't crash if
+        # retry.attempt or retry.attempts is missing from the environ.
+        del event.environ["retry.attempt"]
+        del event.environ["retry.attempts"]
+
+        add_retryable_error_to_sentry_context(event)
+
+    def test_it_doesnt_crash_if_theres_no_exception(self, event):
+        # I don't think this ever happens in our app because we have an
+        # exception view for Exception, but if an app raises a retryable
+        # exception that isn't handled by an exception view then pyramid_retry
+        # calls IBeforeRetry subscribers with request.exception = None.
+        # Let's be defensive and make sure it doesn't crash if that happens.
+        event.request.exception = None
+
+        add_retryable_error_to_sentry_context(event)
+
+    @pytest.fixture
+    def event(self, pyramid_request):
+        return BeforeRetry(pyramid_request)
+
+    @pytest.fixture(autouse=True)
+    def exception(self, pyramid_request):
+        # Add an exception to request.exception as would happen with a real
+        # pyramid_retry retry. Do this with a try/except in order to create an
+        # exception object with an actual traceback.
+        try:
+            raise RuntimeError("Something went wrong")
+        except RuntimeError as err:
+            pyramid_request.exception = err
+
+        return pyramid_request.exception
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        # Add information about retry attempts to request.environ as pyramid_retry does.
+        pyramid_request.environ["retry.attempt"] = 0
+        pyramid_request.environ["retry.attempts"] = 3
+        return pyramid_request
+
+    @pytest.fixture
+    def scope(self, sentry_sdk):
+        return sentry_sdk.configure_scope.return_value.__enter__.return_value
+
+    @pytest.fixture(autouse=True)
+    def sentry_sdk(self, patch):
+        return patch("h.sentry.subscribers.sentry_sdk")
+
+    @pytest.fixture
+    def traceback(self, patch):
+        return patch("h.sentry.subscribers.traceback")

--- a/tests/h/sentry/subscribers_test.py
+++ b/tests/h/sentry/subscribers_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from unittest import mock
 
 from pyramid_retry import BeforeRetry

--- a/tests/setup.cfg
+++ b/tests/setup.cfg
@@ -23,12 +23,4 @@ ignore = \
     E122, E127, E128 \
 
     # "whitespace before ':'" conflicts with the Black code formatter.
-    E203 \
-
-    # flake8-future-import's "__future__ import “*” missing' rules. We run a
-    # separate flake8 command to run these rules because we want them to ignore
-    # certain files, so disable them for our general flake8 command.
-    #
-    # This also disables flake8-future-import's '__future__ import “*” present'
-    # rules. These will become useful once we've moved to Python 3.
-    FI
+    E203

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,6 @@ deps =
     {tests,functests,docstrings,checkdocstrings,analyze}: factory-boy
     {tests,docstrings,checkdocstrings,analyze}: hypothesis
     lint: flake8
-    lint: flake8-future-import
     {format,checkformatting}: black
     coverage: coverage
     codecov: codecov


### PR DESCRIPTION
This pull request upgrades h from pyramid_tm 1.1.1 to 2.2.1, which actually supports the version of Python (3.6) that we're running in production.

This PR also adds pyramid_retry so that we can continue to have request retrying support, because pyramid_tm 1's request retrying support was extracted out into a separate pyramid_retry extension for pyramid_tm 2.

It then fixes a bunch of things to do with closing DB connections, retrying requests, and Sentry crash reporting, that were broken by the upgrade.

**See Also**: [an earlier version of this PR](https://github.com/hypothesis/h/pull/5702) that has a lot of testing notes and details in the PR comments.

Below is a more detailed description of what's changed in pyramid_tm/pyramid_retry and what I had to change in h. I've broken this description into two separate parts, covering the two different issues that come up:

1. Transaction closing and error views
2. Request retrying and crash reporting

## Part 1: Transaction closing and error views

h uses the pyramid_tm extension which creates a transaction for each request (the transaction is lazily created the first time code processing the request tries to access the transaction or anything that needs the transaction). Near the end of the request processing cycle pyramid_tm either commits the transaction if the request was successful or aborts the transaction if the request was unsuccessful (if an exception was raised and an exception view was called).

The main thing that's attached to this pyramid_tm transaction is the sqlalchemy database session: a new DB session and connection is opened when the transaction is opened and either committed or aborted when the transaction is.

The opening and closing of this transaction/DB session/DB connection has changed in subtle ways from pyramid_tm 1 to 2, particularly when exception views are involved.

### How pyramid_tm transactions used to work with pyramid_tm 1

See the [pyramid_tm 1.1 docs](https://docs.pylonsproject.org/projects/pyramid_tm/en/1.x-branch/), but here are the highlights:

* If anything that ran later in Pyramid's request processing pipeline than when pyramid_tm had closed the transaction accessed the DB then this would implicitly open a new transaction and DB session. Since pyramid_tm had already finished for this request, pyramid_tm would not close this implicitly opened transaction. This could lead to leaking unclosed DB connections.

  Accessing the DB can be as simple as reading `request.authenticated_userid`, which can indirectly do a DB query, or reading or writing an ORM object field, or any number of other innocent-looking things.

  This would happen if the DB was accessed by an exception view, exception view template, an authentication policy (that is called during exception view processing), a service called by an exception view or auth policy, most tweens, BeforeRender subscribers, anything called by any of these things, and more.

  This happens all the time in h and some of the ways that it happens are obscure, non-obvious, intermittent, path dependent.

  What was saving our butt here was [our custom finished callback](https://github.com/hypothesis/h/blob/f0f9cb528597c5d97fb8b7cdbecd90d96b42c67f/h/db/__init__.py#L96-L114) that forcibly closes unclosed DB sessions.
  
  The ways that this has all changed with pyramid_tm 2 are subtle, see below.

* Anything that gets _written_ to the DB after pyramid_tm has already closed the transaction (e.g. if something writes to the DB during exception view processing) won't be saved. Our finished callback closes the DB session without committing it. This remains true with pyramid_tm 2: it's nonsensical to write to the DB during error view processing, because the transaction isn't going to be committed. It is harmless to write to the DB like this though, as long as you don't mind what you're writing getting lost.

### How pyramid_tm transactions work on this branch, with pyramid_tm 2

* pyramid_tm now closes the transaction *after* exception views have finished processing. The decision that the transaction is going to be aborted has already been made before exception view processing begins (so there's no point in writing to the DB during exception view processing, for example, because it won't be committed). But the actual abort now happens after exception view processing finishes. This means that if something access the DB during exception view processing that no longer implicitly opens a new transaction and DB session: it uses the request's original transaction, which is now still open during exception view processing, and which will get closed by pyramid_tm later in the request processing pipeline.

* There is still code that runs later in the request processing pipeline than when pyramid_tm closes the transaction: most tweens, response callbacks, `NewResponse` listeners, finished callbacks...

  If this code accesses the DB that will still implicitly open a new transaction that pyramid_tm won't close. When this happens our custom finished callback will still step in and close any unclosed DB sessions.
  
  AFAIK this doesn't happen in h currently and you'd have to be working in obscure callbacks and tweens to introduce this behaviour. But such behaviour could accidentally get introduced in future. If it does the finished callback will continue to prevent us from leaking DB connections.

* pyramid_tm 2 has a few new transaction-related features that we're **not** using:

  * We're not using [pyramid_tm 2's `tm_active=True` view predicate](https://docs.pylonsproject.org/projects/pyramid_tm/en/latest/#error-handling).

    This view predicate exists because Pyramid 1.9+'s default execution policy will call your error views outside of the pyramid_tm transaction if something outside of the pyramid_tm transaction (a tween etc) raises an exception. So your error views might get called at a time when the pyramid_tm transaction has already been closed. Adding `tm_active=True` is a way of saying to Pyramid: don't call this error view outside of the pyramid_tm transaction. But this doesn't apply to us because pyramid_retry replaces the default execution policy with a custom one that doesn't call exception views outside of the pyramid_tm transaction.

  * We're not using the `explicit=True` argument to `transaction.TransactionManager()`.

    This is an option that prevents new transactions from being implicitly created if something tries to access the DB after pyramid_tm has already closed the transaction. By default `TransactionManager` implicitly creates a new transaction for you if you do this, which causes `zope.sqlalchemy` to open a new DB connection, which doesn't get closed, and you leak DB connections. Setting `explicit=True` causes accessing the DB outside of the transaction to crash, rather than implicitly creating a new transaction.

    The pyramid_tm docs recommend that you do use `explicit=True`. But adding it breaks a lot of things in h that implicitly rely on implicit transaction creation: Celery workers, search reindexing, user renaming, command line scripts, and more. Fixing all these would take time, and risks introducing difficult bugs. Also, we already have a finished callback in place that protects us from leaking DB connections.

### What I've changed in this PR

1. [Our finished callback now logs a warning whenever it closes an unclosed DB session](https://github.com/hypothesis/h/pull/5702/commits/e8dfd7a671e439bc4663d2d850a09f98e4f711de), regardless of whether it thinks the session contains any uncommitted changes.

   Previously it was normal, and happened all the time, that this finished callback closed unclosed DB sessions: any exception view that accessed the DB would open a new DB session that the callback would close. Now that pyramid_tm closes the transaction after exception view processing, the callback should no longer have any sessions to close.

    So log a warning whenever the callback does have to close a session, and set up a Papertrail alert for this warning.
   
    Note that you cannot send a crash report or log an error to Sentry in this finished callback! sentry_sdk will open a new DB session and leak the DB connection.

2. I've also [fixed our callback to only warn about "uncommitted changes" if there are also unclosed DB connections](https://github.com/hypothesis/h/pull/5702/commits/f93330a54a6680d5f125d907a1755771b6aed6a4).

   It's perfectly normal for ORM object changes to be made during a request and then not get committed or rolled back. This happens when pyramid_tm aborts the transaction. The database session gets closed without either committing or rolling back the changes. So don't log a warning when this happens.
   
   _Do_ log a warning if there are unclosed DB connections though. And if there are also uncommitted changes, then add that detail to the warning.

## Part 2: Request retrying and crash reporting

Whenever a request raises a "retryable" error, instead of sending an error response back to the client, Pyramid will instead retry the entire request processing pipeline with the same request again, and will either send the client an error response, a successful response, or retry again, depending on the outcome of this retry of the request. Each request can be retried up to twice (making three attempts total including the original try) and then the error response from the last attempt will be sent back to the client even if it continues to raise retryable errors.

With pyramid_tm 1 this retrying was implemented in pyramid_tm itself. With pyramid_tm 2 the retrying functionality has been moved into a separate extension, pyramid_retry, which overrides Pyramid's default "execution policy" with one that does retrying.

### How request retrying used to work with pyramid_tm 1

See the [pyramid_tm 1.1 docs](https://docs.pylonsproject.org/projects/pyramid_tm/en/1.x-branch/#retrying), but here are the highlights:

* Retrying was off by default and you had to set the `tm.attempts` setting to turn it on, which we had done in h (this setting is no longer necessary with pyramid_retry)
* Certain exception classes were marked as retryable by default, including `ZODB.POSException.ConflictError`, `psycopg2.extensions.TransactionRollbackError` and others, and any `transaction.interfaces.TransientError` subclass. These all remain retryable with pyramid_retry
* If you wanted to mark a custom error class as retryable you had to subclass `transaction.interfaces.TransientError`, which [we did for our `ConcurrentUpdateError`](https://github.com/hypothesis/h/blob/f41b7bfb7153006fd094bb0be4bdd2e6d5b28f95/h/models/document.py#L21-L22). <del>**This does not work** with pyramid_retry: if you subclass `TransientError` then your requests _will_ be retried but pyramid_retry things like `is_error_retryable()` will return `False` rather than `True`, and this can for example cause duplicate reporting of a crash to Sentry.</del> <ins>This will now work if we upgrade to the just-released [pyramid_tm 2.3](https://github.com/Pylons/pyramid_tm/blob/master/CHANGES.rst#23-2019-09-30).</ins> There are now other ways of marking exceptions as retryable with pyramid_retry (see below) and these must be used instead
* I suspect there's a bad interaction between pyramid_tm 1 request retrying and sentry_sdk crash reporting on master, causing false reporting and duplicate reporting of `ConcurrentUpdateError`'s. Since this PR changes how all this works anyway I haven't looked into exactly what's happening on master or verified that there is in fact a reporting problem

### What I've changed in this PR

1. Added `config.include("pyramid_rety")` to enable request retrying, and removed the no-longer-needed `tm.attempts` setting

2. Fixed `ConcurrentUpdateError` to [use `mark_error_retryable()` instead of inheriting from `TransientError`](https://github.com/hypothesis/h/pull/5702/commits/f58357be26cd8cce08101222914b6af8874d21e9)

3. Added a filter to [prevent exceptions that will be retried from being reported to Sentry](https://github.com/hypothesis/h/pull/5702/commits/8e6a26d24e7ecd9d5ceeb7cb90638559f4c24433)

4. When a request that has previous failed attempts also fails on its final attempt, and this final attempt gets reported to Sentry, added a subscriber that [adds the previous exceptions as additional context](https://github.com/hypothesis/h/pull/5702/commits/b966071b6005020ecf18386f0d519e1f3340382d) in the final Sentry event

### How pyramid_retry works

See [pyramid_retry's docs](https://docs.pylonsproject.org/projects/pyramid-retry/en/latest/) but here are the key points:

* pyramid_retry wraps the entire request processing pipeline. For example if a request raises a retryable error and is going to be retried, any appropriate exception views will still be called, and an error response will still be generated, even though that response is never going to be sent back to the client. If a request is attempted N times and fails N times, the exception views will also have been called N times even though only the error response from the final attempt will have been sent back. This can cause problems with sentry_sdk, see below.

* The maximum number of attempt defaults to 3 (the first attempt then 2 retries) and doesn't need to be set manually if you're happy with 3. This number can also be customised per-request, but we have no need for that yet.

* Exceptions aren't retryable by default (e.g. if you just raise `RuntimeError`, or `MyCustomError`, it won't be retried).

* Pyramid's built-in [HTTP exceptions](https://docs.pylonsproject.org/projects/pyramid/en/latest/api/httpexceptions.html) aren't retryable by default either (e.g. `raise HTTPInternalServerError()`).

* [pyramid_tm automatically marks certain "transient" errors as retryable, including `ZODB.POSException.ConflictError`, `psycopg2.extensions.TransactionRollbackError`, any `transaction.interfaces.TransientError` subclass, and others).](https://docs.pylonsproject.org/projects/pyramid-tm/en/latest/#retries).

* You can use pyramid_retry's `mark_error_retryable()` to make any error retryable, and if the request raises this error then pyramid_retry will retry the request (if the request isn't already on its final attempt). Example:

  ```python
  from pyramid_retry import mark_error_retryable
  from pyramid.view import view_config

  @view_config(...)
  def raise_an_unhandled_retryable_error(request):
      error = RuntimeError()
      mark_error_retryable(error)
      raise error
  ```

* You can also mark an entire exception class as retryable, e.g. `mark_error_retryable(MyCustomRetryableErrorClass)`. Then any request that raises an instance of that class will be retried.

  This is how you usually want to mark things as retryable, rather than marking one-off exception instances as above.

  If you do this you want to make sure that your `mark_error_retryable()` call is in some code that runs at application startup and not, for example, in a view. If you put this code in a view then the class won't be retryable until a request hits that view, at which point all instances of the class will become retryable for that _and future_ requests that hit other views, until the app restarts!

* Another option is to use the built-in `RetryableException` class, e.g. `raise RetryableException() from some_other_exception`. But that isn't going to make very nice crash reports so don't. Subclassing `RetryableException` *might* also work but isn't documented---again, don't.

* There are view predicates so that you can register separate views to be called only for the request's final attempt, and separate exception views for retryable errors. We don't have any use for these in h yet

* There are also `is_error_retryable()` and `is_last_attempt()` query functions that your code can call. We do make use of these on this branch

* **You have to be careful with request retrying and Sentry crash reporting**.

  There are a couple of problems:
  
  1. In certain edge cases (that I won't detail here) a request that gets attempted N times and fails N times can end up sending N separate events to Sentry, with no indication that those events belong to the same request.
  
     This isn't what usually happens with sentry_sdk and pyramid_retry when a request gets retried. But it does happen under certain specific circumstances.
     
     Fortunately you can prevent this with a sentry_sdk filter that [filters out exceptions that are going to be retried](https://github.com/hypothesis/h/pull/5702/commits/c345de0856db2820e1631ff14d50e65f56882b6b).

  2. If a request is attempted N times and fails N times, and then an error response is sent back to the client (because the final failure was not a retryable error, or because the request had run out of retry attempts) then a single Sentry event will be reported to Sentry for the exception raised by the final attempt at the request. This is good but it makes debugging difficult because you can't see whether this request had previous failed attempts or what the exceptions from those attempts were.
  
     Fortunately you can improve this with a pyramid_retry `IBeforeRetry` subscriber that [adds the request's previous exceptions to the Sentry event's additional context](https://github.com/hypothesis/h/pull/5702/commits/be5d02478b3b85ea751af421f0e242787adebf7f).