### PR TITLE
Moved to resource location based on package rather than relative dir

### DIFF
--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -20,6 +20,7 @@ import zope.sqlalchemy.datamanager
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import exc
 from sqlalchemy.orm import sessionmaker
+from pkg_resources import resource_stream
 
 from h.util.session_tracker import Tracker
 
@@ -128,8 +129,8 @@ def _maybe_create_default_organization(engine, authority):
         default_org = models.Organization(
             name="Hypothesis", authority=authority, pubid="__default__"
         )
-        with open("h/static/images/icons/logo.svg", "rb") as h_logo:
-            default_org.logo = h_logo.read().decode("utf-8")
+        with resource_stream('h', 'static/images/icons/logo.svg') as h_logo:
+            default_org.logo = h_logo.read().decode('utf-8')
         session.add(default_org)
 
     session.commit()

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -129,8 +129,8 @@ def _maybe_create_default_organization(engine, authority):
         default_org = models.Organization(
             name="Hypothesis", authority=authority, pubid="__default__"
         )
-        with resource_stream('h', 'static/images/icons/logo.svg') as h_logo:
-            default_org.logo = h_logo.read().decode('utf-8')
+        with resource_stream("h", "static/images/icons/logo.svg") as h_logo:
+            default_org.logo = h_logo.read().decode("utf-8")
         session.add(default_org)
 
     session.commit()


### PR DESCRIPTION
This allows you to run tests from a different working directory and still
have them pass. This was observed running pytest on the h.sentry tests
from a different dir.

This is the default behavior running tests from Pycharm

To reproduce:

    cd tests/h/sentry
    ../../../.tox/py36-tests/bin/pytest .