### PR TITLE
Add a user activation date migration script

### DIFF
--- a/h/migrations/versions/b9de5c897f73_add_user_activation_date.py
+++ b/h/migrations/versions/b9de5c897f73_add_user_activation_date.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""Add user activation date"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b9de5c897f73"
+down_revision = "8bd83598ad77"
+
+
+def upgrade():
+    op.add_column(
+        "user",
+        sa.Column("activation_date", sa.TIMESTAMP(timezone=False), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("user", "activation_date")


### PR DESCRIPTION
Adds a `activation_date` to the user so we can set and display it when the user is activated in the admin screen: https://github.com/hypothesis/h/pull/5934