### PR TITLE
Ensure that OAuthValidatorService.get_default_redirect_uri() returns a URL

### DIFF
--- a/h/services/oauth_validator.py
+++ b/h/services/oauth_validator.py
@@ -10,7 +10,7 @@ from h import models
 from h.models.auth_client import GrantType as AuthClientGrantType
 from h.services.oauth_provider import ACCESS_TOKEN_PREFIX, REFRESH_TOKEN_PREFIX
 from h.util.db import lru_cache_in_transaction
-from h.util.uri import render_uri_template
+from h.util.uri import render_url_template
 
 AUTHZ_CODE_TTL = datetime.timedelta(minutes=10)
 DEFAULT_SCOPES = ["annotation:read", "annotation:write"]
@@ -144,7 +144,7 @@ class OAuthValidatorService(RequestValidator):
 
         client = self.find_client(client_id)
         if client is not None:
-            return render_uri_template(client.redirect_uri, values=request)
+            return render_url_template(client.redirect_uri, example_url=request.uri)
 
     def get_default_scopes(self, client_id, request, *args, **kwargs):
         """Return the default scopes for the provided client."""

--- a/h/services/oauth_validator.py
+++ b/h/services/oauth_validator.py
@@ -10,6 +10,7 @@ from h import models
 from h.models.auth_client import GrantType as AuthClientGrantType
 from h.services.oauth_provider import ACCESS_TOKEN_PREFIX, REFRESH_TOKEN_PREFIX
 from h.util.db import lru_cache_in_transaction
+from h.util.uri import render_uri_template
 
 AUTHZ_CODE_TTL = datetime.timedelta(minutes=10)
 DEFAULT_SCOPES = ["annotation:read", "annotation:write"]
@@ -143,7 +144,7 @@ class OAuthValidatorService(RequestValidator):
 
         client = self.find_client(client_id)
         if client is not None:
-            return client.redirect_uri
+            return render_uri_template(client.redirect_uri, values=request)
 
     def get_default_scopes(self, client_id, request, *args, **kwargs):
         """Return the default scopes for the provided client."""

--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -70,6 +70,7 @@ from urllib.parse import (
     quote_plus,
     unquote,
     unquote_plus,
+    urlparse,
     urlsplit,
 )
 
@@ -293,20 +294,17 @@ def _blacklisted_query_param(s):
     return any(re.match(patt, s) for patt in BLACKLISTED_QUERY_PARAMS)
 
 
-def render_uri_template(template, values):
+def render_url_template(template, example_url):
     """
-    Replace placeholders in a URI from the provided values object.
+    Update a URL template to have the same scheme and host as the example.
 
     This function is primarily used in development to support creating
     absolute links to h or other Hypothesis services which work when h is
     accessed from the same system (where the h dev server is "localhost:<port>")
     or a different device (when the h dev server is "machine-name.local:<port>").
-
-    The ``values`` object must have the following attributes:
-
-     * ``scheme`` - The scheme (e.g. 'http')
-     * ``domain`` - The domain name (e.g. 'example.com')
     """
-    url = template.replace("{current_host}", values.domain)
-    url = url.replace("{current_scheme}", values.scheme)
+    parsed = urlparse(example_url)
+
+    url = template.replace("{current_host}", parsed.hostname)
+    url = url.replace("{current_scheme}", parsed.scheme)
     return url

--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -291,3 +291,22 @@ def _normalize_queryvalue(value):
 def _blacklisted_query_param(s):
     """Return True if the given string matches any BLACKLISTED_QUERY_PARAMS."""
     return any(re.match(patt, s) for patt in BLACKLISTED_QUERY_PARAMS)
+
+
+def render_uri_template(template, values):
+    """
+    Replace placeholders in a URI from the provided values object.
+
+    This function is primarily used in development to support creating
+    absolute links to h or other Hypothesis services which work when h is
+    accessed from the same system (where the h dev server is "localhost:<port>")
+    or a different device (when the h dev server is "machine-name.local:<port>").
+
+    The ``values`` object must have the following attributes:
+
+     * ``scheme`` - The scheme (e.g. 'http')
+     * ``domain`` - The domain name (e.g. 'example.com')
+    """
+    url = template.replace("{current_host}", values.domain)
+    url = url.replace("{current_scheme}", values.scheme)
+    return url

--- a/h/util/view.py
+++ b/h/util/view.py
@@ -25,18 +25,3 @@ def json_view(**settings):
     settings.setdefault("accept", "application/json")
     settings.setdefault("renderer", "json")
     return view_config(**settings)
-
-
-def render_url_template(url_template, request):
-    """
-    Replace placeholders in a URL with elements of the current request's URL.
-
-    This function is primarily used in development to support creating
-    absolute links to h or other Hypothesis services which work when h is
-    accessed from the same system (where the h dev server is "localhost:<port>")
-    or a different device (when the h dev server is "machine-name.local:<port>").
-    """
-    url = url_template
-    url = url.replace("{current_host}", request.domain)
-    url = url.replace("{current_scheme}", request.scheme)
-    return url

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -12,7 +12,6 @@ from pyramid.view import view_config, view_defaults
 from h import models
 from h.services.oauth_validator import DEFAULT_SCOPES
 from h.util.datetime import utc_iso8601
-from h.util.view import render_url_template
 from h.views.api.config import api_config
 from h.views.api.exceptions import OAuthAuthorizeError, OAuthTokenError
 
@@ -164,8 +163,8 @@ class OAuthAuthorizeController:
                 )
             )
 
-    def _render_web_message_response(self, redirect_uri):
-        redirect_uri = render_url_template(redirect_uri, self.request)
+    @classmethod
+    def _render_web_message_response(cls, redirect_uri):
         location = urlparse(redirect_uri)
         params = parse_qs(location.query)
         origin = "{url.scheme}://{url.netloc}".format(url=location)

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -13,8 +13,7 @@ from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 
 from h import __version__
-from h.util.uri import origin
-from h.util.view import render_url_template
+from h.util.uri import origin, render_uri_template
 
 # Default URL for the client, which points to the latest version of the client
 # that was published to npm.
@@ -26,7 +25,7 @@ def _client_url(request):
     Return the configured URL for the client.
     """
     url = request.registry.settings.get("h.client_url", DEFAULT_CLIENT_URL)
-    url = render_url_template(url, request)
+    url = render_uri_template(url, request)
 
     if request.feature("embed_cachebuster"):
         url += "?cachebuster=" + str(int(time.time()))

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -25,7 +25,7 @@ def _client_url(request):
     Return the configured URL for the client.
     """
     url = request.registry.settings.get("h.client_url", DEFAULT_CLIENT_URL)
-    url = render_url_template(url, request.url)
+    url = render_url_template(url, example_url=request.url)
 
     if request.feature("embed_cachebuster"):
         url += "?cachebuster=" + str(int(time.time()))

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -13,7 +13,7 @@ from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 
 from h import __version__
-from h.util.uri import origin, render_uri_template
+from h.util.uri import origin, render_url_template
 
 # Default URL for the client, which points to the latest version of the client
 # that was published to npm.
@@ -25,7 +25,7 @@ def _client_url(request):
     Return the configured URL for the client.
     """
     url = request.registry.settings.get("h.client_url", DEFAULT_CLIENT_URL)
-    url = render_uri_template(url, request)
+    url = render_url_template(url, request.url)
 
     if request.feature("embed_cachebuster"):
         url += "?cachebuster=" + str(int(time.time()))

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -186,8 +186,8 @@ class TestFindRefreshToken:
 
 class TestGetDefaultRedirectUri:
     def test_returns_clients_redirect_uri(self, svc, client, pyramid_request):
-        pyramid_request.domain = 'example.org'
-        pyramid_request.scheme = 'ftps'
+        pyramid_request.domain = "example.org"
+        pyramid_request.scheme = "ftps"
 
         actual = svc.get_default_redirect_uri(client.id, pyramid_request)
 

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -185,11 +185,10 @@ class TestFindRefreshToken:
 
 
 class TestGetDefaultRedirectUri:
-    def test_returns_clients_redirect_uri(self, svc, client, pyramid_request):
-        pyramid_request.domain = "example.org"
-        pyramid_request.scheme = "ftps"
-
-        actual = svc.get_default_redirect_uri(client.id, pyramid_request)
+    def test_returns_clients_redirect_uri(self, svc, client):
+        actual = svc.get_default_redirect_uri(
+            client.id, OAuthRequest("ftps://example.org")
+        )
 
         assert "ftps://example.org/auth/callback" == actual
 

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -185,9 +185,13 @@ class TestFindRefreshToken:
 
 
 class TestGetDefaultRedirectUri:
-    def test_returns_clients_redirect_uri(self, svc, client):
-        actual = svc.get_default_redirect_uri(client.id, None)
-        assert "https://example.org/auth/callback" == actual
+    def test_returns_clients_redirect_uri(self, svc, client, pyramid_request):
+        pyramid_request.domain = 'example.org'
+        pyramid_request.scheme = 'ftps'
+
+        actual = svc.get_default_redirect_uri(client.id, pyramid_request)
+
+        assert "ftps://example.org/auth/callback" == actual
 
     def test_returns_none_when_client_missing(self, svc):
         id_ = str(uuid.uuid1())
@@ -195,7 +199,7 @@ class TestGetDefaultRedirectUri:
 
     @pytest.fixture
     def client(self, factories):
-        redirect_uri = "https://example.org/auth/callback"
+        redirect_uri = "{current_scheme}://{current_host}/auth/callback"
         return factories.AuthClient(redirect_uri=redirect_uri)
 
 

--- a/tests/h/util/uri_test.py
+++ b/tests/h/util/uri_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from unittest.mock import Mock
 
 import pytest
 

--- a/tests/h/util/uri_test.py
+++ b/tests/h/util/uri_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from unittest.mock import Mock
 
 import pytest
 
@@ -178,3 +179,26 @@ def test_normalize_returns_unicode(url, _):
 )
 def test_origin(url_in, url_out):
     assert uri.origin(url_in) == url_out
+
+
+class TestRenderUrlTemplate:
+    @pytest.mark.parametrize(
+        "url_template,scheme,domain,expected",
+        [
+            (
+                "https://hypothes.is/path",
+                "http",
+                "example.com",
+                "https://hypothes.is/path",
+            ),
+            (
+                "{current_scheme}://{current_host}:5000/app.html",
+                "https",
+                "localhost",
+                "https://localhost:5000/app.html",
+            ),
+        ],
+    )
+    def test_replaces_params(self, url_template, scheme, domain, expected):
+        request = Mock(scheme=scheme, domain=domain)
+        assert uri.render_uri_template(url_template, request) == expected

--- a/tests/h/util/uri_test.py
+++ b/tests/h/util/uri_test.py
@@ -183,22 +183,19 @@ def test_origin(url_in, url_out):
 
 class TestRenderUrlTemplate:
     @pytest.mark.parametrize(
-        "url_template,scheme,domain,expected",
+        "url_template,example_url,expected",
         [
             (
                 "https://hypothes.is/path",
-                "http",
-                "example.com",
+                "ftps://example.com",
                 "https://hypothes.is/path",
             ),
             (
                 "{current_scheme}://{current_host}:5000/app.html",
-                "https",
-                "localhost",
-                "https://localhost:5000/app.html",
+                "ftps://example.com",
+                "ftps://example.com:5000/app.html",
             ),
         ],
     )
-    def test_replaces_params(self, url_template, scheme, domain, expected):
-        request = Mock(scheme=scheme, domain=domain)
-        assert uri.render_uri_template(url_template, request) == expected
+    def test_replaces_params(self, url_template, example_url, expected):
+        assert uri.render_url_template(url_template, example_url) == expected

--- a/tests/h/util/view_test.py
+++ b/tests/h/util/view_test.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from h.util.view import handle_exception, json_view, render_url_template
+from h.util.view import handle_exception, json_view
 
 
 @pytest.mark.usefixtures("sys_exc_info")
@@ -74,26 +74,3 @@ class TestJsonView:
         view_config = patch("h.util.view.view_config")
         view_config.side_effect = _return_kwargs
         return view_config
-
-
-class TestRenderUrlTemplate:
-    @pytest.mark.parametrize(
-        "url_template,scheme,domain,expected",
-        [
-            (
-                "https://hypothes.is/path",
-                "http",
-                "example.com",
-                "https://hypothes.is/path",
-            ),
-            (
-                "{current_scheme}://{current_host}:5000/app.html",
-                "https",
-                "localhost",
-                "https://localhost:5000/app.html",
-            ),
-        ],
-    )
-    def test_replaces_params(self, url_template, scheme, domain, expected):
-        request = Mock(scheme=scheme, domain=domain)
-        assert render_url_template(url_template, request) == expected

--- a/tests/h/views/api/auth_test.py
+++ b/tests/h/views/api/auth_test.py
@@ -20,7 +20,7 @@ from h.views.api import auth as views
 from h.views.api.exceptions import OAuthAuthorizeError, OAuthTokenError
 
 
-@pytest.mark.usefixtures("routes", "oauth_provider", "user_svc", "render_url_template")
+@pytest.mark.usefixtures("routes", "oauth_provider", "user_svc")
 class TestOAuthAuthorizeController:
     @pytest.mark.usefixtures("authenticated_user")
     @pytest.mark.parametrize("view_name", ["get", "get_web_message"])
@@ -134,20 +134,6 @@ class TestOAuthAuthorizeController:
             "origin": "http://client.com",
             "state": "foobar",
         }
-
-    @pytest.mark.usefixtures("authenticated_user")
-    def test_get_web_message_supports_redirect_url_templates(
-        self, controller, auth_client, render_url_template
-    ):
-        auth_client.trusted = True
-
-        def render_url(url, request):
-            return url.replace("http://client.com", "https://client-alias.com")
-
-        render_url_template.side_effect = render_url
-        response = controller.get_web_message()
-
-        assert response["origin"] == "https://client-alias.com"
 
     @pytest.mark.usefixtures("authenticated_user")
     def test_get_web_message_allows_empty_state_in_context_for_trusted_clients(
@@ -289,17 +275,6 @@ class TestOAuthAuthorizeController:
     @pytest.fixture
     def routes(self, pyramid_config):
         pyramid_config.add_route("login", "/login")
-
-    @pytest.fixture
-    def render_url_template(self, patch):
-        mock = patch("h.views.api.auth.render_url_template")
-
-        def render(url, request):
-            return url
-
-        mock.side_effect = render
-
-        return mock
 
 
 @pytest.mark.usefixtures("oauth_provider")

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -9,7 +9,7 @@ from h import __version__
 from h.views import client
 
 
-@pytest.mark.usefixtures("routes", "pyramid_settings", "render_url_template")
+@pytest.mark.usefixtures("routes", "pyramid_settings", "render_uri_template")
 class TestSidebarApp:
     def test_it_includes_client_config(self, pyramid_request):
         ctx = client.sidebar_app(pyramid_request)
@@ -43,17 +43,17 @@ class TestSidebarApp:
         )
 
 
-@pytest.mark.usefixtures("routes", "pyramid_settings", "render_url_template")
+@pytest.mark.usefixtures("routes", "pyramid_settings", "render_uri_template")
 class TestEmbedRedirect:
     def test_redirects_to_client_boot_script(
-        self, pyramid_request, render_url_template
+        self, pyramid_request, render_uri_template
     ):
         pyramid_request.feature.flags["embed_cachebuster"] = False
 
         rsp = client.embed_redirect(pyramid_request)
 
         assert isinstance(rsp, HTTPFound)
-        render_url_template.assert_called_with(
+        render_uri_template.assert_called_with(
             "https://cdn.hypothes.is/hypothesis", pyramid_request
         )
         assert rsp.location == "https://cdn.hypothes.is/hypothesis"
@@ -86,8 +86,8 @@ def pyramid_settings(pyramid_settings):
 
 
 @pytest.fixture
-def render_url_template(patch):
-    mock = patch("h.views.client.render_url_template")
+def render_uri_template(patch):
+    mock = patch("h.views.client.render_uri_template")
 
     def render(url, request):
         return url


### PR DESCRIPTION
As of https://github.com/hypothesis/h/pull/5758, we now use a template for the redirect URL. As of https://github.com/hypothesis/h/pull/5794, `oauthlib` checks to see if our redirect URL is a URL (reasonable) and fails.

This PR is to change it so that when we have no redirect URL specified, and we use the default, a real URL is returned.

## Changes

 * `util.view.render_url_template()` is now `util.uri.render_uri_template()`
   * Kept the `uri` in the name as it often floats about in files alone
   * Named `uri` to match the file, although everything in the file is really `url` stuff :|
 * The `OAuthValidatorService` is now responsible for fixing the redirect URL
 * The auth view no longer messes with redirects at all
   * This also prevents you from putting weird stuff in other parts of the URL
   * Previously they would have been rewritten (not sure if this matters)
 * Moved tests about to compensate