### PR TITLE
Remove obsolete __future__ imports

### DIFF
--- a/h/__init__.py
+++ b/h/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from h._version import get_version
 
 __all__ = ("__version__",)

--- a/h/__main__.py
+++ b/h/__main__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from h.cli import main
 
 if __name__ == "__main__":

--- a/h/_compat.py
+++ b/h/_compat.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Helpers for the Python 2 to Python 3 transition."""
-from __future__ import unicode_literals
-
 import sys
 
 __all__ = (

--- a/h/_version.py
+++ b/h/_version.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import datetime
 import subprocess
 

--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from itsdangerous import URLSafeTimedSerializer
 
 from h.security import derive_key

--- a/h/accounts/events.py
+++ b/h/accounts/events.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 
 class ActivationEvent:

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from codecs import open
 import logging
 

--- a/h/accounts/subscribers.py
+++ b/h/accounts/subscribers.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from pyramid.events import subscriber
 
 from h.accounts import events

--- a/h/accounts/util.py
+++ b/h/accounts/util.py
@@ -1,8 +1,6 @@
 """
 Helpers for account forms
 """
-from __future__ import unicode_literals
-
 import re
 
 from h._compat import urlparse

--- a/h/activity/__init__.py
+++ b/h/activity/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/h/activity/bucketing.py
+++ b/h/activity/bucketing.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Code for bucketing annotations by time frame and document."""
 
-from __future__ import unicode_literals
-
 import collections
 import datetime
 

--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from collections import namedtuple
 
 import newrelic.agent

--- a/h/app.py
+++ b/h/app.py
@@ -2,8 +2,6 @@
 
 """The main h application."""
 
-from __future__ import unicode_literals
-
 from h._compat import urlparse
 import logging
 

--- a/h/assets.py
+++ b/h/assets.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import configparser
 import os
 

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 """Authentication configuration."""
-from __future__ import unicode_literals
-
 import logging
 
 from pyramid.authentication import RemoteUserAuthenticationPolicy

--- a/h/auth/interfaces.py
+++ b/h/auth/interfaces.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from zope.interface import Attribute, Interface
 
 

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid import interfaces
 from pyramid.authentication import BasicAuthAuthenticationPolicy
 from pyramid.authentication import CallbackAuthenticationPolicy

--- a/h/auth/role.py
+++ b/h/auth/role.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 #: Administrators. These users have super cow powers.
-from __future__ import unicode_literals
-
 Admin = "group:__admin__"
 
 #: Hypothesis staff. These users have limited access to admin functionality.

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import datetime
 
 import newrelic.agent

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import re
 
 import hmac

--- a/h/authz.py
+++ b/h/authz.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 """Authorization configuration."""
-from __future__ import unicode_literals
-
 from pyramid.authorization import ACLAuthorizationPolicy
 
 __all__ = ()

--- a/h/celery.py
+++ b/h/celery.py
@@ -8,9 +8,6 @@ integrates it with the Pyramid application by attaching a bootstrapped fake
 "request" object to the application where it can be retrieved by tasks.
 """
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from datetime import timedelta
 import logging
 import os

--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import functools
 import logging
 

--- a/h/config.py
+++ b/h/config.py
@@ -2,8 +2,6 @@
 
 """Configuration for the h application."""
 
-from __future__ import unicode_literals
-
 import logging
 import os
 

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -12,8 +12,6 @@ application startup.
 Most application code should access the database session using the request
 property `request.db` which is provided by this module.
 """
-from __future__ import unicode_literals
-
 import logging
 
 import sqlalchemy

--- a/h/db/mixins.py
+++ b/h/db/mixins.py
@@ -2,8 +2,6 @@
 
 """Reusable mixins for SQLAlchemy declarative models."""
 
-from __future__ import unicode_literals
-
 import datetime
 
 import sqlalchemy as sa

--- a/h/db/types.py
+++ b/h/db/types.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 """Custom SQLAlchemy types for use with the Annotations API database."""
-from __future__ import unicode_literals
-
 from h._compat import string_types
 import binascii
 import base64

--- a/h/emails/__init__.py
+++ b/h/emails/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from h.emails import reply_notification, reset_password, signup
 
 __all__ = ("reply_notification", "reset_password", "signup")

--- a/h/emails/flag_notification.py
+++ b/h/emails/flag_notification.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid.renderers import render
 
 from h.i18n import TranslationString as _  # noqa: N813

--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h import links
 
 from pyramid.renderers import render

--- a/h/emails/reset_password.py
+++ b/h/emails/reset_password.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid.renderers import render
 
 from h.i18n import TranslationString as _  # noqa: N813

--- a/h/emails/signup.py
+++ b/h/emails/signup.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid.renderers import render
 
 from h.i18n import TranslationString as _  # noqa: N813

--- a/h/emails/test.py
+++ b/h/emails/test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 import platform
 

--- a/h/eventqueue.py
+++ b/h/eventqueue.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import collections
 import logging
 

--- a/h/events.py
+++ b/h/events.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 
 class AnnotationEvent:

--- a/h/feeds/__init__.py
+++ b/h/feeds/__init__.py
@@ -2,8 +2,6 @@
 
 """Code for generating feeds (e.g. Atom and RSS feeds)."""
 
-from __future__ import unicode_literals
-
 from h.feeds.render import render_atom
 from h.feeds.render import render_rss
 

--- a/h/feeds/atom.py
+++ b/h/feeds/atom.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Functions for generating Atom feeds."""
-from __future__ import unicode_literals
 from pyramid import i18n
 
 from h import presenters

--- a/h/feeds/render.py
+++ b/h/feeds/render.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from pyramid import renderers
 
 from h.feeds import atom

--- a/h/feeds/rss.py
+++ b/h/feeds/rss.py
@@ -1,6 +1,4 @@
 """Functions for generating RSS feeds."""
-from __future__ import unicode_literals
-
 from calendar import timegm
 from email.utils import formatdate
 

--- a/h/feeds/util.py
+++ b/h/feeds/util.py
@@ -1,5 +1,4 @@
 """Utility functions for feed-generating code."""
-from __future__ import unicode_literals
 from h._compat import urlparse
 
 # See RFC4151 for details of the use and format of the tag date:

--- a/h/form.py
+++ b/h/form.py
@@ -5,7 +5,6 @@ Configure deform to use custom templates.
 Sets up the form handling and rendering library, deform, to use our own custom
 form templates in preference to the defaults.
 """
-from __future__ import unicode_literals
 import deform
 import jinja2
 from pyramid import httpexceptions

--- a/h/formatters/__init__.py
+++ b/h/formatters/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.formatters.annotation_flag import AnnotationFlagFormatter
 from h.formatters.annotation_hidden import AnnotationHiddenFormatter
 from h.formatters.annotation_moderation import AnnotationModerationFormatter

--- a/h/formatters/annotation_flag.py
+++ b/h/formatters/annotation_flag.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from zope.interface import implementer
 
 from h.formatters.interfaces import IAnnotationFormatter

--- a/h/formatters/annotation_hidden.py
+++ b/h/formatters/annotation_hidden.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from zope.interface import implementer
 
 from h.formatters.interfaces import IAnnotationFormatter

--- a/h/formatters/annotation_moderation.py
+++ b/h/formatters/annotation_moderation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from zope.interface import implementer
 
 from h.formatters.interfaces import IAnnotationFormatter

--- a/h/formatters/annotation_user_info.py
+++ b/h/formatters/annotation_user_info.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from zope.interface import implementer
 
 from h import models

--- a/h/formatters/interfaces.py
+++ b/h/formatters/interfaces.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from zope.interface import Interface
 
 

--- a/h/i18n.py
+++ b/h/i18n.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from pyramid.i18n import TranslationStringFactory
 
 TranslationString = TranslationStringFactory("hypothesis")

--- a/h/indexer/__init__.py
+++ b/h/indexer/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from h.indexer.reindexer import reindex
 
 __all__ = ("reindex",)

--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import logging
 
 from h.search.config import (

--- a/h/indexer/subscribers.py
+++ b/h/indexer/subscribers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from h.tasks.indexer import add_annotation, delete_annotation
 
 

--- a/h/interfaces.py
+++ b/h/interfaces.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from zope.interface import Interface
 
 

--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import datetime
 from functools import partial
 import json

--- a/h/links.py
+++ b/h/links.py
@@ -3,8 +3,6 @@
 """
 Provides links to different representations of annotations.
 """
-from __future__ import unicode_literals
-
 
 from h._compat import urlparse, url_unquote
 

--- a/h/migrations/env.py
+++ b/h/migrations/env.py
@@ -1,6 +1,3 @@
-from __future__ import with_statement
-from __future__ import unicode_literals
-
 import logging
 import os
 

--- a/h/migrations/versions/02db2fa6ea98_add_unique_constraint_to_refresh_token_column.py
+++ b/h/migrations/versions/02db2fa6ea98_add_unique_constraint_to_refresh_token_column.py
@@ -6,8 +6,6 @@ Revises: c739ee2ae59c
 Create Date: 2017-01-31 17:24:03.855420
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy
 

--- a/h/migrations/versions/05bd63575f19_add_trusted_column_to_authclient_table.py
+++ b/h/migrations/versions/05bd63575f19_add_trusted_column_to_authclient_table.py
@@ -6,8 +6,6 @@ Revises: dfb8b45674db
 Create Date: 2017-07-18 13:45:12.301240
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/0d1b3fd8807c_create_authzcode_table.py
+++ b/h/migrations/versions/0d1b3fd8807c_create_authzcode_table.py
@@ -6,8 +6,6 @@ Revises: b980b1a8f6af
 Create Date: 2017-07-10 12:04:28.328864
 """
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/h/migrations/versions/140b450225cd_backfill_group_authority.py
+++ b/h/migrations/versions/140b450225cd_backfill_group_authority.py
@@ -6,8 +6,6 @@ Revises: 3acf258322d5
 Create Date: 2016-11-25 15:17:22.792448
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/178270e3ee58_add_user_privacy_agreement_column.py
+++ b/h/migrations/versions/178270e3ee58_add_user_privacy_agreement_column.py
@@ -4,8 +4,6 @@ Add user privacy agreement column
 Add a column to track user's most recent acceptance of privacy policy
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/18dfed902c9e_remove_unused_user_indices.py
+++ b/h/migrations/versions/18dfed902c9e_remove_unused_user_indices.py
@@ -6,8 +6,6 @@ Revises: 7e2443f8d7d6
 Create Date: 2017-03-03 12:13:16.122752
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/1a40e75a524d_add_normalised_username_index.py
+++ b/h/migrations/versions/1a40e75a524d_add_normalised_username_index.py
@@ -6,8 +6,6 @@ Revises: 02db2fa6ea98
 Create Date: 2017-03-02 13:55:24.290975
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/1c995723a271_add_world_group.py
+++ b/h/migrations/versions/1c995723a271_add_world_group.py
@@ -6,8 +6,6 @@ Revises: 21b1ce37e327
 Create Date: 2017-04-18 12:19:33.863557
 """
 
-from __future__ import unicode_literals
-
 import enum
 import sqlalchemy as sa
 from alembic import op

--- a/h/migrations/versions/1e88c31d8b1a_add_authticket_table.py
+++ b/h/migrations/versions/1e88c31d8b1a_add_authticket_table.py
@@ -6,8 +6,6 @@ Revises: f9d3058bec5f
 Create Date: 2016-09-16 12:22:26.480404
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/21b1ce37e327_allow_null_group_creator.py
+++ b/h/migrations/versions/21b1ce37e327_allow_null_group_creator.py
@@ -6,8 +6,6 @@ Revises: 9389d52b037d
 Create Date: 2017-04-13 16:49:16.218511
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 
 

--- a/h/migrations/versions/2a414b3393be_add_UserIdentity_to_User_relation.py
+++ b/h/migrations/versions/2a414b3393be_add_UserIdentity_to_User_relation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Add UserIdentity (many) -> User (one) relation."""
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/2d0ad2b1bf07_add_enforce_scope_column_to_group_table.py
+++ b/h/migrations/versions/2d0ad2b1bf07_add_enforce_scope_column_to_group_table.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 """Add enforce_scope column to group table"""
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/2e2cc6a0c521_fill_in_user_authority_column.py
+++ b/h/migrations/versions/2e2cc6a0c521_fill_in_user_authority_column.py
@@ -6,8 +6,6 @@ Revises: f48100c9af86
 Create Date: 2016-08-15 18:13:08.372479
 """
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/39b1935d9e7b_add_annotation_text_rendered.py
+++ b/h/migrations/versions/39b1935d9e7b_add_annotation_text_rendered.py
@@ -5,8 +5,6 @@ Revises: 6b801ecc60f1
 Create Date: 2016-08-09 15:19:49.572331
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/3acf258322d5_add_authority_column_to_group.py
+++ b/h/migrations/versions/3acf258322d5_add_authority_column_to_group.py
@@ -6,8 +6,6 @@ Revises: c36369fe730f
 Create Date: 2016-11-24 16:33:40.238726
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/3d71ec81d18c_delete_empty_document_titles.py
+++ b/h/migrations/versions/3d71ec81d18c_delete_empty_document_titles.py
@@ -5,8 +5,6 @@ Revision ID: 3d71ec81d18c
 Revises: 6964a8237c88
 Create Date: 2016-09-14 16:03:41.490371
 """
-from __future__ import unicode_literals
-
 import logging
 
 from alembic import op

--- a/h/migrations/versions/3e1727613916_add_document_web_uri_column.py
+++ b/h/migrations/versions/3e1727613916_add_document_web_uri_column.py
@@ -6,8 +6,6 @@ Revises: a001b7b4c78e
 Create Date: 2016-09-12 13:21:56.739838
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/40740282ae9e_add_default_to_document_uri_types.py
+++ b/h/migrations/versions/40740282ae9e_add_default_to_document_uri_types.py
@@ -6,8 +6,6 @@ Revises: 296575bb30b3
 Create Date: 2016-06-29 11:01:40.936313
 """
 
-from __future__ import unicode_literals
-
 revision = "40740282ae9e"
 down_revision = "296573bb30b3"
 

--- a/h/migrations/versions/467ea2898660_fix_document_uri_unique_constraint.py
+++ b/h/migrations/versions/467ea2898660_fix_document_uri_unique_constraint.py
@@ -6,8 +6,6 @@ Revises: 40740282ae9e
 Create Date: 2016-06-16 18:37:20.703447
 """
 
-from __future__ import unicode_literals
-
 revision = "467ea2898660"
 down_revision = "40740282ae9e"
 

--- a/h/migrations/versions/46a22db075d5_add_organization_id_to_group_table.py
+++ b/h/migrations/versions/46a22db075d5_add_organization_id_to_group_table.py
@@ -6,8 +6,6 @@ Revises: 628c53b07
 Create Date: 2018-03-21 09:47:47.642578
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/504a6a4db06d_relax_password_constraints.py
+++ b/h/migrations/versions/504a6a4db06d_relax_password_constraints.py
@@ -6,8 +6,6 @@ Revises: de42d613c18d
 Create Date: 2016-08-18 22:32:51.092582
 """
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/50df3e6782aa_add_annotation_moderation_table.py
+++ b/h/migrations/versions/50df3e6782aa_add_annotation_moderation_table.py
@@ -6,8 +6,6 @@ Revises: e554d862135f
 Create Date: 2017-03-29 15:15:36.092486
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/52a0b2e5a9c2_add_authclient_redirect_uri_check.py
+++ b/h/migrations/versions/52a0b2e5a9c2_add_authclient_redirect_uri_check.py
@@ -6,8 +6,6 @@ Revises: a2295c2bbe29
 Create Date: 2017-07-26 10:47:38.895306
 """
 
-from __future__ import unicode_literals
-
 import enum
 
 import sqlalchemy as sa

--- a/h/migrations/versions/53a74d7ae1b0_remove_nipsa_table.py
+++ b/h/migrations/versions/53a74d7ae1b0_remove_nipsa_table.py
@@ -6,8 +6,6 @@ Revises: 1e88c31d8b1a
 Create Date: 2016-09-20 12:12:03.600081
 """
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/5655d56d7c29_add_flag_table.py
+++ b/h/migrations/versions/5655d56d7c29_add_flag_table.py
@@ -6,8 +6,6 @@ Revises: c322c57b49db
 Create Date: 2017-03-08 15:32:27.288684
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/58bb601c390f_fill_in_missing_denormalized_document_title.py
+++ b/h/migrations/versions/58bb601c390f_fill_in_missing_denormalized_document_title.py
@@ -6,8 +6,6 @@ Revises: 3e1727613916
 Create Date: 2016-09-12 12:21:40.904620
 """
 
-from __future__ import unicode_literals
-
 from collections import namedtuple
 
 from alembic import op

--- a/h/migrations/versions/5bfdfde681ea_add_annotation_deleted_column.py
+++ b/h/migrations/versions/5bfdfde681ea_add_annotation_deleted_column.py
@@ -6,8 +6,6 @@ Revises: 90412d879d1f
 Create Date: 2016-12-19 12:37:53.791428
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/5d256923d642_make_organization_relation_nullable_on_.py
+++ b/h/migrations/versions/5d256923d642_make_organization_relation_nullable_on_.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 """Make organization relation nullable on group"""
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-
 from alembic import op
 
 

--- a/h/migrations/versions/5dce9a8c42c2_disallow_null_annotation_document_id.py
+++ b/h/migrations/versions/5dce9a8c42c2_disallow_null_annotation_document_id.py
@@ -6,8 +6,6 @@ Revises: bcdd81e23920
 Create Date: 2016-09-22 17:22:09.294825
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 
 

--- a/h/migrations/versions/5dd2dd5547a2_add_the_user_identity_table.py
+++ b/h/migrations/versions/5dd2dd5547a2_add_the_user_identity_table.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Add the user_identity table."""
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/5e535a075f16_remove_null_document_titles.py
+++ b/h/migrations/versions/5e535a075f16_remove_null_document_titles.py
@@ -5,8 +5,6 @@ Revision ID: 5e535a075f16
 Revises: a44ef07b085a
 Create Date: 2016-09-14 15:11:26.551596
 """
-from __future__ import unicode_literals
-
 import logging
 
 from alembic import op

--- a/h/migrations/versions/5ed9c8c105f6_add_authority_provided_id_field_to_group.py
+++ b/h/migrations/versions/5ed9c8c105f6_add_authority_provided_id_field_to_group.py
@@ -16,10 +16,6 @@ IDs.
 ``authority_provided_id`` must be unique per authority; ergo the
 unique-enforced index
 """
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/615358b6c428_move_all_groups_to_default_organization.py
+++ b/h/migrations/versions/615358b6c428_move_all_groups_to_default_organization.py
@@ -26,8 +26,6 @@ non-nullable) and we can fix up the resulting organization names and logos
 later.
 
 """
-from __future__ import unicode_literals
-
 import logging
 import random
 

--- a/h/migrations/versions/628c53b07_add_the_organization_table.py
+++ b/h/migrations/versions/628c53b07_add_the_organization_table.py
@@ -6,8 +6,6 @@ Revises: 7bf167611bc3
 Create Date: 2018-03-15 11:00:50.420618
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/63e8b1fe1d4b_clean_up_document_uris.py
+++ b/h/migrations/versions/63e8b1fe1d4b_clean_up_document_uris.py
@@ -5,8 +5,6 @@ Revision ID: 63e8b1fe1d4b
 Revises: 6d9257ad610d
 Create Date: 2016-09-15 15:26:31.286536
 """
-from __future__ import unicode_literals
-
 import logging
 
 from alembic import op

--- a/h/migrations/versions/64cf31f9f721_add_expires_column_to_token_table.py
+++ b/h/migrations/versions/64cf31f9f721_add_expires_column_to_token_table.py
@@ -6,8 +6,6 @@ Revises: d536d9a342f3
 Create Date: 2016-08-15 15:45:21.813078
 """
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/6964a8237c88_strip_whitespace_from_document_titles.py
+++ b/h/migrations/versions/6964a8237c88_strip_whitespace_from_document_titles.py
@@ -5,8 +5,6 @@ Revision ID: 6964a8237c88
 Revises: 5e535a075f16
 Create Date: 2016-09-14 15:17:23.096224
 """
-from __future__ import unicode_literals
-
 import logging
 
 from alembic import op

--- a/h/migrations/versions/6b801ecc60f1_add_a_primary_key_to_the_user_group_.py
+++ b/h/migrations/versions/6b801ecc60f1_add_a_primary_key_to_the_user_group_.py
@@ -6,8 +6,6 @@ Revises: e17d3ce4fcd2
 Create Date: 2016-07-08 17:42:20.891383
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/6d9257ad610d_delete_empty_array_document_titles.py
+++ b/h/migrations/versions/6d9257ad610d_delete_empty_array_document_titles.py
@@ -5,8 +5,6 @@ Revision ID: 6d9257ad610d
 Revises: 3d71ec81d18c
 Create Date: 2016-09-14 16:06:33.439592
 """
-from __future__ import unicode_literals
-
 import logging
 
 from alembic import op

--- a/h/migrations/versions/6f86796f64e0_add_user_profile_columns.py
+++ b/h/migrations/versions/6f86796f64e0_add_user_profile_columns.py
@@ -6,8 +6,6 @@ Revises: 7cf52a00822b
 Create Date: 2016-07-06 11:28:50.075057
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/74bff6a7d9de_make_feature_flag_deletions_cascade.py
+++ b/h/migrations/versions/74bff6a7d9de_make_feature_flag_deletions_cascade.py
@@ -6,8 +6,6 @@ Revises: 52a0b2e5a9c2
 Create Date: 2017-08-01 09:59:51.200253
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 
 

--- a/h/migrations/versions/792debe852c3_make_user_email_nullable.py
+++ b/h/migrations/versions/792debe852c3_make_user_email_nullable.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 """Make user.email nullable."""
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-
 from alembic import op
 
 

--- a/h/migrations/versions/7bf167611bc3_add_the_groupscope_table.py
+++ b/h/migrations/versions/7bf167611bc3_add_the_groupscope_table.py
@@ -6,8 +6,6 @@ Revises: c943c3f8a7e5
 Create Date: 2018-02-08 11:00:50.420618
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/7cf52a00822b_add_group_description_column.py
+++ b/h/migrations/versions/7cf52a00822b_add_group_description_column.py
@@ -6,8 +6,6 @@ Revises: 9e6b4f70f588
 Create Date: 2016-07-06 11:02:08.163718
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/7e2443f8d7d6_make_userid_index_unique.py
+++ b/h/migrations/versions/7e2443f8d7d6_make_userid_index_unique.py
@@ -6,8 +6,6 @@ Revises: faefe3b614db
 Create Date: 2017-03-07 10:25:23.165687
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/7f3d80550fff_correct_timestamps_of_elife_test_annotations.py
+++ b/h/migrations/versions/7f3d80550fff_correct_timestamps_of_elife_test_annotations.py
@@ -12,8 +12,6 @@ Revises: 9bcc39244e82
 Create Date: 2017-11-29 15:06:59.207780
 """
 
-from __future__ import unicode_literals
-
 from datetime import datetime
 import logging
 

--- a/h/migrations/versions/7fe5d688edd9_add_index_to_user_nipsa.py
+++ b/h/migrations/versions/7fe5d688edd9_add_index_to_user_nipsa.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 """Add index to user.nipsa"""
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/8990247b876c_disallow_group_authority_null.py
+++ b/h/migrations/versions/8990247b876c_disallow_group_authority_null.py
@@ -6,8 +6,6 @@ Revises: 140b450225cd
 Create Date: 2016-11-25 15:33:53.417103
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 
 revision = "8990247b876c"

--- a/h/migrations/versions/8a7f31c4525d_add___default___organization.py
+++ b/h/migrations/versions/8a7f31c4525d_add___default___organization.py
@@ -6,8 +6,6 @@ Revises: 46a22db075d5
 Create Date: 2018-03-27 16:50:20.959215
 
 """
-from __future__ import unicode_literals
-
 import logging
 
 from alembic import op

--- a/h/migrations/versions/8ae9d103551f_backfill_group_access_flags.py
+++ b/h/migrations/versions/8ae9d103551f_backfill_group_access_flags.py
@@ -6,8 +6,6 @@ Revises: af88524994ce
 Create Date: 2016-11-29 12:51:31.247598
 """
 
-from __future__ import unicode_literals
-
 import enum
 
 from alembic import op

--- a/h/migrations/versions/8bd83598ad77_add_path_column_to_groupscope.py
+++ b/h/migrations/versions/8bd83598ad77_add_path_column_to_groupscope.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 """Add path column to groupscope, and a composite index for the (origin, path) columns"""
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/90412d879d1f_add_setting_table.py
+++ b/h/migrations/versions/90412d879d1f_add_setting_table.py
@@ -6,8 +6,6 @@ Revises: 8ae9d103551f
 Create Date: 2016-12-19 13:29:39.933771
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/9389d52b037d_add_index_to_annotation_thread_root.py
+++ b/h/migrations/versions/9389d52b037d_add_index_to_annotation_thread_root.py
@@ -6,8 +6,6 @@ Revises: b102c50b1133
 Create Date: 2017-04-18 12:36:53.842280
 """
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/94c989e06363_remove_old_user_constraints.py
+++ b/h/migrations/versions/94c989e06363_remove_old_user_constraints.py
@@ -9,8 +9,6 @@ Revises: b0e1a12de5e8
 Create Date: 2016-09-08 16:21:25.444258
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 
 

--- a/h/migrations/versions/9bcc39244e82_add_token_refresh_token_expires.py
+++ b/h/migrations/versions/9bcc39244e82_add_token_refresh_token_expires.py
@@ -6,8 +6,6 @@ Revises: 74bff6a7d9de
 Create Date: 2017-08-02 15:19:39.710878
 """
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/9cbc5c5ad23d_fill_in_missing_annotation_deleted.py
+++ b/h/migrations/versions/9cbc5c5ad23d_fill_in_missing_annotation_deleted.py
@@ -6,8 +6,6 @@ Revises: 5bfdfde681ea
 Create Date: 2016-12-19 12:41:25.269188
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/9e01b7287da2_remove_duplicates_from_user_group_table.py
+++ b/h/migrations/versions/9e01b7287da2_remove_duplicates_from_user_group_table.py
@@ -6,8 +6,6 @@ Revises: 6f86796f64e0
 Create Date: 2016-07-08 17:54:57.399139
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base

--- a/h/migrations/versions/9e6b4f70f588_removing_trailing_from_pdf_urns.py
+++ b/h/migrations/versions/9e6b4f70f588_removing_trailing_from_pdf_urns.py
@@ -6,8 +6,6 @@ Create Date: 2016-06-21 17:50:14.261947
 
 """
 # pylint: disable=invalid-name, wrong-import-position
-from __future__ import unicode_literals
-
 import logging
 
 # revision identifiers, used by Alembic.

--- a/h/migrations/versions/9f5e274b202c_update_all_document_web_uris.py
+++ b/h/migrations/versions/9f5e274b202c_update_all_document_web_uris.py
@@ -6,8 +6,6 @@ Revises: e10ce4472966
 Create Date: 2017-01-20 16:07:03.442975
 """
 
-from __future__ import unicode_literals
-
 from collections import namedtuple
 import logging
 

--- a/h/migrations/versions/a001b7b4c78e_add_document_title_column.py
+++ b/h/migrations/versions/a001b7b4c78e_add_document_title_column.py
@@ -6,8 +6,6 @@ Revises: 94c989e06363
 Create Date: 2016-09-12 11:59:35.296908
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/a2295c2bbe29_make_client_secret_nullable.py
+++ b/h/migrations/versions/a2295c2bbe29_make_client_secret_nullable.py
@@ -6,8 +6,6 @@ Revises: 05bd63575f19
 Create Date: 2017-07-18 11:15:39.885020
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 
 

--- a/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
+++ b/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
@@ -6,8 +6,6 @@ Revises: 58bb601c390f
 Create Date: 2016-09-12 15:31:00.597582
 """
 
-from __future__ import unicode_literals
-
 from collections import namedtuple
 
 from alembic import op

--- a/h/migrations/versions/addee5d1686f_add_annotation_document_id_column.py
+++ b/h/migrations/versions/addee5d1686f_add_annotation_document_id_column.py
@@ -6,8 +6,6 @@ Revises: 63e8b1fe1d4b
 Create Date: 2016-09-22 15:55:06.069829
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/af88524994ce_add_group_access_flags.py
+++ b/h/migrations/versions/af88524994ce_add_group_access_flags.py
@@ -6,8 +6,6 @@ Revises: 8990247b876c
 Create Date: 2016-11-25 15:58:59.517470
 """
 
-from __future__ import unicode_literals
-
 import enum
 
 from alembic import op

--- a/h/migrations/versions/afd433075707_add_index_to_user_authority_column.py
+++ b/h/migrations/versions/afd433075707_add_index_to_user_authority_column.py
@@ -6,8 +6,6 @@ Revises: 504a6a4db06d
 Create Date: 2016-08-19 14:26:08.706027
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 
 

--- a/h/migrations/versions/b0e1a12de5e8_update_user_unique_constraints.py
+++ b/h/migrations/versions/b0e1a12de5e8_update_user_unique_constraints.py
@@ -6,8 +6,6 @@ Revises: bdaa06b14557
 Create Date: 2016-09-08 16:03:59.857402
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql

--- a/h/migrations/versions/b102c50b1133_clean_up_moderation_extra_key.py
+++ b/h/migrations/versions/b102c50b1133_clean_up_moderation_extra_key.py
@@ -6,8 +6,6 @@ Revises: 50df3e6782aa
 Create Date: 2017-04-10 14:58:14.472500
 """
 
-from __future__ import unicode_literals
-
 import logging
 
 import sqlalchemy as sa

--- a/h/migrations/versions/b7117b569f8b_fill_user_nipsa_column.py
+++ b/h/migrations/versions/b7117b569f8b_fill_user_nipsa_column.py
@@ -6,8 +6,6 @@ Revises: ddb5f0baa429
 Create Date: 2016-09-16 17:03:25.264475
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import orm

--- a/h/migrations/versions/b980b1a8f6af_add_authclient_grant_response_type_columns.py
+++ b/h/migrations/versions/b980b1a8f6af_add_authclient_grant_response_type_columns.py
@@ -6,8 +6,6 @@ Revises: 1c995723a271
 Create Date: 2017-07-11 11:43:01.120391
 """
 
-from __future__ import unicode_literals
-
 import enum
 
 from alembic import op

--- a/h/migrations/versions/bcdd81e23920_fill_in_missing_annotation_document_id.py
+++ b/h/migrations/versions/bcdd81e23920_fill_in_missing_annotation_document_id.py
@@ -6,8 +6,6 @@ Revises: addee5d1686f
 Create Date: 2016-09-22 16:02:42.284670
 """
 
-from __future__ import unicode_literals
-
 from collections import namedtuple
 import logging
 

--- a/h/migrations/versions/bdaa06b14557_add_authclient_table.py
+++ b/h/migrations/versions/bdaa06b14557_add_authclient_table.py
@@ -6,8 +6,6 @@ Revises: afd433075707
 Create Date: 2016-09-08 14:00:17.363281
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql

--- a/h/migrations/versions/c322c57b49db_remove_user_uid_column.py
+++ b/h/migrations/versions/c322c57b49db_remove_user_uid_column.py
@@ -6,8 +6,6 @@ Revises: 18dfed902c9e
 Create Date: 2017-03-03 12:24:19.739583
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/c36369fe730f_add_token_client_id_column.py
+++ b/h/migrations/versions/c36369fe730f_add_token_client_id_column.py
@@ -6,8 +6,6 @@ Revises: e15e47228c43
 Create Date: 2016-10-19 15:24:13.387546
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql

--- a/h/migrations/versions/c739ee2ae59c_add_refresh_token_column_to_token_table.py
+++ b/h/migrations/versions/c739ee2ae59c_add_refresh_token_column_to_token_table.py
@@ -6,8 +6,6 @@ Revises: 9f5e274b202c
 Create Date: 2017-01-24 19:00:07.493002
 """
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/c943c3f8a7e5_update_imported_elife_ann_timestamps.py
+++ b/h/migrations/versions/c943c3f8a7e5_update_imported_elife_ann_timestamps.py
@@ -13,8 +13,6 @@ Revises: 7f3d80550fff
 Create Date: 2018-01-30 11:12:23.520717
 """
 
-from __future__ import unicode_literals
-
 from datetime import datetime
 import logging
 

--- a/h/migrations/versions/ccebe818f8e0_add_not_null_constraint_to_docuri_types.py
+++ b/h/migrations/versions/ccebe818f8e0_add_not_null_constraint_to_docuri_types.py
@@ -6,8 +6,6 @@ Revises: 467ea2898660
 Create Date: 2016-06-29 10:57:37.466053
 """
 
-from __future__ import unicode_literals
-
 revision = "ccebe818f8e0"
 down_revision = "467ea2898660"
 

--- a/h/migrations/versions/d536d9a342f3_fill_in_annotation_text_rendered_column.py
+++ b/h/migrations/versions/d536d9a342f3_fill_in_annotation_text_rendered_column.py
@@ -6,9 +6,6 @@ Revises: 39b1935d9e7b
 Create Date: 2016-08-10 14:09:01.787927
 """
 
-from __future__ import unicode_literals
-from __future__ import print_function
-
 import sys
 from collections import namedtuple
 

--- a/h/migrations/versions/dba81a22ea75_add_redirect_uri_column_to_authclient.py
+++ b/h/migrations/versions/dba81a22ea75_add_redirect_uri_column_to_authclient.py
@@ -6,8 +6,6 @@ Revises: 0d1b3fd8807c
 Create Date: 2017-07-12 15:17:05.036842
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/ddb5f0baa429_add_nipsa_column_to_user_table.py
+++ b/h/migrations/versions/ddb5f0baa429_add_nipsa_column_to_user_table.py
@@ -6,8 +6,6 @@ Revises: 6d9257ad610d
 Create Date: 2016-09-16 16:58:03.585538
 """
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/de42d613c18d_add_constraints_to_user_authority_column.py
+++ b/h/migrations/versions/de42d613c18d_add_constraints_to_user_authority_column.py
@@ -6,8 +6,6 @@ Revises: 2e2cc6a0c521
 Create Date: 2016-08-15 18:18:19.037667
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 
 

--- a/h/migrations/versions/dfb8b45674db_fix_fk_constraint_cascade.py
+++ b/h/migrations/versions/dfb8b45674db_fix_fk_constraint_cascade.py
@@ -6,8 +6,6 @@ Revises: dba81a22ea75
 Create Date: 2017-07-18 13:32:04.515830
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 from sqlalchemy.dialects import postgresql
 

--- a/h/migrations/versions/e10ce4472966_add_index_to_group_readable_by.py
+++ b/h/migrations/versions/e10ce4472966_add_index_to_group_readable_by.py
@@ -6,8 +6,6 @@ Revises: f0f42ffaa27d
 Create Date: 2016-12-22 16:13:53.658938
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 
 

--- a/h/migrations/versions/e15e47228c43_remove_token_userid_uniqueness.py
+++ b/h/migrations/versions/e15e47228c43_remove_token_userid_uniqueness.py
@@ -6,8 +6,6 @@ Revises: 5dce9a8c42c2
 Create Date: 2016-10-19 16:17:06.067310
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 
 

--- a/h/migrations/versions/e17d3ce4fcd2_add_unique_constraint_to_user_group_.py
+++ b/h/migrations/versions/e17d3ce4fcd2_add_unique_constraint_to_user_group_.py
@@ -6,8 +6,6 @@ Revises: 9e01b7287da2
 Create Date: 2016-07-08 18:56:20.118573
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 
 

--- a/h/migrations/versions/e554d862135f_add_index_to_flag_user_id.py
+++ b/h/migrations/versions/e554d862135f_add_index_to_flag_user_id.py
@@ -6,8 +6,6 @@ Revises: 5655d56d7c29
 Create Date: 2017-03-16 12:35:45.791202
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 
 

--- a/h/migrations/versions/f052da9df33b_make_group_organization_id_not_nullable.py
+++ b/h/migrations/versions/f052da9df33b_make_group_organization_id_not_nullable.py
@@ -1,6 +1,4 @@
 """Make group.organization_id not nullable."""
-from __future__ import unicode_literals
-
 from alembic import op
 
 

--- a/h/migrations/versions/f0f42ffaa27d_add_annotation_deleted_constraints.py
+++ b/h/migrations/versions/f0f42ffaa27d_add_annotation_deleted_constraints.py
@@ -6,8 +6,6 @@ Revises: 9cbc5c5ad23d
 Create Date: 2016-12-19 14:06:37.956780
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/migrations/versions/f48100c9af86_add_authority_column_to_user_table.py
+++ b/h/migrations/versions/f48100c9af86_add_authority_column_to_user_table.py
@@ -6,8 +6,6 @@ Revises: 64cf31f9f721
 Create Date: 2016-08-15 18:10:23.511861
 """
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/f9d3058bec5f_add_constraints_to_user_nipsa_column.py
+++ b/h/migrations/versions/f9d3058bec5f_add_constraints_to_user_nipsa_column.py
@@ -6,8 +6,6 @@ Revises: b7117b569f8b
 Create Date: 2016-09-19 13:07:58.098068
 """
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/faefe3b614db_make_user_uid_nullable.py
+++ b/h/migrations/versions/faefe3b614db_make_user_uid_nullable.py
@@ -6,8 +6,6 @@ Revises: 1a40e75a524d
 Create Date: 2017-03-02 14:17:41.708781
 """
 
-from __future__ import unicode_literals
-
 from alembic import op
 import sqlalchemy as sa
 

--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -17,8 +17,6 @@ key to. So for convenience the test module can instead just do
 ``from h import models`` and have all ORM classes be defined.
 
 """
-from __future__ import unicode_literals
-
 from h.models.activation import Activation
 from h.models.annotation import Annotation
 from h.models.annotation_moderation import AnnotationModeration

--- a/h/models/activation.py
+++ b/h/models/activation.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import hashlib
 import random
 import string

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 
 import sqlalchemy as sa

--- a/h/models/annotation_moderation.py
+++ b/h/models/annotation_moderation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 
 from h.db import Base, types

--- a/h/models/auth_client.py
+++ b/h/models/auth_client.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import enum
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql

--- a/h/models/auth_ticket.py
+++ b/h/models/auth_ticket.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 
 from h.db import Base

--- a/h/models/authz_code.py
+++ b/h/models/authz_code.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 

--- a/h/models/blocklist.py
+++ b/h/models/blocklist.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import sqlalchemy as sa
 from sqlalchemy.sql import expression
 

--- a/h/models/document.py
+++ b/h/models/document.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from datetime import datetime
 import logging
 

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import logging
 
 import sqlalchemy as sa

--- a/h/models/feature_cohort.py
+++ b/h/models/feature_cohort.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 
 from h.db import Base

--- a/h/models/flag.py
+++ b/h/models/flag.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 
 from h.db import Base, types

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from collections import namedtuple
 
 import enum

--- a/h/models/group_scope.py
+++ b/h/models/group_scope.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 from sqlalchemy.ext.hybrid import hybrid_property
 

--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import sqlalchemy as sa
 
 from h.db import Base

--- a/h/models/setting.py
+++ b/h/models/setting.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 
 from h.db import Base

--- a/h/models/subscriptions.py
+++ b/h/models/subscriptions.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import sqlalchemy as sa
 from sqlalchemy import func
 

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 
 import sqlalchemy

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import datetime
 import re
 

--- a/h/models/user_identity.py
+++ b/h/models/user_identity.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 
 from h.db import Base

--- a/h/nipsa/__init__.py
+++ b/h/nipsa/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 
 def includeme(config):

--- a/h/nipsa/subscribers.py
+++ b/h/nipsa/subscribers.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 
 def transform_annotation(event):
     """Add a {"nipsa": True} field on moderated annotations or those whose users are flagged."""

--- a/h/notification/__init__.py
+++ b/h/notification/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from webob.cookies import SignedSerializer
 
 from ..security import derive_key

--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from collections import namedtuple
 import logging
 

--- a/h/oauth/__init__.py
+++ b/h/oauth/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.oauth.errors import (
     InvalidJWTGrantTokenClaimError,
     InvalidRefreshTokenError,

--- a/h/oauth/errors.py
+++ b/h/oauth/errors.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from oauthlib.oauth2 import InvalidGrantError, InvalidRequestFatalError
 
 

--- a/h/oauth/jwt_grant.py
+++ b/h/oauth/jwt_grant.py
@@ -35,8 +35,6 @@ For more information, see the `oauthlib documentation`_ on grant types.
 .. _`oauthlib documentation`: http://oauthlib.readthedocs.io/en/latest/oauth2/grants/grants.html
 """
 
-from __future__ import unicode_literals
-
 import json
 
 from oauthlib.oauth2.rfc6749 import errors

--- a/h/oauth/jwt_grant_token.py
+++ b/h/oauth/jwt_grant_token.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 
 import jwt

--- a/h/oauth/tokens.py
+++ b/h/oauth/tokens.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from oauthlib.oauth2 import BearerToken as OAuthlibBearerToken
 
 

--- a/h/paginator.py
+++ b/h/paginator.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-from __future__ import unicode_literals
-
 import functools
 import math
 

--- a/h/panels/__init__.py
+++ b/h/panels/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 
 def includeme(config):

--- a/h/panels/back_link.py
+++ b/h/panels/back_link.py
@@ -2,8 +2,6 @@
 
 """A context-aware link to the previous page."""
 
-from __future__ import unicode_literals
-
 from pyramid_layout.panel import panel_config
 
 from h._compat import urlparse

--- a/h/panels/navbar.py
+++ b/h/panels/navbar.py
@@ -2,8 +2,6 @@
 
 """The navigation bar displayed at the top of most pages."""
 
-from __future__ import unicode_literals
-
 from pyramid_layout.panel import panel_config
 
 from h.i18n import TranslationString as _  # noqa

--- a/h/presenters/__init__.py
+++ b/h/presenters/__init__.py
@@ -5,8 +5,6 @@ Code responsible for rendering domain objects into various output
 formats.
 """
 
-from __future__ import unicode_literals
-
 from h.presenters.annotation_html import AnnotationHTMLPresenter
 from h.presenters.annotation_json import AnnotationJSONPresenter
 from h.presenters.annotation_jsonld import AnnotationJSONLDPresenter

--- a/h/presenters/annotation_base.py
+++ b/h/presenters/annotation_base.py
@@ -4,8 +4,6 @@
 A base presenter for common properties needed when rendering annotations.
 """
 
-from __future__ import unicode_literals
-
 from h.util.datetime import utc_iso8601
 
 

--- a/h/presenters/annotation_html.py
+++ b/h/presenters/annotation_html.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from dateutil import parser
 
 import jinja2

--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import copy
 
 from pyramid import security

--- a/h/presenters/annotation_jsonld.py
+++ b/h/presenters/annotation_jsonld.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.presenters.annotation_base import AnnotationBasePresenter
 
 

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.presenters.annotation_base import AnnotationBasePresenter
 from h.presenters.document_searchindex import DocumentSearchIndexPresenter
 from h.util.user import split_user

--- a/h/presenters/document_html.py
+++ b/h/presenters/document_html.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import jinja2
 
 from h._compat import text_type, urlparse, url_unquote

--- a/h/presenters/document_json.py
+++ b/h/presenters/document_json.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 
 class DocumentJSONPresenter:
     def __init__(self, document):

--- a/h/presenters/document_searchindex.py
+++ b/h/presenters/document_searchindex.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 
 class DocumentSearchIndexPresenter:
     def __init__(self, document):

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.presenters.organization_json import OrganizationJSONPresenter
 
 

--- a/h/presenters/organization_json.py
+++ b/h/presenters/organization_json.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 
 class OrganizationJSONPresenter:
     """Present an organization in the JSON format returned by API requests."""

--- a/h/presenters/user_json.py
+++ b/h/presenters/user_json.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 
 class UserJSONPresenter:
     """Present a user.

--- a/h/pubid.py
+++ b/h/pubid.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 """
 Generate random strings for use as identifiers in URLs (and other places).
 

--- a/h/realtime.py
+++ b/h/realtime.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import base64
 import random
 import struct

--- a/h/renderers.py
+++ b/h/renderers.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pyramid.renderers
 
 

--- a/h/routes.py
+++ b/h/routes.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 
 def includeme(config):
     # Core

--- a/h/schemas/__init__.py
+++ b/h/schemas/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 """Classes for validating data supplied to the application."""
-from __future__ import unicode_literals
-
 from h.schemas.base import ValidationError
 
 __all__ = ("ValidationError",)

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Classes for validating data passed to the annotations API."""
-from __future__ import unicode_literals
-
 import colander
 import copy
 from dateutil.parser import parse

--- a/h/schemas/api/__init__.py
+++ b/h/schemas/api/__init__.py
@@ -1,3 +1,1 @@
 # -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Schema for validating API group resources"""
 
-from __future__ import unicode_literals
-
 from h.schemas.base import JSONSchema, ValidationError
 from h.models.group import (
     GROUP_NAME_MIN_LENGTH,

--- a/h/schemas/api/user.py
+++ b/h/schemas/api/user.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.models.user import (
     DISPLAY_NAME_MAX_LENGTH,
     EMAIL_MAX_LENGTH,

--- a/h/schemas/auth_client.py
+++ b/h/schemas/auth_client.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import colander
 import deform
 

--- a/h/schemas/base.py
+++ b/h/schemas/base.py
@@ -2,8 +2,6 @@
 
 """Shared functionality for schemas."""
 
-from __future__ import unicode_literals
-
 import copy
 
 import colander

--- a/h/schemas/forms/__init__.py
+++ b/h/schemas/forms/__init__.py
@@ -1,3 +1,1 @@
 # -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals

--- a/h/schemas/forms/accounts/__init__.py
+++ b/h/schemas/forms/accounts/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.schemas.forms.accounts.edit_profile import EditProfileSchema
 from h.schemas.forms.accounts.forgot_password import ForgotPasswordSchema
 from h.schemas.forms.accounts.login import LoginSchema

--- a/h/schemas/forms/accounts/edit_profile.py
+++ b/h/schemas/forms/accounts/edit_profile.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import colander
 import deform
 

--- a/h/schemas/forms/accounts/forgot_password.py
+++ b/h/schemas/forms/accounts/forgot_password.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import colander
 import deform
 

--- a/h/schemas/forms/accounts/login.py
+++ b/h/schemas/forms/accounts/login.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import colander
 import deform
 

--- a/h/schemas/forms/accounts/reset_password.py
+++ b/h/schemas/forms/accounts/reset_password.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import colander
 import deform
 from itsdangerous import BadData, SignatureExpired

--- a/h/schemas/forms/accounts/util.py
+++ b/h/schemas/forms/accounts/util.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import colander
 import deform
 

--- a/h/schemas/forms/admin/__init__.py
+++ b/h/schemas/forms/admin/__init__.py
@@ -1,3 +1,1 @@
 # -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals

--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import colander
 from deform.widget import (
     CheckboxWidget,

--- a/h/schemas/forms/admin/organization.py
+++ b/h/schemas/forms/admin/organization.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import colander
 from deform.widget import TextAreaWidget, TextInputWidget
 from xml.etree import ElementTree

--- a/h/schemas/forms/group.py
+++ b/h/schemas/forms/group.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import colander
 import deform
 

--- a/h/schemas/util.py
+++ b/h/schemas/util.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import colander
 from webob.multidict import MultiDict
 

--- a/h/schemas/validators.py
+++ b/h/schemas/validators.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Custom Colander validators."""
 
-from __future__ import unicode_literals
-
 import colander
 
 

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from h.search.client import get_client
 from h.search.config import init
 from h.search.core import Search

--- a/h/search/client.py
+++ b/h/search/client.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import elasticsearch
 
 

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -8,8 +8,6 @@ into Elasticsearch. It also contains some helper functions to create and update
 these settings in an Elasticsearch instance.
 """
 
-from __future__ import unicode_literals
-
 import binascii
 import elasticsearch
 import logging

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import logging
 from collections import namedtuple
 from contextlib import contextmanager

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Functions for updating the search index."""
 
-from __future__ import division, unicode_literals
-
 import logging
 import time
 from collections import namedtuple

--- a/h/search/parser.py
+++ b/h/search/parser.py
@@ -5,8 +5,6 @@ The query parser which converts our subset of the Apache Lucene syntax and
 transforms it into a MultiDict structure that h.search understands.
 """
 
-from __future__ import unicode_literals
-
 from collections import namedtuple
 
 import pyparsing as pp

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from dateutil.parser import parse
 from dateutil import tz
 from datetime import datetime as dt

--- a/h/search/util.py
+++ b/h/search/util.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import re
 from h._compat import urlparse
 

--- a/h/security.py
+++ b/h/security.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import base64
 import hashlib
 import os

--- a/h/sentry/__init__.py
+++ b/h/sentry/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Error tracking service API and setup."""
-from __future__ import unicode_literals
-
 import sentry_sdk
 import sentry_sdk.integrations.celery
 import sentry_sdk.integrations.pyramid

--- a/h/sentry/helpers/__init__.py
+++ b/h/sentry/helpers/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/h/sentry/helpers/before_send.py
+++ b/h/sentry/helpers/before_send.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import logging
 
 from h.sentry.helpers.event import Event

--- a/h/sentry/helpers/event.py
+++ b/h/sentry/helpers/event.py
@@ -9,8 +9,6 @@ whether the event is an exception raised or an error logged. This class
 provides a more convenient interface to the interesting properties of events.
 """
 
-from __future__ import unicode_literals
-
 
 class Event:
     """A decorator for a sentry_sdk event."""

--- a/h/sentry/helpers/filters.py
+++ b/h/sentry/helpers/filters.py
@@ -7,8 +7,6 @@ returns ``True`` if the event should be reported to Sentry or ``False`` to
 filter it out. Every filter function gets called for every event and if any one
 filter returns ``False`` for a given event then the event is not reported.
 """
-from __future__ import unicode_literals
-
 import ws4py.exc
 
 

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -2,8 +2,6 @@
 
 """Service definitions that handle business logic."""
 
-from __future__ import unicode_literals
-
 
 def includeme(config):
     config.register_service_factory(

--- a/h/services/annotation_delete.py
+++ b/h/services/annotation_delete.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from datetime import datetime
 
 from h.events import AnnotationEvent

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from sqlalchemy.orm import subqueryload
 
 from h import formatters

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h import models
 
 

--- a/h/services/annotation_stats.py
+++ b/h/services/annotation_stats.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from webob.multidict import MultiDict
 
 from h.search import Search

--- a/h/services/auth_ticket.py
+++ b/h/services/auth_ticket.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 
 from pyramid_authsanity import interfaces

--- a/h/services/auth_token.py
+++ b/h/services/auth_token.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h import models
 from h.auth.tokens import Token
 

--- a/h/services/delete_group.py
+++ b/h/services/delete_group.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.models import Annotation
 
 

--- a/h/services/delete_user.py
+++ b/h/services/delete_user.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.models import Annotation, Group
 
 

--- a/h/services/developer_token.py
+++ b/h/services/developer_token.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h import models
 from h import security
 from h.util.db import lru_cache_in_transaction

--- a/h/services/document.py
+++ b/h/services/document.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 
 from h.models import Document, Annotation

--- a/h/services/exceptions.py
+++ b/h/services/exceptions.py
@@ -2,8 +2,6 @@
 
 """Exceptions raised by :mod:`h.services`."""
 
-from __future__ import unicode_literals
-
 
 class ServiceError(Exception):
     """Base class for all :mod:`h.services` exception classes."""

--- a/h/services/feature.py
+++ b/h/services/feature.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import re
 
 from h import models

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h import models
 
 

--- a/h/services/flag_count.py
+++ b/h/services/flag_count.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 
 from h.models import Flag

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 
 from h.models import Group, User

--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from functools import partial
 
 from h import session

--- a/h/services/group_links.py
+++ b/h/services/group_links.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 
 class GroupLinksService:
 

--- a/h/services/group_list.py
+++ b/h/services/group_list.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h import models
 from h.models import group
 

--- a/h/services/group_members.py
+++ b/h/services/group_members.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from functools import partial
 
 from h import session

--- a/h/services/group_scope.py
+++ b/h/services/group_scope.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.models import GroupScope
 from h.util import group_scope as scope_util
 

--- a/h/services/group_update.py
+++ b/h/services/group_update.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from sqlalchemy.exc import SQLAlchemyError
 
 from h.services.exceptions import ValidationError, ConflictError

--- a/h/services/groupfinder.py
+++ b/h/services/groupfinder.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from zope.interface import implementer
 
 from h import models

--- a/h/services/links.py
+++ b/h/services/links.py
@@ -2,8 +2,6 @@
 
 """Tools for generating links to domain objects. """
 
-from __future__ import unicode_literals
-
 from pyramid.request import Request
 
 from h.auth import default_authority

--- a/h/services/list_organizations.py
+++ b/h/services/list_organizations.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.models.organization import Organization
 
 

--- a/h/services/nipsa.py
+++ b/h/services/nipsa.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from h.models import User
 from h.tasks.indexer import reindex_user_annotations
 

--- a/h/services/oauth_provider.py
+++ b/h/services/oauth_provider.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 
 from oauthlib.oauth2 import (

--- a/h/services/oauth_validator.py
+++ b/h/services/oauth_validator.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 import hmac
 

--- a/h/services/organization.py
+++ b/h/services/organization.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from h.models import Organization
 
 

--- a/h/services/rename_user.py
+++ b/h/services/rename_user.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h import models
 from h.search import index
 

--- a/h/services/settings.py
+++ b/h/services/settings.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.models import Setting
 
 

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 
 from h.models import User, UserIdentity

--- a/h/services/user_password.py
+++ b/h/services/user_password.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 
 from h._compat import text_type

--- a/h/services/user_signup.py
+++ b/h/services/user_signup.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import logging
 from functools import partial
 

--- a/h/services/user_unique.py
+++ b/h/services/user_unique.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.i18n import TranslationString as _  # noqa: N813
 from h import models
 

--- a/h/services/user_update.py
+++ b/h/services/user_update.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from sqlalchemy.exc import SQLAlchemyError
 
 from h.services.exceptions import ConflictError, ValidationError

--- a/h/session.py
+++ b/h/session.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid.csrf import SessionCSRFStoragePolicy
 from pyramid.session import SignedCookieSessionFactory, JSONSerializer
 

--- a/h/settings.py
+++ b/h/settings.py
@@ -2,8 +2,6 @@
 
 """Helpers for parsing settings from the environment."""
 
-from __future__ import unicode_literals
-
 import logging
 import os
 

--- a/h/stats.py
+++ b/h/stats.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import statsd
 
 __all__ = ("get_client",)

--- a/h/storage.py
+++ b/h/storage.py
@@ -6,8 +6,6 @@ This module provides the core API with access to basic persistence functions
 for storing and retrieving annotations. Data passed to these functions is
 assumed to be validated.
 """
-from __future__ import unicode_literals
-
 # FIXME: This module was originally written to be a single point of
 #        indirection through which the storage backend could be swapped out on
 #        the fly. This helped us to migrate from Elasticsearch-based

--- a/h/streamer/__init__.py
+++ b/h/streamer/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 
 def includeme(config):

--- a/h/streamer/filter.py
+++ b/h/streamer/filter.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import unicodedata
 
 from jsonpointer import resolve_pointer

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from collections import namedtuple
 import logging
 

--- a/h/streamer/streamer.py
+++ b/h/streamer/streamer.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import logging
 import sys
 

--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from pyramid.view import forbidden_view_config
 from pyramid.view import notfound_view_config
 from pyramid.view import view_config

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from collections import namedtuple
 import copy
 import json

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals
 from h import __version__
 from h import emails
 from h import storage

--- a/h/tasks/__init__.py
+++ b/h/tasks/__init__.py
@@ -1,4 +1,3 @@
 # -*- coding: utf-8 -*-
 
 """Background worker task definitions for the h application."""
-from __future__ import unicode_literals

--- a/h/tasks/admin.py
+++ b/h/tasks/admin.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h import models
 from h.celery import celery
 from h.celery import get_task_logger

--- a/h/tasks/cleanup.py
+++ b/h/tasks/cleanup.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from datetime import datetime, timedelta
 
 from h import models

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from h import models, storage
 from h.celery import celery, get_task_logger
 from h.search.index import BatchIndexer, delete, index

--- a/h/tasks/mailer.py
+++ b/h/tasks/mailer.py
@@ -4,8 +4,6 @@ A module for sending email.
 
 This module defines a Celery task for sending emails in a worker process.
 """
-from __future__ import unicode_literals
-
 import smtplib
 
 import pyramid_mailer

--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from h.traversal.roots import Root
 from h.traversal.roots import AnnotationRoot
 from h.traversal.roots import AuthClientRoot

--- a/h/traversal/contexts.py
+++ b/h/traversal/contexts.py
@@ -19,8 +19,6 @@ For such a route Pyramid will conveniently pass the found context object into
 the view callable as the ``context`` argument.
 
 """
-from __future__ import unicode_literals
-
 from pyramid.security import DENY_ALL
 from pyramid.security import Allow
 from pyramid.security import principals_allowed_by_permission

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -60,8 +60,6 @@ shouldn't return model objects directly).
    * https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/traversal.html
 
 """
-from __future__ import unicode_literals
-
 
 from pyramid.security import ALL_PERMISSIONS, DENY_ALL, Allow, Authenticated
 import sqlalchemy.exc

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import collections
 import logging
 from codecs import open

--- a/h/util/__init__.py
+++ b/h/util/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from h.util import db
 from h.util import user
 from h.util import view

--- a/h/util/datetime.py
+++ b/h/util/datetime.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 """Shared utility functions for manipulating dates and times."""
-from __future__ import unicode_literals
 
 
 def utc_iso8601(datetime):

--- a/h/util/db.py
+++ b/h/util/db.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 try:
     from functools import lru_cache
 except ImportError:

--- a/h/util/document_claims.py
+++ b/h/util/document_claims.py
@@ -12,8 +12,6 @@ and returned.
 
 """
 
-from __future__ import unicode_literals
-
 import re
 
 

--- a/h/util/group.py
+++ b/h/util/group.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Some shared utility functions for manipulating group data."""
-from __future__ import unicode_literals
-
 import re
 
 GROUPID_PATTERN = r"^group:([a-zA-Z0-9._\-+!~*()']{1,1024})@(.*)$"

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h._compat import urlparse
 
 

--- a/h/util/logging_filters.py
+++ b/h/util/logging_filters.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Logging Filters."""
-from __future__ import unicode_literals
-
 import logging
 
 

--- a/h/util/markdown.py
+++ b/h/util/markdown.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import re
 from functools import partial
 

--- a/h/util/metrics.py
+++ b/h/util/metrics.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import newrelic.agent
 
 

--- a/h/util/query.py
+++ b/h/util/query.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 """Database query utilities."""
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 
 

--- a/h/util/redirects.py
+++ b/h/util/redirects.py
@@ -23,8 +23,6 @@ The redirect type can be one of the following:
 Lines that contain only whitespace, or which start with a '#' character, will
 be ignored.
 """
-from __future__ import unicode_literals
-
 from collections import namedtuple
 
 

--- a/h/util/session_tracker.py
+++ b/h/util/session_tracker.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from copy import copy
 from enum import Enum
 

--- a/h/util/user.py
+++ b/h/util/user.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Some shared utility functions for manipulating user data."""
-from __future__ import unicode_literals
 import re
 
 

--- a/h/util/view.py
+++ b/h/util/view.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sys
 
 from pyramid.view import view_config

--- a/h/viewderivers.py
+++ b/h/viewderivers.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 
 def csp_protected_view(view, info):
     """

--- a/h/viewpredicates.py
+++ b/h/viewpredicates.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 """Custom Pyramid view predicates."""
-from __future__ import unicode_literals
 
 
 class FeaturePredicate:

--- a/h/views/__init__.py
+++ b/h/views/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 
 def includeme(config):

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import datetime
 
 import deform

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import datetime
 import itertools
 

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -2,8 +2,6 @@
 
 """Activity pages views."""
 
-from __future__ import unicode_literals
-
 from h._compat import urlparse
 
 from jinja2 import Markup

--- a/h/views/admin/__init__.py
+++ b/h/views/admin/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 
 def includeme(config):

--- a/h/views/admin/admins.py
+++ b/h/views/admin/admins.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from pyramid import httpexceptions
 from pyramid.view import view_config
 

--- a/h/views/admin/badge.py
+++ b/h/views/admin/badge.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from pyramid import httpexceptions
 from pyramid.view import view_config
 from sqlalchemy.exc import IntegrityError

--- a/h/views/admin/features.py
+++ b/h/views/admin/features.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from pyramid import httpexceptions
 from pyramid.view import view_config
 

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from jinja2 import Markup
 from pyramid.view import view_config, view_defaults
 from pyramid.httpexceptions import HTTPFound

--- a/h/views/admin/index.py
+++ b/h/views/admin/index.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import platform
 
 from pyramid.view import view_config

--- a/h/views/admin/mailer.py
+++ b/h/views/admin/mailer.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid.httpexceptions import HTTPSeeOther
 from pyramid.view import view_config
 

--- a/h/views/admin/nipsa.py
+++ b/h/views/admin/nipsa.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from pyramid import httpexceptions
 from pyramid.view import view_config
 

--- a/h/views/admin/oauthclients.py
+++ b/h/views/admin/oauthclients.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config, view_defaults
 

--- a/h/views/admin/organizations.py
+++ b/h/views/admin/organizations.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from jinja2 import Markup
 from pyramid.view import view_config, view_defaults
 from pyramid.httpexceptions import HTTPFound

--- a/h/views/admin/staff.py
+++ b/h/views/admin/staff.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from pyramid import httpexceptions
 from pyramid.view import view_config
 

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import jinja2
 from pyramid import httpexceptions
 from pyramid.view import view_config

--- a/h/views/api/__init__.py
+++ b/h/views/api/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 API_VERSIONS = ["v1", "v2"]
 """All of the app's known API versions"""
 

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -16,7 +16,6 @@ particular, requests to the CRUD API endpoints are protected by the Pyramid
 authorization system. You can find the mapping between annotation "permissions"
 objects and Pyramid ACLs in :mod:`h.traversal`.
 """
-from __future__ import unicode_literals
 from pyramid import i18n
 
 from h import search as search_lib

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import json
 import logging
 

--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import venusian
 
 from h.views.api.helpers import cors

--- a/h/views/api/decorators/__init__.py
+++ b/h/views/api/decorators/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from h.views.api.decorators.client_errors import (
     unauthorized_to_not_found,
     normalize_not_found,

--- a/h/views/api/decorators/client_errors.py
+++ b/h/views/api/decorators/client_errors.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """API view decorators for exception views"""
 
-from __future__ import unicode_literals
-
 from pyramid.httpexceptions import HTTPNotFound, HTTPNotAcceptable
 
 from h.views.api.helpers.media_types import valid_media_types

--- a/h/views/api/decorators/response.py
+++ b/h/views/api/decorators/response.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """API view decorators for response headers"""
 
-from __future__ import unicode_literals
-
 from h.views.api import API_VERSION_DEFAULT
 from h.views.api.helpers.media_types import media_type_for_version, version_media_types
 

--- a/h/views/api/errors.py
+++ b/h/views/api/errors.py
@@ -7,8 +7,6 @@ Views rendered by the web application in response to exceptions thrown within
 API views.
 """
 
-from __future__ import unicode_literals
-
 from pyramid.view import forbidden_view_config
 from pyramid.view import notfound_view_config
 from pyramid.view import view_config

--- a/h/views/api/exceptions.py
+++ b/h/views/api/exceptions.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Exceptions raised by the h application."""
 
-from __future__ import unicode_literals
-
 from pyramid import httpexceptions
 
 from h.i18n import TranslationString as _  # noqa: N813

--- a/h/views/api/flags.py
+++ b/h/views/api/flags.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid.httpexceptions import HTTPNoContent
 
 from h.views.api.config import api_config

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid import security
 from pyramid.httpexceptions import (
     HTTPNoContent,

--- a/h/views/api/helpers/__init__.py
+++ b/h/views/api/helpers/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/h/views/api/helpers/angular.py
+++ b/h/views/api/helpers/angular.py
@@ -3,8 +3,6 @@
 Support for providing Angular-compatible routes for the client.
 """
 
-from __future__ import unicode_literals
-
 
 class AngularRouteTemplater:
     """

--- a/h/views/api/helpers/cors.py
+++ b/h/views/api/helpers/cors.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.response import Response
 

--- a/h/views/api/helpers/links.py
+++ b/h/views/api/helpers/links.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Helpers for generating and retrieving service link metadata"""
 
-from __future__ import unicode_literals
-
 
 class ServiceLink:
     """Encapsulate metadata about an API service"""

--- a/h/views/api/helpers/media_types.py
+++ b/h/views/api/helpers/media_types.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from h.views.api import API_VERSIONS
 
 

--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.views.api.config import api_config
 from h.views.api.helpers.angular import AngularRouteTemplater
 from h.views.api.helpers import links as link_helpers

--- a/h/views/api/links.py
+++ b/h/views/api/links.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.views.api.config import api_config
 from h.views.api.helpers.angular import AngularRouteTemplater
 

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid.httpexceptions import HTTPNoContent
 
 from h import events

--- a/h/views/api/profile.py
+++ b/h/views/api/profile.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid.httpexceptions import HTTPBadRequest
 
 from h import session as h_session

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid.httpexceptions import HTTPConflict
 
 from h.auth.util import client_authority

--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid import httpexceptions
 from webob.multidict import MultiDict
 

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -6,8 +6,6 @@ Hypothesis client views.
 Views which exist either to serve or support the Hypothesis client.
 """
 
-from __future__ import unicode_literals
-
 import json
 import time
 

--- a/h/views/errors.py
+++ b/h/views/errors.py
@@ -7,8 +7,6 @@ Views rendered by the web application in response to exceptions thrown within
 views.
 """
 
-from __future__ import unicode_literals
-
 from pyramid.view import forbidden_view_config
 from pyramid.view import notfound_view_config
 from pyramid.view import view_config

--- a/h/views/feeds.py
+++ b/h/views/feeds.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid.view import view_config
 from pyramid import i18n
 from webob.multidict import MultiDict

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import deform
 from pyramid import httpexceptions
 from pyramid import security

--- a/h/views/help.py
+++ b/h/views/help.py
@@ -2,8 +2,6 @@
 
 """Help and documentation views."""
 
-from __future__ import unicode_literals
-
 import binascii
 import os
 

--- a/h/views/home.py
+++ b/h/views/home.py
@@ -2,8 +2,6 @@
 
 """Views serving the homepage and related endpoints."""
 
-from __future__ import unicode_literals
-
 from pyramid import httpexceptions
 from pyramid.view import view_config
 

--- a/h/views/main.py
+++ b/h/views/main.py
@@ -6,8 +6,6 @@ Core application views.
 Important views which don't form part of any other major feature package.
 """
 
-from __future__ import unicode_literals
-
 import logging
 
 from pyramid import httpexceptions

--- a/h/views/notification.py
+++ b/h/views/notification.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from pyramid.httpexceptions import HTTPNotFound
 from pyramid.view import view_config
 

--- a/h/views/organizations.py
+++ b/h/views/organizations.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid.view import view_config
 
 

--- a/h/views/status.py
+++ b/h/views/status.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import logging
 
 from pyramid.httpexceptions import HTTPInternalServerError

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -35,8 +35,6 @@ N.B. Portions of the ws4py code are used here under the terms of the MIT
 license distributed with the ws4py project. Such code remains copyright (c)
 2011-2015, Sylvain Hellegouarch.
 """
-from __future__ import unicode_literals
-
 import logging
 
 from gevent.pool import Pool

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 """Factory classes for easily generating test objects."""
-from __future__ import unicode_literals
-
 from .base import set_session
 
 from .activation import Activation

--- a/tests/common/factories/activation.py
+++ b/tests/common/factories/activation.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from h import models
 
 from .base import ModelFactory

--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 import random
 import uuid

--- a/tests/common/factories/annotation_moderation.py
+++ b/tests/common/factories/annotation_moderation.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import factory
 
 from h import models

--- a/tests/common/factories/auth_client.py
+++ b/tests/common/factories/auth_client.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import factory
 
 from h import models

--- a/tests/common/factories/auth_ticket.py
+++ b/tests/common/factories/auth_ticket.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import base64
 import os
 from datetime import datetime, timedelta

--- a/tests/common/factories/authz_code.py
+++ b/tests/common/factories/authz_code.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import random
 from datetime import datetime, timedelta
 

--- a/tests/common/factories/base.py
+++ b/tests/common/factories/base.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import factory
 import faker
 

--- a/tests/common/factories/document.py
+++ b/tests/common/factories/document.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import factory
 
 from h import models

--- a/tests/common/factories/feature.py
+++ b/tests/common/factories/feature.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import factory
 
 from h import models

--- a/tests/common/factories/flag.py
+++ b/tests/common/factories/flag.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import factory
 
 from h import models

--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import factory
 
 from h import models

--- a/tests/common/factories/group_scope.py
+++ b/tests/common/factories/group_scope.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import factory
 
 from h import models

--- a/tests/common/factories/organization.py
+++ b/tests/common/factories/organization.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import factory
 
 from h import models

--- a/tests/common/factories/setting.py
+++ b/tests/common/factories/setting.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import factory
 
 from h import models

--- a/tests/common/factories/token.py
+++ b/tests/common/factories/token.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from datetime import datetime, timedelta
 
 import factory

--- a/tests/common/factories/user.py
+++ b/tests/common/factories/user.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import factory
 
 from h import models

--- a/tests/common/factories/user_identity.py
+++ b/tests/common/factories/user_identity.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import factory
 
 from h import models

--- a/tests/common/fixtures/__init__.py
+++ b/tests/common/fixtures/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from tests.common.fixtures.elasticsearch import es_client
 from tests.common.fixtures.elasticsearch import init_elasticsearch
 

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import os
 import elasticsearch_dsl
 

--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -26,8 +26,6 @@ output if it fails, e.g.
     E       Actual call: set_value('a string')
 
 """
-from __future__ import unicode_literals
-
 import re
 
 from pyramid import httpexceptions

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/functional/api/__init__.py
+++ b/tests/functional/api/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/functional/api/groups/test_create.py
+++ b/tests/functional/api/groups/test_create.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 import base64
 

--- a/tests/functional/api/groups/test_members.py
+++ b/tests/functional/api/groups/test_members.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 import base64
 

--- a/tests/functional/api/groups/test_read.py
+++ b/tests/functional/api/groups/test_read.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 import base64
 

--- a/tests/functional/api/groups/test_update.py
+++ b/tests/functional/api/groups/test_update.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 import base64
 

--- a/tests/functional/api/groups/test_upsert.py
+++ b/tests/functional/api/groups/test_upsert.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 import base64
 

--- a/tests/functional/api/test_annotations.py
+++ b/tests/functional/api/test_annotations.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 

--- a/tests/functional/api/test_api.py
+++ b/tests/functional/api/test_api.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 

--- a/tests/functional/api/test_errors.py
+++ b/tests/functional/api/test_errors.py
@@ -5,8 +5,6 @@ Functional tests for client API errors
 Uses create-group endpoint as it can raise all relevant client error codes.
 """
 
-from __future__ import unicode_literals
-
 import pytest
 import base64
 

--- a/tests/functional/api/test_flags.py
+++ b/tests/functional/api/test_flags.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 

--- a/tests/functional/api/test_index.py
+++ b/tests/functional/api/test_index.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 

--- a/tests/functional/api/test_moderation.py
+++ b/tests/functional/api/test_moderation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 

--- a/tests/functional/api/test_profile.py
+++ b/tests/functional/api/test_profile.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 

--- a/tests/functional/api/test_users.py
+++ b/tests/functional/api/test_users.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 import base64
 

--- a/tests/functional/api/test_versions.py
+++ b/tests/functional/api/test_versions.py
@@ -3,8 +3,6 @@
 Test the versioning of our API using Accept headers
 """
 
-from __future__ import unicode_literals
-
 
 class TestIndexEndpointVersions:
     def test_index_sets_version_response_header(self, app):

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import contextlib
 import os
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 

--- a/tests/functional/test_feeds.py
+++ b/tests/functional/test_feeds.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 
 def test_atom_feed(app):
     app.get("/stream.atom")

--- a/tests/functional/test_groups.py
+++ b/tests/functional/test_groups.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 

--- a/tests/functional/test_moderation.py
+++ b/tests/functional/test_moderation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 

--- a/tests/functional/test_oauth.py
+++ b/tests/functional/test_oauth.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Functional tests for getting and using OAuth 2 access and refresh tokens."""
 
-from __future__ import unicode_literals
-
 import calendar
 import datetime
 

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Functional tests for the /search page, without JavaScript."""
 
-from __future__ import unicode_literals
-
 
 def test_search_input_text_is_submitted_as_q_without_javascript(app):
     res = app.get("/search")

--- a/tests/functional/test_tweens.py
+++ b/tests/functional/test_tweens.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 
 class TestInvalidPathTweenFactory:

--- a/tests/h/__init__.py
+++ b/tests/h/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/accounts/__init__.py
+++ b/tests/h/accounts/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from unittest import mock
 
 import pytest

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest.mock import Mock
 
 import colander

--- a/tests/h/accounts/util_test.py
+++ b/tests/h/accounts/util_test.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import pytest
 
 from h.accounts.util import validate_orcid, validate_url

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 from unittest.mock import Mock
 

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/admin/__init__.py
+++ b/tests/h/admin/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/assets_test.py
+++ b/tests/h/assets_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from io import StringIO
 from sys import version_info
 from unittest.mock import patch

--- a/tests/h/auth/__init__.py
+++ b/tests/h/auth/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from collections import namedtuple
 from unittest import mock
 

--- a/tests/h/badge/__init__.py
+++ b/tests/h/badge/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/celery_test.py
+++ b/tests/h/celery_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 from billiard.einfo import ExceptionInfo

--- a/tests/h/cli/__init__.py
+++ b/tests/h/cli/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/cli/commands/__init__.py
+++ b/tests/h/cli/commands/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/cli/commands/normalize_uris_test.py
+++ b/tests/h/cli/commands/normalize_uris_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/config_test.py
+++ b/tests/h/config_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import pytest
 
 from h.config import configure

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -4,8 +4,6 @@
 The `conftest` module is automatically loaded by pytest and serves as a place
 to put fixture functions that are useful application-wide.
 """
-from __future__ import unicode_literals
-
 import functools
 import os
 from unittest import mock

--- a/tests/h/db/__init__.py
+++ b/tests/h/db/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/db/types_test.py
+++ b/tests/h/db/types_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import pytest
 
 from sqlalchemy.dialects.postgresql import dialect

--- a/tests/h/emails/__init__.py
+++ b/tests/h/emails/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/emails/flag_notification_test.py
+++ b/tests/h/emails/flag_notification_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.emails.flag_notification import generate

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/emails/reset_password_test.py
+++ b/tests/h/emails/reset_password_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/emails/signup_test.py
+++ b/tests/h/emails/signup_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.emails.signup import generate

--- a/tests/h/emails/test_test.py
+++ b/tests/h/emails/test_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h._compat import string_types

--- a/tests/h/eventqueue_test.py
+++ b/tests/h/eventqueue_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/events_test.py
+++ b/tests/h/events_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 from h.events import AnnotationEvent, AnnotationTransformEvent

--- a/tests/h/feeds/__init__.py
+++ b/tests/h/feeds/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=protected-access
 """Unit tests for h/atom.py."""
-from __future__ import unicode_literals
 from datetime import datetime
 from unittest import mock
 

--- a/tests/h/feeds/render_test.py
+++ b/tests/h/feeds/render_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/feeds/util_test.py
+++ b/tests/h/feeds/util_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/formatters/annotation_flag_test.py
+++ b/tests/h/formatters/annotation_flag_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from collections import namedtuple
 
 import pytest

--- a/tests/h/formatters/annotation_hidden_test.py
+++ b/tests/h/formatters/annotation_hidden_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from collections import namedtuple
 
 import pytest

--- a/tests/h/formatters/annotation_moderation_test.py
+++ b/tests/h/formatters/annotation_moderation_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from collections import namedtuple
 
 import pytest

--- a/tests/h/formatters/annotation_user_info_test.py
+++ b/tests/h/formatters/annotation_user_info_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from collections import namedtuple
 from unittest import mock
 

--- a/tests/h/groups/__init__.py
+++ b/tests/h/groups/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/indexer/__init__.py
+++ b/tests/h/indexer/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/indexer/subscribers_test.py
+++ b/tests/h/indexer/subscribers_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import pytest
 
 from h import events

--- a/tests/h/jinja_extension_test.py
+++ b/tests/h/jinja_extension_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import datetime
 
 from jinja2 import Markup

--- a/tests/h/links_test.py
+++ b/tests/h/links_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/models/activation_test.py
+++ b/tests/h/models/activation_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import re
 
 from h.models import Activation

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.models.annotation import Annotation

--- a/tests/h/models/auth_client_test.py
+++ b/tests/h/models/auth_client_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from sqlalchemy.exc import IntegrityError

--- a/tests/h/models/blocklist_test.py
+++ b/tests/h/models/blocklist_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h import models
 
 

--- a/tests/h/models/document_test.py
+++ b/tests/h/models/document_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/models/feature_test.py
+++ b/tests/h/models/feature_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from sqlalchemy import inspect

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from pyramid import security

--- a/tests/h/models/organization_test.py
+++ b/tests/h/models/organization_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 from h import models
 

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 
 from h.models import Token

--- a/tests/h/models/user_identity_test.py
+++ b/tests/h/models/user_identity_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 import sqlalchemy.exc
 

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 from sqlalchemy import exc
 from pyramid.authorization import ACLAuthorizationPolicy

--- a/tests/h/nipsa/__init__.py
+++ b/tests/h/nipsa/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/nipsa/subscribers_test.py
+++ b/tests/h/nipsa/subscribers_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from collections import namedtuple
 from unittest import mock
 

--- a/tests/h/notification/__init__.py
+++ b/tests/h/notification/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/notification/reply_test.py
+++ b/tests/h/notification/reply_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/oauth/errors_test.py
+++ b/tests/h/oauth/errors_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from json import loads
 
 from h.oauth.errors import (

--- a/tests/h/oauth/jwt_grant_test.py
+++ b/tests/h/oauth/jwt_grant_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import json
 from calendar import timegm
 from datetime import datetime, timedelta

--- a/tests/h/oauth/jwt_grant_token_test.py
+++ b/tests/h/oauth/jwt_grant_token_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from calendar import timegm
 from datetime import datetime, timedelta
 

--- a/tests/h/oauth/tokens_test.py
+++ b/tests/h/oauth/tokens_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from unittest import mock
 
 import pytest

--- a/tests/h/paginator_test.py
+++ b/tests/h/paginator_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/panels/__init__.py
+++ b/tests/h/panels/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/panels/back_link_test.py
+++ b/tests/h/panels/back_link_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest.mock import Mock
 
 import pytest

--- a/tests/h/panels/navbar_test.py
+++ b/tests/h/panels/navbar_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/presenters/__init__.py
+++ b/tests/h/presenters/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/presenters/annotation_base_test.py
+++ b/tests/h/presenters/annotation_base_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/presenters/annotation_html_test.py
+++ b/tests/h/presenters/annotation_html_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/presenters/annotation_jsonld_test.py
+++ b/tests/h/presenters/annotation_jsonld_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/presenters/annotation_searchindex_test.py
+++ b/tests/h/presenters/annotation_searchindex_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/presenters/conftest.py
+++ b/tests/h/presenters/conftest.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/presenters/document_html_test.py
+++ b/tests/h/presenters/document_html_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h._compat import text_type
 
 from unittest import mock

--- a/tests/h/presenters/document_json_test.py
+++ b/tests/h/presenters/document_json_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h import models
 from h.presenters.document_json import DocumentJSONPresenter
 

--- a/tests/h/presenters/document_searchindex_test.py
+++ b/tests/h/presenters/document_searchindex_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h import models

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/presenters/organization_json_test.py
+++ b/tests/h/presenters/organization_json_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.presenters.organization_json import OrganizationJSONPresenter

--- a/tests/h/presenters/user_json_test.py
+++ b/tests/h/presenters/user_json_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.presenters.user_json import UserJSONPresenter, TrustedUserJSONPresenter

--- a/tests/h/realtime_test.py
+++ b/tests/h/realtime_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from datetime import datetime
 from unittest import mock
 

--- a/tests/h/renderers_test.py
+++ b/tests/h/renderers_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from collections import OrderedDict
 from unittest import mock
 

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest.mock import Mock, call
 
 from h.routes import includeme

--- a/tests/h/schemas/__init__.py
+++ b/tests/h/schemas/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/schemas/annotation_test.py
+++ b/tests/h/schemas/annotation_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from copy import deepcopy
 from unittest import mock
 

--- a/tests/h/schemas/api/__init__.py
+++ b/tests/h/schemas/api/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/schemas/api/group_test.py
+++ b/tests/h/schemas/api/group_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from h.models.group import (

--- a/tests/h/schemas/api/user_test.py
+++ b/tests/h/schemas/api/user_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from h.schemas.api.user import CreateUserAPISchema, UpdateUserAPISchema

--- a/tests/h/schemas/base_test.py
+++ b/tests/h/schemas/base_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import enum
 from unittest.mock import Mock
 

--- a/tests/h/schemas/forms/__init__.py
+++ b/tests/h/schemas/forms/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/schemas/forms/accounts/__init__.py
+++ b/tests/h/schemas/forms/accounts/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/schemas/forms/accounts/edit_profile_test.py
+++ b/tests/h/schemas/forms/accounts/edit_profile_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import colander
 import pytest
 

--- a/tests/h/schemas/forms/accounts/forgot_password_test.py
+++ b/tests/h/schemas/forms/accounts/forgot_password_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import colander
 import pytest
 

--- a/tests/h/schemas/forms/accounts/login_test.py
+++ b/tests/h/schemas/forms/accounts/login_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest.mock import Mock
 
 import colander

--- a/tests/h/schemas/forms/accounts/reset_password_test.py
+++ b/tests/h/schemas/forms/accounts/reset_password_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import colander
 import pytest
 from itsdangerous import BadData, SignatureExpired

--- a/tests/h/schemas/forms/admin/__init__.py
+++ b/tests/h/schemas/forms/admin/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/schemas/forms/admin/group_test.py
+++ b/tests/h/schemas/forms/admin/group_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import colander

--- a/tests/h/schemas/forms/admin/organization_test.py
+++ b/tests/h/schemas/forms/admin/organization_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import colander
 import pytest
 

--- a/tests/h/schemas/forms/group_test.py
+++ b/tests/h/schemas/forms/group_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import pytest
 
 import colander

--- a/tests/h/schemas/util_test.py
+++ b/tests/h/schemas/util_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import colander
 from webob.multidict import MultiDict
 import pytest

--- a/tests/h/schemas/validators_test.py
+++ b/tests/h/schemas/validators_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest.mock import Mock
 
 import pytest

--- a/tests/h/search/__init__.py
+++ b/tests/h/search/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 import elasticsearch

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from h._compat import url_quote_plus
 
 import itertools

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -7,8 +7,6 @@ Tests for filtering/matching/aggregating on specific annotation fields are in
 `query_test.py`.
 """
 
-from __future__ import unicode_literals
-
 import datetime
 import pytest
 from webob.multidict import MultiDict

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/search/parser_test.py
+++ b/tests/h/search/parser_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 from hypothesis import strategies as st
 from hypothesis import given, settings

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import datetime
 import elasticsearch_dsl
 import pytest

--- a/tests/h/search/util_test.py
+++ b/tests/h/search/util_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 from h.search import util
 

--- a/tests/h/security_test.py
+++ b/tests/h/security_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from binascii import hexlify, unhexlify
 import string
 

--- a/tests/h/sentry/__init___test.py
+++ b/tests/h/sentry/__init___test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from h.sentry import includeme, report_exception

--- a/tests/h/sentry/helpers/before_send_test.py
+++ b/tests/h/sentry/helpers/before_send_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import logging
 from unittest import mock
 

--- a/tests/h/sentry/helpers/event_test.py
+++ b/tests/h/sentry/helpers/event_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from h.sentry.helpers.event import Event
 
 

--- a/tests/h/sentry/helpers/filters_test.py
+++ b/tests/h/sentry/helpers/filters_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/__init__.py
+++ b/tests/h/services/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/services/annotation_delete_test.py
+++ b/tests/h/services/annotation_delete_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/annotation_moderation_test.py
+++ b/tests/h/services/annotation_moderation_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h import models

--- a/tests/h/services/annotation_stats_test.py
+++ b/tests/h/services/annotation_stats_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/auth_ticket_test.py
+++ b/tests/h/services/auth_ticket_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from datetime import datetime, timedelta
 from unittest import mock
 

--- a/tests/h/services/auth_token_test.py
+++ b/tests/h/services/auth_token_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 
 import pytest

--- a/tests/h/services/delete_group_test.py
+++ b/tests/h/services/delete_group_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/delete_user_test.py
+++ b/tests/h/services/delete_user_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/developer_token_test.py
+++ b/tests/h/services/developer_token_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h import models

--- a/tests/h/services/document_test.py
+++ b/tests/h/services/document_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.services.document import DocumentService

--- a/tests/h/services/exceptions_test.py
+++ b/tests/h/services/exceptions_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.services import exceptions
 
 

--- a/tests/h/services/feature_test.py
+++ b/tests/h/services/feature_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/flag_count_test.py
+++ b/tests/h/services/flag_count_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.services import flag_count

--- a/tests/h/services/flag_test.py
+++ b/tests/h/services/flag_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.services import flag

--- a/tests/h/services/group_create_test.py
+++ b/tests/h/services/group_create_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/group_links_test.py
+++ b/tests/h/services/group_links_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.services.group_links import GroupLinksService

--- a/tests/h/services/group_list_test.py
+++ b/tests/h/services/group_list_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/group_members_test.py
+++ b/tests/h/services/group_members_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/group_scope_test.py
+++ b/tests/h/services/group_scope_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.services.group_scope import group_scope_factory, GroupScopeService

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/services/group_update_test.py
+++ b/tests/h/services/group_update_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/groupfinder_test.py
+++ b/tests/h/services/groupfinder_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.services.groupfinder import groupfinder_service_factory

--- a/tests/h/services/links_test.py
+++ b/tests/h/services/links_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/list_organizations_test.py
+++ b/tests/h/services/list_organizations_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.services.list_organizations import ListOrganizationsService

--- a/tests/h/services/nipsa_test.py
+++ b/tests/h/services/nipsa_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.services.nipsa import NipsaService

--- a/tests/h/services/oauth_provider_test.py
+++ b/tests/h/services/oauth_provider_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 import uuid
 from unittest import mock

--- a/tests/h/services/organization_test.py
+++ b/tests/h/services/organization_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.models import Organization

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/settings_test.py
+++ b/tests/h/services/settings_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/user_password_test.py
+++ b/tests/h/services/user_password_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 from passlib.context import CryptContext
 

--- a/tests/h/services/user_signup_test.py
+++ b/tests/h/services/user_signup_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.models import User

--- a/tests/h/services/user_unique_test.py
+++ b/tests/h/services/user_unique_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/services/user_update_test.py
+++ b/tests/h/services/user_update_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/settings_test.py
+++ b/tests/h/settings_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import logging
 import pytest
 

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import copy
 from unittest import mock
 

--- a/tests/h/streamer/__init__.py
+++ b/tests/h/streamer/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/streamer/filter_test.py
+++ b/tests/h/streamer/filter_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from h.streamer.filter import FilterHandler

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/streamer/streamer_test.py
+++ b/tests/h/streamer/streamer_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 import pytest
 

--- a/tests/h/streamer/views_test.py
+++ b/tests/h/streamer/views_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import pytest
 
 from h.streamer import views

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from collections import namedtuple
 from unittest import mock
 

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/tasks/__init__.py
+++ b/tests/h/tasks/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/tasks/admin_test.py
+++ b/tests/h/tasks/admin_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.tasks.admin import rename_user

--- a/tests/h/tasks/cleanup_test.py
+++ b/tests/h/tasks/cleanup_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from datetime import datetime, timedelta
 
 import pytest

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/tasks/mailer_test.py
+++ b/tests/h/tasks/mailer_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from smtplib import SMTPServerDisconnected
 from unittest import mock
 

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pyramid.authorization

--- a/tests/h/tweens_test.py
+++ b/tests/h/tweens_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from h import tweens

--- a/tests/h/util/__init__.py
+++ b/tests/h/util/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/util/datetime_test.py
+++ b/tests/h/util/datetime_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import datetime
 
 from h.util.datetime import utc_iso8601, utc_us_style_date

--- a/tests/h/util/db_test.py
+++ b/tests/h/util/db_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import random
 from unittest import mock
 

--- a/tests/h/util/document_claims_test.py
+++ b/tests/h/util/document_claims_test.py
@@ -1,7 +1,5 @@
 # -*- encoding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import re
 import pytest
 

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from h.util import group_scope as scope_util

--- a/tests/h/util/group_test.py
+++ b/tests/h/util/group_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.util import group as group_util

--- a/tests/h/util/markdown_test.py
+++ b/tests/h/util/markdown_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.util import markdown

--- a/tests/h/util/metrics_test.py
+++ b/tests/h/util/metrics_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/util/query_test.py
+++ b/tests/h/util/query_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import string
 
 import pytest

--- a/tests/h/util/redirects_test.py
+++ b/tests/h/util/redirects_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import pytest
 from hypothesis import strategies as st
 from hypothesis import given

--- a/tests/h/util/session_tracker_test.py
+++ b/tests/h/util/session_tracker_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from uuid import uuid4
 import pytest
 from sqlalchemy.orm.util import identity_key

--- a/tests/h/util/test_logging_filters.py
+++ b/tests/h/util/test_logging_filters.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 import logging
 from urllib3.exceptions import ReadTimeoutError

--- a/tests/h/util/uri_test.py
+++ b/tests/h/util/uri_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h._compat import text_type

--- a/tests/h/util/user_test.py
+++ b/tests/h/util/user_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import pytest
 
 from h.util import user as user_util

--- a/tests/h/util/view_test.py
+++ b/tests/h/util/view_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest.mock import Mock
 
 import pytest

--- a/tests/h/viewderivers_test.py
+++ b/tests/h/viewderivers_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from h.viewderivers import csp_protected_view

--- a/tests/h/viewpredicates_test.py
+++ b/tests/h/viewpredicates_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 from h.viewpredicates import FeaturePredicate

--- a/tests/h/views/__init__.py
+++ b/tests/h/views/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/views/account_signup_test.py
+++ b/tests/h/views/account_signup_test.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=no-self-use
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=no-self-use
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import datetime
 from unittest import mock
 

--- a/tests/h/views/admin/__init__.py
+++ b/tests/h/views/admin/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/views/admin/admins_test.py
+++ b/tests/h/views/admin/admins_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/admin/badge_test.py
+++ b/tests/h/views/admin/badge_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/admin/features_test.py
+++ b/tests/h/views/admin/features_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/admin/index_test.py
+++ b/tests/h/views/admin/index_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.views.admin import index
 
 

--- a/tests/h/views/admin/mailer_test.py
+++ b/tests/h/views/admin/mailer_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from pyramid.httpexceptions import HTTPSeeOther

--- a/tests/h/views/admin/nipsa_test.py
+++ b/tests/h/views/admin/nipsa_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 from pyramid import httpexceptions
 

--- a/tests/h/views/admin/oauthclients_test.py
+++ b/tests/h/views/admin/oauthclients_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest.mock import create_autospec, Mock
 
 import pytest

--- a/tests/h/views/admin/organizations_test.py
+++ b/tests/h/views/admin/organizations_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from unittest.mock import Mock
 
 import pytest

--- a/tests/h/views/admin/staff_test.py
+++ b/tests/h/views/admin/staff_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 from pyramid import httpexceptions

--- a/tests/h/views/api/__init__.py
+++ b/tests/h/views/api/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/api/auth_test.py
+++ b/tests/h/views/api/auth_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import datetime

--- a/tests/h/views/api/config_test.py
+++ b/tests/h/views/api/config_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/api/decorators/__init__.py
+++ b/tests/h/views/api/decorators/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/views/api/decorators/client_errors_test.py
+++ b/tests/h/views/api/decorators/client_errors_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/api/decorators/response_test.py
+++ b/tests/h/views/api/decorators/response_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/api/errors_test.py
+++ b/tests/h/views/api/errors_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest.mock import Mock
 
 from pyramid.httpexceptions import HTTPExpectationFailed, HTTPNotFound

--- a/tests/h/views/api/exceptions_test.py
+++ b/tests/h/views/api/exceptions_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from h.views.api import exceptions
 
 

--- a/tests/h/views/api/flags_test.py
+++ b/tests/h/views/api/flags_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/api/helpers/__init__.py
+++ b/tests/h/views/api/helpers/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals

--- a/tests/h/views/api/helpers/angular_test.py
+++ b/tests/h/views/api/helpers/angular_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from h.views.api.helpers.angular import AngularRouteTemplater
 
 

--- a/tests/h/views/api/helpers/cors_test.py
+++ b/tests/h/views/api/helpers/cors_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/api/helpers/links_test.py
+++ b/tests/h/views/api/helpers/links_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/api/helpers/media_types_test.py
+++ b/tests/h/views/api/helpers/media_types_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from h.views.api.helpers import media_types

--- a/tests/h/views/api/index_test.py
+++ b/tests/h/views/api/index_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/api/links_test.py
+++ b/tests/h/views/api/links_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid import testing
 
 from h.views.api import links as views

--- a/tests/h/views/api/moderation_test.py
+++ b/tests/h/views/api/moderation_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/api/profile_test.py
+++ b/tests/h/views/api/profile_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import json
 
 from pyramid.httpexceptions import HTTPFound

--- a/tests/h/views/errors_test.py
+++ b/tests/h/views/errors_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest.mock import Mock
 
 from h.views.errors import notfound, error, json_error

--- a/tests/h/views/feeds_test.py
+++ b/tests/h/views/feeds_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import deform

--- a/tests/h/views/help_test.py
+++ b/tests/h/views/help_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 from pyramid import httpexceptions
 

--- a/tests/h/views/home_test.py
+++ b/tests/h/views/home_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from pyramid.httpexceptions import HTTPFound

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 from pyramid import httpexceptions

--- a/tests/h/views/notification_test.py
+++ b/tests/h/views/notification_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tests/h/views/organizations_test.py
+++ b/tests/h/views/organizations_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 from h.views import organizations

--- a/tests/h/views/status_test.py
+++ b/tests/h/views/status_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -98,7 +98,6 @@ commands =
     dev: {posargs:sh bin/hypothesis devserver}
     lint: flake8 h
     lint: flake8 tests
-    lint: flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
     analyze: pylint {posargs:h tests}
     format: black h tests
     checkformatting: black --check h tests


### PR DESCRIPTION
This PR removes obsolete `__future__` imports for changes which are always enabled under Python 3 and removes the lint check for them.

I actually wrote a small [Python script](https://gist.github.com/robertknight/1ddb069150bef18eb0bc8520ac9f6764) to help with this in the end rather than use `2to3` because that left undesirable blank lines in files.

Fixes https://github.com/hypothesis/h/issues/5715