### PR TITLE
Changing pip-compile to work via tox instead of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ checkdocstrings: python
 
 .PHONY: pip-compile
 pip-compile: python
-	tox -q -e py36-dev -- pip-compile
+	tox -q -e py36-pip-compile
 
 .PHONY: upgrade-package
 upgrade-package: python

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,4 +1,3 @@
 -r requirements.txt
 
 honcho
-pip-tools

--- a/tox.ini
+++ b/tox.ini
@@ -91,6 +91,7 @@ deps =
     dev: ipdb
     dev: -r requirements-dev.in
     docker-compose: docker-compose
+    pip-compile: pip-tools
 whitelist_externals =
     {dev,tests,functests}: sh
 changedir =
@@ -115,3 +116,4 @@ commands =
     coverage: coverage report --show-missing
     codecov: codecov
     docker-compose: docker-compose {posargs}
+    pip-compile: pip-compile


### PR DESCRIPTION
Moving pip-compile command out of Make and the dev requirements to be a separate tox command. This means the dev env is very slightly smaller, the compile env is much smaller and we are following the more layered approach (make on tox, not instead).