### PR TITLE
Add stub Bulk API end-point which validates the request

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -132,6 +132,8 @@ def includeme(config):
         factory="h.traversal:AnnotationRoot",
         traverse="/{id}",
     )
+
+    config.add_route("api.bulk", "/api/bulk", request_method="POST")
     config.add_route("api.groups", "/api/groups", factory="h.traversal.GroupRoot")
     config.add_route(
         "api.group_upsert",

--- a/h/views/api/bulk.py
+++ b/h/views/api/bulk.py
@@ -1,0 +1,62 @@
+from itertools import chain
+from logging import getLogger
+
+from pyramid.response import Response
+
+from h.h_api.bulk_api import BulkAPI
+from h.h_api.bulk_api.executor import AutomaticReportExecutor
+from h.views.api.config import api_config
+
+LOG = getLogger(__name__)
+
+
+class FakeBulkAPI(BulkAPI):
+    """Temporary stub for return values.
+
+    When this work is complete, BulkAPI will return values for us. But right
+    now it doesn't and we need something to prove we can build a return value.
+    """
+
+    boo = 1
+
+    @classmethod
+    def from_byte_stream(cls, byte_stream, executor, observer=None):
+        super().from_byte_stream(byte_stream, executor, observer=None)
+
+        if cls.boo:
+            yield b'["Line 1"]\n'
+            yield b'["Line 2"]\n'
+        else:
+            return None
+
+
+@api_config(
+    versions=["v1", "v2"],
+    route_name="api.bulk",
+    request_method="POST",
+    link_name="bulk",
+    description="Perform multiple operations in one call",
+    subtype="x-ndjson",
+)
+def bulk(request):
+    """Retrieve the groups for this request's user."""
+
+    results = FakeBulkAPI.from_byte_stream(
+        request.body_file, executor=AutomaticReportExecutor()
+    )
+
+    # No return view is required
+    if results is None:
+        return Response(status=204)
+
+    # An NDJSON response is required
+
+    if results:
+        # When we get an iterator we must force the first return value to be
+        # created to be sure input validation has occurred. Otherwise we might
+        # raise errors outside of the view
+        results = chain([next(results)], results)
+
+        return Response(
+            app_iter=results, status=200, content_type="application/x-ndjson"
+        )

--- a/h/views/api/bulk.py
+++ b/h/views/api/bulk.py
@@ -17,13 +17,13 @@ class FakeBulkAPI(BulkAPI):
     now it doesn't and we need something to prove we can build a return value.
     """
 
-    boo = 1
+    return_content = True
 
     @classmethod
     def from_byte_stream(cls, byte_stream, executor, observer=None):
         super().from_byte_stream(byte_stream, executor, observer=None)
 
-        if cls.boo:
+        if cls.return_content:
             yield b'["Line 1"]\n'
             yield b'["Line 2"]\n'
         else:
@@ -39,7 +39,18 @@ class FakeBulkAPI(BulkAPI):
     subtype="x-ndjson",
 )
 def bulk(request):
-    """Retrieve the groups for this request's user."""
+    """
+    Perform a bulk request which can modify multiple records in on go.
+
+    This end-point can:
+
+     * Upsert users
+     * Upsert groups
+     * Add users to groups
+
+    This end-point is intended to be called using the classes provided by
+    `h.h_api.bulk_api`.
+    """
 
     results = FakeBulkAPI.from_byte_stream(
         request.body_file, executor=AutomaticReportExecutor()

--- a/h/views/api/errors.py
+++ b/h/views/api/errors.py
@@ -10,6 +10,7 @@ API views.
 from pyramid import httpexceptions
 from pyramid.view import forbidden_view_config, notfound_view_config, view_config
 
+from h.h_api.exceptions import JSONAPIError
 from h.i18n import TranslationString as _  # noqa: N813
 from h.util.view import handle_exception, json_view
 from h.views.api.config import cors_policy
@@ -55,6 +56,14 @@ def api_error(context, request):
     """Handle an expected/deliberately thrown API exception."""
     request.response.status_code = context.status_code
     return {"status": "failure", "reason": context.detail}
+
+
+@json_view(context=JSONAPIError, path_info="/api/bulk", decorator=cors_policy)
+def bulk_api_error(context, request):
+    """Handle JSONAPIErrors produced by the Bulk API."""
+
+    request.response.status_code = context.http_status
+    return context.as_dict()
 
 
 @json_view(context=Exception, path_info="/api/", decorator=cors_policy)

--- a/tests/functional/api/test_bulk.py
+++ b/tests/functional/api/test_bulk.py
@@ -1,0 +1,74 @@
+import json
+
+import pytest
+from h_matchers import Any
+
+from h.h_api.bulk_api import CommandBuilder
+
+
+class TestBulk:
+    @pytest.mark.skip
+    def test_it_requires_authentication(self, app):
+        response = app.post("/api/bulk", b"dummy", headers=None, expect_errors=True)
+
+        assert response.status_int == 404
+
+    def test_it_accepts_a_valid_request(self, app, nd_json, auth_header):
+        response = app.post("/api/bulk", nd_json, headers=auth_header)
+
+        assert response.status_int == 200
+        assert response.content_type == "application/x-ndjson"
+        assert (
+            response.headers["Hypothesis-Media-Type"]
+            == "application/vnd.hypothesis.v1+x-ndjson"
+        )
+
+    def test_it_raises_errors_for_invalid_request(self, app, auth_header):
+        response = app.post(
+            "/api/bulk", '["some-mince"]', headers=auth_header, expect_errors=True
+        )
+
+        assert response.status_int == 400
+        assert response.content_type == "application/json"
+
+        assert response.json == {
+            "errors": Any.list.comprised_of(
+                Any.dict.containing({"code": "SchemaValidationError"})
+            )
+        }
+
+    @pytest.fixture
+    def commands(self):
+        return [
+            CommandBuilder.configure("acct:user1@example.com", total_instructions=4),
+            CommandBuilder.user.upsert(
+                "acct:user2@example.com",
+                {
+                    "username": "user2",
+                    "display_name": "display_name",
+                    "authority": "example.com",
+                    "identities": [
+                        {
+                            "provider": "provider",
+                            "provider_unique_id": "provider_unique_id",
+                        }
+                    ],
+                },
+            ),
+            CommandBuilder.group.upsert(
+                {"groupid": "group:name@example.com", "name": "name"}, "group_ref"
+            ),
+            CommandBuilder.group_membership.create(
+                "acct:user2@example.com", "group_ref"
+            ),
+        ]
+
+    @pytest.fixture
+    def nd_json(self, commands):
+        return "\n".join(json.dumps(command.raw) for command in commands)
+
+
+@pytest.fixture
+def auth_header():
+    # When authentication is on, this should be enabled
+    return

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -14,7 +14,7 @@ def test_includeme():
     # up-to-date is hopefully pretty low (run the tests with -vv, copy the new
     # expected value, strip out any Unicode prefixes) and it serves as a check
     # to ensure that any changes made to the routes were intended.
-    assert config.add_route.mock_calls == [
+    calls = [
         call("index", "/"),
         call("robots", "/robots.txt"),
         call("via_redirect", "/via"),
@@ -127,6 +127,7 @@ def test_includeme():
             factory="h.traversal:AnnotationRoot",
             traverse="/{id}",
         ),
+        call("api.bulk", "/api/bulk", request_method="POST"),
         call("api.groups", "/api/groups", factory="h.traversal.GroupRoot"),
         call(
             "api.group_upsert",
@@ -236,3 +237,11 @@ def test_includeme():
             "wordpress-plugin", "https://wordpress.org/plugins/hypothesis/", static=True
         ),
     ]
+
+    # Test each one one at a time to make it a bit easier to spot which one
+    # isn't in the list
+    for single_call in calls:
+        assert single_call in config.add_route.mock_calls
+
+    # Then we can assert the order here
+    assert config.add_route.mock_calls == calls

--- a/tests/h/views/api/bulk_test.py
+++ b/tests/h/views/api/bulk_test.py
@@ -1,0 +1,69 @@
+from io import BytesIO
+from unittest.mock import create_autospec
+
+import pytest
+from h_matchers import Any
+from webob import Response
+
+from h.h_api.bulk_api import Executor
+from h.h_api.exceptions import SchemaValidationError
+from h.views.api.bulk import bulk
+
+
+class TestBulk:
+    def test_it_calls_bulk_api_correctly(self, pyramid_request, BulkAPI):
+        bulk(pyramid_request)
+
+        BulkAPI.from_byte_stream.assert_called_once_with(
+            pyramid_request.body_file, executor=Any.instance_of(Executor)
+        )
+
+    def test_it_formats_responses_correctly(self, pyramid_request, return_lines):
+        result = bulk(pyramid_request)
+
+        assert isinstance(result, Response)
+        assert result.status == "200 OK"
+        assert result.content_type == "application/x-ndjson"
+        assert result.body == b"".join(return_lines)
+
+    @pytest.mark.usefixtures("no_return_content")
+    def test_it_returns_204_if_no_content_is_to_be_returned(
+        self, pyramid_request, return_lines
+    ):
+        result = bulk(pyramid_request)
+
+        assert result.status == "204 No Content"
+
+    def test_it_raises_with_output_and_invalid_input(self, BulkAPI, pyramid_request):
+        def bad_generator(*_, **__):
+            raise SchemaValidationError([], "Bad!")
+            # Looks like this doesn't do anything, but it turns this into a
+            # generator. Unless the first item is retrieved the above is not
+            # executed.
+            yield "good!"
+
+        BulkAPI.from_byte_stream.side_effect = bad_generator
+
+        with pytest.raises(SchemaValidationError):
+            bulk(pyramid_request)
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.body_file = create_autospec(BytesIO)
+
+        return pyramid_request
+
+    @pytest.fixture
+    def return_lines(self):
+        return [b"line_1\n", b"line_2\n"]
+
+    @pytest.fixture(autouse=True)
+    def BulkAPI(self, patch, return_lines):
+        BulkAPI = patch("h.views.api.bulk.FakeBulkAPI")
+        BulkAPI.from_byte_stream.return_value = (line for line in return_lines)
+
+        return BulkAPI
+
+    @pytest.fixture
+    def no_return_content(self, BulkAPI):
+        BulkAPI.from_byte_stream.return_value = None


### PR DESCRIPTION
This adds an `/api/bulk` end-point which:

 * Reads and checks over the request from NDJSON
 * Catches and returns any `JSONAPIError` format exceptions as JSON responses
 * Renders out some nonsense in JSON API format

---- 

Calling the end-point:

```
curl --request POST \
  --url http://localhost:5000/api/bulk \
  --data '["configure", {"view": null, "user": {"effective": "acct:user@example.com"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
["upsert", {"data": {"type": "user", "id": "acct:user@wat.com", "attributes": {"username": "username", "display_name": "display name", "authority": "authority", "identities": [{"provider": "provider", "provider_unique_id": "provider_unique_id"}]}}}]
["upsert", {"data": {"type": "group", "attributes": {"name": "group:name@example.com"}, "meta": {"query": {"groupid": "group:groupid@example.com"}, "$anchor": "group_ref"}}}]
["create", {"data": {"type": "group_membership", "relationships": {"member": {"data": {"type": "user", "id": "acct:user@wat.com"}}, "group": {"data": {"type": "group", "id": {"$ref": "group_ref"}}}}}}]'
```

This is basically how you would play the fixture from the functional tests yourself.