### PR TITLE
Remove Python 3 standard library backports

### DIFF
--- a/h/util/db.py
+++ b/h/util/db.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
-try:
-    from functools import lru_cache
-except ImportError:
-    from backports.functools_lru_cache import lru_cache
+from functools import lru_cache
 
 import sqlalchemy
 

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,6 @@ click
 deform
 elasticsearch==6.4.0
 elasticsearch-dsl==6.3.1
-enum34
 gevent >= 1.3.5  # TODO: Update to gevent 1.3.6 when released, then remove `greenlet`.
 greenlet==0.4.15  # Pinned dependency of gevent. See https://git.io/fN8Wf
 gunicorn >= 19.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@
 #
 alembic==1.3.0
 amqp==2.5.2               # via kombu
-backports.functools-lru-cache==1.2.1
 bcrypt==3.1.3
 billiard==3.6.1.0         # via celery
 bleach==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ colander==1.7.0           # via deform
 deform==2.0.7
 elasticsearch-dsl==6.3.1
 elasticsearch==6.4.0
-enum34==1.1.6
 gevent==1.3.5
 greenlet==0.4.15
 gunicorn==19.9.0


### PR DESCRIPTION
Remove dependencies (enum34, backports.functools-lru-cache) which are backports of features from the Python 3 standard library.

These are obsolete as we now only run on Python 3.6+.