### PR TITLE
Remove unused `release` property from sidebar app config

### DIFF
--- a/h/views/client.py
+++ b/h/views/client.py
@@ -12,7 +12,6 @@ import time
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 
-from h import __version__
 from h.util.uri import origin, render_url_template
 
 # Default URL for the client, which points to the latest version of the client

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -54,7 +54,6 @@ def sidebar_app(request, extra=None):
         "apiUrl": request.route_url("api.index"),
         "authDomain": request.default_authority,
         "oauthClientId": settings.get("h.client_oauth_id"),
-        "release": __version__,
         # The list of origins that the client will respond to cross-origin RPC
         # requests from.
         "rpcAllowedOrigins": settings.get("h.client_rpc_allowed_origins"),

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -5,7 +5,6 @@ import json
 import pytest
 from pyramid.httpexceptions import HTTPFound
 
-from h import __version__
 from h.views import client
 
 

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -16,7 +16,6 @@ class TestSidebarApp:
         expected_config = {
             "apiUrl": "http://example.com/api",
             "websocketUrl": "wss://example.com/ws",
-            "release": __version__,
             "sentry": {"dsn": "test-sentry-dsn", "environment": "dev"},
             "authDomain": "example.com",
             "googleAnalytics": "UA-4567",


### PR DESCRIPTION
This value is not used by the client, which instead has its own version
number that is baked into it at build time.