### PR TITLE
Bulk API - Fix degenerate calls

### DIFF
--- a/h/h_api/bulk_api/command_builder.py
+++ b/h/h_api/bulk_api/command_builder.py
@@ -1,5 +1,10 @@
 """Tools for deserialising and creating command objects."""
-from h.h_api.bulk_api.model.command import ConfigCommand, CreateCommand, UpsertCommand
+from h.h_api.bulk_api.model.command import (
+    Command,
+    ConfigCommand,
+    CreateCommand,
+    UpsertCommand,
+)
 from h.h_api.bulk_api.model.config_body import Configuration
 from h.h_api.bulk_api.model.data_body import (
     CreateGroupMembership,
@@ -19,15 +24,16 @@ class CommandBuilder:
         :param raw: The data to decode
         :returns: An appropriate child of `Command`
         """
-        command_type = CommandType(raw[0])
 
-        if command_type is CommandType.CONFIGURE:
+        command = Command(raw)
+
+        if command.type is CommandType.CONFIGURE:
             return ConfigCommand(raw)
 
-        if command_type is CommandType.CREATE:
+        if command.type is CommandType.CREATE:
             return CreateCommand(raw)
 
-        elif command_type is CommandType.UPSERT:
+        elif command.type is CommandType.UPSERT:
             return UpsertCommand(raw)
 
     @classmethod

--- a/h/h_api/bulk_api/command_processor.py
+++ b/h/h_api/bulk_api/command_processor.py
@@ -110,8 +110,6 @@ This may cause the CommandBatcher to call the on_flush() callback that we passed
             if not self.command_count:
                 raise CommandSequenceError("No instructions received")
 
-            total = self.config.total_instructions
-
             if self.command_count != total:
                 raise InvalidDeclarationError(
                     f"Expected more instructions. Found {self.command_count} expected {total}"

--- a/h/h_api/bulk_api/command_processor.py
+++ b/h/h_api/bulk_api/command_processor.py
@@ -104,20 +104,26 @@ This may cause the CommandBatcher to call the on_flush() callback that we passed
         :param final: This is the final count check, not incremental
         """
 
+        total = self.config.total_instructions if self.config else None
+
+        if final:
+            if not self.command_count:
+                raise CommandSequenceError("No instructions received")
+
+            total = self.config.total_instructions
+
+            if self.command_count != total:
+                raise InvalidDeclarationError(
+                    f"Expected more instructions. Found {self.command_count} expected {total}"
+                )
+            return
+
         if not self.config:
             return
 
-        total = self.config.total_instructions
-
-        if not final:
-            if self.command_count > total:
-                raise InvalidDeclarationError(
-                    f"More instructions ({self.command_count}) received than declared ({total})"
-                )
-
-        elif self.command_count != total:
+        if self.command_count > total:
             raise InvalidDeclarationError(
-                f"Expected more instructions. Found {self.command_count} expected {total}"
+                f"More instructions ({self.command_count}) received than declared ({total})"
             )
 
     def _execute_batch(self, command_type, data_type, batch):

--- a/h/h_api/resources/schema/bulk_api/wrapper.json
+++ b/h/h_api/resources/schema/bulk_api/wrapper.json
@@ -9,11 +9,13 @@
         {"enum":  ["create", "upsert", "configure"]},
         {"type":  "object"}
     ],
+    "minItems": 2,
+    "maxItems": 2,
+
     "if": {
         "items": [
             {"enum": ["configure"]}
-        ],
-        "additionalItems": true
+        ]
     },
     "then": {
         "items": [

--- a/tests/h/h_api/bulk_api/command_builder_test.py
+++ b/tests/h/h_api/bulk_api/command_builder_test.py
@@ -61,6 +61,11 @@ class TestCommandBuilderFromData:
         with pytest.raises(SchemaValidationError):
             CommandBuilder.from_data([CONFIGURE, configuration_body])
 
+    @pytest.mark.parametrize("data", ([], ["configure"]))
+    def test_we_get_schema_errors_with_malformed_commands(self, data):
+        with pytest.raises(SchemaValidationError):
+            CommandBuilder.from_data(data)
+
 
 class TestCommandBuilderCreation:
     def test_configure(self):

--- a/tests/h/h_api/bulk_api/command_processor_test.py
+++ b/tests/h/h_api/bulk_api/command_processor_test.py
@@ -24,6 +24,10 @@ class TestCommandProcessor:
         with pytest.raises(CommandSequenceError):
             command_processor.process([config_command, config_command])
 
+    def test_if_fails_with_no_commands(self, command_processor):
+        with pytest.raises(CommandSequenceError):
+            command_processor.process([])
+
     def test_it_fails_with_too_many_commands(
         self, command_processor, commands, user_command
     ):

--- a/tests/h/h_api/bulk_api/model/command_test.py
+++ b/tests/h/h_api/bulk_api/model/command_test.py
@@ -29,6 +29,8 @@ class TestCommand:
     @pytest.mark.parametrize(
         "raw",
         (
+            [],
+            ["create"],
             {},
             ["wrong", {}],
             [CommandType.CREATE.value, {}],


### PR DESCRIPTION
Upon starting to use this in the end-point in `h`, I immediately spotted some problems. You could pass through degenerate calls which would pass validation like:

 * A "command" with only an empty list (as the tuple validation in JSON Schema doesn't specify length like I thought it did)
 * No commands at all - As we only check that we match the declaration (no config, no declaration!)