### PR TITLE
Remove unnecessary "u" string literal prefixes

### DIFF
--- a/h/cli/commands/move_uri.py
+++ b/h/cli/commands/move_uri.py
@@ -96,7 +96,7 @@ def _fetch_document_uri_canonical_self_claim(session, uri_):
         session.query(models.DocumentURI)
         .filter(
             models.DocumentURI.uri_normalized == uri.normalize(uri_),
-            models.DocumentURI.type.in_([u"self-claim", u"rel-canonical"]),
+            models.DocumentURI.type.in_(["self-claim", "rel-canonical"]),
         )
         .all()
     )

--- a/h/migrations/versions/4c0c44605c09_create_annotation_table.py
+++ b/h/migrations/versions/4c0c44605c09_create_annotation_table.py
@@ -30,7 +30,7 @@ def upgrade():
         sa.Column("updated", sa.DateTime, server_default=sa.func.now(), nullable=False),
         sa.Column("userid", sa.UnicodeText(), nullable=False),
         sa.Column(
-            "groupid", sa.UnicodeText(), server_default=u"__world__", nullable=False
+            "groupid", sa.UnicodeText(), server_default="__world__", nullable=False
         ),
         sa.Column("text", sa.UnicodeText(), nullable=True),
         sa.Column(

--- a/h/migrations/versions/dfa82518915a_create_document_tables.py
+++ b/h/migrations/versions/dfa82518915a_create_document_tables.py
@@ -35,7 +35,7 @@ def upgrade():
             "value", postgresql.ARRAY(sa.UnicodeText, zero_indexes=True), nullable=False
         ),
         sa.Column("document_id", sa.Integer, nullable=False),
-        sa.ForeignKeyConstraint(["document_id"], [u"document.id"]),
+        sa.ForeignKeyConstraint(["document_id"], ["document.id"]),
         sa.UniqueConstraint("claimant_normalized", "type"),
     )
 
@@ -51,7 +51,7 @@ def upgrade():
         sa.Column("type", sa.UnicodeText, nullable=True),
         sa.Column("content_type", sa.UnicodeText, nullable=True),
         sa.Column("document_id", sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(["document_id"], [u"document.id"]),
+        sa.ForeignKeyConstraint(["document_id"], ["document.id"]),
         sa.UniqueConstraint(
             "claimant_normalized", "uri_normalized", "type", "content_type"
         ),

--- a/tests/h/cli/commands/authclient_test.py
+++ b/tests/h/cli/commands/authclient_test.py
@@ -11,7 +11,7 @@ from h.cli.commands import authclient as authclient_cli
 class TestAddCommand:
     def test_it_creates_a_public_authclient(self, cli, cliconfig, db_session):
         (authclient, _) = self._add_authclient(
-            cli, cliconfig, db_session, type_=u"public"
+            cli, cliconfig, db_session, type_="public"
         )
 
         assert authclient.authority == "publisher.org"
@@ -22,10 +22,10 @@ class TestAddCommand:
         self, cli, cliconfig, db_session, patch
     ):
         token_urlsafe = patch("h.cli.commands.authclient.token_urlsafe")
-        token_urlsafe.return_value = u"fixed-secret-token"
+        token_urlsafe.return_value = "fixed-secret-token"
 
         (authclient, _) = self._add_authclient(
-            cli, cliconfig, db_session, type_=u"confidential"
+            cli, cliconfig, db_session, type_="confidential"
         )
 
         assert authclient.authority == "publisher.org"
@@ -34,7 +34,7 @@ class TestAddCommand:
 
     def test_it_prints_the_id_for_public_client(self, cli, cliconfig, db_session):
         (authclient, output) = self._add_authclient(
-            cli, cliconfig, db_session, type_=u"public"
+            cli, cliconfig, db_session, type_="public"
         )
         expected_id_and_secret = "Client ID: {}".format(authclient.id)
         assert expected_id_and_secret in output
@@ -43,7 +43,7 @@ class TestAddCommand:
         self, cli, cliconfig, db_session
     ):
         (authclient, output) = self._add_authclient(
-            cli, cliconfig, db_session, type_=u"confidential"
+            cli, cliconfig, db_session, type_="confidential"
         )
         expected_id_and_secret = "Client ID: {}\n".format(
             authclient.id
@@ -53,14 +53,7 @@ class TestAddCommand:
     def _add_authclient(self, cli, cliconfig, db_session, type_):
         result = cli.invoke(
             authclient_cli.add,
-            [
-                u"--name",
-                u"Publisher",
-                u"--authority",
-                u"publisher.org",
-                u"--type",
-                type_,
-            ],
+            ["--name", "Publisher", "--authority", "publisher.org", "--type", type_],
             obj=cliconfig,
         )
 
@@ -68,7 +61,7 @@ class TestAddCommand:
 
         authclient = (
             db_session.query(models.AuthClient)
-            .filter(models.AuthClient.authority == u"publisher.org")
+            .filter(models.AuthClient.authority == "publisher.org")
             .first()
         )
         return (authclient, result.output)

--- a/tests/h/cli/commands/user_test.py
+++ b/tests/h/cli/commands/user_test.py
@@ -17,12 +17,12 @@ class TestAddCommand:
         result = cli.invoke(
             user_cli.add,
             [
-                u"--username",
-                u"admin",
-                u"--email",
-                u"admin@localhost",
-                u"--password",
-                u"admin",
+                "--username",
+                "admin",
+                "--email",
+                "admin@localhost",
+                "--password",
+                "admin",
             ],
             obj=cliconfig,
         )
@@ -30,9 +30,9 @@ class TestAddCommand:
         assert result.exit_code == 0
 
         signup_service.signup.assert_called_with(
-            username=u"admin",
-            email=u"admin@localhost",
-            password=u"admin",
+            username="admin",
+            email="admin@localhost",
+            password="admin",
             require_activation=False,
         )
 
@@ -40,14 +40,14 @@ class TestAddCommand:
         result = cli.invoke(
             user_cli.add,
             [
-                u"--username",
-                u"admin",
-                u"--email",
-                u"admin@localhost",
-                u"--password",
-                u"admin",
-                u"--authority",
-                u"publisher.org",
+                "--username",
+                "admin",
+                "--email",
+                "admin@localhost",
+                "--password",
+                "admin",
+                "--authority",
+                "publisher.org",
             ],
             obj=cliconfig,
         )
@@ -55,10 +55,10 @@ class TestAddCommand:
         assert result.exit_code == 0
 
         signup_service.signup.assert_called_with(
-            username=u"admin",
-            email=u"admin@localhost",
-            password=u"admin",
-            authority=u"publisher.org",
+            username="admin",
+            email="admin@localhost",
+            password="admin",
+            authority="publisher.org",
             require_activation=False,
         )
 
@@ -66,7 +66,7 @@ class TestAddCommand:
 class TestAdminCommand:
     def test_it_adds_admin(self, cli, cliconfig, non_admin_user, db_session):
         result = cli.invoke(
-            user_cli.admin, [u"--on", non_admin_user.username], obj=cliconfig
+            user_cli.admin, ["--on", non_admin_user.username], obj=cliconfig
         )
 
         assert result.exit_code == 0
@@ -85,12 +85,12 @@ class TestAdminCommand:
     def test_it_adds_admin_with_specific_authority(
         self, cli, cliconfig, non_admin_user, db_session
     ):
-        non_admin_user.authority = u"partner.org"
+        non_admin_user.authority = "partner.org"
         db_session.flush()
 
         result = cli.invoke(
             user_cli.admin,
-            [u"--authority", u"partner.org", non_admin_user.username],
+            ["--authority", "partner.org", non_admin_user.username],
             obj=cliconfig,
         )
 
@@ -101,7 +101,7 @@ class TestAdminCommand:
 
     def test_it_removes_admin(self, cli, cliconfig, admin_user, db_session):
         result = cli.invoke(
-            user_cli.admin, [u"--off", admin_user.username], obj=cliconfig
+            user_cli.admin, ["--off", admin_user.username], obj=cliconfig
         )
 
         assert result.exit_code == 0
@@ -112,11 +112,11 @@ class TestAdminCommand:
     def test_it_removes_admin_with_specific_authority(
         self, cli, cliconfig, admin_user, db_session
     ):
-        admin_user.authority = u"partner.org"
+        admin_user.authority = "partner.org"
 
         result = cli.invoke(
             user_cli.admin,
-            [u"--off", u"--authority", u"partner.org", admin_user.username],
+            ["--off", "--authority", "partner.org", admin_user.username],
             obj=cliconfig,
         )
 
@@ -169,7 +169,7 @@ class TestPasswordCommand:
         self, cli, cliconfig, user, db_session, password_service
     ):
         result = cli.invoke(
-            user_cli.password, [user.username, u"--password", u"newpass"], obj=cliconfig
+            user_cli.password, [user.username, "--password", "newpass"], obj=cliconfig
         )
 
         assert result.exit_code == 0
@@ -180,12 +180,12 @@ class TestPasswordCommand:
     def test_it_changes_password_with_specific_authority(
         self, cli, cliconfig, user, db_session, password_service
     ):
-        user.authority = u"partner.org"
+        user.authority = "partner.org"
         db_session.flush()
 
         result = cli.invoke(
             user_cli.password,
-            [u"--authority", u"partner.org", user.username, u"--password", u"newpass"],
+            ["--authority", "partner.org", user.username, "--password", "newpass"],
             obj=cliconfig,
         )
 
@@ -199,7 +199,7 @@ class TestPasswordCommand:
     ):
         result = cli.invoke(
             user_cli.password,
-            ["bogus_%s" % user.username, u"--password", u"newpass"],
+            ["bogus_%s" % user.username, "--password", "newpass"],
             obj=cliconfig,
         )
 
@@ -214,7 +214,7 @@ class TestPasswordCommand:
 
         result = cli.invoke(
             user_cli.password,
-            ["--authority", "foo.com", user.username, u"--password", u"newpass"],
+            ["--authority", "foo.com", user.username, "--password", "newpass"],
             obj=cliconfig,
         )
 
@@ -240,12 +240,12 @@ class TestDeleteUserCommand:
     def test_it_deletes_user_with_specific_authority(
         self, cli, cliconfig, user, db_session
     ):
-        user.authority = u"partner.org"
+        user.authority = "partner.org"
         db_session.flush()
 
         result = cli.invoke(
             user_cli.delete,
-            [u"--authority", u"partner.org", user.username],
+            ["--authority", "partner.org", user.username],
             obj=cliconfig,
         )
 


### PR DESCRIPTION
This is the result of running:

```
2to3 -nw h/ tests/
```

And applying any fixes possible now that Python 2 is no longer
supported. It didn't turn up anything interesting, but we said we'd do this as
part of the Python 3 migration.

Some false positives were seen but ignored:

 - Changing `assert_` to `assertTrue` for objects that are not a `unittest.TestCase`
 - Replacing `has_keys` with 'X in Y` on an object that is not a dict