### PR TITLE
Create Bulk API Client library (Roughing it out)

### DIFF
--- a/tests/h/h_api/bulk_api/entry_point_test.py
+++ b/tests/h/h_api/bulk_api/entry_point_test.py
@@ -16,7 +16,7 @@ class TestBulkAPI:
     # This is a glue library, so there's not much to do here but test the
     # interfaces
 
-    def test_from_stream(self, lines, executor, CommandProcessor):
+    def test_from_lines(self, lines, executor, CommandProcessor):
         BulkAPI.from_lines(lines, executor)
 
         CommandProcessor.assert_called_once_with(


### PR DESCRIPTION
This is a colossally messy PR for creating the library for serialising, deserialising and checking BulkAPI requests.

This is here to get the work done, after which this will be chopped up into manageable chunks.