### PR TITLE
Make it easier to test dev client on mobile devices

### DIFF
--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -12,7 +12,7 @@ pyramid.reload_templates: True
 h.authority: localhost
 h.bouncer_url: http://localhost:8000
 h.client_rpc_allowed_origins: http://localhost
-h.client_url: http://localhost:3001/hypothesis
+h.client_url: {current_scheme}://{current_host}:3001/hypothesis
 h.websocket_url: ws://localhost:5001/ws
 
 h.debug: True

--- a/h/util/view.py
+++ b/h/util/view.py
@@ -25,3 +25,18 @@ def json_view(**settings):
     settings.setdefault("accept", "application/json")
     settings.setdefault("renderer", "json")
     return view_config(**settings)
+
+
+def render_url_template(url_template, request):
+    """
+    Replace placeholders in a URL with elements of the current request's URL.
+
+    This function is primarily used in development to support creating
+    absolute links to h or other Hypothesis services which work when h is
+    accessed from the same system (where the h dev server is "localhost:<port>")
+    or a different device (when the h dev server is "machine-name.local:<port>").
+    """
+    url = url_template
+    url = url.replace("{current_host}", request.domain)
+    url = url.replace("{current_scheme}", request.scheme)
+    return url

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -13,6 +13,7 @@ from h import models
 from h.views.api.exceptions import OAuthAuthorizeError, OAuthTokenError
 from h.services.oauth_validator import DEFAULT_SCOPES
 from h.util.datetime import utc_iso8601
+from h.util.view import render_url_template
 from h.views.api.config import api_config
 
 log = logging.getLogger(__name__)
@@ -164,6 +165,7 @@ class OAuthAuthorizeController:
             )
 
     def _render_web_message_response(self, redirect_uri):
+        redirect_uri = render_url_template(redirect_uri, self.request)
         location = urlparse(redirect_uri)
         params = parse_qs(location.query)
         origin = "{url.scheme}://{url.netloc}".format(url=location)

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -14,6 +14,7 @@ from pyramid.view import view_config
 
 from h import __version__
 from h.util.uri import origin
+from h.util.view import render_url_template
 
 # Default URL for the client, which points to the latest version of the client
 # that was published to npm.
@@ -25,6 +26,7 @@ def _client_url(request):
     Return the configured URL for the client.
     """
     url = request.registry.settings.get("h.client_url", DEFAULT_CLIENT_URL)
+    url = render_url_template(url, request)
 
     if request.feature("embed_cachebuster"):
         url += "?cachebuster=" + str(int(time.time()))

--- a/tests/h/util/view_test.py
+++ b/tests/h/util/view_test.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from h.util.view import handle_exception, json_view
+from h.util.view import handle_exception, json_view, render_url_template
 
 
 @pytest.mark.usefixtures("sys_exc_info")
@@ -74,3 +74,26 @@ class TestJsonView:
         view_config = patch("h.util.view.view_config")
         view_config.side_effect = _return_kwargs
         return view_config
+
+
+class TestRenderUrlTemplate:
+    @pytest.mark.parametrize(
+        "url_template,scheme,domain,expected",
+        [
+            (
+                "https://hypothes.is/path",
+                "http",
+                "example.com",
+                "https://hypothes.is/path",
+            ),
+            (
+                "{current_scheme}://{current_host}:5000/app.html",
+                "https",
+                "localhost",
+                "https://localhost:5000/app.html",
+            ),
+        ],
+    )
+    def test_replaces_params(self, url_template, scheme, domain, expected):
+        request = Mock(scheme=scheme, domain=domain)
+        assert render_url_template(url_template, request) == expected

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -9,7 +9,7 @@ from h.views import client
 from h import __version__
 
 
-@pytest.mark.usefixtures("routes", "pyramid_settings")
+@pytest.mark.usefixtures("routes", "pyramid_settings", "render_url_template")
 class TestSidebarApp:
     def test_it_includes_client_config(self, pyramid_request):
         ctx = client.sidebar_app(pyramid_request)
@@ -43,14 +43,19 @@ class TestSidebarApp:
         )
 
 
-@pytest.mark.usefixtures("routes", "pyramid_settings")
+@pytest.mark.usefixtures("routes", "pyramid_settings", "render_url_template")
 class TestEmbedRedirect:
-    def test_redirects_to_client_boot_script(self, pyramid_request):
+    def test_redirects_to_client_boot_script(
+        self, pyramid_request, render_url_template
+    ):
         pyramid_request.feature.flags["embed_cachebuster"] = False
 
         rsp = client.embed_redirect(pyramid_request)
 
         assert isinstance(rsp, HTTPFound)
+        render_url_template.assert_called_with(
+            "https://cdn.hypothes.is/hypothesis", pyramid_request
+        )
         assert rsp.location == "https://cdn.hypothes.is/hypothesis"
 
     def test_adds_cachebuster(self, pyramid_request):
@@ -78,6 +83,18 @@ def pyramid_settings(pyramid_settings):
     )
 
     return pyramid_settings
+
+
+@pytest.fixture
+def render_url_template(patch):
+    mock = patch("h.views.client.render_url_template")
+
+    def render(url, request):
+        return url
+
+    mock.side_effect = render
+
+    return mock
 
 
 @pytest.fixture


### PR DESCRIPTION
Make it easier to test the development client on mobile devices, VMs or
over SSL by removing the need to customize the `h.client_url` setting
and the OAuth client's redirect URL if h is being accessed via a
non-localhost hostname.

This is achieved by supporting `current_scheme` and `current_host` URL
template parameters in a minimal set of contexts, which are replaced
with the corresponding parts of the current request URL. This templating
is currently supported for:

 - The `h.client_url` setting, used by the `/embed.js` route
 - The redirect URL for OAuth clients, but only when using `postMessage`
   to deliver the auth code to the client, as that is the method the
   client uses

This means for example that if you fetch `https://localhost:5000/embed.js` it will redirect to `https://localhost:3001/hypothesis` but if you fetch `http://my-dev-system.local:5000/embed.js` it will redirect to `http://my-dev-system.local:3001/hypothesis`. The result is that, together with the  corresponding [client PR](https://github.com/hypothesis/client/pull/1441), you can browse to eg. `http://my-dev-system.local:3000` on your iOS/Android device, provided that it is on the same network, and use the client as normal.

We could extend this templating support to work with other URLs that h generates in future, such as bouncer.

**See [this comment](https://github.com/hypothesis/h/pull/5758#issuecomment-545400070) for manual testing steps. Also see Lyza's [note here](https://github.com/hypothesis/h/pull/5758#pullrequestreview-311204319).**