### PR TITLE
Replacing custom matchers with those from h-matchers

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 h_pyramid_sentry
+h_matchers
 
 PyJWT
 SQLAlchemy >= 1.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ gevent==1.4.0
 greenlet==0.4.15          # via gevent
 gunicorn==19.9.0
 h_pyramid_sentry==1.2.0
+h-matchers==1.2.0
 hkdf==0.0.3
 hupper==1.8.1             # via pyramid
 importlib-metadata==0.23  # via jsonschema

--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -3,6 +3,7 @@
 Implements some matching objects in the style of h_matchers library for
 comparing with other objects in tests.
 """
+# pylint: disable=too-few-public-methods
 from h_matchers.matcher.core import Matcher
 from pyramid.httpexceptions import HTTPFound, HTTPSeeOther
 

--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -1,152 +1,28 @@
-# -*- coding: utf-8 -*-
+"""Objects that match other objects for testing.
 
+Implements some matching objects in the style of h_matchers library for
+comparing with other objects in tests.
 """
-Matchers for use in tests.
-
-This module contains objects which can be used to write tests which are easier
-to read, especially when using assertions against :py:class:`mock.Mock`
-objects. Each matcher defines an __eq__ method, allowing instances of these
-matchers to be used wherever you would usually pass a plain value.
-
-For example, imagine you wanted to ensure that the `set_value` method of the
-`foo` mock object was called exactly once with an integer. Previously you
-would have to do something like:
-
-    assert foo.set_value.call_count == 1
-    assert isinstance(foo.set_value.call_args[0][0], int)
-
-By using the `InstanceOf` matcher you can simply write:
-
-    foo.set_value.assert_called_once_with(matchers.InstanceOf(int))
-
-As a bonus, the second test will print substantially more useful debugging
-output if it fails, e.g.
-
-    E       AssertionError: Expected call: set_value(<instance of <type 'int'>>)
-    E       Actual call: set_value('a string')
-
-"""
-import re
-
-from pyramid import httpexceptions
-
-
-class Matcher:
-    def __eq__(self, other):
-        raise NotImplementedError("subclasses should provide an __eq__ method")
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-
-class AnyCallable(Matcher):
-    """An object __eq__ to any callable object."""
-
-    def __eq__(self, other):
-        """Return ``True`` if ``other`` is callable, ``False`` otherwise."""
-        return callable(other)
-
-
-class InstanceOf(Matcher):
-    """An object __eq__ to any object which is an instance of `type_`."""
-
-    def __init__(self, type_):
-        self.type = type_
-
-    def __eq__(self, other):
-        return isinstance(other, self.type)
-
-    def __repr__(self):
-        return "<instance of {!r}>".format(self.type)
-
-
-class IterableWith(Matcher):
-    """An object __eq__ to any iterable which yields `items`."""
-
-    def __init__(self, items):
-        self.items = items
-
-    def __eq__(self, other):
-        return list(other) == self.items
-
-    def __repr__(self):
-        return "<iterable with {!r}>".format(self.items)
-
-
-class MappingContaining(Matcher):
-    """An object __eq__ to any mapping with the passed `key`."""
-
-    def __init__(self, key):
-        self.key = key
-
-    def __eq__(self, other):
-        try:
-            other[self.key]
-        except (TypeError, KeyError):
-            return False
-        else:
-            return True
-
-    def __repr__(self):
-        return "<mapping containing {!r}>".format(self.key)
+from h_matchers.matcher.core import Matcher
+from pyramid.httpexceptions import HTTPFound, HTTPSeeOther
 
 
 class Redirect302To(Matcher):
     """Matches any HTTPFound redirect to the given URL."""
 
     def __init__(self, location):
-        self.location = location
-
-    def __eq__(self, other):
-        if not isinstance(other, httpexceptions.HTTPFound):
-            return False
-        return other.location == self.location
+        super().__init__(
+            f"* any redirect to: {location} *",
+            lambda other: isinstance(other, HTTPFound) and other.location == location,
+        )
 
 
 class Redirect303To(Matcher):
     """Matches any HTTPSeeOther redirect to the given URL."""
 
     def __init__(self, location):
-        self.location = location
-
-    def __eq__(self, other):
-        if not isinstance(other, httpexceptions.HTTPSeeOther):
-            return False
-        return other.location == self.location
-
-
-class Regex(Matcher):
-    """Matches any string matching the passed regex."""
-
-    def __init__(self, patt):
-        self.patt = re.compile(patt)
-
-    def __eq__(self, other):
-        return bool(self.patt.match(other))
-
-    def __repr__(self):
-        return "<string matching re {!r}>".format(self.patt.pattern)
-
-
-class UnorderedList(Matcher):
-    """
-    Matches a list with the same items in any order.
-
-    Matches any list that contains the same items as the given list
-    (and no more), regardless of order.
-
-    """
-
-    def __init__(self, items):
-        self.items = items
-
-    def __eq__(self, other):
-        if len(self.items) != len(other):
-            return False
-        for item in self.items:
-            if item not in other:
-                return False
-        return True
-
-    def __repr__(self):
-        return "<unordered list containing {items}".format(items=self.items)
+        super().__init__(
+            f"* any redirect to: {location} *",
+            lambda other: isinstance(other, HTTPSeeOther)
+            and other.location == location,
+        )

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+from h_matchers import Any
 from pyramid.httpexceptions import HTTPFound
 from webob.multidict import MultiDict
 
@@ -392,12 +393,12 @@ class TestExecute:
         assert result.timeframes == bucketing.bucket.return_value
 
     def test_it_fetches_the_groups_from_the_database(
-        self, _fetch_groups, group_pubids, matchers, pyramid_request
+        self, _fetch_groups, group_pubids, pyramid_request
     ):
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
         _fetch_groups.assert_called_once_with(
-            pyramid_request.db, matchers.UnorderedList(group_pubids)
+            pyramid_request.db, Any.iterable.containing(group_pubids).only()
         )
 
     def test_it_returns_each_annotation_presented(self, annotations, pyramid_request):

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -195,6 +195,7 @@ def invalid_form():
 
 @pytest.fixture
 def matchers():
+    # pylint: disable=redefined-outer-name
     from ..common import matchers
 
     return matchers

--- a/tests/h/emails/test_test.py
+++ b/tests/h/emails/test_test.py
@@ -9,7 +9,7 @@ from h.emails.test import generate
 
 class TestGenerate:
     def test_calls_renderers_with_appropriate_context(
-        self, pyramid_request, html_renderer, text_renderer, matchers
+        self, pyramid_request, html_renderer, text_renderer
     ):
         generate(pyramid_request, "meerkat@example.com")
 

--- a/tests/h/emails/test_test.py
+++ b/tests/h/emails/test_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from h_matchers import Any
 
 from h import __version__
 from h.emails.test import generate
@@ -13,9 +14,9 @@ class TestGenerate:
         generate(pyramid_request, "meerkat@example.com")
 
         expected_context = {
-            "time": matchers.InstanceOf(str),
-            "hostname": matchers.InstanceOf(str),
-            "python_version": matchers.InstanceOf(str),
+            "time": Any.string(),
+            "hostname": Any.string(),
+            "python_version": Any.string(),
             "version": __version__,
         }
         html_renderer.assert_(**expected_context)

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+from h_matchers import Any
 
 from h import form
 
@@ -78,15 +79,13 @@ class TestCreateForm:
 
         assert result == Form.return_value
 
-    def test_passes_args_including_renderer_to_form_ctor(
-        self, Form, matchers, pyramid_request
-    ):
+    def test_passes_args_including_renderer_to_form_ctor(self, Form, pyramid_request):
         form.create_form(pyramid_request, mock.sentinel.schema, foo="bar")
 
         Form.assert_called_once_with(
             mock.sentinel.schema,
             foo="bar",
-            renderer=matchers.InstanceOf(form.Jinja2Renderer),
+            renderer=Any.instance_of(form.Jinja2Renderer),
         )
 
     def test_adds_feature_client_to_system_context(self, Form, patch, pyramid_request):
@@ -156,14 +155,14 @@ class TestToXHRResponse:
 
 @pytest.mark.usefixtures("to_xhr_response")
 class TestHandleFormSubmission:
-    def test_it_calls_validate(self, pyramid_request, matchers):
+    def test_it_calls_validate(self, pyramid_request):
         form_ = mock.Mock(spec_set=["validate"])
 
         form.handle_form_submission(
             pyramid_request, form_, mock_callable(), mock.sentinel.on_failure
         )
 
-        post_items = matchers.IterableWith(list(pyramid_request.POST.items()))
+        post_items = Any.iterable.containing(list(pyramid_request.POST.items())).only()
         form_.validate.assert_called_once_with(post_items)
 
     def test_if_validation_fails_it_calls_on_failure(

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -249,7 +249,7 @@ class TestHandleFormSubmission:
         )
 
     def test_if_validation_succeeds_it_passes_on_success_result_to_to_xhr_response(
-        self, form_validating_to, matchers, pyramid_request, to_xhr_response
+        self, form_validating_to, pyramid_request, to_xhr_response
     ):
         """
         A result from on_success() is passed to to_xhr_response().

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -61,7 +61,7 @@ class TestCreateEnvironment:
 
         form.create_environment(base)
 
-        base.overlay.assert_called_once_with(autoescape=True, loader=mock.ANY)
+        base.overlay.assert_called_once_with(autoescape=True, loader=Any())
 
     def test_loader_has_correct_paths(self):
         base = mock.Mock(spec_set=["overlay"])

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -42,7 +42,7 @@ class TestReindex:
             mock.call(["abc123", "def456"]),
         ]
 
-    def test_creates_new_index(self, pyramid_request, es, configure_index, matchers):
+    def test_creates_new_index(self, pyramid_request, es, configure_index):
         """Creates a new target index."""
         reindex(mock.sentinel.session, es, pyramid_request)
 

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from h_matchers import Any
 from sqlalchemy import inspect
 
 from h.models import GroupScope
@@ -58,7 +59,7 @@ class TestGroupScope:
             factories.GroupScope(group=group),
         ]
 
-        assert group.scopes == matchers.UnorderedList(scopes)
+        assert group.scopes == Any.list.containing(scopes).only()
 
     def test_deleting_a_group_deletes_its_groupscopes(self, db_session, factories):
         group = factories.OpenGroup()

--- a/tests/h/realtime_test.py
+++ b/tests/h/realtime_test.py
@@ -69,7 +69,7 @@ class TestConsumer:
         consumer.handle_message({}, message)
 
         statsd_client.timing.assert_called_once_with(
-            "streamer.msg.queueing", Any.instance_of(int)
+            "streamer.msg.queueing", Any.int()
         )
 
     def test_handle_message_doesnt_explode_if_timestamp_missing(

--- a/tests/h/realtime_test.py
+++ b/tests/h/realtime_test.py
@@ -123,7 +123,7 @@ class TestPublisher:
             retry_policy=retry_policy,
         )
 
-    def test_publish_user(self, matchers, producer_pool, pyramid_request, retry_policy):
+    def test_publish_user(self, producer_pool, pyramid_request, retry_policy):
         payload = {"action": "create", "user": {"id": "foobar"}}
         producer = producer_pool["foobar"].acquire().__enter__()
         exchange = realtime.get_exchange()

--- a/tests/h/realtime_test.py
+++ b/tests/h/realtime_test.py
@@ -68,9 +68,7 @@ class TestConsumer:
 
         consumer.handle_message({}, message)
 
-        statsd_client.timing.assert_called_once_with(
-            "streamer.msg.queueing", Any.int()
-        )
+        statsd_client.timing.assert_called_once_with("streamer.msg.queueing", Any.int())
 
     def test_handle_message_doesnt_explode_if_timestamp_missing(
         self, handler, statsd_client

--- a/tests/h/realtime_test.py
+++ b/tests/h/realtime_test.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
+from h_matchers import Any
 
 from h import realtime
 
@@ -57,7 +58,7 @@ class TestConsumer:
         handler.assert_called_once_with(body)
 
     def test_handle_message_records_queue_time_if_timestamp_present(
-        self, handler, matchers, statsd_client
+        self, handler, statsd_client
     ):
         consumer = realtime.Consumer(
             mock.sentinel.connection, "annotation", handler, statsd_client=statsd_client
@@ -68,7 +69,7 @@ class TestConsumer:
         consumer.handle_message({}, message)
 
         statsd_client.timing.assert_called_once_with(
-            "streamer.msg.queueing", matchers.InstanceOf(int)
+            "streamer.msg.queueing", Any.instance_of(int)
         )
 
     def test_handle_message_doesnt_explode_if_timestamp_missing(
@@ -104,9 +105,7 @@ class TestConsumer:
 
 
 class TestPublisher:
-    def test_publish_annotation(
-        self, matchers, producer_pool, pyramid_request, retry_policy
-    ):
+    def test_publish_annotation(self, producer_pool, pyramid_request, retry_policy):
         payload = {"action": "create", "annotation": {"id": "foobar"}}
         producer = producer_pool["foobar"].acquire().__enter__()
         exchange = realtime.get_exchange()
@@ -114,13 +113,12 @@ class TestPublisher:
         publisher = realtime.Publisher(pyramid_request)
         publisher.publish_annotation(payload)
 
-        expected_headers = matchers.MappingContaining("timestamp")
         producer.publish.assert_called_once_with(
             payload,
             exchange=exchange,
             declare=[exchange],
             routing_key="annotation",
-            headers=expected_headers,
+            headers=Any.dict.containing(["timestamp"]),
             retry=True,
             retry_policy=retry_policy,
         )
@@ -133,13 +131,12 @@ class TestPublisher:
         publisher = realtime.Publisher(pyramid_request)
         publisher.publish_user(payload)
 
-        expected_headers = matchers.MappingContaining("timestamp")
         producer.publish.assert_called_once_with(
             payload,
             exchange=exchange,
             declare=[exchange],
             routing_key="user",
-            headers=expected_headers,
+            headers=Any.dict.containing(["timestamp"]),
             retry=True,
             retry_policy=retry_policy,
         )

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -7,6 +7,7 @@ from urllib.parse import quote_plus
 
 import elasticsearch
 import pytest
+from h_matchers import Any
 
 from h.search.client import Client
 from h.search.config import (
@@ -142,23 +143,23 @@ class TestInit:
 
 
 class TestConfigureIndex:
-    def test_creates_randomly_named_index(self, client, matchers):
+    def test_creates_randomly_named_index(self, client):
         configure_index(client)
 
         client.conn.indices.create.assert_called_once_with(
-            matchers.Regex("foo-[0-9a-f]{8}"), body=mock.ANY
+            Any.string.matching("foo-[0-9a-f]{8}"), body=Any()
         )
 
-    def test_returns_index_name(self, client, matchers):
+    def test_returns_index_name(self, client):
         name = configure_index(client)
 
-        assert name == matchers.Regex("foo-[0-9a-f]{8}")
+        assert name == Any.string.matching("foo-[0-9a-f]{8}")
 
     def test_sets_correct_mappings_and_settings(self, client):
         configure_index(client)
 
         client.conn.indices.create.assert_called_once_with(
-            mock.ANY,
+            Any(),
             body={
                 "mappings": {"annotation": ANNOTATION_MAPPING},
                 "settings": {"analysis": ANALYSIS_SETTINGS},

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -10,6 +10,7 @@ Tests for filtering/matching/aggregating on specific annotation fields are in
 import datetime
 
 import pytest
+from h_matchers import Any
 from webob.multidict import MultiDict
 
 from h import search
@@ -41,9 +42,7 @@ class TestSearch:
             pyramid_request, separate_keys
         )
 
-    def test_it_returns_replies_in_annotations_ids(
-        self, matchers, pyramid_request, Annotation
-    ):
+    def test_it_returns_replies_in_annotations_ids(self, pyramid_request, Annotation):
         """Without separate_replies it returns replies in annotation_ids.
 
         Test that if no separate_replies argument is given then it returns the
@@ -56,8 +55,9 @@ class TestSearch:
 
         result = search.Search(pyramid_request).run(MultiDict({}))
 
-        assert result.annotation_ids == matchers.UnorderedList(
-            [annotation.id, reply_1.id, reply_2.id]
+        assert (
+            result.annotation_ids
+            == Any.list.containing([annotation.id, reply_1.id, reply_2.id]).only()
         )
 
     def test_replies_that_dont_match_the_search_arent_included(
@@ -168,7 +168,7 @@ class TestSearchWithSeparateReplies:
     """Unit tests for search.Search when separate_replies=True is given."""
 
     def test_it_returns_replies_separately_from_annotations(
-        self, matchers, pyramid_request, Annotation
+        self, pyramid_request, Annotation
     ):
         """If separate_replies=True replies and annotations are returned separately."""
         annotation = Annotation(shared=True)
@@ -180,7 +180,7 @@ class TestSearchWithSeparateReplies:
         )
 
         assert result.annotation_ids == [annotation.id]
-        assert result.reply_ids == matchers.UnorderedList([reply_1.id, reply_2.id])
+        assert result.reply_ids == Any.list.containing([reply_1.id, reply_2.id]).only()
 
     def test_replies_are_ordered_most_recently_updated_first(
         self, Annotation, pyramid_request

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -6,6 +6,7 @@ from unittest import mock
 import elasticsearch
 import elasticsearch_dsl
 import pytest
+from h_matchers import Any
 
 import h.search.index
 from tests.common.matchers import Matcher
@@ -130,7 +131,7 @@ class TestIndex:
         event = AnnotationTransformEvent.return_value
 
         AnnotationTransformEvent.assert_called_once_with(
-            pyramid_request, annotation, mock.ANY
+            pyramid_request, annotation, Any()
         )
         notify.assert_called_once_with(event)
 

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -60,7 +60,7 @@ class TestAnnotationJSONPresentationService:
         svc.present(annotation_resource)
 
         presenters.AnnotationJSONPresenter.assert_called_once_with(
-            annotation_resource, mock.ANY
+            annotation_resource, Any()
         )
 
     def test_present_adds_formatters(self, svc, annotation_resource, presenters):
@@ -69,7 +69,7 @@ class TestAnnotationJSONPresentationService:
 
         svc.present(annotation_resource)
 
-        presenters.AnnotationJSONPresenter.assert_called_once_with(mock.ANY, formatters)
+        presenters.AnnotationJSONPresenter.assert_called_once_with(Any(), formatters)
 
     def test_present_returns_presenter_dict(self, svc, presenters):
         presenter = presenters.AnnotationJSONPresenter.return_value
@@ -82,7 +82,7 @@ class TestAnnotationJSONPresentationService:
         svc.present_all(["id-1", "id-2"])
 
         storage.fetch_ordered_annotations.assert_called_once_with(
-            svc.session, ["id-1", "id-2"], query_processor=mock.ANY
+            svc.session, ["id-1", "id-2"], query_processor=Any()
         )
 
     def test_present_all_initialises_annotation_resources(

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+from h_matchers import Any
 
 from h.interfaces import IGroupService
 from h.services.annotation_json_presentation import (
@@ -21,11 +22,9 @@ class TestAnnotationJSONPresentationService:
     def test_it_configures_flag_formatter(self, services, formatters, svc):
         assert formatters.AnnotationFlagFormatter.return_value in svc.formatters
 
-    def test_initializes_hidden_formatter(self, matchers, services, formatters, svc):
+    def test_initializes_hidden_formatter(self, services, formatters, svc):
         formatters.AnnotationHiddenFormatter.assert_called_once_with(
-            services["annotation_moderation"],
-            matchers.AnyCallable(),
-            mock.sentinel.user,
+            services["annotation_moderation"], Any.callable(), mock.sentinel.user,
         )
 
     def test_hidden_status_included_if_user_can_moderate_group(

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -24,7 +24,7 @@ class TestAnnotationJSONPresentationService:
 
     def test_initializes_hidden_formatter(self, services, formatters, svc):
         formatters.AnnotationHiddenFormatter.assert_called_once_with(
-            services["annotation_moderation"], Any.callable(), mock.sentinel.user,
+            services["annotation_moderation"], Any.function(), mock.sentinel.user,
         )
 
     def test_hidden_status_included_if_user_can_moderate_group(

--- a/tests/h/services/document_test.py
+++ b/tests/h/services/document_test.py
@@ -17,7 +17,7 @@ class TestFetchByGroupid:
         )
 
     def test_it_does_not_return_documents_annotated_in_other_groups(
-        self, groups, annotations, other_annotations, svc, matchers
+        self, groups, annotations, other_annotations, svc
     ):
         docs = svc.fetch_by_groupid(groupid=groups["target_group"].pubid)
         for other_anno in other_annotations:
@@ -69,7 +69,7 @@ class TestFetchByGroupid:
         )
 
     def test_it_returns_documents_ordered_by_last_activity_desc(
-        self, svc, annotations, groups, factories, db_session, matchers
+        self, svc, annotations, groups, factories, db_session
     ):
         # Update the document associated with ``annotations[1]``...
         annotations[1].document.title = "Bleep bloop"

--- a/tests/h/services/document_test.py
+++ b/tests/h/services/document_test.py
@@ -1,17 +1,20 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from h_matchers import Any
 
 from h.services.document import DocumentService
 
 
 class TestFetchByGroupid:
     def test_it_returns_documents_annotated_within_group(
-        self, svc, groups, annotations, matchers
+        self, svc, groups, annotations
     ):
         docs = svc.fetch_by_groupid(groupid=groups["target_group"].pubid)
 
-        assert docs == matchers.UnorderedList([anno.document for anno in annotations])
+        assert (
+            docs == Any.list.containing([anno.document for anno in annotations]).only()
+        )
 
     def test_it_does_not_return_documents_annotated_in_other_groups(
         self, groups, annotations, other_annotations, svc, matchers
@@ -42,7 +45,7 @@ class TestFetchByGroupid:
         assert docs == [annotations[0].document]
 
     def test_it_returns_only_documents_with_visible_annotations_for_user(
-        self, svc, annotations, groups, target_user, other_user, db_session, matchers
+        self, svc, annotations, groups, target_user, other_user, db_session
     ):
         # This makes an "only me" annotation, associated with our target user
         annotations[1].shared = False
@@ -58,8 +61,11 @@ class TestFetchByGroupid:
 
         # The "only me" annotation for THIS user should be returned, but not the
         # "only me" annotation associated with another user
-        assert docs == matchers.UnorderedList(
-            [annotations[0].document, annotations[1].document]
+        assert (
+            docs
+            == Any.list.containing(
+                [annotations[0].document, annotations[1].document]
+            ).only()
         )
 
     def test_it_returns_documents_ordered_by_last_activity_desc(

--- a/tests/h/services/group_list_test.py
+++ b/tests/h/services/group_list_test.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+from h_matchers import Any
 
 from h.models.group import Group
 from h.services.group_list import GroupListService, group_list_factory
@@ -225,12 +226,15 @@ class TestScopedGroups:
         assert results == []
 
     def test_it_returns_matching_public_groups(
-        self, svc, sample_groups, document_uri, default_authority, matchers
+        self, svc, sample_groups, document_uri, default_authority
     ):
         results = svc.scoped_groups(default_authority, document_uri)
 
-        assert results == matchers.UnorderedList(
-            [sample_groups["restricted"], sample_groups["open"]]
+        assert (
+            results
+            == Any.list.containing(
+                [sample_groups["restricted"], sample_groups["open"]]
+            ).only()
         )
 
     def test_it_returns_matches_from_authority_only(

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 from gevent.queue import Queue
+from h_matchers import Any
 from pyramid import registry, security
 
 from h.streamer import messages
@@ -44,9 +45,9 @@ class TestProcessMessages:
         messages.process_messages({}, "foobar", queue, raise_error=False)
 
         fake_consumer.assert_called_once_with(
-            connection=mock.ANY,
-            routing_key=mock.ANY,
-            handler=mock.ANY,
+            connection=Any(),
+            routing_key=Any(),
+            handler=Any(),
             statsd_client=fake_stats.get_client.return_value,
         )
 
@@ -54,10 +55,7 @@ class TestProcessMessages:
         messages.process_messages({}, "foobar", queue, raise_error=False)
 
         fake_consumer.assert_called_once_with(
-            connection=mock.ANY,
-            routing_key="foobar",
-            handler=mock.ANY,
-            statsd_client=mock.ANY,
+            connection=Any(), routing_key="foobar", handler=Any(), statsd_client=Any(),
         )
 
     def test_initializes_new_connection(self, fake_realtime, fake_consumer, queue):
@@ -71,9 +69,9 @@ class TestProcessMessages:
 
         fake_consumer.assert_called_once_with(
             connection=fake_realtime.get_connection.return_value,
-            routing_key=mock.ANY,
-            handler=mock.ANY,
-            statsd_client=mock.ANY,
+            routing_key=Any(),
+            handler=Any(),
+            statsd_client=Any(),
         )
 
     def test_runs_consumer(self, fake_consumer, queue):

--- a/tests/h/streamer/streamer_test.py
+++ b/tests/h/streamer/streamer_test.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+from h_matchers import Any
 
 from h.streamer import messages, streamer, websocket
 
@@ -15,7 +16,7 @@ def test_process_work_queue_sends_realtime_messages_to_messages_handle_message(s
     streamer.process_work_queue(settings, queue, session_factory=lambda _: session)
 
     messages.handle_message.assert_called_once_with(
-        message, settings, session, topic_handlers=mock.ANY
+        message, settings, session, topic_handlers=Any()
     )
 
 
@@ -34,7 +35,7 @@ def test_process_work_queue_uses_appropriate_topic_handlers_for_realtime_message
     }
 
     messages.handle_message.assert_called_once_with(
-        mock.ANY, settings, session, topic_handlers=topic_handlers
+        Any(), settings, session, topic_handlers=topic_handlers
     )
 
 

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 from gevent.queue import Queue
+from h_matchers import Any
 from jsonschema import ValidationError
 from pyramid import security
 
@@ -253,15 +254,13 @@ class TestHandleClientIDMessage:
 
         assert socket.client_id == "abcd1234"
 
-    def test_missing_value_error(self, matchers, socket):
+    def test_missing_value_error(self, socket):
         message = websocket.Message(socket=socket, payload={"messageType": "client_id"})
 
         with mock.patch.object(websocket.Message, "reply") as mock_reply:
             websocket.handle_client_id_message(message)
 
-        mock_reply.assert_called_once_with(
-            matchers.MappingContaining("error"), ok=False
-        )
+        mock_reply.assert_called_once_with(Any.dict.containing(["error"]), ok=False)
 
     @pytest.fixture
     def socket(self):
@@ -352,18 +351,16 @@ class TestHandleFilterMessage:
 
         expand_uri.assert_called_once_with(session, "http://example.com")
 
-    def test_missing_filter_error(self, matchers, socket):
+    def test_missing_filter_error(self, socket):
         message = websocket.Message(socket=socket, payload={"type": "filter"})
 
         with mock.patch.object(websocket.Message, "reply") as mock_reply:
             websocket.handle_filter_message(message)
 
-        mock_reply.assert_called_once_with(
-            matchers.MappingContaining("error"), ok=False
-        )
+        mock_reply.assert_called_once_with(Any.dict.containing(["error"]), ok=False)
 
     @mock.patch("h.streamer.websocket.jsonschema.validate")
-    def test_invalid_filter_error(self, validate, matchers, socket):
+    def test_invalid_filter_error(self, validate, socket):
         message = websocket.Message(
             socket=socket, payload={"type": "filter", "filter": {"wibble": "giraffe"}}
         )
@@ -372,9 +369,7 @@ class TestHandleFilterMessage:
         with mock.patch.object(websocket.Message, "reply") as mock_reply:
             websocket.handle_filter_message(message)
 
-        mock_reply.assert_called_once_with(
-            matchers.MappingContaining("error"), ok=False
-        )
+        mock_reply.assert_called_once_with(Any.dict.containing(["error"]), ok=False)
 
     @pytest.fixture
     def socket(self):
@@ -415,7 +410,7 @@ class TestHandleWhoamiMessage:
 
 
 class TestUnknownMessage:
-    def test_error(self, matchers):
+    def test_error(self):
         message = websocket.Message(
             socket=mock.sentinel.socket, payload={"type": "wibble"}
         )
@@ -423,6 +418,4 @@ class TestUnknownMessage:
         with mock.patch.object(websocket.Message, "reply") as mock_reply:
             websocket.handle_unknown_message(message)
 
-        mock_reply.assert_called_once_with(
-            matchers.MappingContaining("error"), ok=False
-        )
+        mock_reply.assert_called_once_with(Any.dict.containing(["error"]), ok=False)

--- a/tests/h/util/document_claims_test.py
+++ b/tests/h/util/document_claims_test.py
@@ -3,6 +3,7 @@
 import re
 
 import pytest
+from h_matchers import Any
 
 from h.util import document_claims
 from h.util.document_claims import doi_uri_from_string
@@ -702,7 +703,6 @@ class TestDocumentURIsFromData:
         document_uris_from_highwire_doi,
         document_uris_from_dc,
         document_uri_self_claim,
-        matchers,
     ):
         document_uris_from_links.return_value = [
             {"uri": " from_link_1"},
@@ -729,22 +729,25 @@ class TestDocumentURIsFromData:
             {}, "http://example.com/claimant"
         )
 
-        assert document_uris == matchers.UnorderedList(
-            [
-                {"uri": "from_link_1"},
-                {"uri": "from_link_2"},
-                {"uri": "from_link_3"},
-                {"uri": "highwire_1"},
-                {"uri": "highwire_2"},
-                {"uri": "highwire_3"},
-                {"uri": "doi_1"},
-                {"uri": "doi_2"},
-                {"uri": "doi_3"},
-                {"uri": "dc_1"},
-                {"uri": "dc_2"},
-                {"uri": "dc_3"},
-                document_uri_self_claim.return_value,
-            ]
+        assert (
+            document_uris
+            == Any.list.containing(
+                [
+                    {"uri": "from_link_1"},
+                    {"uri": "from_link_2"},
+                    {"uri": "from_link_3"},
+                    {"uri": "highwire_1"},
+                    {"uri": "highwire_2"},
+                    {"uri": "highwire_3"},
+                    {"uri": "doi_1"},
+                    {"uri": "doi_2"},
+                    {"uri": "doi_3"},
+                    {"uri": "dc_1"},
+                    {"uri": "dc_2"},
+                    {"uri": "dc_3"},
+                    document_uri_self_claim.return_value,
+                ]
+            ).only()
         )
 
     def test_it_strips_whitespace_from_self_claim_uris(

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -3,6 +3,7 @@ import datetime
 from unittest import mock
 
 import pytest
+from h_matchers import Any
 from pyramid import httpexceptions
 from webob.multidict import MultiDict
 
@@ -64,7 +65,7 @@ class TestSearchController:
 
         controller.search()
 
-        paginate.assert_called_once_with(pyramid_request, mock.ANY, page_size=100)
+        paginate.assert_called_once_with(pyramid_request, Any(), page_size=100)
 
     def test_search_generates_tag_links(self, controller):
         result = controller.search()

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -31,7 +31,7 @@ class TestIndex:
     def test_it_paginates_results(self, pyramid_request, routes, paginate):
         groups.groups_index(None, pyramid_request)
 
-        paginate.assert_called_once_with(pyramid_request, mock.ANY, mock.ANY)
+        paginate.assert_called_once_with(pyramid_request, Any(), Any())
 
     def test_it_filters_groups_with_name_param(self, pyramid_request, group_svc):
         pyramid_request.params["q"] = "fingers"

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+from h_matchers import Any
 
 from h.models import Organization
 from h.services.annotation_delete import AnnotationDeleteService
@@ -66,14 +67,14 @@ class TestGroupCreateView:
         assert call_kwargs["organizations"] == {default_org.pubid: default_org}
 
     def test_post_handles_form_submission(
-        self, pyramid_request, handle_form_submission, matchers
+        self, pyramid_request, handle_form_submission
     ):
         view = GroupCreateViews(pyramid_request)
 
         view.post()
 
         handle_form_submission.assert_called_once_with(
-            view.request, view.form, matchers.AnyCallable(), view._template_context
+            view.request, view.form, Any.function(), view._template_context
         )
 
     def test_post_redirects_to_list_view_on_success(

--- a/tests/h/views/admin/oauthclients_test.py
+++ b/tests/h/views/admin/oauthclients_test.py
@@ -188,7 +188,7 @@ class TestAuthClientEditController:
         assert authclient.secret == old_secret
         assert ctx["form"] == self._expected_form(authclient)
 
-    def test_delete_removes_authclient(self, authclient, matchers, pyramid_request):
+    def test_delete_removes_authclient(self, authclient, pyramid_request):
         pyramid_request.db.delete = create_autospec(
             pyramid_request.db.delete, return_value=None
         )

--- a/tests/h/views/admin/organizations_test.py
+++ b/tests/h/views/admin/organizations_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from h_matchers import Any
 
 from h.models import Organization
 from h.views.admin.organizations import (
@@ -161,9 +162,7 @@ class TestOrganizationEditController:
         list_url = pyramid_request.route_path("admin.organizations")
         assert response == matchers.Redirect302To(list_url)
 
-    def test_delete_fails_if_org_has_groups(
-        self, factories, matchers, org, pyramid_request
-    ):
+    def test_delete_fails_if_org_has_groups(self, factories, org, pyramid_request):
         factories.Group(name="Test", organization=org)
         ctrl = OrganizationEditController(org, pyramid_request)
 
@@ -172,7 +171,7 @@ class TestOrganizationEditController:
         assert org not in pyramid_request.db.deleted
         assert pyramid_request.response.status_int == 400
         pyramid_request.session.flash.assert_called_with(
-            matchers.Regex(".*Cannot delete.*1 groups"), "error"
+            Any.string.matching(".*Cannot delete.*1 groups"), "error"
         )
         assert ctx["form"] == self._expected_form(org)
 

--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+from h_matchers import Any
 from pyramid import httpexceptions
 from webob.multidict import MultiDict
 
@@ -55,9 +56,7 @@ def test_badge_returns_0_if_blocked(
 
     result = badge(pyramid_request)
 
-    models.Blocklist.is_blocked.assert_called_with(
-        mock.ANY, "http://blocked-domain.com"
-    )
+    models.Blocklist.is_blocked.assert_called_with(Any(), "http://blocked-domain.com")
     assert not search_run.called
     assert result == {"total": 0}
 

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import deform
 import pytest
+from h_matchers import Any
 from pyramid.httpexceptions import HTTPMovedPermanently
 
 from h.models import Group, User
@@ -22,15 +23,12 @@ class TestGroupCreateController:
         assert result == {"form": "valid form"}
 
     def test_post_calls_handle_form_submission(
-        self, controller, handle_form_submission, matchers
+        self, controller, handle_form_submission
     ):
         controller.post()
 
         handle_form_submission.assert_called_once_with(
-            controller.request,
-            controller.form,
-            matchers.AnyCallable(),
-            matchers.AnyCallable(),
+            controller.request, controller.form, Any.callable(), Any.callable(),
         )
 
     def test_post_returns_handle_form_submission(

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -28,7 +28,7 @@ class TestGroupCreateController:
         controller.post()
 
         handle_form_submission.assert_called_once_with(
-            controller.request, controller.form, Any.callable(), Any.callable(),
+            controller.request, controller.form, Any.function(), Any.function(),
         )
 
     def test_post_returns_handle_form_submission(


### PR DESCRIPTION
Hopefully this will reduce redundancy and increase accuracy, as the `h-matchers` library covers more edge cases when comparing lists in particular.

This cannot be completed until the merge request https://github.com/hypothesis/h-matchers/pull/8 in `h_matchers` is done, and we have a new release containing it. At that point the requirements will need to be updated.