### PR TITLE
Simplify tox commands

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ node {
                 // Unit tests
                 sh 'cd /var/lib/hypothesis && tox'
                 // Functional tests
-                sh 'cd /var/lib/hypothesis && tox -e py36-functests'
+                sh 'cd /var/lib/hypothesis && tox -e functests'
             }
         } finally {
             rabbit.stop()

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ services: python
 
 .PHONY: dev
 dev: build/manifest.json python
-	tox -qe dev
+	@tox -qe dev
 
 .PHONY: devdata
 devdata: python
@@ -49,7 +49,7 @@ devdata: python
 
 .PHONY: shell
 shell: python
-	tox -qe dev -- sh bin/hypothesis --dev shell
+	@tox -qe dev -- sh bin/hypothesis --dev shell
 
 .PHONY: sql
 sql: python
@@ -60,16 +60,16 @@ lint: backend-lint frontend-lint
 
 .PHONY: backend-lint
 backend-lint: python
-	tox -qe lint
+	@tox -qe lint
 
 .PHONY: frontend-lint
 frontend-lint: node_modules/.uptodate
-	npm run-script lint
-	npm run-script checkformatting
+	@npm run-script lint
+	@npm run-script checkformatting
 
 .PHONY: analyze
 analyze: python
-	tox -qe analyze
+	@tox -qe analyze
 
 .PHONY: format
 format: python
@@ -81,36 +81,36 @@ checkformatting: python
 
 .PHONY: test
 test: node_modules/.uptodate python
-	tox -q
-	$(GULP) test
+	@tox -q
+	@$(GULP) test
 
 .PHONY: coverage
 coverage: python
-	tox -qe coverage
+	@tox -qe coverage
 
 .PHONY: functests
 functests: build/manifest.json python
-	tox -qe functests
+	@tox -qe functests
 
 .PHONY: docs
 docs: python
-	tox -qe docs
+	@tox -qe docs
 
 .PHONY: checkdocs
 checkdocs: python
-	tox -qe checkdocs
+	@tox -qe checkdocs
 
 .PHONY: docstrings
 docstrings: python
-	tox -qe docstrings
+	@tox -qe docstrings
 
 .PHONY: checkdocstrings
 checkdocstrings: python
-	tox -qe checkdocstrings
+	@tox -qe checkdocstrings
 
 .PHONY: pip-compile
 pip-compile: python
-	tox -qe pip-compile
+	@tox -qe pip-compile
 
 .PHONY: upgrade-package
 upgrade-package: python
@@ -118,7 +118,7 @@ upgrade-package: python
 
 .PHONY: docker
 docker:
-	git archive --format=tar.gz HEAD | docker build -t hypothesis/hypothesis:$(DOCKER_TAG) -
+	@git archive --format=tar.gz HEAD | docker build -t hypothesis/hypothesis:$(DOCKER_TAG) -
 
 .PHONY: run-docker
 run-docker:
@@ -128,7 +128,7 @@ run-docker:
 	# variable set.
 	#
 	# If you don't intend to use the client with the container, you can skip this.
-	docker run \
+	@docker run \
 		--net h_default \
 		-e "APP_URL=http://localhost:5000" \
 		-e "AUTHORITY=localhost" \
@@ -145,17 +145,17 @@ run-docker:
 
 .PHONY: clean
 clean:
-	find . -type f -name "*.py[co]" -delete
-	find . -type d -name "__pycache__" -delete
-	rm -f node_modules/.uptodate
-	rm -rf build
+	@find . -type f -name "*.py[co]" -delete
+	@find . -type d -name "__pycache__" -delete
+	@rm -f node_modules/.uptodate
+	@rm -rf build
 
 DOCKER_TAG = dev
 
 GULP := node_modules/.bin/gulp
 
 build/manifest.json: node_modules/.uptodate
-	$(GULP) build
+	@$(GULP) build
 
 node_modules/.uptodate: package.json
 	@echo installing javascript dependencies
@@ -168,4 +168,4 @@ python:
 
 .PHONY: gulp
 gulp: node_modules/.uptodate
-	$(GULP) $(args)
+	@$(GULP) $(args)

--- a/Makefile
+++ b/Makefile
@@ -37,30 +37,30 @@ help:
 .PHONY: services
 services: args?=up -d
 services: python
-	@tox -q -e docker-compose -- $(args)
+	@tox -qe docker-compose -- $(args)
 
 .PHONY: dev
 dev: build/manifest.json python
-	tox -q -e py36-dev
+	tox -qe dev
 
 .PHONY: devdata
 devdata: python
-	@tox -q -e py36-dev -- sh bin/hypothesis --dev devdata
+	@tox -qe dev -- sh bin/hypothesis --dev devdata
 
 .PHONY: shell
 shell: python
-	tox -q -e py36-dev -- sh bin/hypothesis --dev shell
+	tox -qe dev -- sh bin/hypothesis --dev shell
 
 .PHONY: sql
 sql: python
-	@tox -q -e docker-compose -- exec postgres psql --pset expanded=auto -U postgres
+	@tox -qe docker-compose -- exec postgres psql --pset expanded=auto -U postgres
 
 .PHONY: lint
 lint: backend-lint frontend-lint
 
 .PHONY: backend-lint
 backend-lint: python
-	tox -q -e py36-lint
+	tox -qe lint
 
 .PHONY: frontend-lint
 frontend-lint: node_modules/.uptodate
@@ -69,52 +69,52 @@ frontend-lint: node_modules/.uptodate
 
 .PHONY: analyze
 analyze: python
-	tox -qq -e py36-analyze
+	tox -qe analyze
 
 .PHONY: format
 format: python
-	@tox -qe py36-format
+	@tox -qe format
 
 PHONY: checkformatting
 checkformatting: python
-	@tox -qe py36-checkformatting
+	@tox -qe checkformatting
 
 .PHONY: test
 test: node_modules/.uptodate python
-	tox
+	tox -q
 	$(GULP) test
 
 .PHONY: coverage
 coverage: python
-	tox -q -e py36-coverage
+	tox -qe coverage
 
 .PHONY: functests
 functests: build/manifest.json python
-	tox -q -e py36-functests
+	tox -qe functests
 
 .PHONY: docs
 docs: python
-	tox -q -e py36-docs
+	tox -qe docs
 
 .PHONY: checkdocs
 checkdocs: python
-	tox -q -e py36-checkdocs
+	tox -qe checkdocs
 
 .PHONY: docstrings
 docstrings: python
-	tox -q -e py36-docstrings
+	tox -qe docstrings
 
 .PHONY: checkdocstrings
 checkdocstrings: python
-	tox -q -e py36-checkdocstrings
+	tox -qe checkdocstrings
 
 .PHONY: pip-compile
 pip-compile: python
-	tox -q -e py36-pip-compile
+	tox -qe pip-compile
 
 .PHONY: upgrade-package
 upgrade-package: python
-	@tox -qe py36-pip-compile -- --upgrade-package $(name)
+	@tox -qe pip-compile -- --upgrade-package $(name)
 
 .PHONY: docker
 docker:

--- a/docs/developing/administration.rst
+++ b/docs/developing/administration.rst
@@ -9,7 +9,7 @@ or use an existing one, and then promote that user to be an ``admin``:
 
 .. code-block:: bash
 
-  tox -e py36-dev -- sh bin/hypothesis --dev add user
+  tox -qe dev -- sh bin/hypothesis --dev add user
 
 This will prompt you to enter the user's 
 
@@ -30,7 +30,7 @@ user to ``admin``.
 
 .. code-block:: bash
 
-  tox -e py36-dev -- sh bin/hypothesis --dev user admin <username>
+  tox -qe dev -- sh bin/hypothesis --dev user admin <username>
 
 When this user signs in they can now access the administration panel at
 ``/admin``. The administration panel has options for managing users and optional

--- a/docs/developing/making-changes-to-model-code.rst
+++ b/docs/developing/making-changes-to-model-code.rst
@@ -47,7 +47,7 @@ steps to create a new migration script for h are:
 
    .. code-block:: bash
 
-      tox -e py36-dev -- sh bin/hypothesis migrate revision -m "Add the foobar table"
+      tox -qe dev -- sh bin/hypothesis migrate revision -m "Add the foobar table"
 
    This will create a new script in ``h/migrations/versions/``.
 
@@ -71,7 +71,7 @@ steps to create a new migration script for h are:
 
    .. code-block:: bash
 
-      tox -e py36-dev -- sh bin/hypothesis migrate upgrade head
+      tox -qe dev -- sh bin/hypothesis migrate upgrade head
 
    After running this command inspect your database's schema to check that it's
    as expected, and run h to check that everything is working.
@@ -86,14 +86,14 @@ steps to create a new migration script for h are:
 
    .. code-block:: bash
 
-      tox -e py36-dev -- sh bin/hypothesis migrate downgrade -1
+      tox -qe dev -- sh bin/hypothesis migrate downgrade -1
 
    After running this command inspect your database's schema to check that it's
    as expected. You can then upgrade it again:
 
    .. code-block:: bash
 
-      tox -e py36-dev -- sh bin/hypothesis migrate upgrade +1
+      tox -qe dev -- sh bin/hypothesis migrate upgrade +1
 
 Batch deletes and updates in migration scripts
 ==============================================

--- a/docs/developing/ssl.rst
+++ b/docs/developing/ssl.rst
@@ -18,7 +18,7 @@ To serve your local dev instance of h over HTTPS:
 
 3. Run ``hypothesis devserver`` with the ``--https`` option::
 
-    tox -e py36-dev -- sh bin/hypothesis devserver --https
+    tox -qe dev -- sh bin/hypothesis devserver --https
 
 4. Since the certificate is self-signed, you will need to instruct your browser to
    trust it explicitly by visiting https://localhost:5000 and selecting the option

--- a/docs/developing/testing.rst
+++ b/docs/developing/testing.rst
@@ -49,16 +49,15 @@ To run the backend test suite only call ``tox`` directly. For example:
    tox
 
    # Run the backend functional tests:
-   tox -e py36-functests
+   tox -qe functests
 
    # Run only one test directory or test file:
    tox tests/h/models/annotation_test.py
-   tox -e py36-tests tests/h/models/annotation_test.py
-   tox -e py36-functests tests/functional/api/test_profile.py
+   tox -qe functests tests/functional/api/test_profile.py
 
    # To pass arguments to pytest put them after a `--`:
    tox -- --exitfirst --pdb --failed-first tests/h
-   tox -e pyXY-FOO -- --exitfirst --pdb --failed-first tests/h
+   tox -qe functests -- --exitfirst --pdb --failed-first tests/functional
 
    # See all of pytest's command line options:
    tox -- -h

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36-tests
+envlist = tests
 skipsdist = true
 minversion = 3.8.0
 requires =


### PR DESCRIPTION
It's not necessary to run `tox -e py36-dev`. You can just run `tox -e dev` and it will use the correct version of Python.
    
What's happening is:

* The default version of Python for the project is specified in the .python-version file (currently 3.6.9)

* You have pyenv installed, since it's a requirement for setting up your development environment. This means that the `python` executable on your PATH is ~/.pyenv/shims/python, rather than your system copy of Python. But by default pyenv's shim just forwards to your system Python

* When you cd into the project directory pyenv reads the .python-version file and activates its copy of Python 3.6.9. Pyenv's ~/.pyenv/shims/python will now forward to pyenv's copy of Python 3.6.9, rather than your system's copy of Python, as long as you're in this project's directory

* When you don't explicitly tell tox which version of Python to use (you just run `tox -e dev` rather than `tox -e py36-dev`) then tox simply uses the `python` executable on your PATH, which is pyenv's shim, which forwards to pyenv's copy of Python 3.6.9

In addition, this commit also:

* Shortens `tox -q -e ...` to the more compact `tox -qe`

* Adds the `-q` argument to the `tox` command that `make test` runs.  This was missing before, which was inconsistent, and meant that `make test` printed out unnecessary tox noise

* Also adds the missing `-q` to some example `tox` commands in the docs

* Improves a couple of example `tox` commands for running tests, in the docs

Also, in a second commit:

Prefix commands in Makefile with `@` to tell make not to print out commands before running them. This is just unnecessary noise for us. We were already doing this with some but not all commands in Makefile.