### PR TITLE
Fix websocket unclosed DB sessions

### DIFF
--- a/h/streamer/__init__.py
+++ b/h/streamer/__init__.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+from h.streamer.tweens import close_db_session_tween_factory
+
+__all__ = ["close_db_session_tween_factory"]
 
 
 def includeme(config):

--- a/h/streamer/tweens.py
+++ b/h/streamer/tweens.py
@@ -1,0 +1,19 @@
+__all__ = ["close_db_session_tween_factory"]
+
+
+def close_db_session_tween_factory(handler, registry):
+    """Return the close_db_session_tween."""
+
+    def close_db_session_tween(request):
+        """Close the sqlalchemy session.
+
+        This tween runs late in the websocket app's Pyramid request processing
+        cycle and makes sure that any DB connections that were opened during
+        the request get closed.
+        """
+        try:
+            return handler(request)
+        finally:
+            request.db.close()
+
+    return close_db_session_tween

--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -21,10 +21,6 @@ def websocket_view(request):
         }
     )
 
-    # ...and ensure that any persistent connections associated with this
-    # WebSocket connection are closed.
-    request.db.close()
-
     app = WebSocketWSGIApplication(handler_cls=websocket.WebSocket)
     return request.get_response(app)
 

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -39,6 +39,7 @@ import logging
 
 from gevent.pool import Pool
 from gunicorn.workers.ggevent import GeventPyWSGIWorker, PyWSGIHandler, PyWSGIServer
+import pyramid
 from ws4py import format_addresses
 
 from h.config import configure
@@ -148,6 +149,12 @@ class Worker(GeventPyWSGIWorker):
 
 def create_app(global_config, **settings):
     config = configure(settings=settings)
+
+    config.add_tween(
+        "h.streamer.close_db_session_tween_factory",
+        over=["pyramid_exclog.exclog_tween_factory", pyramid.tweens.EXCVIEW],
+    )
+
     config.include("pyramid_services")
 
     config.include("h.auth")

--- a/tests/h/streamer/tweens_test.py
+++ b/tests/h/streamer/tweens_test.py
@@ -1,0 +1,43 @@
+from unittest import mock
+
+import pytest
+
+from h.streamer import close_db_session_tween_factory
+
+
+class TestCloseTheDBSessionTweenFactory:
+    def test_it_calls_the_handler(
+        self, close_db_session_tween, handler, pyramid_request
+    ):
+        close_db_session_tween(pyramid_request)
+
+        handler.assert_called_once_with(pyramid_request)
+
+    def test_it_closes_the_db_session(self, close_db_session_tween, pyramid_request):
+        close_db_session_tween(pyramid_request)
+
+        pyramid_request.db.close.assert_called_once_with()
+
+    def test_it_closes_the_db_session_if_an_exception_is_raised(
+        self, close_db_session_tween, handler, pyramid_request
+    ):
+        handler.side_effect = RuntimeError("test_error")
+
+        with pytest.raises(RuntimeError, match="^test_error$"):
+            close_db_session_tween(pyramid_request)
+
+        pyramid_request.db.close.assert_called_once_with()
+
+    @pytest.fixture
+    def close_db_session_tween(self, handler):
+        return close_db_session_tween_factory(handler, mock.sentinel.registry)
+
+    @pytest.fixture
+    def handler(self):
+        handler = mock.create_autospec(lambda request: None)  # pragma: nocover
+        return handler
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.db = mock.MagicMock(spec_set=["close"])
+        return pyramid_request


### PR DESCRIPTION
When we added pyramid_exclog (https://github.com/hypothesis/h/pull/5747)
we started seeing a lot of these warnings getting logged:

    websocket (stderr) | 2019-10-16 15:08:01,627 [59] [h.db:WARNING] closing an unclosed DB session (no uncommitted changes)

I never got to the bottom of exactly why, but something about
pyramid_exclog is causing websocket request processing to end with an
unclosed DB session (possibly the DB session is still getting closed,
but something pyramid_exclog does causes it to get reopened?)

The warning comes from our finished callback which runs at the very end
of request processing and closes any unclosed sessions so that we don't
leak DB connections, but logs a warning because we don't want/expect
this finished callback "hack" to ever actually be needed:
https://github.com/hypothesis/h/blob/fa59f51cf9e9289e798d36dee968f39a6de1e7dd/h/db/__init__.py#L95-L126

Fix the websocket app by moving its builtin DB session closing out of
the view that it was in, into a tween that executes after the
pyramid_exclog tween and other tweens. This moves the call to
`request.db.close()` to much later in the request processing cycle. In
particular it moves it to after pyramid_exclog's tween has executed.
This gets rid of the warning from the finished callback: the tween now
closes the DB session before the finished runs.