### PR TITLE
Add feature flag for annotation-migration preview

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -18,6 +18,7 @@ FEATURES = {
     ),
     "overlay_highlighter": "Use the new overlay highlighter?",
     "client_display_names": "Render display names instead of user names in the client",
+    "client_preact_annotation": "Render the migrated/preact variant of annotations",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.


### PR DESCRIPTION
Add a feature flag that can be enabled during the
migration phase of the client-side Annotation component
to see the new variant.

This feature flag will be used by the client.

Part of https://github.com/hypothesis/client/issues/1650