### PR TITLE
Add user activation date, which is set on activation

### DIFF
--- a/h/models/user.py
+++ b/h/models/user.py
@@ -245,6 +245,7 @@ class User(Base):
         server_default=sa.func.now(),
         nullable=False,
     )
+    activation_date = sa.Column(sa.TIMESTAMP(timezone=False), nullable=True)
 
     # Activation foreign key
     activation_id = sa.Column(sa.Integer, sa.ForeignKey("activation.id"))
@@ -260,6 +261,8 @@ class User(Base):
     def activate(self):
         """Activate the user by deleting any activation they have."""
         session = sa.orm.object_session(self)
+
+        self.activation_date = datetime.datetime.utcnow()
         session.delete(self.activation)
 
     #: Hashed password

--- a/h/templates/admin/users.html.jinja2
+++ b/h/templates/admin/users.html.jinja2
@@ -27,13 +27,14 @@
           <tr><th>Username</th><td>{{ user.username }}</td></tr>
           <tr><th>Authority</th><td>{{ user.authority }}</td></tr>
           <tr><th>Email</th><td>{{ user.email }}</td></tr>
-          <tr><th>Registered</th><td>{{ user.registered_date }}</td></tr>
-          <tr><th>Last login</th><td>{{ user.last_login_date }}</td></tr>
+          <tr><th>Registered</th><td>{{ format_date(user.registered_date) }}</td></tr>
+          <tr><th>Last login</th><td>{{ format_date(user.last_login_date) }}</td></tr>
           <tr>
             <th>Is activated?</th>
             <td>
               {% if user.is_activated %}
                 &#x2714;
+                {% if user.activation_date %}({{ format_date(user.activation_date) }}){% endif %}
               {% else %}
                 &#x2718;
                 <form action="{{request.route_path('admin.users_activate')}}"

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -15,6 +15,13 @@ class UserNotFoundError(Exception):
     pass
 
 
+def format_date(date):
+    """Format a date for presentation in the UI."""
+
+    # Format here is "2012-01-29 21:19"
+    return date.strftime("%Y-%m-%d %H:%M")
+
+
 @view_config(
     route_name="admin.users",
     request_method="GET",
@@ -44,6 +51,7 @@ def users_index(request):
         "authority": authority,
         "user": user,
         "user_meta": user_meta,
+        "format_date": format_date,
     }
 
 

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -11,12 +11,19 @@ from h.services.delete_user import DeleteUserService
 from h.services.user import UserService
 from h.views.admin.users import (
     UserNotFoundError,
+    format_date,
     users_activate,
     users_delete,
     users_index,
 )
 
 users_index_fixtures = pytest.mark.usefixtures("models", "annotation_stats_service")
+
+
+def test_format_date():
+    date = datetime(2001, 11, 29, 21, 50, 59, 999999)
+
+    assert format_date(date) == "2001-11-29 21:50"
 
 
 @users_index_fixtures
@@ -29,6 +36,7 @@ def test_users_index(pyramid_request):
         "authority": None,
         "user": None,
         "user_meta": {},
+        "format_date": format_date,
     }
 
 
@@ -94,6 +102,7 @@ def test_users_index_no_user_found(models, pyramid_request):
         "authority": "foo.org",
         "user": None,
         "user_meta": {},
+        "format_date": format_date,
     }
 
 
@@ -111,6 +120,7 @@ def test_users_index_user_found(models, pyramid_request, db_session, factories):
         "authority": "foo.org",
         "user": user,
         "user_meta": {"annotations_count": 0},
+        "format_date": format_date,
     }
 
 


### PR DESCRIPTION
This is also displayed in the admin screen if available. For users previous to this change the tick will be present, but the date will not. I've made no attempt to set this date: it will just be empty. 

This requires a database migration first: https://github.com/hypothesis/h/pull/5933

This is to allow us to review when users were activated. See: https://github.com/hypothesis/product-backlog/issues/988

This directly implements: https://github.com/hypothesis/product-backlog/issues/1033, but I can't link it as it's not in the `h` repo.

----

I have a couple of questions about this which basically amount to checking if this is the correct solution. 

The motivation for this appears to be that we want to know how long activations are taking. I'm wondering if presenting the date is an indirect solution, or what we actually want? Is this just there so someone can do the maths in their head? We could calculate how long it's been and display that instead, or is it envisioned as being for something else too?

__Answer__ - Yep! This is probably the right thing to do. This date must be compared with when the email was sent by Mail-Chimp, not only against when the user registered. Making this relative to the registration date would make that harder.

Currently we show dates to the nano-second level however, and @klemay suggested this is a tad overkill. We only care to the minute level, e.g. `2020-03-04 17:36`

I'll add that in as well.