### PR TITLE
Preload `/api/` and `/api/links` responses before client app boots

### DIFF
--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -18,6 +18,10 @@
               href="{{ link.href }}"/>
       {% endfor %}
     {% endif %}
+
+    <!-- Prefetch non-authenticated API routes which client will need. !-->
+    <link rel="preload" as="fetch" href="{{ request.route_url("api.index") }}" crossorigin="anonymous">
+    <link rel="preload" as="fetch" href="{{ request.route_url("api.links") }}" crossorigin="anonymous">
   </head>
   <body>
     <hypothesis-app></hypothesis-app>


### PR DESCRIPTION
Improve cold starts of the client's sidebar app by initiating loading
of the non-authenticated `/api/` and `/api/links` routes early, before the
sidebar JS app has booted.

For this to work, the client must fetch these routes without setting any
additional headers which would be make the request incompatible with the
preloaded response.

See also https://github.com/hypothesis/client/pull/1562. That PR **should be deployed before this one**, as Chrome and Safari will log warnings if a resource is preloaded but not used due to a request header mismatch.

Alternative approaches here would be to initiate preloading of the response in JavaScript in the client, but that can only be done once JS in the page starts to run. It seems ~100ms into the boot process is about the earliest we can actually run any code. Another alternative would be to bake these responses into the sidebar app's HTML. That's going to be somewhat more complex than the change here, so I'd like to see how far preloading can get us.