### PR TITLE
Remove Python 2-compatibility code in functional tests

### DIFF
--- a/tests/functional/api/groups/test_create.py
+++ b/tests/functional/api/groups/test_create.py
@@ -8,8 +8,6 @@ import base64
 
 from h.models.auth_client import GrantType
 
-native_str = str
-
 
 class TestCreateGroup:
     def test_it_returns_http_200_with_valid_payload(self, app, token_auth_header):
@@ -69,7 +67,7 @@ class TestCreateGroup:
         self, app, auth_client_header, third_party_user
     ):
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
         group = {"name": "My Group"}
 
         res = app.post_json("/api/groups", group, headers=headers)
@@ -80,7 +78,7 @@ class TestCreateGroup:
         self, app, auth_client_header, third_party_user
     ):
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
         group = {"name": "My Group", "groupid": "group:333vcdfkj~@thirdparty.com"}
 
         res = app.post_json("/api/groups", group, headers=headers)
@@ -96,7 +94,7 @@ class TestCreateGroup:
         self, app, auth_client_header, third_party_user
     ):
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
         group = {"name": "My Group", "groupid": "group:333vcdfkj~@thirdparty.com"}
 
         res = app.post_json("/api/groups", group, headers=headers)
@@ -109,7 +107,7 @@ class TestCreateGroup:
     ):
         # FIXME: This should return a 403
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str("floopflarp")
+        headers["X-Forwarded-User"] = "floopflarp"
         group = {}
 
         res = app.post_json("/api/groups", group, headers=headers, expect_errors=True)
@@ -139,11 +137,7 @@ def auth_client_header(auth_client):
         client_id=auth_client.id, secret=auth_client.secret
     )
     encoded = base64.standard_b64encode(user_pass.encode("utf-8"))
-    return {
-        native_str("Authorization"): native_str(
-            "Basic {creds}".format(creds=encoded.decode("ascii"))
-        )
-    }
+    return {"Authorization": "Basic {creds}".format(creds=encoded.decode("ascii"))}
 
 
 @pytest.fixture
@@ -158,4 +152,4 @@ def user_with_token(db_session, factories):
 @pytest.fixture
 def token_auth_header(user_with_token):
     user, token = user_with_token
-    return {native_str("Authorization"): native_str("Bearer {}".format(token.value))}
+    return {"Authorization": "Bearer {}".format(token.value)}

--- a/tests/functional/api/groups/test_members.py
+++ b/tests/functional/api/groups/test_members.py
@@ -8,8 +8,6 @@ import base64
 
 from h.models.auth_client import GrantType
 
-native_str = str
-
 
 class TestReadMembers:
     def test_it_returns_list_of_members_for_restricted_group_without_authn(
@@ -97,7 +95,7 @@ class TestAddMember:
         user2 = factories.User(authority="thirdparty.com")
         db_session.commit()
 
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
 
         res = app.post_json(
             "/api/groups/{pubid}/members/{userid}".format(
@@ -199,9 +197,7 @@ class TestRemoveMember:
     ):
 
         group_member, token = group_member_with_token
-        headers = {
-            native_str("Authorization"): native_str("Bearer {}".format(token.value))
-        }
+        headers = {"Authorization": "Bearer {}".format(token.value)}
 
         app.delete("/api/groups/{}/members/me".format(group.pubid), headers=headers)
 
@@ -240,11 +236,7 @@ def auth_client_header(auth_client):
         client_id=auth_client.id, secret=auth_client.secret
     )
     encoded = base64.standard_b64encode(user_pass.encode("utf-8"))
-    return {
-        native_str("Authorization"): native_str(
-            "Basic {creds}".format(creds=encoded.decode("ascii"))
-        )
-    }
+    return {"Authorization": "Basic {creds}".format(creds=encoded.decode("ascii"))}
 
 
 @pytest.fixture
@@ -289,4 +281,4 @@ def user_with_token(db_session, factories):
 @pytest.fixture
 def token_auth_header(user_with_token):
     user, token = user_with_token
-    return {native_str("Authorization"): native_str("Bearer {}".format(token.value))}
+    return {"Authorization": "Bearer {}".format(token.value)}

--- a/tests/functional/api/groups/test_read.py
+++ b/tests/functional/api/groups/test_read.py
@@ -8,8 +8,6 @@ import base64
 
 from h.models.auth_client import GrantType
 
-native_str = str
-
 
 class TestReadGroups:
     # TODO: In subsequent versions of the API, this should really be a group
@@ -176,11 +174,7 @@ def auth_client_header(auth_client):
         client_id=auth_client.id, secret=auth_client.secret
     )
     encoded = base64.standard_b64encode(user_pass.encode("utf-8"))
-    return {
-        native_str("Authorization"): native_str(
-            "Basic {creds}".format(creds=encoded.decode("ascii"))
-        )
-    }
+    return {"Authorization": "Basic {creds}".format(creds=encoded.decode("ascii"))}
 
 
 @pytest.fixture
@@ -195,4 +189,4 @@ def user_with_token(db_session, factories):
 @pytest.fixture
 def token_auth_header(user_with_token):
     user, token = user_with_token
-    return {native_str("Authorization"): native_str("Bearer {}".format(token.value))}
+    return {"Authorization": "Bearer {}".format(token.value)}

--- a/tests/functional/api/groups/test_update.py
+++ b/tests/functional/api/groups/test_update.py
@@ -7,8 +7,6 @@ import base64
 
 from h.models.auth_client import GrantType
 
-native_str = str
-
 
 class TestUpdateGroup:
     def test_it_returns_http_200_with_valid_payload_and_user_token(
@@ -123,7 +121,7 @@ class TestUpdateGroup:
         db_session.commit()
 
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
         group_payload = {"name": "My Group"}
 
         path = "/api/groups/{id}".format(id=group.pubid)
@@ -172,7 +170,7 @@ class TestUpdateGroup:
         db_session.commit()
 
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
         group_payload = {
             "name": "My Group",
             "groupid": "group:333vcdfkj~@thirdparty.com",
@@ -203,7 +201,7 @@ class TestUpdateGroup:
         db_session.commit()
 
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
         group_payload = {"groupid": "group:one@thirdparty.com"}
 
         # Attempting to set group2's `groupid` to one already taken by group1
@@ -244,7 +242,7 @@ def user_with_token(db_session, factories, first_party_user):
 @pytest.fixture
 def token_auth_header(user_with_token):
     user, token = user_with_token
-    return {native_str("Authorization"): native_str("Bearer {}".format(token.value))}
+    return {"Authorization": "Bearer {}".format(token.value)}
 
 
 @pytest.fixture
@@ -269,8 +267,4 @@ def auth_client_header(auth_client):
         client_id=auth_client.id, secret=auth_client.secret
     )
     encoded = base64.standard_b64encode(user_pass.encode("utf-8"))
-    return {
-        native_str("Authorization"): native_str(
-            "Basic {creds}".format(creds=encoded.decode("ascii"))
-        )
-    }
+    return {"Authorization": "Basic {creds}".format(creds=encoded.decode("ascii"))}

--- a/tests/functional/api/groups/test_upsert.py
+++ b/tests/functional/api/groups/test_upsert.py
@@ -7,8 +7,6 @@ import base64
 
 from h.models.auth_client import GrantType
 
-native_str = str
-
 
 class TestUpsertGroupUpdate:
     def test_it_returns_http_404_if_no_authenticated_user(self, app, first_party_group):
@@ -105,7 +103,7 @@ class TestUpsertGroupUpdate:
         db_session.commit()
 
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
         group_payload = {"name": "My Group"}
 
         path = "/api/groups/{id}".format(id=group.pubid)
@@ -122,7 +120,7 @@ class TestUpsertGroupUpdate:
         db_session.commit()
 
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
         group_payload = {"name": "My Group"}
 
         path = "/api/groups/{id}".format(id=group.pubid)
@@ -139,7 +137,7 @@ class TestUpsertGroupUpdate:
         db_session.commit()
 
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
         group_payload = {
             "name": "My Group",
             "groupid": "group:333vcdfkj~@thirdparty.com",
@@ -167,7 +165,7 @@ class TestUpsertGroupUpdate:
         db_session.commit()
 
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
         group_payload = {
             "name": "My Group",
             "groupid": "group:ice-cream@thirdparty.com",
@@ -198,7 +196,7 @@ class TestUpsertGroupUpdate:
         db_session.commit()
 
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
         group_payload = {"name": "Whatnot", "groupid": "group:one@thirdparty.com"}
 
         # Attempting to set group2's `groupid` to one already taken by group1
@@ -214,7 +212,7 @@ class TestUpsertGroupCreate:
         self, app, auth_client_header, third_party_user
     ):
         headers = auth_client_header
-        headers[native_str("X-Forwarded-User")] = native_str(third_party_user.userid)
+        headers["X-Forwarded-User"] = third_party_user.userid
         group = {
             "name": "My Group",
             "groupid": "group:foothold@{auth}".format(auth=third_party_user.authority),
@@ -267,7 +265,7 @@ def user_with_token(db_session, factories, first_party_user):
 @pytest.fixture
 def token_auth_header(user_with_token):
     user, token = user_with_token
-    return {native_str("Authorization"): native_str("Bearer {}".format(token.value))}
+    return {"Authorization": "Bearer {}".format(token.value)}
 
 
 @pytest.fixture
@@ -292,8 +290,4 @@ def auth_client_header(auth_client):
         client_id=auth_client.id, secret=auth_client.secret
     )
     encoded = base64.standard_b64encode(user_pass.encode("utf-8"))
-    return {
-        native_str("Authorization"): native_str(
-            "Basic {creds}".format(creds=encoded.decode("ascii"))
-        )
-    }
+    return {"Authorization": "Basic {creds}".format(creds=encoded.decode("ascii"))}

--- a/tests/functional/api/test_annotations.py
+++ b/tests/functional/api/test_annotations.py
@@ -4,21 +4,12 @@ from __future__ import unicode_literals
 
 import pytest
 
-# String type for request/response headers and metadata in WSGI.
-#
-# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
-# though it has different meanings.
-#
-# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
-native_str = str
-
 
 class TestGetAnnotation:
     def test_it_returns_annotation_if_shared(self, app, annotation):
         """Unauthenticated users may view shared annotations assuming they have group access"""
         res = app.get(
-            "/api/annotations/" + annotation.id,
-            headers={native_str("accept"): native_str("application/json")},
+            "/api/annotations/" + annotation.id, headers={"accept": "application/json"}
         )
         data = res.json
         assert data["id"] == annotation.id
@@ -28,7 +19,7 @@ class TestGetAnnotation:
     ):
         res = app.get(
             "/api/annotations/" + private_annotation.id,
-            headers={native_str("accept"): native_str("application/json")},
+            headers={"accept": "application/json"},
             expect_errors=True,
         )
 
@@ -54,7 +45,7 @@ class TestGetAnnotationJSONLD:
         """Unauthenticated users may view shared annotations assuming they have group access"""
         res = app.get(
             "/api/annotations/" + annotation.id + ".jsonld",
-            headers={native_str("accept"): native_str("application/json")},
+            headers={"accept": "application/json"},
         )
         data = res.json
 
@@ -68,7 +59,7 @@ class TestGetAnnotationJSONLD:
     ):
         res = app.get(
             "/api/annotations/" + private_annotation.id + ".jsonld",
-            headers={native_str("accept"): native_str("application/json")},
+            headers={"accept": "application/json"},
             expect_errors=True,
         )
 

--- a/tests/functional/api/test_api.py
+++ b/tests/functional/api/test_api.py
@@ -4,14 +4,6 @@ from __future__ import unicode_literals
 
 import pytest
 
-# String type for request/response headers and metadata in WSGI.
-#
-# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
-# though it has different meanings.
-#
-# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
-native_str = str
-
 
 class TestCorsPreflight:
     def test_cors_preflight(self, app):

--- a/tests/functional/api/test_flags.py
+++ b/tests/functional/api/test_flags.py
@@ -4,14 +4,6 @@ from __future__ import unicode_literals
 
 import pytest
 
-# String type for request/response headers and metadata in WSGI.
-#
-# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
-# though it has different meanings.
-#
-# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
-native_str = str
-
 
 class TestPutFlag:
     def test_it_returns_http_204_if_user_allowed_to_flag_shared_annotation(

--- a/tests/functional/api/test_index.py
+++ b/tests/functional/api/test_index.py
@@ -4,14 +4,6 @@ from __future__ import unicode_literals
 
 import pytest
 
-# String type for request/response headers and metadata in WSGI.
-#
-# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
-# though it has different meanings.
-#
-# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
-native_str = str
-
 
 class TestGetIndex:
     def test_it_returns_links(self, app):
@@ -25,11 +17,11 @@ class TestGetIndex:
         ["application/vnd.hypothesis.v1+json", "application/vnd.hypothesis.v2+json"],
     )
     def test_it_supports_versions(self, app, media_type):
-        headers = {native_str("accept"): native_str(media_type)}
+        headers = {"accept": media_type}
 
         res = app.get("/api/", headers=headers)
 
-        assert res.headers["Hypothesis-Media-Type"] == native_str(media_type)
+        assert res.headers["Hypothesis-Media-Type"] == media_type
 
     def test_it_returns_links_for_resources(self, app):
         res = app.get("/api/")
@@ -90,9 +82,7 @@ class TestGetIndex:
     def test_it_returns_expected_resource_service_links_for_v2(
         self, app, resource, expected_services
     ):
-        headers = {
-            native_str("accept"): native_str("application/vnd.hypothesis.v2+json")
-        }
+        headers = {"accept": "application/vnd.hypothesis.v2+json"}
         res = app.get("/api/", headers=headers)
 
         for service in expected_services:
@@ -107,9 +97,7 @@ class TestGetIndex:
     def test_it_returns_expected_nested_resource_service_links_for_v2(
         self, app, resource, nested_resource, expected_services
     ):
-        headers = {
-            native_str("accept"): native_str("application/vnd.hypothesis.v2+json")
-        }
+        headers = {"accept": "application/vnd.hypothesis.v2+json"}
         res = app.get("/api/", headers=headers)
 
         assert nested_resource in res.json["links"][resource]

--- a/tests/functional/api/test_moderation.py
+++ b/tests/functional/api/test_moderation.py
@@ -4,14 +4,6 @@ from __future__ import unicode_literals
 
 import pytest
 
-# String type for request/response headers and metadata in WSGI.
-#
-# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
-# though it has different meanings.
-#
-# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
-native_str = str
-
 
 class TestPutHide:
     def test_it_returns_http_204_for_group_creator(

--- a/tests/functional/api/test_profile.py
+++ b/tests/functional/api/test_profile.py
@@ -4,14 +4,6 @@ from __future__ import unicode_literals
 
 import pytest
 
-# String type for request/response headers and metadata in WSGI.
-#
-# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
-# though it has different meanings.
-#
-# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
-native_str = str
-
 
 class TestGetProfile:
     def test_it_returns_profile_with_single_group_when_not_authd(self, app):
@@ -92,7 +84,7 @@ class TestPatchProfile:
 
         user, token = user_with_token
 
-        headers = {"Authorization": native_str("Bearer {}".format(token.value))}
+        headers = {"Authorization": "Bearer {}".format(token.value)}
         profile = {"preferences": {"show_sidebar_tutorial": True}}
 
         res = app.patch_json("/api/profile", profile, headers=headers)
@@ -107,7 +99,7 @@ class TestPatchProfile:
 
         user, token = user_with_token
 
-        headers = {"Authorization": native_str("Bearer {}".format(token.value))}
+        headers = {"Authorization": "Bearer {}".format(token.value)}
         profile = {"preferences": {"show_sidebar_tutorial": False}}
 
         res = app.patch_json("/api/profile", profile, headers=headers)
@@ -136,7 +128,7 @@ class TestPatchProfile:
     def test_it_raises_http_400_for_disallowed_setting(self, app, user_with_token):
         _, token = user_with_token
         profile = {"preferences": {"foo": "bar"}}
-        headers = {"Authorization": native_str("Bearer {}".format(token.value))}
+        headers = {"Authorization": "Bearer {}".format(token.value)}
 
         res = app.patch_json(
             "/api/profile", profile, headers=headers, expect_errors=True

--- a/tests/functional/api/test_users.py
+++ b/tests/functional/api/test_users.py
@@ -8,14 +8,6 @@ import base64
 
 from h.models.auth_client import GrantType
 
-# String type for request/response headers and metadata in WSGI.
-#
-# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
-# though it has different meanings.
-#
-# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
-native_str = str
-
 
 class TestReadUser:
     def test_it_returns_http_404_if_auth_client_missing(self, app, user):
@@ -184,11 +176,7 @@ def auth_client_header(auth_client):
         client_id=auth_client.id, secret=auth_client.secret
     )
     encoded = base64.standard_b64encode(user_pass.encode("utf-8"))
-    return {
-        native_str("Authorization"): native_str(
-            "Basic {creds}".format(creds=encoded.decode("ascii"))
-        )
-    }
+    return {"Authorization": "Basic {creds}".format(creds=encoded.decode("ascii"))}
 
 
 @pytest.fixture

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -5,14 +5,6 @@ Test the versioning of our API using Accept headers
 
 from __future__ import unicode_literals
 
-# String type for request/response headers and metadata in WSGI.
-#
-# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
-# though it has different meanings.
-#
-# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
-native_str = str
-
 
 class TestIndexEndpointVersions:
     def test_index_sets_version_response_header(self, app):


### PR DESCRIPTION
 - Remove `native_str = str` alias
 - Remove helper for normalizing certain formatted messages for Py 2/3 consistency