### PR TITLE
Fix build issues with Venusian

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@
 #
 alembic==1.3.0
 amqp==2.5.2               # via kombu
+backports.functools-lru-cache==1.6.1
 bcrypt==3.1.3
 billiard==3.6.1.0         # via celery
 bleach==3.1.0
@@ -68,7 +69,7 @@ text-unidecode==1.3       # via python-slugify
 transaction==2.4.0
 translationstring==1.3    # via colander, deform, pyramid
 urllib3==1.25.6           # via elasticsearch, sentry-sdk
-venusian==2.0.0
+venusian==3.0.0
 vine==1.3.0               # via amqp, celery
 webencodings==0.5.1       # via bleach
 webob==1.8.5              # via pyramid


### PR DESCRIPTION
Venusian has retracted a version on PyPI, stuffing our build. `2.0.0` is listed in our `requirements.txt` but was retracted:

https://pypi.org/project/venusian/#description

> ## 3.0.0 (2019-10-04)
> 
> This release matches 2.0.0 other than in the version number. This fixes an issue with Requires-Python metadata not being uploaded correctly to PyPi.
> 
> This version is only compatible with Python 3.5+

Interestingly they fixed the `imp` warning, which means we may be able to strip that out of some of our `pytest` config. `h` doesn't mention it, but I'm sure others do.