### PR TITLE
Add `make devdata`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ celerybeat-schedule.*
 
 # Temp file for `make test-py3` target
 tests/py3-actual-failures.txt
+
+.devdata.env

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ help:
 	@echo 'make services          Run the services that `make dev` requires'
 	@echo "                       (Postgres, Elasticsearch, etc) in Docker Compose"
 	@echo "make dev               Run the app in the development server"
+	@echo "make devdata           Upsert standard development data into the DB, and set"
+	@echo "                       standard environment variables for a development"
+	@echo "                       environment"
 	@echo "make shell             Launch a Python shell in the dev environment"
 	@echo "make sql               Connect to the dev database with a psql shell"
 	@echo "make lint              Run the code linter(s) and print any warnings"
@@ -40,6 +43,10 @@ services:
 .PHONY: dev
 dev: build/manifest.json python
 	tox -q -e py36-dev
+
+.PHONY: devdata
+devdata: python
+	@tox -q -e py36-dev -- sh bin/hypothesis --dev devdata
 
 .PHONY: shell
 shell: python

--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -10,6 +10,10 @@ pyramid.debug_all: True
 pyramid.reload_templates: True
 
 h.authority: localhost
+h.bouncer_url: http://localhost:8000
+h.client_rpc_allowed_origins: http://localhost
+h.client_url: http://localhost:3001/hypothesis
+h.websocket_url: ws://localhost:5001/ws
 
 h.debug: True
 h.reload_assets: True

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -65,6 +65,22 @@ Start the services that h requires using Docker Compose:
 
    make services
 
+Create the development data and settings
+----------------------------------------
+
+Create the database contents and environment variable settings needed to get h
+working nicely with your local development instances of the rest of the
+Hypothesis apps:
+
+.. code-block:: shell
+
+    make devdata
+
+This requires you to have a git SSH key set up that has access to the private
+https://github.com/hypothesis/devdata repo. Otherwise ``make devdata`` will
+crash. If you aren't a Hypothesis team member and don't have access to this
+repo, you can skip this step and continue without the dev data.
+
 Start the development server
 ----------------------------
 

--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -17,6 +17,7 @@ SUBCOMMANDS = (
     "h.cli.commands.annotation_id.annotation_id",
     "h.cli.commands.authclient.authclient",
     "h.cli.commands.celery.celery",
+    "h.cli.commands.devdata.devdata",
     "h.cli.commands.devserver.devserver",
     "h.cli.commands.init.init",
     "h.cli.commands.initdb.initdb",

--- a/h/cli/commands/devdata.py
+++ b/h/cli/commands/devdata.py
@@ -1,0 +1,164 @@
+"""
+A CLI command for inserting standard dev data into the DB.
+
+Usage:
+
+    bin/hypothesis --dev devdata
+"""
+import click
+import json
+import os.path
+import pathlib
+import shutil
+import subprocess
+import tempfile
+
+import h
+from h import models
+
+
+class DevDataFactory:
+    """Factory class for inserting standard dev data into the DB."""
+
+    def __init__(self, request, devdata):
+        self.db = request.db
+        self.tm = request.tm
+        self.devdata = devdata
+
+        self.user_password_service = request.find_service(name="user_password")
+        self.group_service = request.find_service(name="group")
+        self.group_create_service = request.find_service(name="group_create")
+
+    def create_all(self):
+        """
+        Create all the standard dev data in the DB.
+
+        Create standard dev data objects (users, groups, etc) if they don't
+        exist. If objects with the same identifier already exist in the DB
+        (e.g. a user with the same name as a standard dev data user, or a group
+        with the same pubid, etc) but those objects have different values for
+        some fields, then overwrite those incorrect values with the standard
+        values.
+        """
+        for data_dict in self.devdata:
+            type_ = data_dict.pop("type")
+            if type_ == "authclient":
+                self.upsert_authclient(data_dict)
+            elif type_ == "organization":
+                self.upsert_organization(data_dict)
+            elif type_ == "user":
+                self.upsert_user(data_dict)
+            elif type_ == "open_group":
+                self.upsert_open_group(data_dict)
+            elif type_ == "restricted_group":
+                self.upsert_restricted_group(data_dict)
+            else:
+                raise RuntimeError(f"Unrecognized type: {type_}")
+
+        self.tm.commit()
+
+    def upsert_authclient(self, authclient_data):
+        authclient = (
+            self.db.query(models.AuthClient)
+            .filter_by(name=authclient_data["name"])
+            .one_or_none()
+        )
+
+        if not authclient:
+            authclient = models.AuthClient()
+            self.db.add(authclient)
+
+        self.setattrs(authclient, authclient_data)
+
+    def upsert_organization(self, organization_data):
+        organization = (
+            self.db.query(models.Organization)
+            .filter_by(pubid=organization_data["pubid"])
+            .one_or_none()
+        )
+
+        if not organization:
+            organization = models.Organization()
+            self.db.add(organization)
+
+        self.setattrs(organization, organization_data)
+
+    def upsert_user(self, user_data):
+        user = models.User.get_by_username(
+            self.db, user_data["username"], user_data["authority"]
+        )
+
+        if not user:
+            user = models.User()
+            self.db.add(user)
+
+        password = user_data.pop("password")
+        self.user_password_service.update_password(user, password)
+
+        self.setattrs(user, user_data)
+
+    def upsert_open_group(self, group_data):
+        return self.upsert_group(
+            group_data, self.group_create_service.create_open_group
+        )
+
+    def upsert_restricted_group(self, group_data):
+        return self.upsert_group(
+            group_data, self.group_create_service.create_restricted_group
+        )
+
+    def upsert_group(self, group_data, group_create_method):
+        creator = models.User.get_by_username(
+            self.db, group_data.pop("creator_username"), group_data["authority"]
+        )
+        assert creator
+
+        organization = (
+            self.db.query(models.Organization)
+            .filter_by(pubid=group_data.pop("organization_pubid"))
+            .one()
+        )
+
+        group = self.group_service.fetch_by_pubid(group_data["pubid"])
+
+        if not group:
+            group = group_create_method(group_data.pop("name"), creator.userid, [])
+
+        group.creator = creator
+        group.organization = organization
+        group.scopes = [
+            models.GroupScope(scope=scope) for scope in group_data.pop("scopes")
+        ]
+
+        self.setattrs(group, group_data)
+
+    @staticmethod
+    def setattrs(object_, attrs):
+        for name, value in attrs.items():
+            setattr(object_, name, value)
+
+
+@click.command()
+@click.pass_context
+def devdata(ctx):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # The directory that we'll clone the devdata git repo into.
+        git_dir = os.path.join(tmpdirname, "devdata")
+
+        # Clone the private devdata repo from GitHub.
+        # This will fail if your SSH key doesn't have access to the private
+        # repo.
+        subprocess.check_call(
+            ["git", "clone", "git@github.com:hypothesis/devdata.git", git_dir]
+        )
+
+        # Copy environment variables file into place.
+        shutil.copyfile(
+            os.path.join(git_dir, "h", "devdata.env"),
+            os.path.join(pathlib.Path(h.__file__).parent.parent, ".devdata.env"),
+        )
+
+        DevDataFactory(
+            ctx.obj["bootstrap"](),
+            json.loads(open(os.path.join(git_dir, "h", "devdata.json"), "r").read()),
+        ).create_all()

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ minversion = 3.8.0
 requires =
   tox-pip-extensions
   tox-pyenv
+  tox-envfile
 tox_pip_extensions_ext_venv_update = true
 # Exclusively use Python commands from pyenv's copies of Python, don't fall
 # back to tox's default non-pyenv command search strategy.


### PR DESCRIPTION
Depends on https://github.com/hypothesis/devdata/pull/2

This adds a `make devdata` command that:

1. Clones the https://github.com/hypothesis/devdata/ repo to a temporary directory. (This will fail if you don't have your git ssh keys set up and access to the private repo.)

2. Reads an `h/devdata.json` file from the private repo, and creates or updates users, groups, organizations and authclients in the DB according to the contents of the JSON file.

3. Copies an `h/devdata.env` file from the private repo to a git-ignored location in your h work tree. This file is read by tox and the envvars it contains are set in the tox envs.