### PR TITLE
Add step in docs to show how to create user

### DIFF
--- a/docs/developing/administration.rst
+++ b/docs/developing/administration.rst
@@ -2,18 +2,36 @@ Accessing the admin interface
 -----------------------------
 
 To access the admin interface, a user must be logged in and have admin
-permissions. To grant admin permissions to a user, run the following command:
+permissions. To grant admin permissions to a user, first create a user, 
+or use an existing one, and then promote that user to be an ``admin``:
+
+**Create the user (if needed)**
+
+.. code-block:: bash
+
+  tox -e py36-dev -- sh bin/hypothesis --dev add user
+
+This will prompt you to enter the user's 
+
+  #. unique name
+  #. unique email address
+  #. password
+
+Once you have entered that information, then you may promote the 
+user to ``admin``.
+
+**Promote to admin level**
+
+.. note::
+
+    Replace ``<username>`` with the value you entered in the previous step
+    or appropriate user's name.
+
 
 .. code-block:: bash
 
   tox -e py36-dev -- sh bin/hypothesis --dev user admin <username>
 
-For example, to make the user 'joe' an admin in the development environment:
-
-.. code-block:: bash
-
-  tox -e py36-dev -- sh bin/hypothesis --dev user admin joe
-
-When this user signs in they can now access the adminstration panel at
+When this user signs in they can now access the administration panel at
 ``/admin``. The administration panel has options for managing users and optional
 features.


### PR DESCRIPTION
I noticed this step was missing but its useful to show when setting up /h

![Screen Shot 2019-11-26 at 1 10 53 PM](https://user-images.githubusercontent.com/3939074/69673015-37ed1800-104e-11ea-80ee-51a9cd79e371.png)
