### PR TITLE
Bumping oauthlib from 2.0.2 to 2.0.3 to try and fix compatibility issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ markupsafe==1.1.1         # via jinja2, mako, pyramid-jinja2
 mistune==0.8.4
 more-itertools==7.2.0     # via zipp
 newrelic==5.2.3.131
-oauthlib==2.0.2
+oauthlib==2.0.3
 passlib==1.7.1
 pastedeploy==2.0.1        # via plaster-pastedeploy
 peppercorn==0.6           # via deform

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -256,7 +256,7 @@ class TestFindToken:
         assert token.value == token.value
 
     def test_it_returns_None_when_token_is_missing(self, svc, token):
-        result = svc.find_token('missing-value')
+        result = svc.find_token("missing-value")
 
         assert result is None
 

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -95,14 +95,23 @@ class TestClientAuthenticationRequired:
         assert svc.client_authentication_required(oauth_request) is False
 
     def test_returns_false_for_refresh_token_with_jwt_client(
-        self, svc, oauth_request, factories
+        self, svc, oauth_request, factories, client
     ):
-        client = factories.ConfidentialAuthClient(
-            grant_type=AuthClientGrantType.jwt_bearer
-        )
         oauth_request.client_id = client.id
         oauth_request.grant_type = "refresh_token"
         assert svc.client_authentication_required(oauth_request) is False
+
+    def test_returns_false_for_revoke_token(self, svc, oauth_request, client):
+        oauth_request.client_id = client.id
+        oauth_request.h_revoke_request = True
+
+        assert svc.client_authentication_required(oauth_request) is False
+
+    @pytest.fixture
+    def client(self, factories):
+        return factories.ConfidentialAuthClient(
+            grant_type=AuthClientGrantType.jwt_bearer
+        )
 
     @pytest.fixture
     def oauth_request(self):

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -244,6 +244,27 @@ class TestInvalidateAuthorizationCode:
         assert db_session.query(models.AuthzCode).get(keep_code.id) is not None
 
 
+class TestFindToken:
+    def test_it_can_get_token_by_refresh_value(self, svc, token):
+        token = svc.find_token(token.refresh_token)
+
+        assert token.refresh_token == token.refresh_token
+
+    def test_it_can_get_token_by_value(self, svc, token):
+        token = svc.find_token(token.value)
+
+        assert token.value == token.value
+
+    def test_it_returns_None_when_token_is_missing(self, svc, token):
+        result = svc.find_token('missing-value')
+
+        assert result is None
+
+    @pytest.fixture
+    def token(self, factories):
+        return factories.OAuth2Token()
+
+
 class TestInvalidateRefreshToken:
     def test_it_shortens_refresh_token_expires(self, svc, oauth_request, token, utcnow):
         utcnow.return_value = datetime.datetime(2017, 8, 2, 18, 36, 53)


### PR DESCRIPTION
`oauthlib` has changed the way the token revocation works in this commit:

 * https://github.com/oauthlib/oauthlib/commit/bf2f9dbff3e04addd16ad825e6dae30537677afc

Previously we could specify that an end-point did not require client authentication and it would be skipped, now the code requires client_id authentication.

## Behavior

The previous behavior was:

 * You can revoke any token you know of without authentication
 * ~This seems wrong, as you can drop other peoples tokens~
 * ~This could conceivably be used to create a denial of service attack on a particular user if the attacker gained access to the access token in some way~
 * ~I don't think this is very likely as it would only effect a single user, and only as long as it takes them to log back in unless the attacker has regular access to their HTTP traffic (in which case you've got bigger issues)~

This is kind of nonsense. If the caller is revoking the access token, then asking them to provide it in the Bearer token doesn't add anything. If they have the refresh token, they can use that to get the access token and we're back to square one. Basically if they have either they are indistinguishable from the real user.

The two possible future behaviors are:

 * We still don't require authentication of any kind (and bodge the check somehow)
 * ~We do require it (as per the spec https://tools.ietf.org/html/rfc7009#section-2.1) and make this work somehow~

## What's the fix?

The fix that has been implemented is:

 * Override `validate_revocation_request()` in `OAuthProviderService`
  * This reads the token and sets the `client_id` on the request
 * This also sets a flag to let `OAuthValidatorService` know that we should use client id auth not client auth
