### PR TITLE
Add missing "lang" attribute for sidebar HTML page

### DIFF
--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />


### PR DESCRIPTION
This attribute reflects the language of the UI, which is currently
always English. In future when we internationalize the client, this will
be updated to reflect that.

Part of https://github.com/hypothesis/client/issues/1794.