### PR TITLE
Remove obsolete feature flags

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -13,10 +13,6 @@ FEATURES = {
         "Cache-bust client entry point URL to prevent browser/CDN from "
         "using a cached version?"
     ),
-    "filter_highlights": (
-        "Filter highlights in document based on visible" " annotations in sidebar?"
-    ),
-    "overlay_highlighter": "Use the new overlay highlighter?",
     "client_display_names": "Render display names instead of user names in the client",
     "client_preact_annotation": "Render the migrated/preact variant of annotations",
 }
@@ -39,10 +35,7 @@ FEATURES = {
 #
 # 4. Finally, remove the feature from FEATURES_PENDING_REMOVAL.
 #
-FEATURES_PENDING_REMOVAL = {
-    "api_render_user_info": "Return users' extended info in API responses?",
-    "community_groups": "Turn on community groups in the client and api.",
-}
+FEATURES_PENDING_REMOVAL = {}
 
 
 class Feature(Base):


### PR DESCRIPTION
 - Remove two client feature flags that are no longer used
 - Remove two h feature flags for features that were deployed to
   production a long time ago