### PR TITLE
Run pip-compile in its own tox env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ pip-compile: python
 
 .PHONY: upgrade-package
 upgrade-package: python
-	@tox -qe py36-dev -- pip-compile --upgrade-package $(name)
+	@tox -qe py36-pip-compile -- --upgrade-package $(name)
 
 .PHONY: docker
 docker:

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ deps =
     docker-compose: docker-compose
     pip-compile: pip-tools
 whitelist_externals =
-    {dev,tests,functests}: sh
+    {dev,tests,functests,pip-compile}: sh
 changedir =
     {docs,checkdocs}: docs
 commands =
@@ -115,4 +115,4 @@ commands =
     coverage: coverage report --show-missing
     codecov: codecov
     docker-compose: docker-compose {posargs}
-    pip-compile: pip-compile
+    pip-compile: pip-compile {posargs}


### PR DESCRIPTION
There's no need for pip-compile to be run in the dev tox env, and this
prevents `bin/hypothesis --dev init` (which the dev env runs before
running its main command) from being run when you're just trying to run
pip-compile and potentially breaking things.