### PR TITLE
Add a convenient entry point for calling the BulkAPI

### DIFF
--- a/h/h_api/bulk_api/__init__.py
+++ b/h/h_api/bulk_api/__init__.py
@@ -1,0 +1,7 @@
+from h.h_api.bulk_api.command_builder import CommandBuilder
+from h.h_api.bulk_api.entry_point import BulkAPI
+from h.h_api.bulk_api.executor import Executor
+from h.h_api.bulk_api.model.report import Report
+
+# Export the minimum items a user will need to work with us
+__all__ = ["CommandBuilder", "BulkAPI", "Report", "Executor"]

--- a/h/h_api/bulk_api/entry_point.py
+++ b/h/h_api/bulk_api/entry_point.py
@@ -1,0 +1,91 @@
+"""Wrappers for common ways to use the bulk API."""
+
+import json
+from io import StringIO
+from json import JSONDecodeError
+
+from h.h_api.bulk_api.command_builder import CommandBuilder
+from h.h_api.bulk_api.command_processor import CommandProcessor
+from h.h_api.bulk_api.executor import AutomaticReportExecutor, Executor
+from h.h_api.bulk_api.observer import Observer, SerialisingObserver
+from h.h_api.exceptions import InvalidJSONError
+
+
+class BulkAPI:
+    """Convenience methods for streaming to and from the BulkAPI."""
+
+    @classmethod
+    def from_stream(cls, lines, executor, observer=None):
+        """
+        Read from a stream of lines where each line is one command.
+
+        :param lines: An iterator of strings
+        :param executor: `Executor` to process batches of commands
+        :param observer: `Observer` to view individual commands
+        """
+        if observer is None:
+            observer = Observer()
+
+        if not isinstance(observer, Observer):
+            raise TypeError(f"Expected 'Observer' instance not '{type(observer)}'")
+
+        if not isinstance(executor, Executor):
+            raise TypeError(f"Expected 'Executor' instance not '{type(executor)}'")
+
+        CommandProcessor(executor=executor, observer=observer).process(
+            cls._commands_from_ndjson(lines)
+        )
+
+    @classmethod
+    def from_string(cls, string, executor, observer=None):
+        """
+        Read from a string of NDJSON.
+
+        Convenience wrapper for `from_stream`.
+        """
+
+        lines = (line for line in string.strip().split("\n"))
+
+        cls.from_stream(lines, executor, observer)
+
+    @classmethod
+    def to_stream(cls, handle, commands):
+        """
+        Check a series of commands for correctness and stream to NDJSON.
+
+        :param handle: File-like object to write NDJSON to
+        :param commands: Iterator of commands to process
+        """
+        CommandProcessor(
+            executor=AutomaticReportExecutor(),
+            observer=SerialisingObserver(handle),
+            # We want to know as soon as we can if we've passed in rubbish
+            batch_size=1,
+        ).process(commands)
+
+    @classmethod
+    def to_string(cls, commands):
+        """
+        Check a series of commands for correctness and create an NDJSON string.
+
+        Convenience wrapper for `to_stream`.
+        """
+
+        handle = StringIO()
+
+        BulkAPI.to_stream(handle, commands)
+
+        return handle.getvalue()
+
+    @staticmethod
+    def _commands_from_ndjson(lines):
+        for line_number, line in enumerate(lines):
+            try:
+                data = json.loads(line)
+            except JSONDecodeError as e:
+                raise InvalidJSONError(
+                    f"Invalid JSON on line {line_number}: {e.args[0]}"
+                )
+
+            # Try catch JSON errors here
+            yield CommandBuilder.from_data(data)

--- a/h/h_api/exceptions.py
+++ b/h/h_api/exceptions.py
@@ -46,6 +46,12 @@ class InvalidDeclarationError(SimpleJSONAPIError):
     http_status = 400
 
 
+class InvalidJSONError(SimpleJSONAPIError):
+    """The client sent a string we cannot interpret as JSON."""
+
+    http_status = 400
+
+
 class UnpopulatedReferenceError(SimpleJSONAPIError):
     """The client used an id reference which was not created."""
 

--- a/tests/h/h_api/bulk_api/command_processor_test.py
+++ b/tests/h/h_api/bulk_api/command_processor_test.py
@@ -6,7 +6,6 @@ from h_matchers import Any
 # Import... ALL OF THE THINGS
 from h.h_api.bulk_api.command_builder import CommandBuilder
 from h.h_api.bulk_api.command_processor import CommandProcessor
-from h.h_api.bulk_api.executor import AutomaticReportExecutor, Executor
 from h.h_api.bulk_api.model.report import Report
 from h.h_api.bulk_api.observer import Observer
 from h.h_api.enums import CommandResult, CommandStatus, CommandType, DataType
@@ -179,15 +178,6 @@ class TestCommandProcessor:
     @pytest.fixture
     def command_processor(self, executor, observer):
         return CommandProcessor(executor, observer)
-
-    @pytest.fixture
-    def executor(self):
-        executor = create_autospec(Executor, instance=True)
-        fake_report_executor = AutomaticReportExecutor()
-
-        executor.execute_batch.side_effect = fake_report_executor.execute_batch
-
-        return executor
 
     @pytest.fixture
     def observer(self):

--- a/tests/h/h_api/bulk_api/entry_point_test.py
+++ b/tests/h/h_api/bulk_api/entry_point_test.py
@@ -1,0 +1,97 @@
+import json
+from io import StringIO
+from types import GeneratorType
+
+import pytest
+from h_matchers import Any
+from pkg_resources import resource_string
+
+from h.h_api.bulk_api import BulkAPI
+from h.h_api.bulk_api.model.command import Command
+from h.h_api.bulk_api.observer import Observer
+from h.h_api.exceptions import InvalidJSONError
+
+
+class TestBulkAPI:
+    # This is a glue library, so there's not much to do here but test the
+    # interfaces
+
+    def test_from_stream(self, lines, executor, CommandProcessor):
+        BulkAPI.from_stream(lines, executor)
+
+        CommandProcessor.assert_called_once_with(
+            executor=executor, observer=Any.instance_of(Observer)
+        )
+
+        self._assert_process_called_with_generator_of_commands(CommandProcessor)
+
+    def test_from_string(self, nd_json, executor, CommandProcessor):
+        BulkAPI.from_string(nd_json, executor)
+
+        CommandProcessor.assert_called_once_with(
+            executor=executor, observer=Any.instance_of(Observer)
+        )
+
+        self._assert_process_called_with_generator_of_commands(CommandProcessor)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        (
+            pytest.param({"executor": "not an executor"}, id="bad executor"),
+            pytest.param({"observer": "not an observer"}, id="bad observer"),
+        ),
+    )
+    @pytest.mark.parametrize("method", (BulkAPI.from_stream, BulkAPI.from_string))
+    def test_we_reject_bad_arguments(self, method, kwargs, executor):
+        kwargs.setdefault("executor", executor)
+
+        with pytest.raises(TypeError):
+            method("any string", **kwargs)
+
+    def test_to_stream(self, commands):
+        handle = StringIO()
+
+        BulkAPI.to_stream(handle, commands)
+
+        self._assert_nd_json_matches_commands(handle.getvalue(), commands)
+
+    def test_to_string(self, commands):
+        nd_json = BulkAPI.to_string(commands)
+
+        self._assert_nd_json_matches_commands(nd_json, commands)
+
+    def test_we_catch_json_parsing_errors(self, config_command, executor):
+        bad_string = json.dumps(config_command.raw) + '\n["Nonsense'
+
+        with pytest.raises(InvalidJSONError):
+            BulkAPI.from_string(bad_string, executor)
+
+    def _assert_process_called_with_generator_of_commands(self, CommandProcessor):
+        (generator,), _ = CommandProcessor.return_value.process.call_args
+
+        assert isinstance(generator, GeneratorType)
+        assert generator == Any.iterable.comprised_of(Any.instance_of(Command)).of_size(
+            4
+        )
+
+    def _assert_nd_json_matches_commands(self, nd_json, commands):
+        data = [json.loads(data) for data in nd_json.strip().split("\n")]
+        assert data == [command.raw for command in commands]
+
+    @pytest.fixture
+    def commands(self, config_command, user_command):
+        return [config_command, user_command]
+
+    @pytest.fixture
+    def CommandProcessor(self, patch):
+        return patch("h.h_api.bulk_api.entry_point.CommandProcessor")
+
+    @pytest.fixture
+    def nd_json(self):
+        return resource_string("tests", "h/h_api/fixtures/bulk_api.ndjson").decode(
+            "utf-8"
+        )
+
+    @pytest.fixture
+    def lines(self, nd_json):
+        return nd_json.strip().split("\n")

--- a/tests/h/h_api/bulk_api/functional_test.py
+++ b/tests/h/h_api/bulk_api/functional_test.py
@@ -1,0 +1,101 @@
+import json
+from unittest.mock import call
+
+import pytest
+from h_matchers import Any
+from pkg_resources import resource_filename
+
+from h.h_api.bulk_api import BulkAPI, CommandBuilder
+from h.h_api.bulk_api.executor import AutomaticReportExecutor
+from h.h_api.bulk_api.model.command import DataCommand
+from h.h_api.bulk_api.model.config_body import Configuration
+from h.h_api.bulk_api.observer import Observer
+from h.h_api.enums import CommandStatus, CommandType, DataType
+
+
+class TestBulkAPIFunctional:
+    def test_command_parsing_ok(self, executor):
+        """Sanity test that hits most elements of parsing."""
+
+        fixture = resource_filename("tests", "h/h_api/fixtures/bulk_api.ndjson")
+
+        with open(fixture) as lines:
+            BulkAPI.from_stream(lines, executor=executor, observer=Observer())
+
+        executor.configure.assert_called_with(config=Any.instance_of(Configuration))
+
+        executor.execute_batch.assert_has_calls(
+            [
+                call(
+                    command_type=CommandType.UPSERT,
+                    data_type=DataType.USER,
+                    batch=[Any.instance_of(DataCommand)],
+                    default_config={},
+                ),
+                call(
+                    command_type=CommandType.UPSERT,
+                    data_type=DataType.GROUP,
+                    batch=[Any.instance_of(DataCommand)],
+                    default_config={},
+                ),
+                call(
+                    command_type=CommandType.CREATE,
+                    data_type=DataType.GROUP_MEMBERSHIP,
+                    batch=[Any.instance_of(DataCommand)],
+                    default_config={"on_duplicate": "continue"},
+                ),
+            ]
+        )
+
+    def test_command_serialisation_ok(self, commands):
+        """A sanity check that hits most of the behavior of creation.
+
+        This is a happy path check. We expect this to work."""
+
+        ndjson = BulkAPI.to_string(commands)
+        lines = ndjson.strip().split("\n")
+        command_data = [json.loads(line) for line in lines]
+
+        assert len(command_data) == 4
+
+        assert command_data == [
+            ["configure", Any.dict()],
+            ["upsert", {"data": Any.dict.containing({"type": "user"})}],
+            ["upsert", {"data": Any.dict.containing({"type": "group"})}],
+            ["create", {"data": Any.dict.containing({"type": "group_membership"})}],
+        ]
+
+    def test_round_tripping(self, commands, collecting_observer):
+        """Check that sending and decoding results in the same data."""
+
+        original_raw = [command.raw for command in commands]
+
+        BulkAPI.from_string(
+            BulkAPI.to_string(commands),
+            executor=AutomaticReportExecutor(),
+            observer=collecting_observer,
+        )
+
+        final_raw = [command.raw for command in collecting_observer.commands]
+
+        assert original_raw == final_raw
+
+    @pytest.fixture
+    def collecting_observer(self):
+        class CollectingObserver(Observer):
+            commands = []
+
+            def observe_command(self, command, status):
+                if status == CommandStatus.AS_RECEIVED:
+                    self.commands.append(command)
+
+        return CollectingObserver()
+
+    @pytest.fixture
+    def commands(self, user_command, group_command, membership_command):
+        return (
+            CommandBuilder.configure("acct:user@example.com", total_instructions=4),
+            user_command,
+            group_command,
+            membership_command,
+        )

--- a/tests/h/h_api/conftest.py
+++ b/tests/h/h_api/conftest.py
@@ -1,8 +1,10 @@
 from copy import deepcopy
+from unittest.mock import create_autospec
 
 import pytest
 
 from h.h_api.bulk_api.command_builder import CommandBuilder
+from h.h_api.bulk_api.executor import AutomaticReportExecutor, Executor
 from h.h_api.schema import Schema
 
 
@@ -62,3 +64,13 @@ def user_attributes(upsert_user_body):
 @pytest.fixture
 def group_attributes():
     return {"name": "name", "groupid": "group:name@example.com"}
+
+
+@pytest.fixture
+def executor():
+    executor = create_autospec(Executor, instance=True)
+    fake_report_executor = AutomaticReportExecutor()
+
+    executor.execute_batch.side_effect = fake_report_executor.execute_batch
+
+    return executor

--- a/tests/h/h_api/fixtures/bulk_api.ndjson
+++ b/tests/h/h_api/fixtures/bulk_api.ndjson
@@ -1,0 +1,4 @@
+["configure", {"view": null, "user": {"effective": "acct:user@example.com"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
+["upsert", {"data": {"type": "user", "id": "acct:user@wat.com", "attributes": {"username": "username", "display_name": "display name", "authority": "authority", "identities": [{"provider": "provider", "provider_unique_id": "provider_unique_id"}]}}}]
+["upsert", {"data": {"type": "group", "attributes": {"name": "group:name@example.com"}, "meta": {"query": {"groupid": "group:groupid@example.com"}, "$anchor": "group_ref"}}}]
+["create", {"data": {"type": "group_membership", "relationships": {"member": {"data": {"type": "user", "id": "acct:user@wat.com"}}, "group": {"data": {"type": "group", "id": {"$ref": "group_ref"}}}}}}]


### PR DESCRIPTION
This pulls together all the various items you need to plug together to call the command processor correctly as well as adding some more general functional tests which try and hit the whole stack
from top to bottom (in a fairly narrow way).

I'm seeing this as the public API to this, which contains the minimum knowledge to get this going. I don't think we're going to know the actual surface area you need to be aware of until we actually start using it. So I'd still like to delay making too many choices about it at this point.