### PR TITLE
Adding a tween to rollback the db handle in the case of exceptions

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -52,6 +52,7 @@ def includeme(config):
     )
 
     config.add_tween("h.tweens.conditional_http_tween_factory", under=EXCVIEW)
+    config.add_tween("h.tweens.rollback_db_session_on_exception_factory", under=EXCVIEW)
     config.add_tween("h.tweens.redirect_tween_factory")
     config.add_tween("h.tweens.invalid_path_tween_factory")
     config.add_tween("h.tweens.security_header_tween_factory")

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -123,3 +123,23 @@ def cache_header_tween_factory(handler, registry):
         return resp
 
     return cache_header_tween
+
+
+def rollback_db_session_on_exception_factory(handler, registry):
+    """
+    Catches exceptions and rolls the database handle back so it can be reliably
+    used again regardless of what exception caused the error.
+    """
+
+    # Intended to be run before excview_tween_factory here:
+    # https://docs.pylonsproject.org/projects/pyramid/en/1.10-branch/_modules/pyramid/tweens.html#excview_tween_factory
+    def rollback_db_session_on_exception(request):
+        try:
+            return handler(request)
+
+        except Exception:
+            request.db.rollback()
+            # Pass off to excview_tween to start exception view processing
+            raise
+
+    return rollback_db_session_on_exception

--- a/tests/h/tweens_test.py
+++ b/tests/h/tweens_test.py
@@ -122,7 +122,7 @@ class TestDBRollbackSessionOnExceptionTween:
 
     @pytest.fixture
     def handler(self):
-        return mock.create_autospec(lambda request: None)
+        return mock.create_autospec(lambda request: None)  # pragma: nocover
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
This is to solve the issue when view processing raises an IntegrityError
which invalidates the db session and exception view processing attempts to
re-use that handle for any other purpose (raising an InvalidRequestError).

Fixes: https://github.com/hypothesis/h/issues/5745