### PR TITLE
Using a custom error to trigger 400 bad request for bad userid's

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -282,7 +282,7 @@ class AuthClientPolicy:
         user_service = request.find_service(name="user")
         try:
             user = user_service.fetch(forwarded_userid)
-        except InvalidUserId:  # raised if userid is invalid format
+        except InvalidUserId:  # raised if userid is invalidly formatted
             return None  # invalid user, so we are failing here
 
         if user and user.authority == client.authority:

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -9,9 +9,10 @@ from pyramid.security import Authenticated
 from zope import interface
 
 from h.auth import util
-
 #: List of route name-method combinations that should
 #: allow AuthClient authentication
+from h.exceptions import InvalidUserId
+
 AUTH_CLIENT_API_WHITELIST = [
     ("api.groups", "POST"),
     ("api.group", "PATCH"),
@@ -281,7 +282,7 @@ class AuthClientPolicy:
         user_service = request.find_service(name="user")
         try:
             user = user_service.fetch(forwarded_userid)
-        except ValueError:  # raised if userid is invalid format
+        except InvalidUserId:  # raised if userid is invalid format
             return None  # invalid user, so we are failing here
 
         if user and user.authority == client.authority:

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -9,10 +9,10 @@ from pyramid.security import Authenticated
 from zope import interface
 
 from h.auth import util
-#: List of route name-method combinations that should
-#: allow AuthClient authentication
 from h.exceptions import InvalidUserId
 
+#: List of route name-method combinations that should
+#: allow AuthClient authentication
 AUTH_CLIENT_API_WHITELIST = [
     ("api.groups", "POST"),
     ("api.group", "PATCH"),

--- a/h/exceptions.py
+++ b/h/exceptions.py
@@ -1,3 +1,5 @@
 class InvalidUserId(Exception):
+    """The userid does not meet the expected pattern."""
+
     def __init__(self, user_id):
         super().__init__(f"User id '{user_id}' is not valid")

--- a/h/exceptions.py
+++ b/h/exceptions.py
@@ -1,0 +1,3 @@
+class InvalidUserId(Exception):
+    def __init__(self, user_id):
+        super().__init__(f"User id '{user_id}' is not valid")

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import Comparator, hybrid_property
 
 from h.db import Base
+from h.exceptions import InvalidUserId
 from h.util.user import split_user
 
 USERNAME_MIN_LENGTH = 3
@@ -98,7 +99,7 @@ class UserIDComparator(Comparator):
         if isinstance(other, str):
             try:
                 val = split_user(other)
-            except ValueError:
+            except InvalidUserId:
                 # The value being compared isn't a valid userid
                 return False
             else:
@@ -110,7 +111,7 @@ class UserIDComparator(Comparator):
         for userid in userids:
             try:
                 val = split_user(userid)
-            except ValueError:
+            except InvalidUserId:
                 continue
 
             other = sa.tuple_(_normalise_username(val["username"]), val["domain"])

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -49,7 +49,7 @@ class UserService:
           user_service.fetch('foo', 'example.com')
 
         :returns: a user instance, if found
-        :raises InvalidUserId: If the username cannot be parsed
+        :raises InvalidUserId: If the userid cannot be parsed
         :rtype: h.models.User or None
 
         """

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -49,6 +49,7 @@ class UserService:
           user_service.fetch('foo', 'example.com')
 
         :returns: a user instance, if found
+        :raises InvalidUserId: If the username cannot be parsed
         :rtype: h.models.User or None
 
         """

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -288,8 +288,8 @@ class UserUserIDRoot:
         try:
             user = self.user_svc.fetch(userid)
         except InvalidUserId as e:
-            # In this context we failed because the user provided a bad id
-            # We need to tell them that so they can attempt to resolve it
+            # In this context we failed because the user provided a userid
+            # we cannot parse, not because it could not be found
             raise HTTPBadRequest(e.args[0]) from e
 
         if not user:

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -63,11 +63,13 @@ shouldn't return model objects directly).
 
 import sqlalchemy.exc
 import sqlalchemy.orm.exc
+from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.security import ALL_PERMISSIONS, DENY_ALL, Allow, Authenticated
 
 from h import storage
 from h.auth import role
 from h.auth.util import client_authority
+from h.exceptions import InvalidUserId
 from h.interfaces import IGroupService
 from h.models import AuthClient, Organization
 from h.traversal import contexts
@@ -283,7 +285,12 @@ class UserUserIDRoot:
         self.user_svc = self.request.find_service(name="user")
 
     def __getitem__(self, userid):
-        user = self.user_svc.fetch(userid)
+        try:
+            user = self.user_svc.fetch(userid)
+        except InvalidUserId as e:
+            # In this context we failed because the user provided a bad id
+            # We need to tell them that so they can attempt to resolve it
+            raise HTTPBadRequest(e.args[0]) from e
 
         if not user:
             raise KeyError()

--- a/h/util/user.py
+++ b/h/util/user.py
@@ -2,6 +2,8 @@
 """Some shared utility functions for manipulating user data."""
 import re
 
+from h.exceptions import InvalidUserId
+
 
 def split_user(userid):
     """Return the user and domain parts from the given user id as a dict.
@@ -9,10 +11,10 @@ def split_user(userid):
     For example if userid is u'acct:seanh@hypothes.is' then return
     {'username': u'seanh', 'domain': u'hypothes.is'}'
 
-    :raises ValueError: if the given userid isn't a valid userid
+    :raises InvalidUserId: if the given userid isn't a valid userid
 
     """
     match = re.match(r"^acct:([^@]+)@(.*)$", userid)
     if match:
         return {"username": match.groups()[0], "domain": match.groups()[1]}
-    raise ValueError("{userid} isn't a valid userid".format(userid=userid))
+    raise InvalidUserId(userid)

--- a/h/views/main.py
+++ b/h/views/main.py
@@ -11,6 +11,7 @@ import logging
 from pyramid import httpexceptions, response
 from pyramid.view import view_config
 
+from h.exceptions import InvalidUserId
 from h.util.user import split_user
 from h.views.client import sidebar_app
 
@@ -107,7 +108,7 @@ def stream_user_redirect(request):
     if user.startswith("acct:"):
         try:
             user = split_user(user)["username"]
-        except ValueError:
+        except InvalidUserId:
             # If it's not a valid userid, catch the exception and just treat
             # the parameter as a literal username.
             pass

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -14,6 +14,7 @@ from h.auth.policy import (
     AuthenticationPolicy,
     TokenAuthenticationPolicy,
 )
+from h.exceptions import InvalidUserId
 from h.services.user import UserService
 
 API_PATHS = ("/api", "/api/foo", "/api/annotations/abc123")
@@ -555,6 +556,18 @@ class TestAuthClientAuthenticationPolicy:
 
         principals = AuthClientPolicy.check(
             "someusername", "somepassword", pyramid_request
+        )
+
+        assert principals is None
+
+    def test_check_returns_None_if_username_is_invalid(
+        self, pyramid_request, verify_auth_client, user_service
+    ):
+        user_service.fetch.side_effect = InvalidUserId("badly_formatted")
+        pyramid_request.headers["X-Forwarded-User"] = "badly_formatted"
+
+        principals = AuthClientPolicy.check(
+            mock.sentinel.username, mock.sentinel.password, pyramid_request
         )
 
         assert principals is None

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -596,7 +596,7 @@ class TestAuthClientAuthenticationPolicy:
 
         user_service.fetch.assert_called_once_with("acct:flop@woebang.baz")
 
-    def test_check_returns_None_if_username_is_invalid(
+    def test_check_returns_None_if_userid_is_invalid(
         self, pyramid_request, verify_auth_client, user_service
     ):
         pyramid_request.headers["X-Forwarded-User"] = "badly_formatted"

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -560,18 +560,6 @@ class TestAuthClientAuthenticationPolicy:
 
         assert principals is None
 
-    def test_check_returns_None_if_username_is_invalid(
-        self, pyramid_request, verify_auth_client, user_service
-    ):
-        user_service.fetch.side_effect = InvalidUserId("badly_formatted")
-        pyramid_request.headers["X-Forwarded-User"] = "badly_formatted"
-
-        principals = AuthClientPolicy.check(
-            mock.sentinel.username, mock.sentinel.password, pyramid_request
-        )
-
-        assert principals is None
-
     def test_check_proxies_to_principals_for_auth_client_if_no_forwarded_user(
         self, pyramid_request, verify_auth_client, principals_for_auth_client
     ):
@@ -608,15 +596,14 @@ class TestAuthClientAuthenticationPolicy:
 
         user_service.fetch.assert_called_once_with("acct:flop@woebang.baz")
 
-    def test_check_returns_None_if_user_fetch_raises_valueError(
+    def test_check_returns_None_if_username_is_invalid(
         self, pyramid_request, verify_auth_client, user_service
     ):
-
-        pyramid_request.headers["X-Forwarded-User"] = "flop@woebang.baz"
-        user_service.fetch.side_effect = ValueError("whoops")
+        pyramid_request.headers["X-Forwarded-User"] = "badly_formatted"
+        user_service.fetch.side_effect = InvalidUserId("badly_formatted")
 
         principals = AuthClientPolicy.check(
-            "someusername", "somepassword", pyramid_request
+            mock.sentinel.username, mock.sentinel.password, pyramid_request
         )
 
         assert principals is None

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -126,7 +126,7 @@ class TestUserModelUserId:
         assert result == fred
 
     def test_userid_equals_query_with_invalid_userid(self, db_session):
-        # This is to ensure that we don't expose the ValueError that could
+        # This is to ensure that we don't expose the InvalidUserId that could
         # potentially be thrown by split_user.
 
         result = (
@@ -166,7 +166,7 @@ class TestUserModelUserId:
         assert alice in result
 
     def test_userid_in_query_with_invalid_userid_mixed_in(self, db_session):
-        # This is to ensure that we don't expose the ValueError that could
+        # This is to ensure that we don't expose the InvalidUserId that could
         # potentially be thrown by split_user.
 
         fred = models.User(
@@ -185,7 +185,7 @@ class TestUserModelUserId:
         assert fred in result
 
     def test_userid_in_query_with_only_invalid_userid(self, db_session):
-        # This is to ensure that we don't expose the ValueError that could
+        # This is to ensure that we don't expose the InvalidUserId that could
         # potentially be thrown by split_user.
 
         result = (

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -511,7 +511,7 @@ class TestUserUserIDRoot:
 
         user_service.fetch.assert_called_once_with("acct:bob@example.com")
 
-    def test_it_fails_with_bad_request_with_invalid_ids(
+    def test_it_fails_with_bad_request_if_the_userid_is_invalid(
         self, pyramid_request, user_userid_root, user_service
     ):
         user_service.fetch.side_effect = InvalidUserId("dummy id")

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -5,9 +5,11 @@ from unittest import mock
 import pyramid.authorization
 import pyramid.security
 import pytest
+from pyramid.httpexceptions import HTTPBadRequest
 
 import h.auth
 from h.auth import role
+from h.exceptions import InvalidUserId
 from h.models import AuthClient
 from h.services.group import GroupService
 from h.services.user import UserService
@@ -508,6 +510,14 @@ class TestUserUserIDRoot:
         user_userid_root["acct:bob@example.com"]
 
         user_service.fetch.assert_called_once_with("acct:bob@example.com")
+
+    def test_it_fails_with_bad_request_with_invalid_ids(
+        self, pyramid_request, user_userid_root, user_service
+    ):
+        user_service.fetch.side_effect = InvalidUserId("dummy id")
+
+        with pytest.raises(HTTPBadRequest):
+            user_userid_root["total_nonsense"]
 
     def test_it_raises_KeyError_if_the_user_does_not_exist(
         self, user_userid_root, user_service

--- a/tests/h/util/user_test.py
+++ b/tests/h/util/user_test.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from h.exceptions import InvalidUserId
 from h.util import user as user_util
 
 
@@ -11,5 +12,5 @@ def test_split_user():
 
 
 def test_split_user_no_match():
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidUserId):
         user_util.split_user("donkeys")


### PR DESCRIPTION
 * This only applies to retreiving users via `/api/users/`
 * We still want to crash with 500 in other cases
 * At least now you stand a chance of catching it!

# What's changed?

 * Instead of using `ValueError` when a user id cannot be parsed we now raise a custom error `InvalidUserId`.
 * We can then more selectively choose what to do in that case
 * In the case of getting a user (via `/api/users/{userid}`) we now return HTTP status `400` to tell the user the format of their request will never work with any value (the structure is wrong, not the content)

# Steps to reproduce

With services running and `make dev` going, switch between branches to see the old and new behavior:

## Previous behavior (master):

 * Go to: http://127.0.0.1:5000/api/users/broken
 * The response has HTTP status `500`
 * You see a big HTML failure page

 ## Happy path! (master/user-id-error):
 * Go to: http://127.0.0.1:5000/api/users/acct:blah@blah.com
 * The response has HTTP status `404`
 * Return body is JSON containing:
```
Status: 404
{
"status": "failure",
"reason": "Either the resource you requested doesn't exist, or you are not currently authorized to see it."
}
```

 ## Sad path! (user-id-error):

 * Go to: http://127.0.0.1:5000/api/users/broken
 * The response has HTTP status `400`
 * Return body is JSON containing:
```
{
"status": "failure",
"reason": "User id 'broken' is not valid"
}
```
