### PR TITLE
Add information on how to add a user

### DIFF
--- a/docs/developing/administration.rst
+++ b/docs/developing/administration.rst
@@ -13,6 +13,14 @@ For example, to make the user 'joe' an admin in the development environment:
 .. code-block:: bash
 
   tox -e py36-dev -- sh bin/hypothesis --dev user admin joe
+  
+Given an enivornment where there is no capability to verify a user's email
+address, a user can be created by running the following command and 
+providing input to the prompts:
+
+.. code-block:: bash
+
+  tox -e py36-dev -- sh bin/hypothesis --app-url="http://localhost:5000" --dev user add
 
 When this user signs in they can now access the adminstration panel at
 ``/admin``. The administration panel has options for managing users and optional


### PR DESCRIPTION
When an email server is not available, add info on how to add a user.