### PR TITLE
#1 Add Bulk API Observer interface for serialisation

### DIFF
--- a/h/h_api/bulk_api/observer.py
+++ b/h/h_api/bulk_api/observer.py
@@ -1,0 +1,40 @@
+"""Implementations of an 'Observer' which is informed of commands."""
+
+
+import json
+
+from h.h_api.enums import CommandStatus
+
+
+class Observer:
+    """A callback for being informed of every command processed by BulkJob.
+
+    This implementation serves as the base class and takes no action when
+    informed of a command."""
+
+    def observe_command(self, command, status):
+        """A call back for various stages in the command life cycle.
+
+        :param command: Command being inspected
+        :param status: Status of the command
+        """
+        pass
+
+
+class SerialisingObserver(Observer):
+    """An Observer which serialises commands to provided handle."""
+
+    def __init__(self, handle):
+        """
+        :param handle: A file like object
+        """
+        self.handle = handle
+
+    def observe_command(self, command, status):
+        """Write all commands the handle as JSON."""
+        if status != CommandStatus.AS_RECEIVED:
+            return
+
+        # By this point we've done so much validation it should be basically
+        # impossible for this to not serialise.
+        self.handle.write(json.dumps(command.raw) + "\n")

--- a/h/h_api/enums.py
+++ b/h/h_api/enums.py
@@ -17,3 +17,10 @@ class CommandType(Enum):
     CONFIGURE = "configure"
     UPSERT = "upsert"
     CREATE = "create"
+
+
+class CommandStatus(Enum):
+    """BulkAPI command processing statuses."""
+
+    AS_RECEIVED = "as_received"
+    POST_EXECUTE = "post_execute"

--- a/tests/h/h_api/bulk_api/observer_test.py
+++ b/tests/h/h_api/bulk_api/observer_test.py
@@ -1,0 +1,19 @@
+import json
+from io import StringIO
+
+from h.h_api.bulk_api.observer import SerialisingObserver
+from h.h_api.enums import CommandStatus
+
+
+class TestSerialisingObserver:
+    def test_it_only_serialises_commands_as_received(self, user_command, group_command):
+        handle = StringIO()
+        observer = SerialisingObserver(handle)
+
+        observer.observe_command(user_command, CommandStatus.AS_RECEIVED)
+        observer.observe_command(group_command, CommandStatus.AS_RECEIVED)
+        observer.observe_command(group_command, CommandStatus.POST_EXECUTE)
+
+        data = [json.loads(line) for line in handle.getvalue().strip().split("\n")]
+
+        assert data == [user_command.raw, group_command.raw]

--- a/tests/h/h_api/conftest.py
+++ b/tests/h/h_api/conftest.py
@@ -2,11 +2,22 @@ from copy import deepcopy
 
 import pytest
 
+from h.h_api.bulk_api.command_builder import CommandBuilder
 from h.h_api.schema import Schema
 
 
 def get_schema_example(schema_path):
     return deepcopy(Schema.get_schema(schema_path)["examples"][0])
+
+
+@pytest.fixture
+def group_command(group_attributes):
+    return CommandBuilder.group.upsert(group_attributes, "id_ref")
+
+
+@pytest.fixture
+def user_command(user_attributes):
+    return CommandBuilder.user.upsert("acct:user@example.com", user_attributes)
 
 
 @pytest.fixture


### PR DESCRIPTION
This is mostly used for serialisation, but it's also extremely handy for debugging.