### PR TITLE
#1 Fix group membership relationship validation

### DIFF
--- a/h/h_api/model/json_api.py
+++ b/h/h_api/model/json_api.py
@@ -39,8 +39,8 @@ class JSONAPIData(Model):
     """A single JSON API data object (request or response)."""
 
     # TODO! - This would be nice but introduces a circular dependency with
-    # Schema as it needs the error stuff above via SchemaValdiationError
-    # schema = Schema.get_validator('json_api.json#/$defs/resourceObject')
+    # Schema as it needs the error stuff above via SchemaValidationError
+    # schema = Schema.get_validator('json_api.json#/$defs/document')
 
     @classmethod
     def create(

--- a/h/h_api/resources/schema/json_api.json
+++ b/h/h_api/resources/schema/json_api.json
@@ -12,8 +12,7 @@
                     "$comment": "Data can be an array, but we never do that",
                     "$ref":  "#/$defs/resourceObject"
                 },
-                "meta": {"$ref": "#/$defs/metaData"},
-                "relationships": {"$ref": "#/$defs/relationships"}
+                "meta": {"$ref": "#/$defs/metaData"}
             },
             "required": ["data"],
             "additionalProperties": false,
@@ -56,9 +55,11 @@
                 "id": {"type": "string"},
                 "type": {"type": "string"},
                 "attributes": {"type": "object"},
+                "relationships": {"$ref": "#/$defs/relationships"},
                 "meta": {"$ref": "#/$defs/metaData"}
             },
             "required": ["type"],
+            "additionalProperties": false,
 
             "examples": [
                 {

--- a/tests/h/h_api/bulk_api/model/data_body_test.py
+++ b/tests/h/h_api/bulk_api/model/data_body_test.py
@@ -5,6 +5,7 @@ from h.h_api.bulk_api.model.data_body import (
     UpsertGroup,
     UpsertUser,
 )
+from h.h_api.exceptions import SchemaValidationError
 
 
 class TestUpsertUser:
@@ -29,7 +30,7 @@ class TestUpsertUser:
         }
 
     def test_create_can_fail(self):
-        with pytest.raises(Exception):
+        with pytest.raises(SchemaValidationError):
             UpsertUser.create("bad", {})
 
 
@@ -67,9 +68,24 @@ class TestCreateGroupMembership:
             }
         }
 
-    def test_create_can_fail(self,):
-        with pytest.raises(Exception):
+    def test_create_can_fail(self):
+        with pytest.raises(SchemaValidationError):
             CreateGroupMembership.create("bad", None)
+
+    def test_validation_can_fail(self):
+        with pytest.raises(SchemaValidationError):
+            CreateGroupMembership(
+                {
+                    "data": {
+                        "type": "group_membership",
+                        "relationships": {
+                            # This isn't good enough, these should have bodies
+                            "member": {},
+                            "group": {},
+                        },
+                    }
+                }
+            )
 
     def test_accessors(self, create_group_membership_body):
         data = CreateGroupMembership(create_group_membership_body)


### PR DESCRIPTION
We weren't applying the schema correctly, so you could have any old nonsense in the relationship dicts.

Also fixed a misleading comment relating to this and some misnamed tests