### PR TITLE
Remove user last login date default in model and fix admin page

### DIFF
--- a/h/models/user.py
+++ b/h/models/user.py
@@ -233,12 +233,7 @@ class User(Base):
 
     email = sa.Column(sa.UnicodeText())
 
-    last_login_date = sa.Column(
-        sa.TIMESTAMP(timezone=False),
-        default=datetime.datetime.utcnow,
-        server_default=sa.func.now(),
-        nullable=False,
-    )
+    last_login_date = sa.Column(sa.TIMESTAMP(timezone=False), nullable=True)
     registered_date = sa.Column(
         sa.TIMESTAMP(timezone=False),
         default=datetime.datetime.utcnow,

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -18,6 +18,9 @@ class UserNotFoundError(Exception):
 def format_date(date):
     """Format a date for presentation in the UI."""
 
+    if date is None:
+        return ""
+
     # Format here is "2012-01-29 21:19"
     return date.strftime("%Y-%m-%d %H:%M")
 

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -20,10 +20,12 @@ from h.views.admin.users import (
 users_index_fixtures = pytest.mark.usefixtures("models", "annotation_stats_service")
 
 
-def test_format_date():
-    date = datetime(2001, 11, 29, 21, 50, 59, 999999)
-
-    assert format_date(date) == "2001-11-29 21:50"
+@pytest.mark.parametrize(
+    "input,expected",
+    ((datetime(2001, 11, 29, 21, 50, 59, 999999), "2001-11-29 21:50"), (None, "")),
+)
+def test_format_date(input, expected):
+    assert format_date(input) == expected
 
 
 @users_index_fixtures


### PR DESCRIPTION
This is for https://github.com/hypothesis/product-backlog/issues/1035, to ensure that the login date is only set on the first successful login. There was no implementation required to not set the date on sign-up, removing the default did all of that for us.

The admin date formatting function expected there to be a value and would crash otherwise.

This requires the DB changes in: https://github.com/hypothesis/h/pull/5938
