### PR TITLE
Move coverage from Travis to Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,29 +9,6 @@ matrix:
       script:
         make checkformatting
 
-    # Python (backend) tests
-    - env: ACTION=tox
-      language: python
-      python: '3.6'
-      services:
-        - postgresql
-      addons:
-        postgresql: "11"
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get --yes remove postgresql\*
-        - sudo apt-get install -y postgresql-11 postgresql-client-11
-        - sudo cp /etc/postgresql/{9.6,11}/main/pg_hba.conf
-        - sudo service postgresql restart 11
-        - ./scripts/elasticsearch.sh
-      install: pip install tox>=3.8.0
-      before_script:
-        - psql -c 'CREATE ROLE travis SUPERUSER LOGIN CREATEDB;' -U postgres
-        - createdb htest
-      script: tox
-      after_success:
-        make coverage
-
     # Test web application frontend
     - env: ACTION=gulp
       language: node_js

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,8 @@ node {
 
                 // Unit tests
                 sh 'cd /var/lib/hypothesis && tox'
+                // Coverage
+                sh 'cd /var/lib/hypothesis && tox -e coverage'
                 // Functional tests
                 sh 'cd /var/lib/hypothesis && tox -e functests'
             }

--- a/scripts/elasticsearch.sh
+++ b/scripts/elasticsearch.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# Install Elasticsearch in /tmp and run it.
-set -ev
-mkdir /tmp/elasticsearch
-wget -O - https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.4.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
-/tmp/elasticsearch/bin/elasticsearch-plugin install analysis-icu
-/tmp/elasticsearch/bin/elasticsearch -E http.port=9200 -E path.data=/tmp/elasticsearch_data -d


### PR DESCRIPTION
Travis is currently failing for some reason which is the main
motivator here, but we also run the tests twice, which seems wasteful.

Backend tests + coverage are no longer run in Travis at all, and coverage has been added to Jenkins (it was already running the tests).