### PR TITLE
Remove a few obsolete mentions of Python 3 as a non-default scenario

### DIFF
--- a/docs/developing/testing.rst
+++ b/docs/developing/testing.rst
@@ -48,9 +48,6 @@ To run the backend test suite only call ``tox`` directly. For example:
    # Run the backend unit tests:
    tox
 
-   # Run the backend unit tests in Python 3:
-   tox -e py36-tests
-
    # Run the backend functional tests:
    tox -e py36-functests
 

--- a/h/_version.py
+++ b/h/_version.py
@@ -3,12 +3,7 @@
 import datetime
 import subprocess
 
-try:
-    from subprocess import DEVNULL  # Python 3
-except ImportError:
-    import os
-
-    DEVNULL = open(os.devnull, "wb")
+from subprocess import DEVNULL
 
 __all__ = ("get_version",)
 

--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -111,8 +111,8 @@ def group_organization_select_widget(node, kw):
         org_labels.append("{} ({})".format(org.name, org.authority))
         org_pubids.append(org.pubid)
 
-    # `zip` returns an iterator in Python 3. The `SelectWidget` constructor
-    # requires an actual list.
+    # `zip` returns an iterator. The `SelectWidget` constructor requires an
+    # actual list.
     return SelectWidget(values=list(zip(org_pubids, org_labels)))
 
 

--- a/tests/h/util/view_test.py
+++ b/tests/h/util/view_test.py
@@ -25,7 +25,7 @@ class TestHandleException:
     @pytest.fixture
     def old_exception(self):
         try:
-            # Create exception and populate `__traceback__` in Python 3.
+            # Create exception and populate `__traceback__`.
             raise Exception("An earlier exception raised in thread")
         except Exception as exc:
             result = exc


### PR DESCRIPTION
Remove a few references to Python 3 as a non-default scenario at runtime
and an obsolete comment about running unit tests with Python 3 as the
previous comment, which used to refer to running them under Python 2,
now already runs them under Python 3.