### PR TITLE
Fix a Python 3 compat issue in `bin/hypothesis user add` CLI command

### DIFF
--- a/h/cli/commands/user.py
+++ b/h/cli/commands/user.py
@@ -37,7 +37,7 @@ def add(ctx, username, email, password, authority):
     try:
         request.tm.commit()
     except sqlalchemy.exc.IntegrityError as err:
-        upstream_error = "\n".join("    " + line for line in err.message.split("\n"))
+        upstream_error = "\n".join("    " + line for line in str(err).split("\n"))
         message = "could not create user due to integrity constraint.\n\n{}".format(
             upstream_error
         )


### PR DESCRIPTION
Fix an exception when trying to handle a database constraint error when running
`bin/hypothesis user add` due to use of `Exception.message` which was
removed in Python 3.

To reproduce, run:

```
tox -e py36-dev -- sh bin/hypothesis --dev user add --username $USERNAME --email $EMAIL
```

Where `$USERNAME` is a user that already exists.

Found via pylint (see https://github.com/hypothesis/h/issues/5517)