### PR TITLE
Prevent unhandled HTTP 500 on `GET /users/{userid}` when `userid` malformed

### DIFF
--- a/h/services/user.py
+++ b/h/services/user.py
@@ -50,6 +50,9 @@ class UserService:
 
         :returns: a user instance, if found
         :rtype: h.models.User or None
+        :raises ValueError: If no value is passed for ``authority`` and
+                            ``userid_or_username`` is not a
+                            properly-formatted ``userid``.
 
         """
         if authority is not None:

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -284,7 +284,11 @@ class UserUserIDRoot:
         self.user_svc = self.request.find_service(name="user")
 
     def __getitem__(self, userid):
-        user = self.user_svc.fetch(userid)
+        try:
+            user = self.user_svc.fetch(userid)
+        except ValueError:
+            # If the `userid` is malformed
+            raise KeyError()
 
         if not user:
             raise KeyError()

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -508,6 +508,14 @@ class TestUserUserIDRoot:
 
         user_service.fetch.assert_called_once_with("acct:bob@example.com")
 
+    def test_it_raises_KeyError_if_userid_malformed_and_service_raises(
+        self, user_userid_root, user_service
+    ):
+        user_service.fetch.side_effect = ValueError("nope")
+
+        with pytest.raises(KeyError):
+            user_userid_root["acct:bob@example.com"]
+
     def test_it_raises_KeyError_if_the_user_does_not_exist(
         self, user_userid_root, user_service
     ):


### PR DESCRIPTION
(@LMS007 is encountering this issue and it is complicating his local debug for LMS configuration).

Before: Traversal for a `userid` param that was incorrectly formatted resulted in
an unhandled `ValueError` (originating from `h.util.user.split_user`). This resulted in unhandled 500 responses.

`h.traversal.roots.UserUserIdRoot` now handles `ValueError`s and raises
a `KeyError` when encountering one (net result: the endpoint will now
return a 404 on a wonky `userid`).

Fixes: https://sentry.io/organizations/hypothesis/issues/1106040600/?project=37293

(I thought we had a GH Sentry issue tracking this one but I'm not seeing it)

It's arguable that in the future we should increase the nuance of the Exceptions in our traversal layer, but we don't have precedent for handling things like validation problems at that layer yet, so I didn't want to introduce anything at this point. So: `KeyError` it is for now.