### PR TITLE
Remove codecov and add a coverage minimum value

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,3 +10,5 @@ omit =
 
 [report]
 show_missing = True
+precision = 2
+fail_under = 96.32

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       before_script: createdb htest
       script: tox
       after_success:
-        make coverage codecov
+        make coverage
 
     # Test web application frontend
     - env: ACTION=gulp

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ help:
 	@echo "make checkformatting   Crash if the code isn't correctly formatted"
 	@echo "make test              Run the unit tests"
 	@echo "make coverage          Print the unit test coverage report"
-	@echo "make codecov           Upload the coverage report to codecov.io"
 	@echo "make functests         Run the functional tests"
 	@echo "make docs              Build docs website and serve it locally"
 	@echo "make checkdocs         Crash if building the docs website fails"
@@ -88,10 +87,6 @@ test: node_modules/.uptodate python
 .PHONY: coverage
 coverage: python
 	tox -q -e py36-coverage
-
-.PHONY: codecov
-codecov: python
-	tox -q -e py36-codecov
 
 .PHONY: functests
 functests: build/manifest.json python

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,6 @@ h
 .. image:: https://travis-ci.org/hypothesis/h.svg?branch=master
    :target: https://travis-ci.org/hypothesis/h
    :alt: Build Status
-.. image:: https://codecov.io/github/hypothesis/h/coverage.svg?branch=master
-   :target: https://codecov.io/github/hypothesis/h?branch=master
-   :alt: Code Coverage
 .. image:: https://img.shields.io/badge/IRC-%23hypothes.is-blue.svg
    :target: `#hypothes.is`_
    :alt: #hypothes.is IRC channel

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,6 @@ passenv =
     {tests,functests}: ELASTICSEARCH_URL
     {tests,functests}: PYTEST_ADDOPTS
     functests: BROKER_URL
-    codecov: CI TRAVIS*
 setenv = dev: PYTHONPATH = .
 deps =
     tests: coverage
@@ -81,7 +80,6 @@ deps =
     {format,checkformatting}: black
     {format,checkformatting}: isort
     coverage: coverage
-    codecov: codecov
     {functests,docstrings,checkdocstrings,analyze}: webtest
     {docs,docstrings}: sphinx-autobuild
     {docs,checkdocs,docstrings,checkdocstrings}: sphinx
@@ -117,6 +115,5 @@ commands =
     checkdocstrings: sphinx-build -qTn -b dirhtml {envdir}/rst {envdir}/dirhtml
     coverage: -coverage combine
     coverage: coverage report --show-missing
-    codecov: codecov
     docker-compose: docker-compose {posargs}
     pip-compile: pip-compile {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -114,6 +114,6 @@ commands =
     docstrings: sphinx-autobuild -BqT -z h -z tests -b dirhtml {envdir}/rst {envdir}/dirhtml
     checkdocstrings: sphinx-build -qTn -b dirhtml {envdir}/rst {envdir}/dirhtml
     coverage: -coverage combine
-    coverage: coverage report --show-missing
+    coverage: coverage report
     docker-compose: docker-compose {posargs}
     pip-compile: pip-compile {posargs}


### PR DESCRIPTION
Much like we did in LMS, removing the optional information of Codecov for a hard limit which must be met to pass the build.