### PR TITLE
Cache rarely-changing resources on the critical path of client startup

### DIFF
--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -5,7 +5,13 @@ from h.views.api.helpers import links as link_helpers
 from h.views.api.helpers.angular import AngularRouteTemplater
 
 
-@api_config(versions=["v1"], route_name="api.index")
+@api_config(
+    versions=["v1"],
+    route_name="api.index",
+    # nb. We assume that the API index document is the same for all users,
+    # regardless of authorization.
+    http_cache=(60 * 5, {"public": True}),
+)
 def index(context, request):
     """Return the API descriptor document.
 
@@ -25,7 +31,14 @@ def index(context, request):
     return {"links": link_helpers.format_nested_links(api_links, templater)}
 
 
-@api_config(versions=["v2"], route_name="api.index", link_name="index")
+@api_config(
+    versions=["v2"],
+    route_name="api.index",
+    link_name="index",
+    # nb. We assume that the API index document is the same for all users,
+    # regardless of authorization.
+    http_cache=(60 * 5, {"public": True}),
+)
 def index_v2(context, request):
     """Return the API descriptor document.
 

--- a/h/views/api/links.py
+++ b/h/views/api/links.py
@@ -10,6 +10,9 @@ from h.views.api.helpers.angular import AngularRouteTemplater
     link_name="links",
     renderer="json_sorted",
     description="URL templates for generating URLs for HTML pages",
+    # nb. We assume that the returned URLs and URL templates are the same for all users,
+    # regardless of authorization.
+    http_cache=(60 * 5, {"public": True}),
 )
 def links(context, request):
     templater = AngularRouteTemplater(request.route_url, params=["user"])

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -35,6 +35,7 @@ def _client_url(request):
     route_name="sidebar_app",
     renderer="h:templates/app.html.jinja2",
     csp_insecure_optout=True,
+    http_cache=(60 * 5, {"public": True}),
 )
 def sidebar_app(request, extra=None):
     """


### PR DESCRIPTION
Enable short-term HTTP caching (5 minutes) of `/app.html` (the HTML for the client's sidebar app), `/api/` and `/api/links` documents which are resources on the critical path for the client's
startup, but have the same value for all users and change rarely.

The effectiveness of caching of `/app.html` will be limited in some recent browsers as the HTTP cache is partitioned by top-level domain. However Cloudflare can still cache it locally to the user.

For context, see [this Slack thread](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1575447372326000) which illustrates the cost of round-trips to fetch these resources. There are more advanced solutions we could implement, but this could potentially be a very easy win.