### PR TITLE
Upgrade Jenkins CI to Postgres 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       language: python
       python: '3.6'
       addons:
+        # TODO - Switch to Postgres 11 once we have rolled out PG 11 in production.
         postgresql: "9.4"
       before_install:
         - ./scripts/elasticsearch.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node {
     stage('test') {
         hostIp = sh(script: 'facter ipaddress_eth0', returnStdout: true).trim()
 
-        postgres = docker.image('postgres:9.4').run('-P -e POSTGRES_DB=htest')
+        postgres = docker.image('postgres:11.5').run('-P -e POSTGRES_DB=htest')
         databaseUrl = "postgresql://postgres@${hostIp}:${containerPort(postgres, 5432)}/htest"
 
         elasticsearch = docker.image('hypothesis/elasticsearch').run('-P -e "discovery.type=single-node"')


### PR DESCRIPTION
In preparation for switching our production RDS database to Postgres 11,
change Jenkins CI to run unit and functional tests in PG 11.

Travis stays at PG 9.4 so that we're continuing to run at least unit
tests in a PG 9.4 environment until the PG 11 change has been fully
rolled out.