### PR TITLE
Add `NODE_ENV` to allowed env vars in dev environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,7 @@ passenv =
     dev: WEBSOCKET_URL
     dev: NEW_RELIC_LICENSE_KEY
     dev: NEW_RELIC_APP_NAME
+    dev: NODE_ENV
     {tests,functests}: TEST_DATABASE_URL
     {tests,functests}: ELASTICSEARCH_URL
     {tests,functests}: PYTEST_ADDOPTS


### PR DESCRIPTION
This makes it possible to test a local dev build where JS/CSS assets are
built in production mode using:

```
env NODE_ENV=production make dev
```

Context: https://hypothes-is.slack.com/archives/C1M8NH76X/p1575297351066900