### PR TITLE
Replace `set([...])` with set literals

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -125,14 +125,12 @@ def execute(request, query, page_size):
     result.timeframes.extend(bucketing.bucket(anns))
 
     # Fetch all groups
-    group_pubids = set(
-        [
-            a.groupid
-            for t in result.timeframes
-            for b in t.document_buckets.values()
-            for a in b.annotations
-        ]
-    )
+    group_pubids = {
+        a.groupid
+        for t in result.timeframes
+        for b in t.document_buckets.values()
+        for a in b.annotations
+    }
     groups = {g.pubid: g for g in _fetch_groups(request.db, group_pubids)}
 
     # Add group information to buckets and present annotations

--- a/h/schemas/forms/group.py
+++ b/h/schemas/forms/group.py
@@ -21,7 +21,7 @@ _ = i18n.TranslationString
 
 def unblacklisted_group_name_slug(node, value):
     """Colander validator that ensures the "slugified" group name is not blacklisted."""
-    if slugify.slugify(value).lower() in set(["edit", "leave"]):
+    if slugify.slugify(value).lower() in {"edit", "leave"}:
         raise colander.Invalid(
             node,
             _("Sorry, this group name is not allowed. " "Please choose another one."),

--- a/h/search/parser.py
+++ b/h/search/parser.py
@@ -18,35 +18,33 @@ pp.ParserElement.enablePackrat()
 # Named fields we support when querying (e.g. `user:luke`)
 named_fields = ["user", "tag", "group", "uri", "url"]
 
-whitespace = set(
-    [
-        "\u0009",  # character tabulation
-        "\u000a",  # line feed
-        "\u000b",  # line tabulation
-        "\u000c",  # form feed
-        "\u000d",  # carriage return
-        "\u0020",  # space
-        "\u0085",  # next line
-        "\u00a0",  # no-break space
-        "\u1680",  # ogham space mark
-        "\u2000",  # en quad
-        "\u2001",  # em quad
-        "\u2002",  # en space
-        "\u2003",  # em space
-        "\u2004",  # three-per-em space
-        "\u2005",  # four-per-em space
-        "\u2006",  # six-per-em space
-        "\u2007",  # figure space
-        "\u2008",  # punctuation space
-        "\u2009",  # thin space
-        "\u200a",  # hair space
-        "\u2028",  # line separator
-        "\u2029",  # paragraph separator
-        "\u202f",  # narrow no-break space
-        "\u205f",  # medium mathematical space
-        "\u3000",  # ideographic space
-    ]
-)
+whitespace = {
+    "\u0009",  # character tabulation
+    "\u000a",  # line feed
+    "\u000b",  # line tabulation
+    "\u000c",  # form feed
+    "\u000d",  # carriage return
+    "\u0020",  # space
+    "\u0085",  # next line
+    "\u00a0",  # no-break space
+    "\u1680",  # ogham space mark
+    "\u2000",  # en quad
+    "\u2001",  # em quad
+    "\u2002",  # en space
+    "\u2003",  # em space
+    "\u2004",  # three-per-em space
+    "\u2005",  # four-per-em space
+    "\u2006",  # six-per-em space
+    "\u2007",  # figure space
+    "\u2008",  # punctuation space
+    "\u2009",  # thin space
+    "\u200a",  # hair space
+    "\u2028",  # line separator
+    "\u2029",  # paragraph separator
+    "\u202f",  # narrow no-break space
+    "\u205f",  # medium mathematical space
+    "\u3000",  # ideographic space
+}
 
 parser = None
 Match = namedtuple("Match", ["key", "value"])

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -38,7 +38,7 @@ class AnnotationModerationService:
             models.AnnotationModeration.annotation_id.in_(annotation_ids)
         )
 
-        return set([m.annotation_id for m in query])
+        return {m.annotation_id for m in query}
 
     def hide(self, annotation):
         """

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -49,7 +49,7 @@ class FlagService:
             models.Flag.annotation_id.in_(annotation_ids), models.Flag.user == user
         )
 
-        return set([f.annotation_id for f in query])
+        return {f.annotation_id for f in query}
 
     def create(self, user, annotation):
         """

--- a/h/services/nipsa.py
+++ b/h/services/nipsa.py
@@ -32,7 +32,7 @@ class NipsaService:
 
         # Filter using `is_` to match the index predicate for `User.nipsa`.
         query = self.session.query(User).filter(User.nipsa.is_(True))
-        self._flagged_userids = set([u.userid for u in query])
+        self._flagged_userids = {u.userid for u in query}
 
         return self._flagged_userids
 

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -8,7 +8,7 @@ from h.models import User, UserIdentity
 from h.util.user import split_user
 from h.util.db import on_transaction_end
 
-UPDATE_PREFS_ALLOWED_KEYS = set(["show_sidebar_tutorial"])
+UPDATE_PREFS_ALLOWED_KEYS = {"show_sidebar_tutorial"}
 
 
 class UserNotActivated(Exception):

--- a/h/util/document_claims.py
+++ b/h/util/document_claims.py
@@ -164,7 +164,7 @@ def document_uris_from_links(link_dicts, claimant):
 
         # Disregard Highwire PDF links as these are being added separately from
         # the highwire metadata later on.
-        if set(link_keys) == set(["href", "type"]):
+        if set(link_keys) == {"href", "type"}:
             if link["type"] == "application/pdf":
                 continue
 

--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -66,31 +66,29 @@ import re
 
 from h._compat import url_quote, url_quote_plus, url_unquote, url_unquote_plus, urlparse
 
-URL_SCHEMES = set(["http", "https"])
+URL_SCHEMES = {"http", "https"}
 
 # List of regular expressions matching the names of query parameters that we
 # strip from URLs as part of normalization.
 BLACKLISTED_QUERY_PARAMS = [
     re.compile(regex)
-    for regex in set(
-        [
-            # Google AdWords tracking identifier. Reference:
-            #
-            #    https://support.google.com/analytics/answer/2938246?hl=en
-            #
-            r"^gclid$",
-            # Google Analytics campaigns. Reference:
-            #
-            #     https://support.google.com/analytics/answer/1033867?hl=en
-            #
-            r"^utm_(campaign|content|medium|source|term)$",
-            # WebTrends Analytics query params. Reference:
-            #
-            #     http://help.webtrends.com/en/analytics10/#qpr_about.html
-            #
-            r"^WT\..+$",
-        ]
-    )
+    for regex in {
+        # Google AdWords tracking identifier. Reference:
+        #
+        #    https://support.google.com/analytics/answer/2938246?hl=en
+        #
+        r"^gclid$",
+        # Google Analytics campaigns. Reference:
+        #
+        #     https://support.google.com/analytics/answer/1033867?hl=en
+        #
+        r"^utm_(campaign|content|medium|source|term)$",
+        # WebTrends Analytics query params. Reference:
+        #
+        #     http://help.webtrends.com/en/analytics10/#qpr_about.html
+        #
+        r"^WT\..+$",
+    }
 ]
 
 # From RFC3986. The ABNF for path segments is

--- a/h/views/api/helpers/cors.py
+++ b/h/views/api/helpers/cors.py
@@ -79,7 +79,7 @@ def set_cors_headers(
         )
 
     # Always explicitly allow OPTIONS requests.
-    methods = set(["OPTIONS"])
+    methods = {"OPTIONS"}
     if allow_methods is not None:
         methods.update(allow_methods)
 

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.usefixtures("pyramid_config")
 
 class TestUnblacklistedUsername:
     def test(self, dummy_node):
-        blacklist = set(["admin", "root", "postmaster"])
+        blacklist = {"admin", "root", "postmaster"}
 
         # Should not raise for valid usernames
         schemas.unblacklisted_username(dummy_node, "john", blacklist)

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -107,7 +107,7 @@ class TestDocumentBucket:
         bucket = bucketing.DocumentBucket(document)
         bucket.append(ann_1)
         bucket.append(ann_2)
-        assert bucket.tags == set(["foo", "bar", "baz"])
+        assert bucket.tags == {"foo", "bar", "baz"}
 
     def test_append_adds_unique_annotation_user_to_bucket(self, document):
         ann_1 = factories.Annotation(userid="luke")
@@ -118,7 +118,7 @@ class TestDocumentBucket:
         bucket.append(ann_1)
         bucket.append(ann_2)
         bucket.append(ann_3)
-        assert bucket.users == set(["luke", "alice"])
+        assert bucket.users == {"luke", "alice"}
 
     def test_eq(self, document):
         bucket_1 = bucketing.DocumentBucket(document)

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -812,9 +812,11 @@ class TestTokenAuthenticationPolicy:
 
         result = policy.effective_principals(pyramid_request)
 
-        assert set(result) > set(
-            ["acct:foo@example.com", "acct:foo@example.com.foo", "group:donkeys"]
-        )
+        assert set(result) > {
+            "acct:foo@example.com",
+            "acct:foo@example.com.foo",
+            "group:donkeys",
+        }
 
     @pytest.fixture
     def fake_token(self):

--- a/tests/h/cli/commands/normalize_uris_test.py
+++ b/tests/h/cli/commands/normalize_uris_test.py
@@ -176,7 +176,7 @@ def test_it_reindexes_changed_annotations(req, index, factories, db_session):
 
     normalize_uris.normalize_annotations(req)
 
-    indexer.index.assert_called_once_with(set([annotation_1.id, annotation_2.id]))
+    indexer.index.assert_called_once_with({annotation_1.id, annotation_2.id})
 
 
 def test_it_skips_reindexing_unaltered_annotations(req, index, factories, db_session):
@@ -190,7 +190,7 @@ def test_it_skips_reindexing_unaltered_annotations(req, index, factories, db_ses
 
     normalize_uris.normalize_annotations(req)
 
-    indexer.index.assert_called_once_with(set([annotation_2.id]))
+    indexer.index.assert_called_once_with({annotation_2.id})
 
 
 @pytest.fixture

--- a/tests/h/formatters/annotation_user_info_test.py
+++ b/tests/h/formatters/annotation_user_info_test.py
@@ -20,7 +20,7 @@ class TestAnnotationUserInfoFormatter:
         formatter.preload([annotation_1.id, annotation_2.id])
 
         user_svc.fetch_all.assert_called_once_with(
-            set([annotation_1.userid, annotation_2.userid])
+            {annotation_1.userid, annotation_2.userid}
         )
 
     def test_preload_skips_fetching_for_empty_ids(self, formatter, user_svc):

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -174,10 +174,10 @@ class TestThread:
         assert root.thread_ids == []
 
     def test_thread_with_replies(self, root, reply, subreply):
-        assert set(root.thread) == set([reply, subreply])
+        assert set(root.thread) == {reply, subreply}
 
     def test_thread_ids_with_replies(self, root, reply, subreply):
-        assert set(root.thread_ids) == set([reply.id, subreply.id])
+        assert set(root.thread_ids) == {reply.id, subreply.id}
 
     @pytest.mark.usefixtures("subreply")
     def test_reply_has_no_thread(self, reply):

--- a/tests/h/models/feature_test.py
+++ b/tests/h/models/feature_test.py
@@ -54,7 +54,7 @@ class TestFeature:
 
         Feature.remove_old_flags(db_session)
 
-        remaining = set([f.name for f in db_session.query(Feature).all()])
+        remaining = {f.name for f in db_session.query(Feature).all()}
         assert remaining == {"abouttoberemoved", "notification"}
 
     @pytest.fixture

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -146,9 +146,10 @@ class TestGroupJSONPresenter:
 
         assert "scopes" in model
         assert model["scopes"]["enforced"] is False
-        assert set(model["scopes"]["uri_patterns"]) == set(
-            ["http://foo.com/bar*", "https://foo.com/baz*"]
-        )
+        assert set(model["scopes"]["uri_patterns"]) == {
+            "http://foo.com/bar*",
+            "https://foo.com/baz*",
+        }
 
     def test_expanded_scopes_uri_patterns_empty_if_no_scopes(
         self, factories, GroupContext

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -504,7 +504,7 @@ class TestBatchIndexer:
 
     def test_it_returns_errored_annotation_ids(self, batch_indexer, factories):
         annotations = factories.Annotation.create_batch(3)
-        expected_errored_ids = set([annotations[0].id, annotations[2].id])
+        expected_errored_ids = {annotations[0].id, annotations[2].id}
 
         elasticsearch.helpers.streaming_bulk = mock.Mock()
         elasticsearch.helpers.streaming_bulk.return_value = [
@@ -521,7 +521,7 @@ class TestBatchIndexer:
         self, db_session, es_client, factories, pyramid_request
     ):
         annotations = factories.Annotation.create_batch(3)
-        expected_errored_ids = set([annotations[1].id])
+        expected_errored_ids = {annotations[1].id}
 
         elasticsearch.helpers.streaming_bulk = mock.Mock()
         elasticsearch.helpers.streaming_bulk.return_value = [

--- a/tests/h/services/flag_test.py
+++ b/tests/h/services/flag_test.py
@@ -27,7 +27,7 @@ class TestFlagServiceFlagged:
 
         all_flagged = svc.all_flagged(user, [f.annotation_id for f in flags])
 
-        assert all_flagged == set([flags[-1].annotation_id])
+        assert all_flagged == {flags[-1].annotation_id}
 
     @pytest.mark.usefixtures("flags")
     def test_it_handles_all_flagged_with_no_ids(self, svc, factories):

--- a/tests/h/services/nipsa_test.py
+++ b/tests/h/services/nipsa_test.py
@@ -13,9 +13,10 @@ class TestNipsaService:
     def test_fetch_all_flagged_userids_returns_set_of_userids(self, db_session):
         svc = NipsaService(db_session)
 
-        assert svc.fetch_all_flagged_userids() == set(
-            ["acct:renata@example.com", "acct:cecilia@example.com"]
-        )
+        assert svc.fetch_all_flagged_userids() == {
+            "acct:renata@example.com",
+            "acct:cecilia@example.com",
+        }
 
     def test_is_flagged_returns_true_for_flagged_users(self, db_session, users):
         svc = NipsaService(db_session)
@@ -79,9 +80,10 @@ class TestNipsaService:
 
         # Returns `True` because status is cached.
         assert svc.is_flagged("acct:renata@example.com")
-        assert svc.fetch_all_flagged_userids() == set(
-            ["acct:renata@example.com", "acct:cecilia@example.com"]
-        )
+        assert svc.fetch_all_flagged_userids() == {
+            "acct:renata@example.com",
+            "acct:cecilia@example.com",
+        }
 
     def test_flag_updates_cache(self, db_session, users):
         svc = NipsaService(db_session)

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -86,7 +86,7 @@ class TestRenameUserService:
         service.rename(user, "panda")
 
         userids = [ann.userid for ann in db_session.query(models.Annotation)]
-        assert set([user.userid]) == set(userids)
+        assert {user.userid} == set(userids)
 
     def test_rename_reindexes_the_users_annotations(
         self, service, user, annotations, indexer

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -695,7 +695,7 @@ class TestNotificationsController:
         controller.get()
 
         controller.form.set_appstruct.assert_called_once_with(
-            {"notifications": set(["reply"])}
+            {"notifications": {"reply"}}
         )
 
     def test_it_does_not_render_form_if_user_has_no_email_address(
@@ -746,7 +746,7 @@ class TestNotificationsController:
         subs = [FakeSubscription("reply", True), FakeSubscription("foo", False)]
         subscriptions_model.get_subscriptions_for_uri.return_value = subs
         controller = views.NotificationsController(pyramid_request)
-        controller.form = form_validating_to({"notifications": set(["foo"])})
+        controller.form = form_validating_to({"notifications": {"foo"}})
 
         controller.post()
 

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -380,8 +380,8 @@ class TestGroupSearchController:
     ):
         result = controller.search()
 
-        actual = set([m["username"] for m in result["group_users_args"][1]])
-        expected = set([m.username for m in test_group.members])
+        actual = {m["username"] for m in result["group_users_args"][1]}
+        expected = {m.username for m in test_group.members}
         assert actual == expected
 
     @pytest.mark.parametrize(
@@ -394,8 +394,8 @@ class TestGroupSearchController:
     ):
         result = controller.search()
 
-        actual = set([m["userid"] for m in result["group_users_args"][1]])
-        expected = set([m.userid for m in test_group.members])
+        actual = {m["userid"] for m in result["group_users_args"][1]}
+        expected = {m.userid for m in test_group.members}
         assert actual == expected
 
     @pytest.mark.parametrize(
@@ -449,8 +449,8 @@ class TestGroupSearchController:
     ):
         result = controller.search()
 
-        actual = set([m["username"] for m in result["group_users_args"][1]])
-        expected = set([test_group.creator.username])
+        actual = {m["username"] for m in result["group_users_args"][1]}
+        expected = {test_group.creator.username}
         assert actual == expected
 
     @pytest.mark.parametrize(
@@ -463,8 +463,8 @@ class TestGroupSearchController:
     ):
         result = controller.search()
 
-        actual = set([m["userid"] for m in result["group_users_args"][1]])
-        expected = set([test_group.creator.userid])
+        actual = {m["userid"] for m in result["group_users_args"][1]}
+        expected = {test_group.creator.userid}
         assert actual == expected
 
     @pytest.mark.parametrize(

--- a/tests/h/views/admin/admins_test.py
+++ b/tests/h/views/admin/admins_test.py
@@ -21,9 +21,11 @@ class TestAdminsIndex:
     def test_context_contains_admin_usernames(self, pyramid_request):
         result = admins_index(pyramid_request)
 
-        assert set(result["admin_users"]) == set(
-            ["acct:agnos@example.com", "acct:bojan@example.com", "acct:cristof@foo.org"]
-        )
+        assert set(result["admin_users"]) == {
+            "acct:agnos@example.com",
+            "acct:bojan@example.com",
+            "acct:cristof@foo.org",
+        }
 
 
 @pytest.mark.usefixtures("users", "routes")

--- a/tests/h/views/admin/nipsa_test.py
+++ b/tests/h/views/admin/nipsa_test.py
@@ -13,9 +13,11 @@ class TestNipsaIndex:
     def test_lists_flagged_usernames(self, pyramid_request):
         result = nipsa_index(pyramid_request)
 
-        assert set(result["userids"]) == set(
-            ["acct:kiki@example.com", "acct:ursula@foo.org", "acct:osono@example.com"]
-        )
+        assert set(result["userids"]) == {
+            "acct:kiki@example.com",
+            "acct:ursula@foo.org",
+            "acct:osono@example.com",
+        }
 
     def test_lists_flagged_usernames_no_results(self, nipsa_service, pyramid_request):
         nipsa_service.flagged = set([])
@@ -85,10 +87,10 @@ class TestNipsaAddRemove:
 
 class FakeNipsaService:
     def __init__(self, users):
-        self.flagged = set([u for u in users if u.nipsa])
+        self.flagged = {u for u in users if u.nipsa}
 
     def fetch_all_flagged_userids(self):
-        return set([u.userid for u in self.flagged])
+        return {u.userid for u in self.flagged}
 
     def flag(self, user):
         self.flagged.add(user)

--- a/tests/h/views/admin/staff_test.py
+++ b/tests/h/views/admin/staff_test.py
@@ -21,9 +21,11 @@ class TestStaffIndex:
     def test_context_contains_staff_usernames(self, pyramid_request):
         result = staff_index(pyramid_request)
 
-        assert set(result["staff"]) == set(
-            ["acct:agnos@example.com", "acct:bojan@example.com", "acct:cristof@foo.org"]
-        )
+        assert set(result["staff"]) == {
+            "acct:agnos@example.com",
+            "acct:bojan@example.com",
+            "acct:cristof@foo.org",
+        }
 
 
 @pytest.mark.usefixtures("users", "routes")


### PR DESCRIPTION
This is the result of running:

```
2to3 -nw -f set_literal h tests
make format
```

This change is mostly for stylistic consistency, although set literals
are a little cheaper to construct.

Fixes #5717