### PR TITLE
Add activated_date column to User which is set on activation

### DIFF
--- a/h/migrations/versions/b9de5c897f73_add_user_activated_date.py
+++ b/h/migrations/versions/b9de5c897f73_add_user_activated_date.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""Add user activated date"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b9de5c897f73"
+down_revision = "8bd83598ad77"
+
+
+def upgrade():
+    op.add_column(
+        "user", sa.Column("activated_date", sa.TIMESTAMP(timezone=False), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("user", "activated_date")

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -245,6 +245,7 @@ class User(Base):
         server_default=sa.func.now(),
         nullable=False,
     )
+    activated_date = sa.Column(sa.TIMESTAMP(timezone=False), nullable=True)
 
     # Activation foreign key
     activation_id = sa.Column(sa.Integer, sa.ForeignKey("activation.id"))
@@ -260,6 +261,8 @@ class User(Base):
     def activate(self):
         """Activate the user by deleting any activation they have."""
         session = sa.orm.object_session(self)
+
+        self.activated_date = datetime.datetime.utcnow()
         session.delete(self.activation)
 
     #: Hashed password


### PR DESCRIPTION
This is to allow us to review when users were activated. See: https://github.com/hypothesis/product-backlog/issues/988

This directly implements: https://github.com/hypothesis/product-backlog/issues/1033, but I can't link it as it's not in the `h` repo.

----

For existing activated users I've made no attempt to set this date. It will just be empty. We might have to handle this case in the interface. There's no real sensible way of handling this I can see.

I've tested this at the unit test level at the moment, but it seems to work just great without me having added the column to the DB. This suggests there's a gap in my understanding of how this works.

I've not actually triggered a sign-up email, and I'm not sure I could locally.