### PR TITLE
Bulk API - Stream from bytes

### DIFF
--- a/h/h_api/bulk_api/entry_point.py
+++ b/h/h_api/bulk_api/entry_point.py
@@ -110,7 +110,7 @@ class BulkAPI:
         :param string: A string to split
         :return: A generator of strings containing single lines
         """
-        return (line for line in string.strip().split("\n"))
+        return string.strip().split("\n")
 
     @staticmethod
     def _bytes_to_lines(stream, chunk_size=16384):

--- a/tests/h/h_api/bulk_api/functional_test.py
+++ b/tests/h/h_api/bulk_api/functional_test.py
@@ -20,7 +20,7 @@ class TestBulkAPIFunctional:
         fixture = resource_filename("tests", "h/h_api/fixtures/bulk_api.ndjson")
 
         with open(fixture) as lines:
-            BulkAPI.from_stream(lines, executor=executor, observer=Observer())
+            BulkAPI.from_lines(lines, executor=executor, observer=Observer())
 
         executor.configure.assert_called_with(config=Any.instance_of(Configuration))
 

--- a/tests/h/h_api/fixtures/bulk_api.ndjson
+++ b/tests/h/h_api/fixtures/bulk_api.ndjson
@@ -1,4 +1,8 @@
+
 ["configure", {"view": null, "user": {"effective": "acct:user@example.com"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
+
+
 ["upsert", {"data": {"type": "user", "id": "acct:user@wat.com", "attributes": {"username": "username", "display_name": "display name", "authority": "authority", "identities": [{"provider": "provider", "provider_unique_id": "provider_unique_id"}]}}}]
 ["upsert", {"data": {"type": "group", "attributes": {"name": "group:name@example.com"}, "meta": {"query": {"groupid": "group:groupid@example.com"}, "$anchor": "group_ref"}}}]
 ["create", {"data": {"type": "group_membership", "relationships": {"member": {"data": {"type": "user", "id": "acct:user@wat.com"}}, "group": {"data": {"type": "group", "id": {"$ref": "group_ref"}}}}}}]
+


### PR DESCRIPTION
Really should of looked this up ahead of time, but the two methods of getting body content in `pyramid` are either as a string, or a stream of bytes. This adds an adaptor to convert a stream of bytes into lines by splitting on new lines.