### PR TITLE
Turn off extra_info logging for websocket

### DIFF
--- a/h/websocket.py
+++ b/h/websocket.py
@@ -175,6 +175,5 @@ def create_app(global_config, **settings):
 
     # Add support for logging exceptions whenever they arise
     config.include("pyramid_exclog")
-    config.add_settings({"exclog.extra_info": True})
 
     return config.make_wsgi_app()


### PR DESCRIPTION
Turn off pyramid_exclog's extra_info setting for the websocket.

It looks like pyramid_exclog is indirectly accessing something that is
doing a DB read and implicitly opening a new DB session which is not
getting closed.

Hopefully turning off its extra_info option will fix it