### PR TITLE
Add port localhost:8001 to h.client_rpc_allowed_origins in dev

### DIFF
--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -11,7 +11,7 @@ pyramid.reload_templates: True
 
 h.authority: localhost
 h.bouncer_url: http://localhost:8000
-h.client_rpc_allowed_origins: http://localhost
+h.client_rpc_allowed_origins: http://localhost:8001
 h.client_url: {current_scheme}://{current_host}:3001/hypothesis
 h.websocket_url: ws://localhost:5001/ws
 


### PR DESCRIPTION
This allows the sidebar to accept requests from the LMS app on 8001

**One point of confusion I have:** I did notice that the env var `CLIENT_RPC_ALLOWED_ORIGINS ` can take a space-separated list which gets formatted into an array, but I'm not sure how to set the `client_rpc_allowed_origins` as an array for local development? Or maybe it can translate into one?

This is local dev (using development-app.ini)
![Screen Shot 2019-11-22 at 10 25 35 AM](https://user-images.githubusercontent.com/3939074/69450739-b24a2f00-0d12-11ea-868c-4bae58a97fc2.png)

This is on QA using the space separated `CLIENT_RPC_ALLOWED_ORIGINS`
![Screen Shot 2019-11-22 at 10 26 42 AM](https://user-images.githubusercontent.com/3939074/69450777-c9891c80-0d12-11ea-91e5-ab73181df924.png)


The client sidebar can deal with both versions (array or space separated string), but I think we should be more strict with the type as this can confusing and ideally just have it be an array.
