### PR TITLE
Upgrade the dev env to Postgres 11.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,21 @@ matrix:
     - env: ACTION=tox
       language: python
       python: '3.6'
+      services:
+        - postgresql
       addons:
-        # TODO - Switch to Postgres 11 once we have rolled out PG 11 in production.
-        postgresql: "9.4"
+        postgresql: "11"
       before_install:
+        - sudo apt-get update
+        - sudo apt-get --yes remove postgresql\*
+        - sudo apt-get install -y postgresql-11 postgresql-client-11
+        - sudo cp /etc/postgresql/{9.6,11}/main/pg_hba.conf
+        - sudo service postgresql restart 11
         - ./scripts/elasticsearch.sh
       install: pip install tox>=3.8.0
-      before_script: createdb htest
+      before_script:
+        - psql -c 'CREATE ROLE travis SUPERUSER LOGIN CREATEDB;' -U postgres
+        - createdb htest
       script: tox
       after_success:
         make coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres:9.4-alpine
+    image: postgres:11.5-alpine
     ports:
       - '127.0.0.1:5432:5432'
   elasticsearch:


### PR DESCRIPTION
11.5 is the version of Postgres that we're currently using in
production.

For developers:

* Before you `git pull` this commit, backup your DB to a `dump.sql` file:

      .tox/docker-compose/bin/docker-compose exec postgres pg_dump -U postgres postgres > dump.sql

* If you already have `make services` running then `make dev` will
  continue using Postgres 9.4 and your existing data

* But the next time you run `make services`, though, it will recreate
  your DB as a Postgres 11.5 DB. At this point your DB will be broken
  because it's a Postgres 11.5 DB with Postgres 9.4 contents. `make dev`
  will fail.

* You need to delete your DB contents and allow them to be created from
  scratch again, to get it working:

      make services args='down'
      make services

* You now have a working Postgres 11.5 DB but its contents are empty.

* You can restore the standard dev data by running `make devdata`

* **Or** you can restore your entire DB contents from the `dump.sql`
file that you made above by running:

      .tox/docker-compose/bin/docker-compose exec -T postgres psql -U postgres < dump.sql

* You'll also need to recreate your search index (even if you didn't restore a DB backup):

      tox -qe dev -- sh bin/hypothesis --dev search reindex

* You can test whether you've successfully upgraded to 11.5 by running:

      .tox/docker-compose/bin/docker-compose exec postgres psql -U postgres -d postgres -c 'select version();'

See also:

* [How can I backup and restore my development database?](https://stackoverflow.com/c/hypothesis/questions/188/189)

* [How do I use docker-compose?](https://stackoverflow.com/c/hypothesis/questions/186)