### PR TITLE
Add automatic import sorting with isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,9 @@
+# A Black (https://github.com/psf/black)-compatible isort
+# (https://timothycrosley.github.io/isort/) config. Copy-pasted from Black's
+# README.
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,14 @@ test: node_modules/.uptodate python
 	tox
 	$(GULP) test
 
+.PHONY: isort
+isort: python
+	@tox -qe py36-tests --run-command "isort --recursive --quiet --atomic h tests"
+
+.PHONY: checkisort
+checkisort: python
+	@tox -qe py36-tests --run-command "isort --recursive --quiet --check-only h tests"
+
 .PHONY: coverage
 coverage: python
 	tox -q -e py36-coverage

--- a/h/_version.py
+++ b/h/_version.py
@@ -2,7 +2,6 @@
 
 import datetime
 import subprocess
-
 from subprocess import DEVNULL
 
 __all__ = ("get_version",)

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from codecs import open
 import logging
+from codecs import open
 
 import colander
 import deform

--- a/h/activity/bucketing.py
+++ b/h/activity/bucketing.py
@@ -8,9 +8,7 @@ from urllib.parse import urlparse
 import newrelic.agent
 from pyramid import i18n
 
-from h import links
-from h import presenters
-
+from h import links, presenters
 
 _ = i18n.TranslationStringFactory(__package__)
 

--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -6,18 +6,16 @@ import newrelic.agent
 from pyramid.httpexceptions import HTTPFound
 from sqlalchemy.orm import subqueryload
 
-from h import links
-from h import presenters
-from h import storage
+from h import links, presenters, storage
 from h.activity import bucketing
 from h.models import Annotation, Group
-from h.search import Search
-from h.search import parser
 from h.search import (
-    TopLevelAnnotationsFilter,
     AuthorityFilter,
+    Search,
     TagsAggregation,
+    TopLevelAnnotationsFilter,
     UsersAggregation,
+    parser,
 )
 
 

--- a/h/assets.py
+++ b/h/assets.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import configparser
+import json
 import os
 
-import json
 from pyramid.settings import asbool, aslist
 from pyramid.static import static_view
 

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -3,13 +3,15 @@
 """Authentication configuration."""
 import logging
 
-from pyramid.authentication import RemoteUserAuthenticationPolicy
 import pyramid_authsanity
+from pyramid.authentication import RemoteUserAuthenticationPolicy
 
-from h.auth.policy import AuthenticationPolicy
-from h.auth.policy import APIAuthenticationPolicy
-from h.auth.policy import AuthClientPolicy
-from h.auth.policy import TokenAuthenticationPolicy
+from h.auth.policy import (
+    APIAuthenticationPolicy,
+    AuthClientPolicy,
+    AuthenticationPolicy,
+    TokenAuthenticationPolicy,
+)
 from h.auth.util import default_authority, groupfinder
 from h.security import derive_key
 

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from pyramid import interfaces
-from pyramid.authentication import BasicAuthAuthenticationPolicy
-from pyramid.authentication import CallbackAuthenticationPolicy
+from pyramid.authentication import (
+    BasicAuthAuthenticationPolicy,
+    CallbackAuthenticationPolicy,
+)
 from pyramid.security import Authenticated
 from zope import interface
 

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import re
-
 import hmac
+import re
 
 import sqlalchemy as sa
 from pyramid import security
 
 from h.auth import role
-from h.models.auth_client import GrantType, AuthClient
+from h.models.auth_client import AuthClient, GrantType
 
 
 def groupfinder(userid, request):

--- a/h/celery.py
+++ b/h/celery.py
@@ -8,12 +8,11 @@ integrates it with the Pyramid application by attaching a bootstrapped fake
 "request" object to the application where it can be retrieved by tasks.
 """
 
-from datetime import timedelta
 import logging
 import os
+from datetime import timedelta
 
-from celery import Celery
-from celery import signals
+from celery import Celery, signals
 from celery.utils.log import get_task_logger
 from kombu import Exchange, Queue
 

--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -3,8 +3,7 @@ import functools
 import logging
 
 import click
-from pyramid import paster
-from pyramid import path
+from pyramid import paster, path
 from pyramid.request import Request
 
 from h import __version__

--- a/h/cli/commands/annotation_id.py
+++ b/h/cli/commands/annotation_id.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import click
-
 from uuid import UUID
+
+import click
 
 from h.db.types import _get_hex_from_urlsafe, _get_urlsafe_from_hex
 

--- a/h/cli/commands/devdata.py
+++ b/h/cli/commands/devdata.py
@@ -5,13 +5,14 @@ Usage:
 
     bin/hypothesis --dev devdata
 """
-import click
 import json
 import os.path
 import pathlib
 import shutil
 import subprocess
 import tempfile
+
+import click
 
 import h
 from h import models

--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -3,13 +3,12 @@
 import logging
 import os
 
-import alembic.config
 import alembic.command
+import alembic.config
 import click
 import sqlalchemy
 
-from h import db
-from h import search
+from h import db, search
 
 log = logging.getLogger(__name__)
 

--- a/h/config.py
+++ b/h/config.py
@@ -8,7 +8,7 @@ import os
 from pyramid.config import Configurator
 from pyramid.settings import asbool, aslist
 
-from h.settings import database_url, SettingsManager
+from h.settings import SettingsManager, database_url
 from h.util.logging_filters import ExceptionFilter
 
 __all__ = ("configure",)

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -17,10 +17,9 @@ import logging
 import sqlalchemy
 import zope.sqlalchemy
 import zope.sqlalchemy.datamanager
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import exc
-from sqlalchemy.orm import sessionmaker
 from pkg_resources import resource_stream
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import exc, sessionmaker
 
 from h.util.session_tracker import Tracker
 

--- a/h/db/types.py
+++ b/h/db/types.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
 """Custom SQLAlchemy types for use with the Annotations API database."""
-import binascii
 import base64
+import binascii
 import uuid
 
 from sqlalchemy import types
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import DontWrapMixin
-
 
 # A magic byte (expressed as two hexadecimal nibbles) which we use to expand a
 # 15-byte ElasticSearch flake ID into a 16-byte UUID.

--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from h import links
-
 from pyramid.renderers import render
+
+from h import links
 
 
 def generate(request, notification):

--- a/h/eventqueue.py
+++ b/h/eventqueue.py
@@ -7,7 +7,6 @@ from zope.interface import providedBy
 
 from h.sentry import report_exception
 
-
 log = logging.getLogger(__name__)
 
 

--- a/h/feeds/__init__.py
+++ b/h/feeds/__init__.py
@@ -2,7 +2,6 @@
 
 """Code for generating feeds (e.g. Atom and RSS feeds)."""
 
-from h.feeds.render import render_atom
-from h.feeds.render import render_rss
+from h.feeds.render import render_atom, render_rss
 
 __all__ = ("render_atom", "render_rss")

--- a/h/feeds/atom.py
+++ b/h/feeds/atom.py
@@ -2,9 +2,8 @@
 """Functions for generating Atom feeds."""
 from pyramid import i18n
 
-from h import presenters
-from h import util
 import h.feeds.util
+from h import presenters, util
 
 _ = i18n.TranslationStringFactory(__package__)
 

--- a/h/feeds/render.py
+++ b/h/feeds/render.py
@@ -1,7 +1,6 @@
 from pyramid import renderers
 
-from h.feeds import atom
-from h.feeds import rss
+from h.feeds import atom, rss
 
 
 def render_atom(request, annotations, atom_url, html_url, title, subtitle):

--- a/h/feeds/rss.py
+++ b/h/feeds/rss.py
@@ -4,10 +4,8 @@ from email.utils import formatdate
 
 from pyramid import i18n
 
-from h import presenters
-from h import util
 import h.feeds.util
-
+from h import presenters, util
 
 _ = i18n.TranslationStringFactory(__package__)
 

--- a/h/form.py
+++ b/h/form.py
@@ -7,12 +7,11 @@ form templates in preference to the defaults.
 """
 import deform
 import jinja2
-from pyramid import httpexceptions
 import pyramid_jinja2
+from pyramid import httpexceptions
 from pyramid.path import AssetResolver
 
 from h import i18n
-
 
 ENVIRONMENT_KEY = "h.form.jinja2_environment"
 

--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
 
 import datetime
-from functools import partial
 import json
+from functools import partial
 from urllib.parse import unquote
+
+from jinja2 import Markup
+from jinja2.ext import Extension
 
 try:
     from xml.etree import cElementTree as ElementTree
 except ImportError:
     from xml.etree import ElementTree
 
-from jinja2 import Markup
-from jinja2.ext import Extension
 
 SVG_NAMESPACE_URI = "http://www.w3.org/2000/svg"
 

--- a/h/links.py
+++ b/h/links.py
@@ -3,7 +3,7 @@
 """
 Provides links to different representations of annotations.
 """
-from urllib.parse import urlparse, unquote, urljoin
+from urllib.parse import unquote, urljoin, urlparse
 
 
 def pretty_link(url):

--- a/h/migrations/env.py
+++ b/h/migrations/env.py
@@ -7,7 +7,6 @@ from sqlalchemy import engine_from_config, pool
 from h import db
 from h.settings import database_url
 
-# Import all model modules here in order to populate the metadata
 from h import models  # noqa
 
 # this is the Alembic Config object, which provides

--- a/h/migrations/env.py
+++ b/h/migrations/env.py
@@ -4,10 +4,9 @@ import os
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
+from h import models  # noqa
 from h import db
 from h.settings import database_url
-
-from h import models  # noqa
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/h/migrations/versions/02db2fa6ea98_add_unique_constraint_to_refresh_token_column.py
+++ b/h/migrations/versions/02db2fa6ea98_add_unique_constraint_to_refresh_token_column.py
@@ -6,9 +6,8 @@ Revises: c739ee2ae59c
 Create Date: 2017-01-31 17:24:03.855420
 """
 
-from alembic import op
 import sqlalchemy
-
+from alembic import op
 
 revision = "02db2fa6ea98"
 down_revision = "c739ee2ae59c"

--- a/h/migrations/versions/05bd63575f19_add_trusted_column_to_authclient_table.py
+++ b/h/migrations/versions/05bd63575f19_add_trusted_column_to_authclient_table.py
@@ -6,8 +6,8 @@ Revises: dfb8b45674db
 Create Date: 2017-07-18 13:45:12.301240
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "05bd63575f19"
 down_revision = "dfb8b45674db"

--- a/h/migrations/versions/0d4755a0d88b_remove_status_column_from_user_table.py
+++ b/h/migrations/versions/0d4755a0d88b_remove_status_column_from_user_table.py
@@ -10,8 +10,8 @@ Create Date: 2016-03-21 20:07:07.002482
 revision = "0d4755a0d88b"
 down_revision = "2494fea98d2d"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/140b450225cd_backfill_group_authority.py
+++ b/h/migrations/versions/140b450225cd_backfill_group_authority.py
@@ -6,8 +6,8 @@ Revises: 3acf258322d5
 Create Date: 2016-11-25 15:17:22.792448
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "140b450225cd"
 down_revision = "3acf258322d5"

--- a/h/migrations/versions/178270e3ee58_add_user_privacy_agreement_column.py
+++ b/h/migrations/versions/178270e3ee58_add_user_privacy_agreement_column.py
@@ -4,9 +4,8 @@ Add user privacy agreement column
 Add a column to track user's most recent acceptance of privacy policy
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "178270e3ee58"
 down_revision = "f052da9df33b"

--- a/h/migrations/versions/18dfed902c9e_remove_unused_user_indices.py
+++ b/h/migrations/versions/18dfed902c9e_remove_unused_user_indices.py
@@ -6,9 +6,8 @@ Revises: 7e2443f8d7d6
 Create Date: 2017-03-03 12:13:16.122752
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "18dfed902c9e"
 down_revision = "7e2443f8d7d6"

--- a/h/migrations/versions/1a40e75a524d_add_normalised_username_index.py
+++ b/h/migrations/versions/1a40e75a524d_add_normalised_username_index.py
@@ -6,9 +6,8 @@ Revises: 02db2fa6ea98
 Create Date: 2017-03-02 13:55:24.290975
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "1a40e75a524d"
 down_revision = "02db2fa6ea98"

--- a/h/migrations/versions/1c995723a271_add_world_group.py
+++ b/h/migrations/versions/1c995723a271_add_world_group.py
@@ -7,6 +7,7 @@ Create Date: 2017-04-18 12:19:33.863557
 """
 
 import enum
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.ext.declarative import declarative_base

--- a/h/migrations/versions/1e88c31d8b1a_add_authticket_table.py
+++ b/h/migrations/versions/1e88c31d8b1a_add_authticket_table.py
@@ -6,9 +6,8 @@ Revises: f9d3058bec5f
 Create Date: 2016-09-16 12:22:26.480404
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "1e88c31d8b1a"
 down_revision = "f9d3058bec5f"

--- a/h/migrations/versions/1ef80156ee4_add_sidebar_tutorial_dismissed_column_.py
+++ b/h/migrations/versions/1ef80156ee4_add_sidebar_tutorial_dismissed_column_.py
@@ -10,8 +10,8 @@ Create Date: 2015-12-21 18:49:15.688177
 revision = "1ef80156ee4"
 down_revision = "43e7c4ed2fd7"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/21b1ce37e327_allow_null_group_creator.py
+++ b/h/migrations/versions/21b1ce37e327_allow_null_group_creator.py
@@ -8,7 +8,6 @@ Create Date: 2017-04-13 16:49:16.218511
 
 from alembic import op
 
-
 revision = "21b1ce37e327"
 down_revision = "9389d52b037d"
 

--- a/h/migrations/versions/21f87f395e26_add_group_name_index.py
+++ b/h/migrations/versions/21f87f395e26_add_group_name_index.py
@@ -10,8 +10,8 @@ Create Date: 2016-03-24 15:12:59.803179
 revision = "21f87f395e26"
 down_revision = "0d4755a0d88b"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/2494fea98d2d_add_the_token_table.py
+++ b/h/migrations/versions/2494fea98d2d_add_the_token_table.py
@@ -10,8 +10,8 @@ Create Date: 2016-02-15 11:20:00.787358
 revision = "2494fea98d2d"
 down_revision = "4886d7a14074"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/296573bb30b3_add_feature_featurecohort_association_table.py
+++ b/h/migrations/versions/296573bb30b3_add_feature_featurecohort_association_table.py
@@ -10,8 +10,8 @@ Create Date: 2016-06-09 16:35:09.065224
 revision = "296573bb30b3"
 down_revision = "f6ffcfc50583"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/2a414b3393be_add_UserIdentity_to_User_relation.py
+++ b/h/migrations/versions/2a414b3393be_add_UserIdentity_to_User_relation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Add UserIdentity (many) -> User (one) relation."""
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "2a414b3393be"
 down_revision = "5dd2dd5547a2"

--- a/h/migrations/versions/2d0ad2b1bf07_add_enforce_scope_column_to_group_table.py
+++ b/h/migrations/versions/2d0ad2b1bf07_add_enforce_scope_column_to_group_table.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Add enforce_scope column to group table"""
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "2d0ad2b1bf07"
 down_revision = "5ed9c8c105f6"

--- a/h/migrations/versions/39b1935d9e7b_add_annotation_text_rendered.py
+++ b/h/migrations/versions/39b1935d9e7b_add_annotation_text_rendered.py
@@ -5,9 +5,8 @@ Revises: 6b801ecc60f1
 Create Date: 2016-08-09 15:19:49.572331
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "39b1935d9e7b"
 down_revision = "6b801ecc60f1"

--- a/h/migrations/versions/3acf258322d5_add_authority_column_to_group.py
+++ b/h/migrations/versions/3acf258322d5_add_authority_column_to_group.py
@@ -6,9 +6,8 @@ Revises: c36369fe730f
 Create Date: 2016-11-24 16:33:40.238726
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "3acf258322d5"
 down_revision = "c36369fe730f"

--- a/h/migrations/versions/3bcd62dd7260_add_featurecohort_table.py
+++ b/h/migrations/versions/3bcd62dd7260_add_featurecohort_table.py
@@ -10,8 +10,8 @@ Create Date: 2016-05-10 17:01:02.704596
 revision = "3bcd62dd7260"
 down_revision = "dfa82518915a"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/3d71ec81d18c_delete_empty_document_titles.py
+++ b/h/migrations/versions/3d71ec81d18c_delete_empty_document_titles.py
@@ -7,12 +7,11 @@ Create Date: 2016-09-14 16:03:41.490371
 """
 import logging
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-
 
 revision = "3d71ec81d18c"
 down_revision = "6964a8237c88"

--- a/h/migrations/versions/3e1727613916_add_document_web_uri_column.py
+++ b/h/migrations/versions/3e1727613916_add_document_web_uri_column.py
@@ -6,9 +6,8 @@ Revises: a001b7b4c78e
 Create Date: 2016-09-12 13:21:56.739838
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "3e1727613916"
 down_revision = "a001b7b4c78e"

--- a/h/migrations/versions/42bd46b9b1ea_fill_in_missing_password_updated_fields.py
+++ b/h/migrations/versions/42bd46b9b1ea_fill_in_missing_password_updated_fields.py
@@ -12,8 +12,8 @@ down_revision = None
 
 import datetime
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.orm import sessionmaker
 
 Session = sessionmaker()

--- a/h/migrations/versions/43e7c4ed2fd7_make_user_password_updated_non_nullable.py
+++ b/h/migrations/versions/43e7c4ed2fd7_make_user_password_updated_non_nullable.py
@@ -10,8 +10,8 @@ Create Date: 2015-12-22 15:48:14.867487
 revision = "43e7c4ed2fd7"
 down_revision = "42bd46b9b1ea"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/467ea2898660_fix_document_uri_unique_constraint.py
+++ b/h/migrations/versions/467ea2898660_fix_document_uri_unique_constraint.py
@@ -11,8 +11,8 @@ down_revision = "40740282ae9e"
 
 import logging
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 

--- a/h/migrations/versions/46a22db075d5_add_organization_id_to_group_table.py
+++ b/h/migrations/versions/46a22db075d5_add_organization_id_to_group_table.py
@@ -6,8 +6,8 @@ Revises: 628c53b07
 Create Date: 2018-03-21 09:47:47.642578
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "46a22db075d5"
 down_revision = "628c53b07"

--- a/h/migrations/versions/4886d7a14074_add_constraints_to_sidebar_tutorial_.py
+++ b/h/migrations/versions/4886d7a14074_add_constraints_to_sidebar_tutorial_.py
@@ -10,8 +10,8 @@ Create Date: 2016-01-07 12:51:33.807404
 revision = "4886d7a14074"
 down_revision = "6f6a853fa2a"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/4c0c44605c09_create_annotation_table.py
+++ b/h/migrations/versions/4c0c44605c09_create_annotation_table.py
@@ -10,8 +10,8 @@ Create Date: 2016-01-20 12:58:16.249481
 revision = "4c0c44605c09"
 down_revision = "21f87f395e26"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 from h.db import types

--- a/h/migrations/versions/504a6a4db06d_relax_password_constraints.py
+++ b/h/migrations/versions/504a6a4db06d_relax_password_constraints.py
@@ -9,7 +9,6 @@ Create Date: 2016-08-18 22:32:51.092582
 import sqlalchemy as sa
 from alembic import op
 
-
 revision = "504a6a4db06d"
 down_revision = "de42d613c18d"
 

--- a/h/migrations/versions/50df3e6782aa_add_annotation_moderation_table.py
+++ b/h/migrations/versions/50df3e6782aa_add_annotation_moderation_table.py
@@ -6,11 +6,10 @@ Revises: e554d862135f
 Create Date: 2017-03-29 15:15:36.092486
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from h.db import types
-
 
 revision = "50df3e6782aa"
 down_revision = "e554d862135f"

--- a/h/migrations/versions/53a74d7ae1b0_remove_nipsa_table.py
+++ b/h/migrations/versions/53a74d7ae1b0_remove_nipsa_table.py
@@ -9,7 +9,6 @@ Create Date: 2016-09-20 12:12:03.600081
 import sqlalchemy as sa
 from alembic import op
 
-
 revision = "53a74d7ae1b0"
 down_revision = "1e88c31d8b1a"
 

--- a/h/migrations/versions/5655d56d7c29_add_flag_table.py
+++ b/h/migrations/versions/5655d56d7c29_add_flag_table.py
@@ -6,11 +6,10 @@ Revises: c322c57b49db
 Create Date: 2017-03-08 15:32:27.288684
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from h.db import types
-
 
 revision = "5655d56d7c29"
 down_revision = "c322c57b49db"

--- a/h/migrations/versions/58bb601c390f_fill_in_missing_denormalized_document_title.py
+++ b/h/migrations/versions/58bb601c390f_fill_in_missing_denormalized_document_title.py
@@ -8,12 +8,10 @@ Create Date: 2016-09-12 12:21:40.904620
 
 from collections import namedtuple
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm import subqueryload
-
+from sqlalchemy.orm import sessionmaker, subqueryload
 
 revision = "58bb601c390f"
 down_revision = "3e1727613916"

--- a/h/migrations/versions/5bfdfde681ea_add_annotation_deleted_column.py
+++ b/h/migrations/versions/5bfdfde681ea_add_annotation_deleted_column.py
@@ -6,9 +6,8 @@ Revises: 90412d879d1f
 Create Date: 2016-12-19 12:37:53.791428
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "5bfdfde681ea"
 down_revision = "90412d879d1f"

--- a/h/migrations/versions/5d256923d642_make_organization_relation_nullable_on_.py
+++ b/h/migrations/versions/5d256923d642_make_organization_relation_nullable_on_.py
@@ -2,7 +2,6 @@
 """Make organization relation nullable on group"""
 from alembic import op
 
-
 revision = "5d256923d642"
 down_revision = "7fe5d688edd9"
 

--- a/h/migrations/versions/5dce9a8c42c2_disallow_null_annotation_document_id.py
+++ b/h/migrations/versions/5dce9a8c42c2_disallow_null_annotation_document_id.py
@@ -8,7 +8,6 @@ Create Date: 2016-09-22 17:22:09.294825
 
 from alembic import op
 
-
 revision = "5dce9a8c42c2"
 down_revision = "bcdd81e23920"
 

--- a/h/migrations/versions/5dd2dd5547a2_add_the_user_identity_table.py
+++ b/h/migrations/versions/5dd2dd5547a2_add_the_user_identity_table.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Add the user_identity table."""
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "5dd2dd5547a2"
 down_revision = "178270e3ee58"

--- a/h/migrations/versions/5e535a075f16_remove_null_document_titles.py
+++ b/h/migrations/versions/5e535a075f16_remove_null_document_titles.py
@@ -7,12 +7,11 @@ Create Date: 2016-09-14 15:11:26.551596
 """
 import logging
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-
 
 revision = "5e535a075f16"
 down_revision = "a44ef07b085a"

--- a/h/migrations/versions/5ed9c8c105f6_add_authority_provided_id_field_to_group.py
+++ b/h/migrations/versions/5ed9c8c105f6_add_authority_provided_id_field_to_group.py
@@ -16,9 +16,8 @@ IDs.
 ``authority_provided_id`` must be unique per authority; ergo the
 unique-enforced index
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "5ed9c8c105f6"
 down_revision = "5d256923d642"

--- a/h/migrations/versions/615358b6c428_move_all_groups_to_default_organization.py
+++ b/h/migrations/versions/615358b6c428_move_all_groups_to_default_organization.py
@@ -29,11 +29,10 @@ later.
 import logging
 import random
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-
 
 revision = "615358b6c428"
 down_revision = "8a7f31c4525d"

--- a/h/migrations/versions/628c53b07_add_the_organization_table.py
+++ b/h/migrations/versions/628c53b07_add_the_organization_table.py
@@ -6,8 +6,8 @@ Revises: 7bf167611bc3
 Create Date: 2018-03-15 11:00:50.420618
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "628c53b07"
 down_revision = "7bf167611bc3"

--- a/h/migrations/versions/63e8b1fe1d4b_clean_up_document_uris.py
+++ b/h/migrations/versions/63e8b1fe1d4b_clean_up_document_uris.py
@@ -7,11 +7,10 @@ Create Date: 2016-09-15 15:26:31.286536
 """
 import logging
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-
 
 revision = "63e8b1fe1d4b"
 down_revision = "53a74d7ae1b0"

--- a/h/migrations/versions/6964a8237c88_strip_whitespace_from_document_titles.py
+++ b/h/migrations/versions/6964a8237c88_strip_whitespace_from_document_titles.py
@@ -7,12 +7,11 @@ Create Date: 2016-09-14 15:17:23.096224
 """
 import logging
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-
 
 revision = "6964a8237c88"
 down_revision = "5e535a075f16"

--- a/h/migrations/versions/6b801ecc60f1_add_a_primary_key_to_the_user_group_.py
+++ b/h/migrations/versions/6b801ecc60f1_add_a_primary_key_to_the_user_group_.py
@@ -6,9 +6,8 @@ Revises: e17d3ce4fcd2
 Create Date: 2016-07-08 17:42:20.891383
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "6b801ecc60f1"
 down_revision = "e17d3ce4fcd2"

--- a/h/migrations/versions/6d9257ad610d_delete_empty_array_document_titles.py
+++ b/h/migrations/versions/6d9257ad610d_delete_empty_array_document_titles.py
@@ -7,12 +7,11 @@ Create Date: 2016-09-14 16:06:33.439592
 """
 import logging
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-
 
 revision = "6d9257ad610d"
 down_revision = "3d71ec81d18c"

--- a/h/migrations/versions/6f6a853fa2a_fill_in_sidebar_tutorial_dismissed_.py
+++ b/h/migrations/versions/6f6a853fa2a_fill_in_sidebar_tutorial_dismissed_.py
@@ -10,10 +10,9 @@ Create Date: 2016-01-06 19:12:14.402260
 revision = "6f6a853fa2a"
 down_revision = "1ef80156ee4"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy import orm
-
 
 Session = orm.sessionmaker()
 

--- a/h/migrations/versions/6f86796f64e0_add_user_profile_columns.py
+++ b/h/migrations/versions/6f86796f64e0_add_user_profile_columns.py
@@ -6,9 +6,8 @@ Revises: 7cf52a00822b
 Create Date: 2016-07-06 11:28:50.075057
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "6f86796f64e0"
 down_revision = "7cf52a00822b"

--- a/h/migrations/versions/74bff6a7d9de_make_feature_flag_deletions_cascade.py
+++ b/h/migrations/versions/74bff6a7d9de_make_feature_flag_deletions_cascade.py
@@ -8,7 +8,6 @@ Create Date: 2017-08-01 09:59:51.200253
 
 from alembic import op
 
-
 revision = "74bff6a7d9de"
 down_revision = "52a0b2e5a9c2"
 

--- a/h/migrations/versions/77c2af032aca_add_document_uri_and_meta_docid_ix.py
+++ b/h/migrations/versions/77c2af032aca_add_document_uri_and_meta_docid_ix.py
@@ -10,8 +10,8 @@ Create Date: 2016-05-13 15:06:55.496502
 revision = "77c2af032aca"
 down_revision = "f3b8e76ae9f5"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/792debe852c3_make_user_email_nullable.py
+++ b/h/migrations/versions/792debe852c3_make_user_email_nullable.py
@@ -2,7 +2,6 @@
 """Make user.email nullable."""
 from alembic import op
 
-
 revision = "792debe852c3"
 down_revision = "2a414b3393be"
 

--- a/h/migrations/versions/7bf167611bc3_add_the_groupscope_table.py
+++ b/h/migrations/versions/7bf167611bc3_add_the_groupscope_table.py
@@ -6,8 +6,8 @@ Revises: c943c3f8a7e5
 Create Date: 2018-02-08 11:00:50.420618
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "7bf167611bc3"
 down_revision = "c943c3f8a7e5"

--- a/h/migrations/versions/7cf52a00822b_add_group_description_column.py
+++ b/h/migrations/versions/7cf52a00822b_add_group_description_column.py
@@ -6,9 +6,8 @@ Revises: 9e6b4f70f588
 Create Date: 2016-07-06 11:02:08.163718
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "7cf52a00822b"
 down_revision = "9e6b4f70f588"

--- a/h/migrations/versions/7e2443f8d7d6_make_userid_index_unique.py
+++ b/h/migrations/versions/7e2443f8d7d6_make_userid_index_unique.py
@@ -6,9 +6,8 @@ Revises: faefe3b614db
 Create Date: 2017-03-07 10:25:23.165687
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "7e2443f8d7d6"
 down_revision = "faefe3b614db"

--- a/h/migrations/versions/7f3d80550fff_correct_timestamps_of_elife_test_annotations.py
+++ b/h/migrations/versions/7f3d80550fff_correct_timestamps_of_elife_test_annotations.py
@@ -12,16 +12,15 @@ Revises: 9bcc39244e82
 Create Date: 2017-11-29 15:06:59.207780
 """
 
-from datetime import datetime
 import logging
+from datetime import datetime
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from h.db import types
-
 
 revision = "7f3d80550fff"
 down_revision = "9bcc39244e82"

--- a/h/migrations/versions/7fe5d688edd9_add_index_to_user_nipsa.py
+++ b/h/migrations/versions/7fe5d688edd9_add_index_to_user_nipsa.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Add index to user.nipsa"""
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "7fe5d688edd9"
 down_revision = "792debe852c3"

--- a/h/migrations/versions/8a7f31c4525d_add___default___organization.py
+++ b/h/migrations/versions/8a7f31c4525d_add___default___organization.py
@@ -8,8 +8,8 @@ Create Date: 2018-03-27 16:50:20.959215
 """
 import logging
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 

--- a/h/migrations/versions/8ae9d103551f_backfill_group_access_flags.py
+++ b/h/migrations/versions/8ae9d103551f_backfill_group_access_flags.py
@@ -8,9 +8,8 @@ Create Date: 2016-11-29 12:51:31.247598
 
 import enum
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "8ae9d103551f"
 down_revision = "af88524994ce"

--- a/h/migrations/versions/8bd83598ad77_add_path_column_to_groupscope.py
+++ b/h/migrations/versions/8bd83598ad77_add_path_column_to_groupscope.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Add path column to groupscope, and a composite index for the (origin, path) columns"""
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "8bd83598ad77"
 down_revision = "2d0ad2b1bf07"

--- a/h/migrations/versions/90412d879d1f_add_setting_table.py
+++ b/h/migrations/versions/90412d879d1f_add_setting_table.py
@@ -6,9 +6,8 @@ Revises: 8ae9d103551f
 Create Date: 2016-12-19 13:29:39.933771
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "90412d879d1f"
 down_revision = "8ae9d103551f"

--- a/h/migrations/versions/94c989e06363_remove_old_user_constraints.py
+++ b/h/migrations/versions/94c989e06363_remove_old_user_constraints.py
@@ -11,7 +11,6 @@ Create Date: 2016-09-08 16:21:25.444258
 
 from alembic import op
 
-
 revision = "94c989e06363"
 down_revision = "b0e1a12de5e8"
 

--- a/h/migrations/versions/98157e28a7e1_make_annotation_extra_non_nullable.py
+++ b/h/migrations/versions/98157e28a7e1_make_annotation_extra_non_nullable.py
@@ -10,8 +10,8 @@ Create Date: 2016-06-06 14:52:41.277688
 revision = "98157e28a7e1"
 down_revision = "77c2af032aca"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/9cbc5c5ad23d_fill_in_missing_annotation_deleted.py
+++ b/h/migrations/versions/9cbc5c5ad23d_fill_in_missing_annotation_deleted.py
@@ -6,8 +6,8 @@ Revises: 5bfdfde681ea
 Create Date: 2016-12-19 12:41:25.269188
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "9cbc5c5ad23d"
 down_revision = "5bfdfde681ea"

--- a/h/migrations/versions/9e01b7287da2_remove_duplicates_from_user_group_table.py
+++ b/h/migrations/versions/9e01b7287da2_remove_duplicates_from_user_group_table.py
@@ -6,8 +6,8 @@ Revises: 6f86796f64e0
 Create Date: 2016-07-08 17:54:57.399139
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 

--- a/h/migrations/versions/9e6b4f70f588_removing_trailing_from_pdf_urns.py
+++ b/h/migrations/versions/9e6b4f70f588_removing_trailing_from_pdf_urns.py
@@ -10,9 +10,10 @@ import logging
 
 import sqlalchemy as sa
 from alembic import op
-from h.db import types
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+
+from h.db import types
 
 # revision identifiers, used by Alembic.
 revision = "9e6b4f70f588"

--- a/h/migrations/versions/9e6b4f70f588_removing_trailing_from_pdf_urns.py
+++ b/h/migrations/versions/9e6b4f70f588_removing_trailing_from_pdf_urns.py
@@ -8,16 +8,16 @@ Create Date: 2016-06-21 17:50:14.261947
 # pylint: disable=invalid-name, wrong-import-position
 import logging
 
+import sqlalchemy as sa
+from alembic import op
+from h.db import types
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
 # revision identifiers, used by Alembic.
 revision = "9e6b4f70f588"
 down_revision = "ccebe818f8e0"
 
-from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.ext.declarative import declarative_base
-
-from h.db import types
 
 Base = declarative_base()
 Session = sessionmaker()

--- a/h/migrations/versions/9f5e274b202c_update_all_document_web_uris.py
+++ b/h/migrations/versions/9f5e274b202c_update_all_document_web_uris.py
@@ -6,16 +6,14 @@ Revises: e10ce4472966
 Create Date: 2017-01-20 16:07:03.442975
 """
 
-from collections import namedtuple
 import logging
+from collections import namedtuple
 from urllib.parse import urlparse
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm import subqueryload
-
+from sqlalchemy.orm import sessionmaker, subqueryload
 
 revision = "9f5e274b202c"
 down_revision = "e10ce4472966"

--- a/h/migrations/versions/a001b7b4c78e_add_document_title_column.py
+++ b/h/migrations/versions/a001b7b4c78e_add_document_title_column.py
@@ -6,9 +6,8 @@ Revises: 94c989e06363
 Create Date: 2016-09-12 11:59:35.296908
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "a001b7b4c78e"
 down_revision = "94c989e06363"

--- a/h/migrations/versions/a2295c2bbe29_make_client_secret_nullable.py
+++ b/h/migrations/versions/a2295c2bbe29_make_client_secret_nullable.py
@@ -8,7 +8,6 @@ Create Date: 2017-07-18 11:15:39.885020
 
 from alembic import op
 
-
 revision = "a2295c2bbe29"
 down_revision = "05bd63575f19"
 

--- a/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
+++ b/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
@@ -9,12 +9,10 @@ Create Date: 2016-09-12 15:31:00.597582
 from collections import namedtuple
 from urllib.parse import urlparse
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm import subqueryload
-
+from sqlalchemy.orm import sessionmaker, subqueryload
 
 revision = "a44ef07b085a"
 down_revision = "58bb601c390f"

--- a/h/migrations/versions/addee5d1686f_add_annotation_document_id_column.py
+++ b/h/migrations/versions/addee5d1686f_add_annotation_document_id_column.py
@@ -6,9 +6,8 @@ Revises: 63e8b1fe1d4b
 Create Date: 2016-09-22 15:55:06.069829
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "addee5d1686f"
 down_revision = "63e8b1fe1d4b"

--- a/h/migrations/versions/af88524994ce_add_group_access_flags.py
+++ b/h/migrations/versions/af88524994ce_add_group_access_flags.py
@@ -8,8 +8,8 @@ Create Date: 2016-11-25 15:58:59.517470
 
 import enum
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "af88524994ce"
 down_revision = "8990247b876c"

--- a/h/migrations/versions/afd433075707_add_index_to_user_authority_column.py
+++ b/h/migrations/versions/afd433075707_add_index_to_user_authority_column.py
@@ -8,7 +8,6 @@ Create Date: 2016-08-19 14:26:08.706027
 
 from alembic import op
 
-
 revision = "afd433075707"
 down_revision = "504a6a4db06d"
 

--- a/h/migrations/versions/b0e1a12de5e8_update_user_unique_constraints.py
+++ b/h/migrations/versions/b0e1a12de5e8_update_user_unique_constraints.py
@@ -6,8 +6,8 @@ Revises: bdaa06b14557
 Create Date: 2016-09-08 16:03:59.857402
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision = "b0e1a12de5e8"

--- a/h/migrations/versions/b7117b569f8b_fill_user_nipsa_column.py
+++ b/h/migrations/versions/b7117b569f8b_fill_user_nipsa_column.py
@@ -6,8 +6,8 @@ Revises: ddb5f0baa429
 Create Date: 2016-09-16 17:03:25.264475
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy import orm
 
 from h.util.user import split_user

--- a/h/migrations/versions/b980b1a8f6af_add_authclient_grant_response_type_columns.py
+++ b/h/migrations/versions/b980b1a8f6af_add_authclient_grant_response_type_columns.py
@@ -8,8 +8,8 @@ Create Date: 2017-07-11 11:43:01.120391
 
 import enum
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "b980b1a8f6af"
 down_revision = "1c995723a271"

--- a/h/migrations/versions/bcdd81e23920_fill_in_missing_annotation_document_id.py
+++ b/h/migrations/versions/bcdd81e23920_fill_in_missing_annotation_document_id.py
@@ -6,18 +6,16 @@ Revises: addee5d1686f
 Create Date: 2016-09-22 16:02:42.284670
 """
 
-from collections import namedtuple
 import logging
+from collections import namedtuple
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm import subqueryload
+from sqlalchemy.orm import sessionmaker, subqueryload
 
 from h.db import types
 from h.util.uri import normalize as uri_normalize
-
 
 revision = "bcdd81e23920"
 down_revision = "addee5d1686f"

--- a/h/migrations/versions/bdaa06b14557_add_authclient_table.py
+++ b/h/migrations/versions/bdaa06b14557_add_authclient_table.py
@@ -6,8 +6,8 @@ Revises: afd433075707
 Create Date: 2016-09-08 14:00:17.363281
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision = "bdaa06b14557"

--- a/h/migrations/versions/c322c57b49db_remove_user_uid_column.py
+++ b/h/migrations/versions/c322c57b49db_remove_user_uid_column.py
@@ -6,9 +6,8 @@ Revises: 18dfed902c9e
 Create Date: 2017-03-03 12:24:19.739583
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "c322c57b49db"
 down_revision = "18dfed902c9e"

--- a/h/migrations/versions/c36369fe730f_add_token_client_id_column.py
+++ b/h/migrations/versions/c36369fe730f_add_token_client_id_column.py
@@ -6,10 +6,9 @@ Revises: e15e47228c43
 Create Date: 2016-10-19 15:24:13.387546
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
-
 
 revision = "c36369fe730f"
 down_revision = "e15e47228c43"

--- a/h/migrations/versions/c739ee2ae59c_add_refresh_token_column_to_token_table.py
+++ b/h/migrations/versions/c739ee2ae59c_add_refresh_token_column_to_token_table.py
@@ -9,7 +9,6 @@ Create Date: 2017-01-24 19:00:07.493002
 import sqlalchemy as sa
 from alembic import op
 
-
 revision = "c739ee2ae59c"
 down_revision = "9f5e274b202c"
 

--- a/h/migrations/versions/c943c3f8a7e5_update_imported_elife_ann_timestamps.py
+++ b/h/migrations/versions/c943c3f8a7e5_update_imported_elife_ann_timestamps.py
@@ -13,16 +13,15 @@ Revises: 7f3d80550fff
 Create Date: 2018-01-30 11:12:23.520717
 """
 
-from datetime import datetime
 import logging
+from datetime import datetime
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from h.db import types
-
 
 revision = "c943c3f8a7e5"
 down_revision = "7f3d80550fff"

--- a/h/migrations/versions/d536d9a342f3_fill_in_annotation_text_rendered_column.py
+++ b/h/migrations/versions/d536d9a342f3_fill_in_annotation_text_rendered_column.py
@@ -9,13 +9,12 @@ Create Date: 2016-08-10 14:09:01.787927
 import sys
 from collections import namedtuple
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from h.util import markdown
-
 
 revision = "d536d9a342f3"
 down_revision = "39b1935d9e7b"

--- a/h/migrations/versions/dba81a22ea75_add_redirect_uri_column_to_authclient.py
+++ b/h/migrations/versions/dba81a22ea75_add_redirect_uri_column_to_authclient.py
@@ -6,9 +6,8 @@ Revises: 0d1b3fd8807c
 Create Date: 2017-07-12 15:17:05.036842
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "dba81a22ea75"
 down_revision = "0d1b3fd8807c"

--- a/h/migrations/versions/ddb5f0baa429_add_nipsa_column_to_user_table.py
+++ b/h/migrations/versions/ddb5f0baa429_add_nipsa_column_to_user_table.py
@@ -9,7 +9,6 @@ Create Date: 2016-09-16 16:58:03.585538
 import sqlalchemy as sa
 from alembic import op
 
-
 revision = "ddb5f0baa429"
 down_revision = "6d9257ad610d"
 

--- a/h/migrations/versions/de42d613c18d_add_constraints_to_user_authority_column.py
+++ b/h/migrations/versions/de42d613c18d_add_constraints_to_user_authority_column.py
@@ -8,7 +8,6 @@ Create Date: 2016-08-15 18:18:19.037667
 
 from alembic import op
 
-
 revision = "de42d613c18d"
 down_revision = "2e2cc6a0c521"
 

--- a/h/migrations/versions/dfa82518915a_create_document_tables.py
+++ b/h/migrations/versions/dfa82518915a_create_document_tables.py
@@ -10,8 +10,8 @@ Create Date: 2016-02-10 14:52:08.236839
 revision = "dfa82518915a"
 down_revision = "4c0c44605c09"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 

--- a/h/migrations/versions/e10ce4472966_add_index_to_group_readable_by.py
+++ b/h/migrations/versions/e10ce4472966_add_index_to_group_readable_by.py
@@ -8,7 +8,6 @@ Create Date: 2016-12-22 16:13:53.658938
 
 from alembic import op
 
-
 revision = "e10ce4472966"
 down_revision = "f0f42ffaa27d"
 

--- a/h/migrations/versions/e15e47228c43_remove_token_userid_uniqueness.py
+++ b/h/migrations/versions/e15e47228c43_remove_token_userid_uniqueness.py
@@ -8,7 +8,6 @@ Create Date: 2016-10-19 16:17:06.067310
 
 from alembic import op
 
-
 revision = "e15e47228c43"
 down_revision = "5dce9a8c42c2"
 

--- a/h/migrations/versions/e17d3ce4fcd2_add_unique_constraint_to_user_group_.py
+++ b/h/migrations/versions/e17d3ce4fcd2_add_unique_constraint_to_user_group_.py
@@ -8,7 +8,6 @@ Create Date: 2016-07-08 18:56:20.118573
 
 from alembic import op
 
-
 revision = "e17d3ce4fcd2"
 down_revision = "9e01b7287da2"
 

--- a/h/migrations/versions/e554d862135f_add_index_to_flag_user_id.py
+++ b/h/migrations/versions/e554d862135f_add_index_to_flag_user_id.py
@@ -8,7 +8,6 @@ Create Date: 2017-03-16 12:35:45.791202
 
 from alembic import op
 
-
 revision = "e554d862135f"
 down_revision = "5655d56d7c29"
 

--- a/h/migrations/versions/f052da9df33b_make_group_organization_id_not_nullable.py
+++ b/h/migrations/versions/f052da9df33b_make_group_organization_id_not_nullable.py
@@ -1,7 +1,6 @@
 """Make group.organization_id not nullable."""
 from alembic import op
 
-
 revision = "f052da9df33b"
 down_revision = "615358b6c428"
 

--- a/h/migrations/versions/f0f42ffaa27d_add_annotation_deleted_constraints.py
+++ b/h/migrations/versions/f0f42ffaa27d_add_annotation_deleted_constraints.py
@@ -6,9 +6,8 @@ Revises: 9cbc5c5ad23d
 Create Date: 2016-12-19 14:06:37.956780
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "f0f42ffaa27d"
 down_revision = "9cbc5c5ad23d"

--- a/h/migrations/versions/f3b8e76ae9f5_add_document_uri_and_meta_updated_index.py
+++ b/h/migrations/versions/f3b8e76ae9f5_add_document_uri_and_meta_updated_index.py
@@ -10,8 +10,8 @@ Create Date: 2016-05-13 14:58:37.679724
 revision = "f3b8e76ae9f5"
 down_revision = "fde6cdcdd39a"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/f48100c9af86_add_authority_column_to_user_table.py
+++ b/h/migrations/versions/f48100c9af86_add_authority_column_to_user_table.py
@@ -9,7 +9,6 @@ Create Date: 2016-08-15 18:10:23.511861
 import sqlalchemy as sa
 from alembic import op
 
-
 revision = "f48100c9af86"
 down_revision = "64cf31f9f721"
 

--- a/h/migrations/versions/f6ffcfc50583_add_annotation_extra_server_default.py
+++ b/h/migrations/versions/f6ffcfc50583_add_annotation_extra_server_default.py
@@ -10,8 +10,8 @@ Create Date: 2016-06-06 15:14:36.642775
 revision = "f6ffcfc50583"
 down_revision = "98157e28a7e1"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/f9d3058bec5f_add_constraints_to_user_nipsa_column.py
+++ b/h/migrations/versions/f9d3058bec5f_add_constraints_to_user_nipsa_column.py
@@ -9,7 +9,6 @@ Create Date: 2016-09-19 13:07:58.098068
 import sqlalchemy as sa
 from alembic import op
 
-
 revision = "f9d3058bec5f"
 down_revision = "b7117b569f8b"
 

--- a/h/migrations/versions/faefe3b614db_make_user_uid_nullable.py
+++ b/h/migrations/versions/faefe3b614db_make_user_uid_nullable.py
@@ -6,9 +6,8 @@ Revises: 1a40e75a524d
 Create Date: 2017-03-02 14:17:41.708781
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision = "faefe3b614db"
 down_revision = "1a40e75a524d"

--- a/h/migrations/versions/fde6cdcdd39a_add_annotation_updated_index.py
+++ b/h/migrations/versions/fde6cdcdd39a_add_annotation_updated_index.py
@@ -10,8 +10,8 @@ Create Date: 2016-04-27 13:42:14.201644
 revision = "fde6cdcdd39a"
 down_revision = "3bcd62dd7260"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade():

--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -29,8 +29,8 @@ from h.models.feature import Feature
 from h.models.feature_cohort import FeatureCohort
 from h.models.flag import Flag
 from h.models.group import Group
-from h.models.organization import Organization
 from h.models.group_scope import GroupScope
+from h.models.organization import Organization
 from h.models.setting import Setting
 from h.models.subscriptions import Subscriptions
 from h.models.token import Token

--- a/h/models/auth_client.py
+++ b/h/models/auth_client.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import enum
+
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 

--- a/h/models/document.py
+++ b/h/models/document.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
 import logging
+from datetime import datetime
 from urllib.parse import urlparse
 
-from pyramid_retry import mark_error_retryable
 import sqlalchemy as sa
+from pyramid_retry import mark_error_retryable
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.hybrid import hybrid_property
 

--- a/h/models/feature_cohort.py
+++ b/h/models/feature_cohort.py
@@ -2,8 +2,7 @@
 
 import sqlalchemy as sa
 
-from h.db import Base
-from h.db import mixins
+from h.db import Base, mixins
 
 
 class FeatureCohort(Base, mixins.Timestamps):

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -1,19 +1,17 @@
 # -*- coding: utf-8 -*-
 
-from collections import namedtuple
-
 import enum
 import re
+from collections import namedtuple
+
+import slugify
 import sqlalchemy as sa
 from pyramid import security
-import slugify
 
-from h.db import Base
-from h.db import mixins
 from h import pubid
 from h.auth import role
+from h.db import Base, mixins
 from h.util.group import split_groupid
-
 
 GROUP_NAME_MIN_LENGTH = 3
 GROUP_NAME_MAX_LENGTH = 25

--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -2,9 +2,8 @@
 
 import sqlalchemy as sa
 
-from h.db import Base
-from h.db import mixins
 from h import pubid
+from h.db import Base, mixins
 
 ORGANIZATION_DEFAULT_PUBID = "__default__"
 ORGANIZATION_NAME_MIN_CHARS = 1

--- a/h/models/setting.py
+++ b/h/models/setting.py
@@ -2,8 +2,7 @@
 
 import sqlalchemy as sa
 
-from h.db import Base
-from h.db import mixins
+from h.db import Base, mixins
 
 
 class Setting(Base, mixins.Timestamps):

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -5,8 +5,7 @@ import datetime
 import sqlalchemy
 from sqlalchemy.dialects import postgresql
 
-from h.db import Base
-from h.db import mixins
+from h.db import Base, mixins
 
 
 class Token(Base, mixins.Timestamps):

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -4,9 +4,9 @@ import datetime
 import re
 
 import sqlalchemy as sa
-from sqlalchemy.ext.hybrid import Comparator, hybrid_property
-from sqlalchemy.ext.declarative import declared_attr
 from pyramid import security
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.ext.hybrid import Comparator, hybrid_property
 
 from h.db import Base
 from h.util.user import split_user

--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from collections import namedtuple
 import logging
+from collections import namedtuple
 
 from h import storage
 from h.models import Subscriptions

--- a/h/presenters/__init__.py
+++ b/h/presenters/__init__.py
@@ -12,9 +12,8 @@ from h.presenters.annotation_searchindex import AnnotationSearchIndexPresenter
 from h.presenters.document_html import DocumentHTMLPresenter
 from h.presenters.document_json import DocumentJSONPresenter
 from h.presenters.document_searchindex import DocumentSearchIndexPresenter
-from h.presenters.group_json import GroupJSONPresenter
-from h.presenters.group_json import GroupsJSONPresenter
-from h.presenters.user_json import UserJSONPresenter, TrustedUserJSONPresenter
+from h.presenters.group_json import GroupJSONPresenter, GroupsJSONPresenter
+from h.presenters.user_json import TrustedUserJSONPresenter, UserJSONPresenter
 
 __all__ = (
     "AnnotationHTMLPresenter",

--- a/h/presenters/annotation_html.py
+++ b/h/presenters/annotation_html.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from dateutil import parser
-
 import jinja2
+from dateutil import parser
 
 from h.presenters.document_html import DocumentHTMLPresenter
 

--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -3,8 +3,8 @@
 import copy
 
 from pyramid import security
-from zope.interface.verify import verifyObject
 from zope.interface.exceptions import DoesNotImplement
+from zope.interface.verify import verifyObject
 
 from h.formatters.interfaces import IAnnotationFormatter
 from h.presenters.annotation_base import AnnotationBasePresenter

--- a/h/presenters/document_html.py
+++ b/h/presenters/document_html.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from urllib.parse import urlparse, unquote
+from urllib.parse import unquote, urlparse
 
 import jinja2
 

--- a/h/renderers.py
+++ b/h/renderers.py
@@ -2,7 +2,6 @@
 
 import pyramid.renderers
 
-
 json_sorted_factory = pyramid.renderers.JSON(sort_keys=True)
 
 

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Classes for validating data passed to the annotations API."""
-import colander
 import copy
+
+import colander
 from dateutil.parser import parse
 from pyramid import i18n
 

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 """Schema for validating API group resources"""
 
-from h.schemas.base import JSONSchema, ValidationError
-from h.models.group import (
-    GROUP_NAME_MIN_LENGTH,
-    GROUP_NAME_MAX_LENGTH,
-    GROUP_DESCRIPTION_MAX_LENGTH,
-)
-from h.util.group import GROUPID_PATTERN, split_groupid
 from h.i18n import TranslationString as _
+from h.models.group import (
+    GROUP_DESCRIPTION_MAX_LENGTH,
+    GROUP_NAME_MAX_LENGTH,
+    GROUP_NAME_MIN_LENGTH,
+)
+from h.schemas.base import JSONSchema, ValidationError
+from h.util.group import GROUPID_PATTERN, split_groupid
 
 GROUP_SCHEMA_PROPERTIES = {
     "name": {

--- a/h/schemas/base.py
+++ b/h/schemas/base.py
@@ -7,8 +7,8 @@ import copy
 import colander
 import deform
 import jsonschema
-from pyramid.csrf import check_csrf_token, get_csrf_token
 from pyramid import httpexceptions
+from pyramid.csrf import check_csrf_token, get_csrf_token
 
 
 @colander.deferred

--- a/h/schemas/forms/accounts/__init__.py
+++ b/h/schemas/forms/accounts/__init__.py
@@ -3,9 +3,7 @@
 from h.schemas.forms.accounts.edit_profile import EditProfileSchema
 from h.schemas.forms.accounts.forgot_password import ForgotPasswordSchema
 from h.schemas.forms.accounts.login import LoginSchema
-from h.schemas.forms.accounts.reset_password import ResetCode
-from h.schemas.forms.accounts.reset_password import ResetPasswordSchema
-
+from h.schemas.forms.accounts.reset_password import ResetCode, ResetPasswordSchema
 
 __all__ = (
     "EditProfileSchema",

--- a/h/schemas/forms/accounts/login.py
+++ b/h/schemas/forms/accounts/login.py
@@ -3,8 +3,8 @@ import colander
 import deform
 
 from h import i18n
-from h.services.user import UserNotActivated
 from h.schemas.base import CSRFSchema
+from h.services.user import UserNotActivated
 
 _ = i18n.TranslationString
 

--- a/h/schemas/forms/accounts/util.py
+++ b/h/schemas/forms/accounts/util.py
@@ -4,7 +4,6 @@ import deform
 
 from h.schemas import validators
 
-
 PASSWORD_MIN_LENGTH = 2  # FIXME: this is ridiculous
 
 

--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -10,12 +10,12 @@ from deform.widget import (
 )
 
 from h import i18n
-from h.schemas import validators
 from h.models.group import (
-    GROUP_NAME_MIN_LENGTH,
-    GROUP_NAME_MAX_LENGTH,
     GROUP_DESCRIPTION_MAX_LENGTH,
+    GROUP_NAME_MAX_LENGTH,
+    GROUP_NAME_MIN_LENGTH,
 )
+from h.schemas import validators
 from h.schemas.base import CSRFSchema
 from h.util import group_scope
 

--- a/h/schemas/forms/admin/organization.py
+++ b/h/schemas/forms/admin/organization.py
@@ -1,11 +1,12 @@
+from xml.etree import ElementTree
+
 import colander
 from deform.widget import TextAreaWidget, TextInputWidget
-from xml.etree import ElementTree
 
 import h.i18n
 from h.models.organization import (
-    ORGANIZATION_NAME_MIN_CHARS,
     ORGANIZATION_NAME_MAX_CHARS,
+    ORGANIZATION_NAME_MIN_CHARS,
 )
 from h.schemas import validators
 from h.schemas.base import CSRFSchema

--- a/h/schemas/forms/group.py
+++ b/h/schemas/forms/group.py
@@ -2,18 +2,16 @@
 
 import colander
 import deform
-
 import slugify
 
 from h import i18n
-from h.schemas import validators
 from h.accounts.schemas import CSRFSchema
 from h.models.group import (
     GROUP_DESCRIPTION_MAX_LENGTH,
-    GROUP_NAME_MIN_LENGTH,
     GROUP_NAME_MAX_LENGTH,
+    GROUP_NAME_MIN_LENGTH,
 )
-
+from h.schemas import validators
 
 _ = i18n.TranslationString
 

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -4,12 +4,12 @@ from h.search.client import get_client
 from h.search.config import init
 from h.search.core import Search
 from h.search.query import (
-    TopLevelAnnotationsFilter,
+    AuthorityFilter,
     DeletedFilter,
     Limiter,
-    UserFilter,
-    AuthorityFilter,
     TagsAggregation,
+    TopLevelAnnotationsFilter,
+    UserFilter,
     UsersAggregation,
 )
 

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -9,10 +9,10 @@ these settings in an Elasticsearch instance.
 """
 
 import binascii
-import elasticsearch
 import logging
 import os
 
+import elasticsearch
 
 log = logging.getLogger(__name__)
 

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -2,8 +2,9 @@
 import logging
 from collections import namedtuple
 from contextlib import contextmanager
-from elasticsearch.exceptions import ConnectionTimeout
+
 import elasticsearch_dsl
+from elasticsearch.exceptions import ConnectionTimeout
 from webob.multidict import MultiDict
 
 from h.search import query

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -9,8 +9,7 @@ import sqlalchemy as sa
 from elasticsearch import helpers as es_helpers
 from sqlalchemy.orm import subqueryload
 
-from h import models
-from h import presenters
+from h import models, presenters
 from h.events import AnnotationTransformEvent
 from h.util.query import column_windows
 

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from dateutil.parser import parse
-from dateutil import tz
 from datetime import datetime as dt
 
-from h import storage
-from h.util import uri
+from dateutil import tz
+from dateutil.parser import parse
 from elasticsearch_dsl import Q
 from elasticsearch_dsl.query import SimpleQueryString
+
+from h import storage
 from h.search.util import add_default_scheme, wildcard_uri_is_valid
+from h.util import uri
 
 LIMIT_DEFAULT = 20
 # Elasticsearch requires offset + limit must be <= 10,000.

--- a/h/sentry/helpers/before_send.py
+++ b/h/sentry/helpers/before_send.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from h.sentry.helpers.event import Event
 from h.sentry.helpers import filters
-
+from h.sentry.helpers.event import Event
 
 log = logging.getLogger(__name__)
 

--- a/h/sentry/helpers/filters.py
+++ b/h/sentry/helpers/filters.py
@@ -7,9 +7,9 @@ returns ``True`` if the event should be reported to Sentry or ``False`` to
 filter it out. Every filter function gets called for every event and if any one
 filter returns ``False`` for a given event then the event is not reported.
 """
+import ws4py.exc
 from pyramid.threadlocal import get_current_request
 from pyramid_retry import is_error_retryable
-import ws4py.exc
 
 
 def filter_ws4py_error_logging(event):

--- a/h/sentry/subscribers.py
+++ b/h/sentry/subscribers.py
@@ -1,8 +1,8 @@
 import traceback
 
+import sentry_sdk
 from pyramid.events import subscriber
 from pyramid_retry import IBeforeRetry
-import sentry_sdk
 
 
 @subscriber(IBeforeRetry)

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -2,11 +2,7 @@
 
 from sqlalchemy.orm import subqueryload
 
-from h import formatters
-from h import models
-from h import presenters
-from h import traversal
-from h import storage
+from h import formatters, models, presenters, storage, traversal
 from h.interfaces import IGroupService
 
 

--- a/h/services/annotation_stats.py
+++ b/h/services/annotation_stats.py
@@ -2,8 +2,13 @@
 
 from webob.multidict import MultiDict
 
-from h.search import Search
-from h.search import Limiter, DeletedFilter, UserFilter, TopLevelAnnotationsFilter
+from h.search import (
+    DeletedFilter,
+    Limiter,
+    Search,
+    TopLevelAnnotationsFilter,
+    UserFilter,
+)
 
 
 class AnnotationStatsService:

--- a/h/services/auth_ticket.py
+++ b/h/services/auth_ticket.py
@@ -2,8 +2,8 @@
 
 import datetime
 
-from pyramid_authsanity import interfaces
 import sqlalchemy as sa
+from pyramid_authsanity import interfaces
 from zope import interface
 
 from h import models

--- a/h/services/developer_token.py
+++ b/h/services/developer_token.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from h import models
-from h import security
+from h import models, security
 from h.util.db import lru_cache_in_transaction
 
 PREFIX = "6879-"

--- a/h/services/document.py
+++ b/h/services/document.py
@@ -2,7 +2,7 @@
 
 import sqlalchemy as sa
 
-from h.models import Document, Annotation
+from h.models import Annotation, Document
 
 MAX_DOCUMENT_COUNT = 100
 

--- a/h/services/group_update.py
+++ b/h/services/group_update.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from h.services.exceptions import ValidationError, ConflictError
+from h.services.exceptions import ConflictError, ValidationError
 
 
 class GroupUpdateService:

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -3,8 +3,8 @@
 import sqlalchemy as sa
 
 from h.models import User, UserIdentity
-from h.util.user import split_user
 from h.util.db import on_transaction_end
+from h.util.user import split_user
 
 UPDATE_PREFS_ALLOWED_KEYS = {"show_sidebar_tutorial"}
 

--- a/h/services/user_signup.py
+++ b/h/services/user_signup.py
@@ -7,8 +7,8 @@ from sqlalchemy.exc import IntegrityError
 
 from h.emails import signup
 from h.models import Activation, Subscriptions, User, UserIdentity
-from h.tasks import mailer
 from h.services.exceptions import ConflictError
+from h.tasks import mailer
 
 log = logging.getLogger(__name__)
 

--- a/h/services/user_unique.py
+++ b/h/services/user_unique.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from h.i18n import TranslationString as _  # noqa: N813
 from h import models
+from h.i18n import TranslationString as _  # noqa: N813
 
 
 class DuplicateUserError(Exception):

--- a/h/session.py
+++ b/h/session.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from pyramid.csrf import SessionCSRFStoragePolicy
-from pyramid.session import SignedCookieSessionFactory, JSONSerializer
+from pyramid.session import JSONSerializer, SignedCookieSessionFactory
 
 from h.security import derive_key
 

--- a/h/storage.py
+++ b/h/storage.py
@@ -22,8 +22,8 @@ from pyramid import i18n
 
 from h import models, schemas
 from h.db import types
-from h.util.group_scope import url_in_scope
 from h.models.document import update_document_metadata
+from h.util.group_scope import url_in_scope
 
 _ = i18n.TranslationStringFactory(__package__)
 

--- a/h/streamer/filter.py
+++ b/h/streamer/filter.py
@@ -3,6 +3,7 @@
 import unicodedata
 
 from jsonpointer import resolve_pointer
+
 from h.util.uri import normalize as normalize_uri
 
 SCHEMA = {

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -1,23 +1,21 @@
 # -*- coding: utf-8 -*-
 
-from collections import namedtuple
 import logging
+from collections import namedtuple
 
 from gevent.queue import Full
 
-from h import presenters
-from h import realtime
-from h import storage
+import h.stats
+from h import presenters, realtime, storage
+from h.auth.util import translate_annotation_principals
 from h.formatters import AnnotationUserInfoFormatter
 from h.realtime import Consumer
-from h.traversal import AnnotationContext
-from h.auth.util import translate_annotation_principals
+from h.services.groupfinder import GroupfinderService
 from h.services.links import LinksService
 from h.services.nipsa import NipsaService
-from h.services.groupfinder import GroupfinderService
 from h.services.user import UserService
 from h.streamer import websocket
-import h.stats
+from h.traversal import AnnotationContext
 
 log = logging.getLogger(__name__)
 

--- a/h/streamer/streamer.py
+++ b/h/streamer/streamer.py
@@ -5,10 +5,8 @@ import sys
 
 import gevent
 
-from h import db
-from h import stats
-from h.streamer import messages
-from h.streamer import websocket
+from h import db, stats
+from h.streamer import messages, websocket
 
 log = logging.getLogger(__name__)
 

--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from pyramid.view import forbidden_view_config
-from pyramid.view import notfound_view_config
-from pyramid.view import view_config
+from pyramid.view import forbidden_view_config, notfound_view_config, view_config
 from ws4py.exc import HandshakeError
 from ws4py.server.wsgiutils import WebSocketWSGIApplication
 

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from collections import namedtuple
 import copy
 import json
 import logging
 import weakref
+from collections import namedtuple
 
-from gevent.queue import Full
 import jsonschema
+from gevent.queue import Full
 from ws4py.websocket import WebSocket as _WebSocket
 
 from h import storage

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from h import __version__
-from h import emails
-from h import storage
+from h import __version__, emails, storage
 from h.notification import reply
 from h.tasks import mailer
 

--- a/h/tasks/admin.py
+++ b/h/tasks/admin.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from h import models
-from h.celery import celery
-from h.celery import get_task_logger
-
+from h.celery import celery, get_task_logger
 
 log = get_task_logger(__name__)
 

--- a/h/tasks/cleanup.py
+++ b/h/tasks/cleanup.py
@@ -3,9 +3,7 @@
 from datetime import datetime, timedelta
 
 from h import models
-from h.celery import celery
-from h.celery import get_task_logger
-
+from h.celery import celery, get_task_logger
 
 log = get_task_logger(__name__)
 

--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -1,19 +1,23 @@
 # -*- coding: utf-8 -*-
-from h.traversal.roots import Root
-from h.traversal.roots import AnnotationRoot
-from h.traversal.roots import AuthClientRoot
-from h.traversal.roots import OrganizationRoot
-from h.traversal.roots import OrganizationLogoRoot
-from h.traversal.roots import ProfileRoot
-from h.traversal.roots import GroupRoot
-from h.traversal.roots import GroupUpsertRoot
-from h.traversal.roots import UserRoot
-from h.traversal.roots import UserUserIDRoot
-from h.traversal.contexts import AnnotationContext
-from h.traversal.contexts import OrganizationContext
-from h.traversal.contexts import GroupContext
-from h.traversal.contexts import GroupUpsertContext
-from h.traversal.contexts import UserContext
+from h.traversal.contexts import (
+    AnnotationContext,
+    GroupContext,
+    GroupUpsertContext,
+    OrganizationContext,
+    UserContext,
+)
+from h.traversal.roots import (
+    AnnotationRoot,
+    AuthClientRoot,
+    GroupRoot,
+    GroupUpsertRoot,
+    OrganizationLogoRoot,
+    OrganizationRoot,
+    ProfileRoot,
+    Root,
+    UserRoot,
+    UserUserIDRoot,
+)
 
 __all__ = (
     "Root",

--- a/h/traversal/contexts.py
+++ b/h/traversal/contexts.py
@@ -19,9 +19,7 @@ For such a route Pyramid will conveniently pass the found context object into
 the view callable as the ``context`` argument.
 
 """
-from pyramid.security import DENY_ALL
-from pyramid.security import Allow
-from pyramid.security import principals_allowed_by_permission
+from pyramid.security import DENY_ALL, Allow, principals_allowed_by_permission
 
 from h.auth import role
 from h.models.organization import ORGANIZATION_DEFAULT_PUBID

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -61,16 +61,15 @@ shouldn't return model objects directly).
 
 """
 
-from pyramid.security import ALL_PERMISSIONS, DENY_ALL, Allow, Authenticated
 import sqlalchemy.exc
 import sqlalchemy.orm.exc
+from pyramid.security import ALL_PERMISSIONS, DENY_ALL, Allow, Authenticated
 
 from h import storage
-from h.models import AuthClient
-from h.models import Organization
 from h.auth import role
 from h.auth.util import client_authority
 from h.interfaces import IGroupService
+from h.models import AuthClient, Organization
 from h.traversal import contexts
 
 

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -6,8 +6,8 @@ from codecs import open
 from pyramid import httpexceptions
 from pyramid.util import DottedNameResolver
 
-from h.util.redirects import parse as parse_redirects
 from h.util.redirects import lookup as lookup_redirects
+from h.util.redirects import parse as parse_redirects
 
 log = logging.getLogger(__name__)
 resolver = DottedNameResolver(None)

--- a/h/util/__init__.py
+++ b/h/util/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from h.util import db
-from h.util import user
-from h.util import view
+from h.util import db, user, view
 
 __all__ = ("db", "user", "view")

--- a/h/util/document_claims.py
+++ b/h/util/document_claims.py
@@ -14,7 +14,6 @@ and returned.
 
 import re
 
-
 # Pattern that matches DOIs (eg. "10.1000/123456").
 #
 # See https://www.doi.org/doi_handbook/2_Numbering.html#2.2 The registrant code

--- a/h/util/logging_filters.py
+++ b/h/util/logging_filters.py
@@ -2,7 +2,6 @@
 """Logging Filters."""
 import logging
 
-
 # logging levels from https://docs.python.org/2/library/logging.html#logging-levels
 LEVELS = {
     "CRITICAL": 50,

--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -63,7 +63,6 @@ elsewhere in the Hypothesis application. URI expansion is handled by
 :py:func:`h.storage.expand_uri`.
 """
 import re
-
 from urllib.parse import (
     SplitResult,
     parse_qsl,

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -7,27 +7,26 @@ from urllib.parse import urlparse
 import colander
 import deform
 import jinja2
-from pyramid import httpexceptions
-from pyramid import security
+from pyramid import httpexceptions, security
 from pyramid.exceptions import BadCSRFToken
 from pyramid.view import view_config, view_defaults
 
-from h import accounts
-from h import form
-from h import i18n
-from h import models
-from h import session
+from h import accounts, form, i18n, models, session
 from h.accounts import schemas
-from h.schemas.forms.accounts import EditProfileSchema
-from h.schemas.forms.accounts import ForgotPasswordSchema
-from h.schemas.forms.accounts import LoginSchema
-from h.schemas.forms.accounts import ResetCode
-from h.schemas.forms.accounts import ResetPasswordSchema
-from h.accounts.events import ActivationEvent
-from h.accounts.events import PasswordResetEvent
-from h.accounts.events import LogoutEvent
-from h.accounts.events import LoginEvent
+from h.accounts.events import (
+    ActivationEvent,
+    LoginEvent,
+    LogoutEvent,
+    PasswordResetEvent,
+)
 from h.emails import reset_password
+from h.schemas.forms.accounts import (
+    EditProfileSchema,
+    ForgotPasswordSchema,
+    LoginSchema,
+    ResetCode,
+    ResetPasswordSchema,
+)
 from h.tasks import mailer
 from h.util.view import json_view
 

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -5,10 +5,8 @@
 from urllib.parse import urlparse
 
 from jinja2 import Markup
-from pyramid import httpexceptions
-from pyramid import security
-from pyramid.view import view_config
-from pyramid.view import view_defaults
+from pyramid import httpexceptions, security
+from pyramid.view import view_config, view_defaults
 
 from h import util
 from h.activity import query
@@ -17,11 +15,10 @@ from h.links import pretty_link
 from h.models.group import ReadableBy
 from h.paginator import paginate
 from h.search import parser
+from h.traversal import OrganizationContext
+from h.util.datetime import utc_us_style_date
 from h.util.user import split_user
 from h.views.groups import check_slug
-from h.util.datetime import utc_us_style_date
-from h.traversal import OrganizationContext
-
 
 PAGE_SIZE = 200
 

--- a/h/views/admin/features.py
+++ b/h/views/admin/features.py
@@ -3,8 +3,7 @@
 from pyramid import httpexceptions
 from pyramid.view import view_config
 
-from h import models
-from h import paginator
+from h import models, paginator
 from h.i18n import TranslationString as _  # noqa: N813
 
 

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 from jinja2 import Markup
-from pyramid.view import view_config, view_defaults
 from pyramid.httpexceptions import HTTPFound
-
+from pyramid.view import view_config, view_defaults
 
 from h import form  # noqa F401
-from h import i18n
-from h import models
-from h import paginator
+from h import i18n, models, paginator
 from h.models.annotation import Annotation
 from h.models.group_scope import GroupScope
 from h.models.organization import Organization

--- a/h/views/admin/oauthclients.py
+++ b/h/views/admin/oauthclients.py
@@ -3,8 +3,7 @@
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config, view_defaults
 
-from h import form
-from h import i18n
+from h import form, i18n
 from h.models import AuthClient
 from h.models.auth_client import GrantType, ResponseType
 from h.schemas.auth_client import CreateAuthClientSchema, EditAuthClientSchema

--- a/h/views/admin/organizations.py
+++ b/h/views/admin/organizations.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 from jinja2 import Markup
-from pyramid.view import view_config, view_defaults
 from pyramid.httpexceptions import HTTPFound
+from pyramid.view import view_config, view_defaults
 from sqlalchemy import func
 
-from h import form
-from h import i18n
-from h import models
+from h import form, i18n, models, paginator
 from h.models.organization import Organization
-from h import paginator
 from h.schemas.forms.admin.organization import OrganizationSchema
 
 _ = i18n.TranslationString

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -6,9 +6,9 @@ from pyramid.view import view_config
 
 from h import models
 from h.accounts.events import ActivationEvent
+from h.i18n import TranslationString as _  # noqa
 from h.services.rename_user import UserRenameError
 from h.tasks.admin import rename_user
-from h.i18n import TranslationString as _  # noqa
 
 
 class UserNotFoundError(Exception):

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -20,18 +20,18 @@ from pyramid import i18n
 
 from h import search as search_lib
 from h import storage
-from h.views.api.exceptions import PayloadError
 from h.events import AnnotationEvent
 from h.interfaces import IGroupService
 from h.presenters import AnnotationJSONLDPresenter
-from h.traversal import AnnotationContext
-from h.schemas.util import validate_query_params
 from h.schemas.annotation import (
     CreateAnnotationSchema,
     SearchParamsSchema,
     UpdateAnnotationSchema,
 )
+from h.schemas.util import validate_query_params
+from h.traversal import AnnotationContext
 from h.views.api.config import api_config
+from h.views.api.exceptions import PayloadError
 
 _ = i18n.TranslationStringFactory(__package__)
 

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -10,10 +10,10 @@ from pyramid.httpexceptions import HTTPFound, exception_response
 from pyramid.view import view_config, view_defaults
 
 from h import models
-from h.views.api.exceptions import OAuthAuthorizeError, OAuthTokenError
 from h.services.oauth_validator import DEFAULT_SCOPES
 from h.util.datetime import utc_iso8601
 from h.views.api.config import api_config
+from h.views.api.exceptions import OAuthAuthorizeError, OAuthTokenError
 
 log = logging.getLogger(__name__)
 

--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -1,12 +1,9 @@
 import venusian
 
-from h.views.api.helpers import cors
-from h.views.api.helpers import links
-from h.views.api.helpers.media_types import media_type_for_version
+from h.views.api import API_VERSION_DEFAULT, API_VERSIONS
 from h.views.api.decorators.response import version_media_type_header
-
-from h.views.api import API_VERSIONS, API_VERSION_DEFAULT
-
+from h.views.api.helpers import cors, links
+from h.views.api.helpers.media_types import media_type_for_version
 
 #: Decorator that adds CORS headers to API responses.
 #:

--- a/h/views/api/decorators/__init__.py
+++ b/h/views/api/decorators/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from h.views.api.decorators.client_errors import (
-    unauthorized_to_not_found,
     normalize_not_found,
+    unauthorized_to_not_found,
     validate_media_types,
 )
 from h.views.api.decorators.response import version_media_type_header

--- a/h/views/api/decorators/client_errors.py
+++ b/h/views/api/decorators/client_errors.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """API view decorators for exception views"""
 
-from pyramid.httpexceptions import HTTPNotFound, HTTPNotAcceptable
+from pyramid.httpexceptions import HTTPNotAcceptable, HTTPNotFound
 
 from h.views.api.helpers.media_types import valid_media_types
 

--- a/h/views/api/errors.py
+++ b/h/views/api/errors.py
@@ -7,17 +7,15 @@ Views rendered by the web application in response to exceptions thrown within
 API views.
 """
 
-from pyramid.view import forbidden_view_config
-from pyramid.view import notfound_view_config
-from pyramid.view import view_config
 from pyramid import httpexceptions
+from pyramid.view import forbidden_view_config, notfound_view_config, view_config
 
 from h.i18n import TranslationString as _  # noqa: N813
 from h.util.view import handle_exception, json_view
 from h.views.api.config import cors_policy
 from h.views.api.decorators import (
-    unauthorized_to_not_found,
     normalize_not_found,
+    unauthorized_to_not_found,
     validate_media_types,
 )
 from h.views.api.exceptions import OAuthAuthorizeError

--- a/h/views/api/flags.py
+++ b/h/views/api/flags.py
@@ -2,11 +2,11 @@
 
 from pyramid.httpexceptions import HTTPNoContent
 
-from h.views.api.config import api_config
-from h.emails import flag_notification
 from h import links
+from h.emails import flag_notification
 from h.interfaces import IGroupService
 from h.tasks import mailer
+from h.views.api.config import api_config
 
 
 @api_config(

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -2,19 +2,19 @@
 
 from pyramid import security
 from pyramid.httpexceptions import (
-    HTTPNoContent,
     HTTPBadRequest,
-    HTTPNotFound,
     HTTPConflict,
+    HTTPNoContent,
+    HTTPNotFound,
 )
 
 from h.auth.util import client_authority
-from h.views.api.exceptions import PayloadError
 from h.i18n import TranslationString as _  # noqa: N813
 from h.presenters import GroupJSONPresenter, GroupsJSONPresenter, UserJSONPresenter
 from h.schemas.api.group import CreateGroupAPISchema, UpdateGroupAPISchema
 from h.traversal import GroupContext
 from h.views.api.config import api_config
+from h.views.api.exceptions import PayloadError
 
 
 @api_config(

--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from h.views.api.config import api_config
-from h.views.api.helpers.angular import AngularRouteTemplater
 from h.views.api.helpers import links as link_helpers
+from h.views.api.helpers.angular import AngularRouteTemplater
 
 
 @api_config(versions=["v1"], route_name="api.index")

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -3,12 +3,12 @@
 from pyramid.httpexceptions import HTTPConflict
 
 from h.auth.util import client_authority
-from h.views.api.exceptions import PayloadError
-from h.views.api.config import api_config
 from h.presenters import TrustedUserJSONPresenter
-from h.schemas.api.user import CreateUserAPISchema, UpdateUserAPISchema
 from h.schemas import ValidationError
+from h.schemas.api.user import CreateUserAPISchema, UpdateUserAPISchema
 from h.services.user_unique import DuplicateUserError
+from h.views.api.config import api_config
+from h.views.api.exceptions import PayloadError
 
 
 @api_config(

--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -4,8 +4,8 @@ from pyramid import httpexceptions
 from webob.multidict import MultiDict
 
 from h import models, search
-from h.util.view import json_view
 from h.util.uri import normalize
+from h.util.view import json_view
 
 
 def _has_uri_ever_been_annotated(db, uri):

--- a/h/views/errors.py
+++ b/h/views/errors.py
@@ -7,9 +7,7 @@ Views rendered by the web application in response to exceptions thrown within
 views.
 """
 
-from pyramid.view import forbidden_view_config
-from pyramid.view import notfound_view_config
-from pyramid.view import view_config
+from pyramid.view import forbidden_view_config, notfound_view_config, view_config
 
 from h.i18n import TranslationString as _  # noqa: N813
 from h.util.view import handle_exception, json_view

--- a/h/views/feeds.py
+++ b/h/views/feeds.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from pyramid.view import view_config
 from pyramid import i18n
+from pyramid.view import view_config
 from webob.multidict import MultiDict
 
 from h import search
 from h.feeds import render_atom, render_rss
 from h.storage import fetch_ordered_annotations
-
 
 _ = i18n.TranslationStringFactory(__package__)
 

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import deform
-from pyramid import httpexceptions
-from pyramid import security
+from pyramid import httpexceptions, security
 from pyramid.view import view_config, view_defaults
 
-from h import form
-from h import i18n
+from h import form, i18n
 from h.schemas.forms.group import group_schema
 
 _ = i18n.TranslationString

--- a/h/views/main.py
+++ b/h/views/main.py
@@ -8,12 +8,11 @@ Important views which don't form part of any other major feature package.
 
 import logging
 
-from pyramid import httpexceptions
-from pyramid import response
+from pyramid import httpexceptions, response
 from pyramid.view import view_config
 
-from h.views.client import sidebar_app
 from h.util.user import split_user
+from h.views.client import sidebar_app
 
 log = logging.getLogger(__name__)
 

--- a/h/views/status.py
+++ b/h/views/status.py
@@ -6,7 +6,6 @@ from pyramid.httpexceptions import HTTPInternalServerError
 
 from h.util.view import json_view
 
-
 log = logging.getLogger(__name__)
 
 

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -37,9 +37,9 @@ license distributed with the ws4py project. Such code remains copyright (c)
 """
 import logging
 
+import pyramid
 from gevent.pool import Pool
 from gunicorn.workers.ggevent import GeventPyWSGIWorker, PyWSGIHandler, PyWSGIServer
-import pyramid
 from ws4py import format_addresses
 
 from h.config import configure

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
 """Factory classes for easily generating test objects."""
-from .base import set_session
-
 from .activation import Activation
 from .annotation import Annotation
 from .annotation_moderation import AnnotationModeration
 from .auth_client import AuthClient, ConfidentialAuthClient
 from .auth_ticket import AuthTicket
 from .authz_code import AuthzCode
+from .base import set_session
 from .document import Document, DocumentMeta, DocumentURI
 from .feature import Feature
 from .flag import Flag

--- a/tests/common/fixtures/__init__.py
+++ b/tests/common/fixtures/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from tests.common.fixtures.elasticsearch import es_client
-from tests.common.fixtures.elasticsearch import init_elasticsearch
-
+from tests.common.fixtures.elasticsearch import es_client, init_elasticsearch
 
 __all__ = ("es_client", "init_elasticsearch")

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
-import elasticsearch_dsl
 
+import elasticsearch_dsl
 import pytest
 
 from h import search

--- a/tests/functional/api/groups/test_create.py
+++ b/tests/functional/api/groups/test_create.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import pytest
 import base64
 
+import pytest
 
 from h.models.auth_client import GrantType
 

--- a/tests/functional/api/groups/test_members.py
+++ b/tests/functional/api/groups/test_members.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import pytest
 import base64
 
+import pytest
 
 from h.models.auth_client import GrantType
 

--- a/tests/functional/api/groups/test_read.py
+++ b/tests/functional/api/groups/test_read.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import pytest
 import base64
 
+import pytest
 
 from h.models.auth_client import GrantType
 

--- a/tests/functional/api/groups/test_update.py
+++ b/tests/functional/api/groups/test_update.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import pytest
 import base64
+
+import pytest
 
 from h.models.auth_client import GrantType
 

--- a/tests/functional/api/groups/test_upsert.py
+++ b/tests/functional/api/groups/test_upsert.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import pytest
 import base64
+
+import pytest
 
 from h.models.auth_client import GrantType
 

--- a/tests/functional/api/test_errors.py
+++ b/tests/functional/api/test_errors.py
@@ -5,9 +5,9 @@ Functional tests for client API errors
 Uses create-group endpoint as it can raise all relevant client error codes.
 """
 
-import pytest
 import base64
 
+import pytest
 
 from h.models.auth_client import GrantType
 

--- a/tests/functional/api/test_users.py
+++ b/tests/functional/api/test_users.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import pytest
 import base64
 
+import pytest
 
 from h.models.auth_client import GrantType
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -3,13 +3,11 @@ import contextlib
 import os
 
 import pytest
-from webtest import TestApp
 
 from tests.common.fixtures import es_client  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
-from tests.common.fixtures.elasticsearch import ELASTICSEARCH_URL
-from tests.common.fixtures.elasticsearch import ELASTICSEARCH_INDEX
-
+from tests.common.fixtures.elasticsearch import ELASTICSEARCH_INDEX, ELASTICSEARCH_URL
+from webtest import TestApp
 
 TEST_SETTINGS = {
     "es.url": ELASTICSEARCH_URL,

--- a/tests/functional/test_oauth.py
+++ b/tests/functional/test_oauth.py
@@ -4,9 +4,8 @@
 import calendar
 import datetime
 
-import pytest
-
 import jwt
+import pytest
 
 from h.models.auth_client import GrantType
 

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -8,7 +8,6 @@ from pyramid.exceptions import BadCSRFToken
 from h.accounts import schemas
 from h.services.user_password import UserPasswordService
 
-
 pytestmark = pytest.mark.usefixtures("pyramid_config")
 
 

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -8,7 +8,6 @@ import pytest
 from h.activity import bucketing
 from tests.common import factories
 
-
 UTCNOW = datetime.datetime(year=1970, month=2, day=21, hour=19, minute=30)
 FIVE_MINS_AGO = UTCNOW - datetime.timedelta(minutes=5)
 YESTERDAY = UTCNOW - datetime.timedelta(days=1)

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -3,11 +3,10 @@
 from unittest import mock
 
 import pytest
-
 from pyramid.httpexceptions import HTTPFound
 from webob.multidict import MultiDict
 
-from h.activity.query import execute, extract, check_url, fetch_annotations
+from h.activity.query import check_url, execute, extract, fetch_annotations
 
 
 class TestExtract:

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 
+import base64
 from unittest import mock
 
 import pytest
-import base64
-
 from pyramid.interfaces import IAuthenticationPolicy
-from pyramid.security import Everyone, Authenticated
+from pyramid.security import Authenticated, Everyone
 
-from h.auth.policy import AuthenticationPolicy
-from h.auth.policy import TokenAuthenticationPolicy
-from h.auth.policy import APIAuthenticationPolicy
-from h.auth.policy import AuthClientPolicy
-from h.auth.policy import AUTH_CLIENT_API_WHITELIST
-
+from h.auth.policy import (
+    AUTH_CLIENT_API_WHITELIST,
+    APIAuthenticationPolicy,
+    AuthClientPolicy,
+    AuthenticationPolicy,
+    TokenAuthenticationPolicy,
+)
 from h.services.user import UserService
 
 API_PATHS = ("/api", "/api/foo", "/api/annotations/abc123")

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -4,10 +4,8 @@ import datetime
 from unittest import mock
 
 import jwt
-
-
-from hypothesis import strategies as st
 from hypothesis import assume, given
+from hypothesis import strategies as st
 
 from h.auth import tokens
 

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -5,13 +5,11 @@ from unittest import mock
 
 import pytest
 import sqlalchemy as sa
-
 from pyramid import security
 
-from h.auth import role
-from h.auth import util
-from h.models.auth_client import GrantType
+from h.auth import role, util
 from h.models import AuthClient
+from h.models.auth_client import GrantType
 from h.services.user import UserService
 
 FakeUser = namedtuple("FakeUser", ["authority", "admin", "staff", "groups"])

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -8,18 +8,16 @@ import functools
 import os
 from unittest import mock
 
+import click.testing
 import deform
 import pytest
-
-import click.testing
 import sqlalchemy
 from pyramid import testing
 from pyramid.request import apply_request_extensions
 from sqlalchemy.orm import sessionmaker
 from webob.multidict import MultiDict
 
-from h import db
-from h import models
+from h import db, models
 from h.settings import database_url
 from tests.common.fixtures import es_client  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401

--- a/tests/h/db/types_test.py
+++ b/tests/h/db/types_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-
 from sqlalchemy.dialects.postgresql import dialect
 
 from h.db import types

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -6,8 +6,7 @@ from unittest import mock
 import pytest
 
 from h.emails.reply_notification import generate
-from h.models import Annotation
-from h.models import Document
+from h.models import Annotation, Document
 from h.notification.reply import Notification
 
 

--- a/tests/h/emails/test_test.py
+++ b/tests/h/emails/test_test.py
@@ -2,9 +2,8 @@
 
 import pytest
 
-from h.emails.test import generate
-
 from h import __version__
+from h.emails.test import generate
 
 
 class TestGenerate:

--- a/tests/h/feeds/render_test.py
+++ b/tests/h/feeds/render_test.py
@@ -3,7 +3,6 @@
 from unittest import mock
 
 import pytest
-
 from pyramid.response import Response
 
 from h.feeds import render

--- a/tests/h/jinja_extension_test.py
+++ b/tests/h/jinja_extension_test.py
@@ -2,8 +2,8 @@
 
 import datetime
 
-from jinja2 import Markup
 import pytest
+from jinja2 import Markup
 
 from h import jinja_extensions as ext
 

--- a/tests/h/links_test.py
+++ b/tests/h/links_test.py
@@ -4,8 +4,7 @@ from unittest import mock
 
 import pytest
 
-from h import models
-from h import links
+from h import links, models
 
 
 class FakeAnnotation:

--- a/tests/h/models/auth_client_test.py
+++ b/tests/h/models/auth_client_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import pytest
-
 from sqlalchemy.exc import IntegrityError
 
 from h.models import AuthClient

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-
 from sqlalchemy import inspect
 
 from h.models import GroupScope

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -1,17 +1,16 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-
 from pyramid import security
 from pyramid.authorization import ACLAuthorizationPolicy
 
-from h.auth import role
 from h import models
+from h.auth import role
 from h.models.group import (
+    AUTHORITY_PROVIDED_ID_MAX_LENGTH,
     JoinableBy,
     ReadableBy,
     WriteableBy,
-    AUTHORITY_PROVIDED_ID_MAX_LENGTH,
 )
 
 

--- a/tests/h/models/organization_test.py
+++ b/tests/h/models/organization_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+
 from h import models
 
 

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
-from sqlalchemy import exc
 from pyramid.authorization import ACLAuthorizationPolicy
+from sqlalchemy import exc
 
 from h import models
 

--- a/tests/h/notification/reply_test.py
+++ b/tests/h/notification/reply_test.py
@@ -4,11 +4,8 @@ from unittest import mock
 
 import pytest
 
-from h.models import Annotation
-from h.models import Document, DocumentMeta
-from h.models import Subscriptions
-from h.notification.reply import Notification
-from h.notification.reply import get_notification
+from h.models import Annotation, Document, DocumentMeta, Subscriptions
+from h.notification.reply import Notification, get_notification
 from h.services.user import UserService
 
 FIXTURE_DATA = {

--- a/tests/h/oauth/jwt_grant_test.py
+++ b/tests/h/oauth/jwt_grant_test.py
@@ -5,15 +5,14 @@ from calendar import timegm
 from datetime import datetime, timedelta
 from unittest import mock
 
-import pytest
-
 import jwt
+import pytest
 from oauthlib.common import Request as OAuthRequest
 from oauthlib.oauth2.rfc6749 import errors
 
 from h.oauth.jwt_grant import JWTAuthorizationGrant
-from h.services.user import user_service_factory
 from h.services.oauth_validator import Client
+from h.services.user import user_service_factory
 
 
 class TestJWTAuthorizationGrantCreateTokenResponse:

--- a/tests/h/oauth/jwt_grant_token_test.py
+++ b/tests/h/oauth/jwt_grant_token_test.py
@@ -3,9 +3,8 @@
 from calendar import timegm
 from datetime import datetime, timedelta
 
-import pytest
-
 import jwt
+import pytest
 from oauthlib.oauth2 import (
     InvalidClientError,
     InvalidGrantError,

--- a/tests/h/oauth/tokens_test.py
+++ b/tests/h/oauth/tokens_test.py
@@ -3,7 +3,6 @@
 from unittest import mock
 
 import pytest
-
 from oauthlib.common import Request as OAuthRequest
 
 from h.oauth.tokens import BearerToken

--- a/tests/h/paginator_test.py
+++ b/tests/h/paginator_test.py
@@ -5,8 +5,7 @@ from unittest import mock
 import pytest
 from webob.multidict import NestedMultiDict
 
-from h.paginator import paginate
-from h.paginator import paginate_query
+from h.paginator import paginate, paginate_query
 
 
 class TestPaginate:

--- a/tests/h/presenters/annotation_base_test.py
+++ b/tests/h/presenters/annotation_base_test.py
@@ -3,8 +3,7 @@
 import datetime
 from unittest import mock
 
-from h.presenters.annotation_base import AnnotationBasePresenter
-from h.presenters.annotation_base import utc_iso8601
+from h.presenters.annotation_base import AnnotationBasePresenter, utc_iso8601
 
 
 class TestAnnotationBasePresenter:

--- a/tests/h/presenters/annotation_html_test.py
+++ b/tests/h/presenters/annotation_html_test.py
@@ -3,8 +3,8 @@
 import datetime
 from unittest import mock
 
-import pytest
 import jinja2
+import pytest
 
 from h.presenters.annotation_html import AnnotationHTMLPresenter
 

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -4,7 +4,6 @@ import datetime
 from unittest import mock
 
 import pytest
-
 from pyramid import security
 from pyramid.authorization import ACLAuthorizationPolicy
 from zope.interface import implementer

--- a/tests/h/presenters/document_html_test.py
+++ b/tests/h/presenters/document_html_test.py
@@ -2,8 +2,8 @@
 
 from unittest import mock
 
-import pytest
 import jinja2
+import pytest
 
 from h.presenters.document_html import DocumentHTMLPresenter
 

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -4,9 +4,9 @@ from unittest import mock
 
 import pytest
 
+from h import traversal
 from h.presenters.group_json import GroupJSONPresenter, GroupsJSONPresenter
 from h.services.group_links import GroupLinksService
-from h import traversal
 
 
 class TestGroupJSONPresenter:

--- a/tests/h/presenters/organization_json_test.py
+++ b/tests/h/presenters/organization_json_test.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from h.presenters.organization_json import OrganizationJSONPresenter
 from h.models.organization import Organization
+from h.presenters.organization_json import OrganizationJSONPresenter
 from h.traversal import OrganizationContext
 
 

--- a/tests/h/presenters/user_json_test.py
+++ b/tests/h/presenters/user_json_test.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from h.presenters.user_json import UserJSONPresenter, TrustedUserJSONPresenter
+from h.presenters.user_json import TrustedUserJSONPresenter, UserJSONPresenter
 
 
 class TestUserJSONPresenter:

--- a/tests/h/renderers_test.py
+++ b/tests/h/renderers_test.py
@@ -5,8 +5,7 @@ from unittest import mock
 
 import pytest
 
-from h.renderers import json_sorted_factory
-from h.renderers import SVGRenderer
+from h.renderers import SVGRenderer, json_sorted_factory
 
 
 class TestSortedJSONRenderer:

--- a/tests/h/schemas/annotation_test.py
+++ b/tests/h/schemas/annotation_test.py
@@ -3,9 +3,8 @@ from copy import deepcopy
 from unittest import mock
 
 import pytest
-from webob.multidict import NestedMultiDict, MultiDict
+from webob.multidict import MultiDict, NestedMultiDict
 
-from h.search.query import LIMIT_DEFAULT, LIMIT_MAX, OFFSET_MAX
 from h.schemas import ValidationError
 from h.schemas.annotation import (
     CreateAnnotationSchema,
@@ -13,6 +12,7 @@ from h.schemas.annotation import (
     UpdateAnnotationSchema,
 )
 from h.schemas.util import validate_query_params
+from h.search.query import LIMIT_DEFAULT, LIMIT_MAX, OFFSET_MAX
 
 
 def create_annotation_schema_validate(request, data):

--- a/tests/h/schemas/api/group_test.py
+++ b/tests/h/schemas/api/group_test.py
@@ -2,18 +2,17 @@
 import pytest
 
 from h.models.group import (
-    GROUP_NAME_MIN_LENGTH,
-    GROUP_NAME_MAX_LENGTH,
-    GROUP_DESCRIPTION_MAX_LENGTH,
     AUTHORITY_PROVIDED_ID_MAX_LENGTH,
-)
-
-from h.schemas.api.group import (
-    GroupAPISchema,
-    CreateGroupAPISchema,
-    UpdateGroupAPISchema,
+    GROUP_DESCRIPTION_MAX_LENGTH,
+    GROUP_NAME_MAX_LENGTH,
+    GROUP_NAME_MIN_LENGTH,
 )
 from h.schemas import ValidationError
+from h.schemas.api.group import (
+    CreateGroupAPISchema,
+    GroupAPISchema,
+    UpdateGroupAPISchema,
+)
 
 
 class TestGroupAPISchema:

--- a/tests/h/schemas/api/user_test.py
+++ b/tests/h/schemas/api/user_test.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from h.schemas.api.user import CreateUserAPISchema, UpdateUserAPISchema
 from h.schemas import ValidationError
+from h.schemas.api.user import CreateUserAPISchema, UpdateUserAPISchema
 
 
 class TestCreateUserAPISchema:

--- a/tests/h/schemas/base_test.py
+++ b/tests/h/schemas/base_test.py
@@ -3,15 +3,13 @@
 import enum
 from unittest.mock import Mock
 
-import pytest
-
 import colander
+import pytest
 from pyramid import csrf
 from pyramid.exceptions import BadCSRFToken
 
 from h.schemas import ValidationError
-from h.schemas.base import enum_type, CSRFSchema, JSONSchema
-
+from h.schemas.base import CSRFSchema, JSONSchema, enum_type
 
 pytestmark = pytest.mark.usefixtures("pyramid_config")
 

--- a/tests/h/schemas/forms/accounts/edit_profile_test.py
+++ b/tests/h/schemas/forms/accounts/edit_profile_test.py
@@ -4,7 +4,6 @@ import pytest
 
 from h.schemas.forms.accounts import EditProfileSchema
 
-
 pytestmark = pytest.mark.usefixtures("pyramid_config")
 
 

--- a/tests/h/schemas/forms/accounts/forgot_password_test.py
+++ b/tests/h/schemas/forms/accounts/forgot_password_test.py
@@ -4,7 +4,6 @@ import pytest
 
 from h.schemas.forms.accounts import ForgotPasswordSchema
 
-
 pytestmark = pytest.mark.usefixtures("pyramid_config")
 
 

--- a/tests/h/schemas/forms/accounts/reset_password_test.py
+++ b/tests/h/schemas/forms/accounts/reset_password_test.py
@@ -5,7 +5,6 @@ from itsdangerous import BadData, SignatureExpired
 
 from h.schemas.forms.accounts import ResetPasswordSchema
 
-
 pytestmark = pytest.mark.usefixtures("pyramid_config")
 
 

--- a/tests/h/schemas/forms/admin/group_test.py
+++ b/tests/h/schemas/forms/admin/group_test.py
@@ -5,9 +5,9 @@ import colander
 import pytest
 
 from h.models.group import (
-    GROUP_NAME_MIN_LENGTH,
-    GROUP_NAME_MAX_LENGTH,
     GROUP_DESCRIPTION_MAX_LENGTH,
+    GROUP_NAME_MAX_LENGTH,
+    GROUP_NAME_MIN_LENGTH,
 )
 from h.models.organization import Organization
 from h.schemas.forms.admin.group import CreateAdminGroupSchema

--- a/tests/h/schemas/forms/admin/organization_test.py
+++ b/tests/h/schemas/forms/admin/organization_test.py
@@ -2,10 +2,9 @@ import colander
 import pytest
 
 from h.schemas.forms.admin.organization import (
-    OrganizationSchema,
     ORGANIZATION_LOGO_MAX_CHARS,
+    OrganizationSchema,
 )
-
 
 pytestmark = pytest.mark.usefixtures("pyramid_config")
 

--- a/tests/h/schemas/forms/group_test.py
+++ b/tests/h/schemas/forms/group_test.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-
 import colander
+import pytest
 
 from h.schemas.forms.group import unblacklisted_group_name_slug
 

--- a/tests/h/schemas/util_test.py
+++ b/tests/h/schemas/util_test.py
@@ -1,6 +1,6 @@
 import colander
-from webob.multidict import MultiDict
 import pytest
+from webob.multidict import MultiDict
 
 from h.schemas.base import ValidationError
 from h.schemas.util import validate_query_params

--- a/tests/h/schemas/validators_test.py
+++ b/tests/h/schemas/validators_test.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from unittest.mock import Mock
 
-import pytest
 import colander
+import pytest
 
 from h.schemas.validators import Email
 

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 
+import elasticsearch
 import pytest
 
-import elasticsearch
-
-from h.search.client import get_client
-from h.search.client import Client
+from h.search.client import Client, get_client
 
 
 class TestClient:

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -1,22 +1,21 @@
 # -*- coding: utf-8 -*-
 
-from urllib.parse import quote_plus
-
 import itertools
 import re
 from unittest import mock
+from urllib.parse import quote_plus
 
-import pytest
 import elasticsearch
+import pytest
 
 from h.search.client import Client
 from h.search.config import (
-    ANNOTATION_MAPPING,
     ANALYSIS_SETTINGS,
-    init,
+    ANNOTATION_MAPPING,
     configure_index,
     delete_index,
     get_aliased_index,
+    init,
     update_aliased_index,
     update_index_settings,
 )

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -4,8 +4,8 @@ from unittest import mock
 import pytest
 
 import h.search.index
-from h.services.group import GroupService
 from h.services.annotation_moderation import AnnotationModerationService
+from h.services.group import GroupService
 
 
 @pytest.fixture

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -8,6 +8,7 @@ Tests for filtering/matching/aggregating on specific annotation fields are in
 """
 
 import datetime
+
 import pytest
 from webob.multidict import MultiDict
 

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 import datetime
+import logging
 from unittest import mock
 
 import elasticsearch
 import elasticsearch_dsl
-import logging
 import pytest
 
 import h.search.index
-
 from tests.common.matchers import Matcher
 
 

--- a/tests/h/search/parser_test.py
+++ b/tests/h/search/parser_test.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from hypothesis import strategies as st
 from hypothesis import given, settings
+from hypothesis import strategies as st
 from webob.multidict import MultiDict
 
 from h.search import parser

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
+
 import elasticsearch_dsl
 import pytest
 import webob

--- a/tests/h/search/util_test.py
+++ b/tests/h/search/util_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from h.search import util
 
 

--- a/tests/h/security_test.py
+++ b/tests/h/security_test.py
@@ -1,17 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from binascii import hexlify, unhexlify
 import string
+from binascii import hexlify, unhexlify
 
-from passlib.context import CryptContext
 import pytest
-from hypothesis import assume
+from hypothesis import assume, given
 from hypothesis import strategies as st
-from hypothesis import given
+from passlib.context import CryptContext
 
-from h.security import derive_key
-from h.security import password_context
-from h.security import token_urlsafe
+from h.security import derive_key, password_context, token_urlsafe
 
 REASONABLE_INFO = st.text(alphabet=string.printable)
 REASONABLE_KEY_MATERIAL = st.binary(min_size=8, max_size=128)

--- a/tests/h/sentry/helpers/filters_test.py
+++ b/tests/h/sentry/helpers/filters_test.py
@@ -2,7 +2,6 @@
 from unittest import mock
 
 import pytest
-
 import ws4py
 
 from h.sentry.helpers import filters

--- a/tests/h/sentry/subscribers_test.py
+++ b/tests/h/sentry/subscribers_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
-from pyramid_retry import BeforeRetry
 import pytest
+from pyramid_retry import BeforeRetry
 
 from h.sentry.subscribers import add_retryable_error_to_sentry_context
 

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -5,8 +5,8 @@ from unittest import mock
 import pytest
 
 from h.interfaces import IGroupService
-from h.services.annotation_json_presentation import AnnotationJSONPresentationService
 from h.services.annotation_json_presentation import (
+    AnnotationJSONPresentationService,
     annotation_json_presentation_service_factory,
 )
 

--- a/tests/h/services/annotation_moderation_test.py
+++ b/tests/h/services/annotation_moderation_test.py
@@ -3,8 +3,10 @@
 import pytest
 
 from h import models
-from h.services.annotation_moderation import AnnotationModerationService
-from h.services.annotation_moderation import annotation_moderation_service_factory
+from h.services.annotation_moderation import (
+    AnnotationModerationService,
+    annotation_moderation_service_factory,
+)
 
 
 class TestAnnotationModerationServiceHidden:

--- a/tests/h/services/annotation_stats_test.py
+++ b/tests/h/services/annotation_stats_test.py
@@ -4,10 +4,14 @@ from unittest import mock
 
 import pytest
 
-from h.services.annotation_stats import AnnotationStatsService
-from h.services.annotation_stats import annotation_stats_factory
-from h.search import Search
-from h.search import Limiter, DeletedFilter, UserFilter, TopLevelAnnotationsFilter
+from h.search import (
+    DeletedFilter,
+    Limiter,
+    Search,
+    TopLevelAnnotationsFilter,
+    UserFilter,
+)
+from h.services.annotation_stats import AnnotationStatsService, annotation_stats_factory
 
 
 class TestAnnotationStatsService:

--- a/tests/h/services/auth_ticket_test.py
+++ b/tests/h/services/auth_ticket_test.py
@@ -6,14 +6,14 @@ from unittest import mock
 import pytest
 
 from h import models
-from h.services.user import UserService
 from h.services.auth_ticket import (
-    auth_ticket_service_factory,
-    AuthTicketNotLoadedError,
-    AuthTicketService,
     TICKET_REFRESH_INTERVAL,
     TICKET_TTL,
+    AuthTicketNotLoadedError,
+    AuthTicketService,
+    auth_ticket_service_factory,
 )
+from h.services.user import UserService
 
 
 class TestAuthTicketService:

--- a/tests/h/services/auth_token_test.py
+++ b/tests/h/services/auth_token_test.py
@@ -4,8 +4,7 @@ import datetime
 
 import pytest
 
-from h.services.auth_token import AuthTokenService
-from h.services.auth_token import auth_token_service_factory
+from h.services.auth_token import AuthTokenService, auth_token_service_factory
 
 
 class TestAuthTokenService:

--- a/tests/h/services/delete_group_test.py
+++ b/tests/h/services/delete_group_test.py
@@ -4,12 +4,12 @@ from unittest import mock
 
 import pytest
 
+from h.services.annotation_delete import AnnotationDeleteService
 from h.services.delete_group import (
-    delete_group_service_factory,
     DeleteGroupService,
     DeletePublicGroupError,
+    delete_group_service_factory,
 )
-from h.services.annotation_delete import AnnotationDeleteService
 
 
 @pytest.mark.usefixtures("annotation_delete_service")

--- a/tests/h/services/delete_user_test.py
+++ b/tests/h/services/delete_user_test.py
@@ -6,8 +6,8 @@ import pytest
 import sqlalchemy
 
 from h.models import Annotation, Document
-from h.services.delete_user import delete_user_service_factory
 from h.services.annotation_delete import AnnotationDeleteService
+from h.services.delete_user import delete_user_service_factory
 
 
 @pytest.mark.usefixtures("annotation_delete_service")

--- a/tests/h/services/flag_test.py
+++ b/tests/h/services/flag_test.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from h.services import flag
 from h import models
+from h.services import flag
 
 
 @pytest.mark.usefixtures("flags")

--- a/tests/h/services/group_create_test.py
+++ b/tests/h/services/group_create_test.py
@@ -4,10 +4,9 @@ from unittest import mock
 
 import pytest
 
-from h.models import Group, User, GroupScope
+from h.models import Group, GroupScope, User
 from h.models.group import JoinableBy, ReadableBy, WriteableBy
-from h.services.group_create import GroupCreateService
-from h.services.group_create import group_create_factory
+from h.services.group_create import GroupCreateService, group_create_factory
 from h.services.user import UserService
 from tests.common.matchers import Matcher
 

--- a/tests/h/services/group_links_test.py
+++ b/tests/h/services/group_links_test.py
@@ -2,8 +2,7 @@
 
 import pytest
 
-from h.services.group_links import GroupLinksService
-from h.services.group_links import group_links_factory
+from h.services.group_links import GroupLinksService, group_links_factory
 
 
 @pytest.mark.usefixtures("routes")

--- a/tests/h/services/group_list_test.py
+++ b/tests/h/services/group_list_test.py
@@ -4,10 +4,9 @@ from unittest import mock
 
 import pytest
 
-from h.services.group_list import GroupListService
-from h.services.group_list import group_list_factory
-from h.services.group_scope import GroupScopeService
 from h.models.group import Group
+from h.services.group_list import GroupListService, group_list_factory
+from h.services.group_scope import GroupScopeService
 
 
 class TestListGroupsSessionGroups:

--- a/tests/h/services/group_members_test.py
+++ b/tests/h/services/group_members_test.py
@@ -4,9 +4,8 @@ from unittest import mock
 
 import pytest
 
-from h.models import User, GroupScope
-from h.services.group_members import GroupMembersService
-from h.services.group_members import group_members_factory
+from h.models import GroupScope, User
+from h.services.group_members import GroupMembersService, group_members_factory
 from h.services.user import UserService
 from tests.common.matchers import Matcher
 

--- a/tests/h/services/group_scope_test.py
+++ b/tests/h/services/group_scope_test.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from h.services.group_scope import group_scope_factory, GroupScopeService
+from h.services.group_scope import GroupScopeService, group_scope_factory
 
 
 class TestFetchByScope:

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -5,10 +5,9 @@ from unittest import mock
 
 import pytest
 
-from h.models import User, Group, GroupScope
+from h.models import Group, GroupScope, User
 from h.models.group import ReadableBy
-from h.services.group import GroupService
-from h.services.group import groups_factory
+from h.services.group import GroupService, groups_factory
 from h.services.user import UserService
 from tests.common.matchers import Matcher
 

--- a/tests/h/services/group_update_test.py
+++ b/tests/h/services/group_update_test.py
@@ -3,12 +3,10 @@
 from unittest import mock
 
 import pytest
-
 from sqlalchemy.exc import SQLAlchemyError
 
 from h.services.exceptions import ConflictError, ValidationError
-from h.services.group_update import GroupUpdateService
-from h.services.group_update import group_update_factory
+from h.services.group_update import GroupUpdateService, group_update_factory
 
 
 class TestGroupUpdate:

--- a/tests/h/services/groupfinder_test.py
+++ b/tests/h/services/groupfinder_test.py
@@ -2,8 +2,7 @@
 
 import pytest
 
-from h.services.groupfinder import groupfinder_service_factory
-from h.services.groupfinder import GroupfinderService
+from h.services.groupfinder import GroupfinderService, groupfinder_service_factory
 
 
 class TestGroupfinderService:

--- a/tests/h/services/list_organizations_test.py
+++ b/tests/h/services/list_organizations_test.py
@@ -2,10 +2,12 @@
 
 import pytest
 
-from h.services.list_organizations import ListOrganizationsService
-from h.services.list_organizations import list_organizations_factory
-from h.services.organization import organization_factory
 from h.models import Organization
+from h.services.list_organizations import (
+    ListOrganizationsService,
+    list_organizations_factory,
+)
+from h.services.organization import organization_factory
 
 
 class TestListOrganizations:

--- a/tests/h/services/nipsa_test.py
+++ b/tests/h/services/nipsa_test.py
@@ -2,8 +2,7 @@
 
 import pytest
 
-from h.services.nipsa import NipsaService
-from h.services.nipsa import nipsa_factory
+from h.services.nipsa import NipsaService, nipsa_factory
 
 
 @pytest.mark.usefixtures("users", "reindex_user_annotations")

--- a/tests/h/services/oauth_provider_test.py
+++ b/tests/h/services/oauth_provider_test.py
@@ -3,7 +3,6 @@
 from unittest import mock
 
 import pytest
-
 from oauthlib.common import Request as OAuthRequest
 
 from h.oauth.errors import InvalidRefreshTokenError

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -5,7 +5,6 @@ import uuid
 from unittest import mock
 
 import pytest
-
 from oauthlib.common import Request as OAuthRequest
 from oauthlib.oauth2 import InvalidClientIdError
 

--- a/tests/h/services/organization_test.py
+++ b/tests/h/services/organization_test.py
@@ -3,8 +3,7 @@
 import pytest
 
 from h.models import Organization
-from h.services.organization import OrganizationService
-from h.services.organization import organization_factory
+from h.services.organization import OrganizationService, organization_factory
 
 
 class TestOrganizationService:

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 from h import models
-from h.services.rename_user import make_indexer, RenameUserService, UserRenameError
+from h.services.rename_user import RenameUserService, UserRenameError, make_indexer
 
 
 class TestRenameUserService:

--- a/tests/h/services/settings_test.py
+++ b/tests/h/services/settings_test.py
@@ -5,8 +5,7 @@ from unittest import mock
 import pytest
 
 from h.models import Setting
-from h.services.settings import SettingsService
-from h.services.settings import settings_factory
+from h.services.settings import SettingsService, settings_factory
 
 
 class TestSettingsService:

--- a/tests/h/services/user_signup_test.py
+++ b/tests/h/services/user_signup_test.py
@@ -4,13 +4,12 @@ import datetime
 from unittest import mock
 
 import pytest
-
 from sqlalchemy.exc import IntegrityError
 
 from h.models import Activation, Subscriptions, User
+from h.services.exceptions import ConflictError
 from h.services.user_password import UserPasswordService
 from h.services.user_signup import UserSignupService, user_signup_service_factory
-from h.services.exceptions import ConflictError
 
 
 class TestUserSignupService:

--- a/tests/h/services/user_unique_test.py
+++ b/tests/h/services/user_unique_test.py
@@ -4,9 +4,12 @@ from unittest import mock
 
 import pytest
 
-from h.services.user_unique import UserUniqueService, user_unique_factory
-from h.services.user_unique import DuplicateUserError
 from h.services.user import UserService
+from h.services.user_unique import (
+    DuplicateUserError,
+    UserUniqueService,
+    user_unique_factory,
+)
 
 
 class TestUserUniqueEnsureUnique:

--- a/tests/h/services/user_update_test.py
+++ b/tests/h/services/user_update_test.py
@@ -3,12 +3,10 @@
 from unittest import mock
 
 import pytest
-
 from sqlalchemy.exc import SQLAlchemyError
 
 from h.services.exceptions import ConflictError, ValidationError
-from h.services.user_update import UserUpdateService
-from h.services.user_update import user_update_factory
+from h.services.user_update import UserUpdateService, user_update_factory
 
 
 class TestUserUpdate:

--- a/tests/h/settings_test.py
+++ b/tests/h/settings_test.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import logging
+
 import pytest
 
-from h.settings import SettingsManager, SettingError, database_url
+from h.settings import SettingError, SettingsManager, database_url
 
 
 def asutf8(string):

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -5,10 +5,9 @@ from unittest import mock
 
 import pytest
 
+from h import storage
 from h.models.annotation import Annotation
 from h.models.document import Document, DocumentURI
-
-from h import storage
 from h.schemas import ValidationError
 
 

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -4,8 +4,7 @@ from unittest import mock
 
 import pytest
 from gevent.queue import Queue
-from pyramid import security
-from pyramid import registry
+from pyramid import registry, security
 
 from h.streamer import messages
 

--- a/tests/h/streamer/streamer_test.py
+++ b/tests/h/streamer/streamer_test.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from unittest import mock
+
 import pytest
 
-from h.streamer import messages
-from h.streamer import streamer
-from h.streamer import websocket
+from h.streamer import messages, streamer, websocket
 
 
 def test_process_work_queue_sends_realtime_messages_to_messages_handle_message(session):

--- a/tests/h/streamer/views_test.py
+++ b/tests/h/streamer/views_test.py
@@ -2,8 +2,7 @@
 
 import pytest
 
-from h.streamer import views
-from h.streamer import streamer
+from h.streamer import streamer, views
 
 
 def test_websocket_view_adds_auth_state_to_environ(pyramid_config, pyramid_request):

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -10,7 +10,6 @@ from pyramid import security
 
 from h.streamer import websocket
 
-
 FakeMessage = namedtuple("FakeMessage", ["data"])
 
 

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -8,11 +8,13 @@ from pyramid.authorization import ACLAuthorizationPolicy
 from h.auth import role
 from h.models import Organization
 from h.services.group_links import GroupLinksService
-from h.traversal.contexts import AnnotationContext
-from h.traversal.contexts import GroupContext
-from h.traversal.contexts import GroupUpsertContext
-from h.traversal.contexts import OrganizationContext
-from h.traversal.contexts import UserContext
+from h.traversal.contexts import (
+    AnnotationContext,
+    GroupContext,
+    GroupUpsertContext,
+    OrganizationContext,
+    UserContext,
+)
 
 
 @pytest.mark.usefixtures("group_service", "links_service")

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -7,22 +7,23 @@ import pyramid.security
 import pytest
 
 import h.auth
-from h.models import AuthClient
 from h.auth import role
+from h.models import AuthClient
 from h.services.group import GroupService
 from h.services.user import UserService
-from h.traversal.roots import Root
-from h.traversal.roots import AnnotationRoot
-from h.traversal.roots import AuthClientRoot
-from h.traversal.roots import OrganizationRoot
-from h.traversal.roots import OrganizationLogoRoot
-from h.traversal.roots import GroupRoot
-from h.traversal.roots import GroupUpsertRoot
-from h.traversal.roots import ProfileRoot
-from h.traversal.roots import UserRoot
-from h.traversal.roots import UserUserIDRoot
-from h.traversal.contexts import AnnotationContext
-from h.traversal.contexts import UserContext
+from h.traversal.contexts import AnnotationContext, UserContext
+from h.traversal.roots import (
+    AnnotationRoot,
+    AuthClientRoot,
+    GroupRoot,
+    GroupUpsertRoot,
+    OrganizationLogoRoot,
+    OrganizationRoot,
+    ProfileRoot,
+    Root,
+    UserRoot,
+    UserUserIDRoot,
+)
 
 
 class TestRoot:

--- a/tests/h/util/document_claims_test.py
+++ b/tests/h/util/document_claims_test.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 import re
+
 import pytest
 
 from h.util import document_claims

--- a/tests/h/util/query_test.py
+++ b/tests/h/util/query_test.py
@@ -3,11 +3,9 @@
 import string
 
 import pytest
-
 import sqlalchemy as sa
 
 from h.util.query import column_windows
-
 
 meta = sa.MetaData()
 

--- a/tests/h/util/redirects_test.py
+++ b/tests/h/util/redirects_test.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from hypothesis import strategies as st
 from hypothesis import given
+from hypothesis import strategies as st
 
 from h.util.redirects import ParseError, Redirect, lookup, parse
 

--- a/tests/h/util/session_tracker_test.py
+++ b/tests/h/util/session_tracker_test.py
@@ -1,10 +1,11 @@
 from uuid import uuid4
+
 import pytest
 from sqlalchemy.orm.util import identity_key
 
 from h.db.types import _get_urlsafe_from_hex
 from h.models import Annotation, Document
-from h.util.session_tracker import Tracker, ObjectState
+from h.util.session_tracker import ObjectState, Tracker
 
 
 def generate_ann_id():

--- a/tests/h/util/test_logging_filters.py
+++ b/tests/h/util/test_logging_filters.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
-import pytest
 import logging
+
+import pytest
 from urllib3.exceptions import ReadTimeoutError
+
 from h.util.logging_filters import ExceptionFilter
 
 

--- a/tests/h/views/account_signup_test.py
+++ b/tests/h/views/account_signup_test.py
@@ -4,12 +4,11 @@
 from unittest import mock
 
 import pytest
-
 from pyramid import httpexceptions
 
+from h.services.exceptions import ConflictError
 from h.services.user_signup import UserSignupService
 from h.views import account_signup as views
-from h.services.exceptions import ConflictError
 
 
 @pytest.mark.usefixtures("pyramid_config", "routes", "user_signup_service")

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -3,9 +3,8 @@
 
 from unittest import mock
 
-import pytest
 import colander
-
+import pytest
 from pyramid import httpexceptions
 
 from h.services.developer_token import developer_token_service_factory

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -7,10 +7,9 @@ from pyramid import httpexceptions
 from webob.multidict import MultiDict
 
 from h.activity.query import ActivityResults
-from h.views import activity
 from h.models import Organization
 from h.services.annotation_stats import AnnotationStatsService
-
+from h.views import activity
 
 GROUP_TYPE_OPTIONS = ("group", "open_group", "restricted_group")
 

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -5,16 +5,16 @@ from unittest import mock
 import pytest
 
 from h.models import Organization
-from h.views.admin import groups
-from h.views.admin.groups import GroupCreateViews, GroupEditViews
-from h.services.user import UserService
+from h.services.annotation_delete import AnnotationDeleteService
+from h.services.delete_group import DeleteGroupService
 from h.services.group import GroupService
 from h.services.group_create import GroupCreateService
-from h.services.group_update import GroupUpdateService
 from h.services.group_members import GroupMembersService
-from h.services.delete_group import DeleteGroupService
-from h.services.annotation_delete import AnnotationDeleteService
+from h.services.group_update import GroupUpdateService
 from h.services.list_organizations import ListOrganizationsService
+from h.services.user import UserService
+from h.views.admin import groups
+from h.views.admin.groups import GroupCreateViews, GroupEditViews
 
 
 class FakeForm:

--- a/tests/h/views/admin/mailer_test.py
+++ b/tests/h/views/admin/mailer_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-
 from pyramid.httpexceptions import HTTPSeeOther
 
 from h.views.admin.mailer import mailer_index, mailer_test

--- a/tests/h/views/admin/oauthclients_test.py
+++ b/tests/h/views/admin/oauthclients_test.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from unittest.mock import create_autospec, Mock
+from unittest.mock import Mock, create_autospec
 
 import pytest
 
 from h.models.auth_client import AuthClient, GrantType, ResponseType
 from h.views.admin.oauthclients import (
-    index,
     AuthClientCreateController,
     AuthClientEditController,
+    index,
 )
 
 

--- a/tests/h/views/admin/organizations_test.py
+++ b/tests/h/views/admin/organizations_test.py
@@ -4,9 +4,9 @@ import pytest
 
 from h.models import Organization
 from h.views.admin.organizations import (
-    index,
     OrganizationCreateController,
     OrganizationEditController,
+    index,
 )
 
 

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -2,13 +2,13 @@
 
 from unittest import mock
 
-from pyramid import httpexceptions
 import pytest
+from pyramid import httpexceptions
 
+from h.models import Annotation
 from h.services.annotation_stats import AnnotationStatsService
 from h.services.delete_user import DeleteUserService
 from h.services.user import UserService
-from h.models import Annotation
 from h.views.admin.users import (
     UserNotFoundError,
     users_activate,

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -3,7 +3,7 @@
 from unittest import mock
 
 import pytest
-from webob.multidict import NestedMultiDict, MultiDict
+from webob.multidict import MultiDict, NestedMultiDict
 
 from h.schemas import ValidationError
 from h.search.core import SearchResult

--- a/tests/h/views/api/auth_test.py
+++ b/tests/h/views/api/auth_test.py
@@ -1,18 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from unittest import mock
-
 import datetime
 import json
+from unittest import mock
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-
-from oauthlib.oauth2 import InvalidRequestFatalError
 from oauthlib.common import Request as OAuthRequest
+from oauthlib.oauth2 import InvalidRequestFatalError
 from pyramid import httpexceptions
 
-from h.views.api.exceptions import OAuthTokenError
 from h.models.auth_client import ResponseType
 from h.services.auth_token import auth_token_service_factory
 from h.services.oauth_provider import OAuthProviderService
@@ -20,7 +17,7 @@ from h.services.oauth_validator import DEFAULT_SCOPES
 from h.services.user import user_service_factory
 from h.util.datetime import utc_iso8601
 from h.views.api import auth as views
-from h.views.api.exceptions import OAuthAuthorizeError
+from h.views.api.exceptions import OAuthAuthorizeError, OAuthTokenError
 
 
 @pytest.mark.usefixtures("routes", "oauth_provider", "user_svc")

--- a/tests/h/views/api/decorators/client_errors_test.py
+++ b/tests/h/views/api/decorators/client_errors_test.py
@@ -2,14 +2,13 @@
 from unittest import mock
 
 import pytest
-
+from pyramid.httpexceptions import HTTPForbidden, HTTPNotAcceptable, HTTPNotFound
 from pyramid.response import Response
-from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound, HTTPNotAcceptable
 from webob.acceptparse import create_accept_header
 
 from h.views.api.decorators.client_errors import (
-    unauthorized_to_not_found,
     normalize_not_found,
+    unauthorized_to_not_found,
     validate_media_types,
 )
 

--- a/tests/h/views/api/decorators/response_test.py
+++ b/tests/h/views/api/decorators/response_test.py
@@ -2,7 +2,6 @@
 from unittest import mock
 
 import pytest
-
 from pyramid.response import Response
 from webob.acceptparse import create_accept_header
 

--- a/tests/h/views/api/flags_test.py
+++ b/tests/h/views/api/flags_test.py
@@ -3,13 +3,12 @@
 from unittest import mock
 
 import pytest
-
 from pyramid.httpexceptions import HTTPNoContent
 
-from h.views.api import flags as views
 from h.services.flag import FlagService
 from h.services.groupfinder import GroupfinderService
 from h.traversal import AnnotationContext
+from h.views.api import flags as views
 
 
 @pytest.mark.usefixtures(

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -3,23 +3,22 @@
 from unittest import mock
 
 import pytest
-
 from pyramid.httpexceptions import (
-    HTTPNoContent,
     HTTPBadRequest,
-    HTTPNotFound,
     HTTPConflict,
+    HTTPNoContent,
+    HTTPNotFound,
 )
 
-from h.views.api import groups as views
-from h.services.group_list import GroupListService
+from h import traversal
 from h.services.group import GroupService
 from h.services.group_create import GroupCreateService
-from h.services.group_update import GroupUpdateService
-from h.services.group_members import GroupMembersService
-from h.services.user import UserService
 from h.services.group_links import GroupLinksService
-from h import traversal
+from h.services.group_list import GroupListService
+from h.services.group_members import GroupMembersService
+from h.services.group_update import GroupUpdateService
+from h.services.user import UserService
+from h.views.api import groups as views
 
 pytestmark = pytest.mark.usefixtures("GroupsJSONPresenter")
 

--- a/tests/h/views/api/helpers/cors_test.py
+++ b/tests/h/views/api/helpers/cors_test.py
@@ -2,10 +2,9 @@
 from unittest import mock
 
 import pytest
-
+from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.request import Request
 from pyramid.response import Response
-from pyramid.httpexceptions import HTTPBadRequest
 
 from h.views.api.helpers.cors import add_preflight_view, policy, set_cors_headers
 

--- a/tests/h/views/api/index_test.py
+++ b/tests/h/views/api/index_test.py
@@ -3,7 +3,6 @@
 from unittest import mock
 
 import pytest
-
 from pyramid.config import Configurator
 
 from h.views.api import index as views

--- a/tests/h/views/api/moderation_test.py
+++ b/tests/h/views/api/moderation_test.py
@@ -3,7 +3,6 @@
 from unittest import mock
 
 import pytest
-
 from pyramid.httpexceptions import HTTPNoContent
 
 from h.views.api import moderation as views

--- a/tests/h/views/api/profile_test.py
+++ b/tests/h/views/api/profile_test.py
@@ -3,7 +3,6 @@
 from unittest import mock
 
 import pytest
-
 from pyramid.httpexceptions import HTTPBadRequest
 
 from h.services.group_list import GroupListService

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -5,14 +5,14 @@ from unittest import mock
 import pytest
 from pyramid.httpexceptions import HTTPConflict
 
-from h.views.api.exceptions import PayloadError
 from h.models.auth_client import GrantType
 from h.schemas import ValidationError
 from h.services.user_signup import UserSignupService
+from h.services.user_unique import DuplicateUserError, UserUniqueService
 from h.services.user_update import UserUpdateService
-from h.services.user_unique import UserUniqueService, DuplicateUserError
 from h.traversal import UserContext
-from h.views.api.users import read, create, update
+from h.views.api.exceptions import PayloadError
+from h.views.api.users import create, read, update
 
 
 class TestRead:

--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -3,12 +3,10 @@
 from unittest import mock
 
 import pytest
-
 from pyramid import httpexceptions
 from webob.multidict import MultiDict
 
 from h.views.badge import badge
-
 
 badge_fixtures = pytest.mark.usefixtures("models", "search_lib")
 

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -2,11 +2,11 @@
 
 import json
 
-from pyramid.httpexceptions import HTTPFound
 import pytest
+from pyramid.httpexceptions import HTTPFound
 
-from h.views import client
 from h import __version__
+from h.views import client
 
 
 @pytest.mark.usefixtures("routes", "pyramid_settings")

--- a/tests/h/views/errors_test.py
+++ b/tests/h/views/errors_test.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import Mock
 
-from h.views.errors import notfound, error, json_error
+from h.views.errors import error, json_error, notfound
 
 
 def test_notfound_view(pyramid_request):

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -6,10 +6,10 @@ import deform
 import pytest
 from pyramid.httpexceptions import HTTPMovedPermanently
 
-from h.views import groups as views
 from h.models import Group, User
 from h.models.group import JoinableBy
 from h.services.group_create import GroupCreateService
+from h.views import groups as views
 
 
 @pytest.mark.usefixtures("group_create_service", "handle_form_submission", "routes")

--- a/tests/h/views/home_test.py
+++ b/tests/h/views/home_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-
 from pyramid.httpexceptions import HTTPFound
 
 from h.views.home import index_redirect

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -2,8 +2,8 @@
 
 from unittest import mock
 
-from pyramid import httpexceptions
 import pytest
+from pyramid import httpexceptions
 
 from h.models import Annotation
 from h.traversal import AnnotationContext

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ requires =
   tox-pip-extensions
   tox-pyenv
   tox-envfile
+  tox-run-command
 tox_pip_extensions_ext_venv_update = true
 # Exclusively use Python commands from pyenv's copies of Python, don't fall
 # back to tox's default non-pyenv command search strategy.
@@ -73,6 +74,7 @@ passenv =
 setenv = dev: PYTHONPATH = .
 deps =
     tests: coverage
+    tests: isort[requirements]
     {tests,functests,docstrings,checkdocstrings,analyze}: pytest
     {tests,functests,docstrings,checkdocstrings,analyze}: factory-boy
     {tests,docstrings,checkdocstrings,analyze}: hypothesis


### PR DESCRIPTION
Add isort (https://timothycrosley.github.io/isort/) import sorting to `make format` and checking that the imports are sorted correclty to `make checkformatting` (which is run on CI).

The isort config is the Black-compatible one from https://github.com/psf/black#how-black-wraps-lines
