### PR TITLE
Reduce duplication and modernise group functests

### DIFF
--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -9,6 +9,7 @@ from pyramid.httpexceptions import (
 )
 
 from h.auth.util import client_authority
+from h.exceptions import InvalidUserId
 from h.i18n import TranslationString as _  # noqa: N813
 from h.presenters import GroupJSONPresenter, GroupsJSONPresenter, UserJSONPresenter
 from h.schemas.api.group import CreateGroupAPISchema, UpdateGroupAPISchema
@@ -245,7 +246,7 @@ def add_member(group, request):
 
     try:
         user = user_svc.fetch(request.matchdict["userid"])
-    except ValueError:
+    except (ValueError, InvalidUserId):
         raise HTTPNotFound()
 
     if user is None:

--- a/tests/functional/api/groups/conftest.py
+++ b/tests/functional/api/groups/conftest.py
@@ -1,0 +1,86 @@
+import base64
+
+import pytest
+
+from h.models.auth_client import GrantType
+
+
+@pytest.fixture
+def authority():
+    return "example.com"
+
+
+@pytest.fixture
+def authority_3rd_party():
+    return "thirdparty.example.com"
+
+
+@pytest.fixture
+def user(_user_for_authority, authority):
+    return _user_for_authority(authority)
+
+
+@pytest.fixture
+def user_3rd_party(_user_for_authority, authority_3rd_party):
+    return _user_for_authority(authority_3rd_party)
+
+
+@pytest.fixture
+def auth_header(_auth_header_for_authority, authority):
+    return _auth_header_for_authority(authority)
+
+
+@pytest.fixture
+def auth_headers_3rd_party(
+    _auth_header_for_authority, authority_3rd_party, user_3rd_party
+):
+    headers = _auth_header_for_authority(authority_3rd_party)
+    headers["X-Forwarded-User"] = user_3rd_party.userid
+
+    return headers
+
+
+@pytest.fixture
+def token_auth_header(db_session, factories, user):
+    token = factories.DeveloperToken(userid=user.userid)
+    db_session.add(token)
+    db_session.commit()
+
+    return {"Authorization": f"Bearer {token.value}"}
+
+
+@pytest.fixture
+def group(db_session, factories, user):
+    group = factories.Group(
+        name="My First Group",
+        description="Original description",
+        creator=user,
+        authority=user.authority,
+    )
+    db_session.commit()
+    return group
+
+
+@pytest.fixture
+def _user_for_authority(db_session, factories):
+    def _make_user(authority):
+        user = factories.User(authority=authority)
+        db_session.commit()
+        return user
+
+    return _make_user
+
+
+@pytest.fixture
+def _auth_header_for_authority(db_session, factories):
+    def _make_headers(authority):
+        auth_client = factories.ConfidentialAuthClient(
+            authority=authority, grant_type=GrantType.client_credentials
+        )
+        db_session.commit()
+
+        user_pass = f"{auth_client.id}:{auth_client.secret}".encode("utf-8")
+        encoded = base64.standard_b64encode(user_pass).decode("ascii")
+        return {"Authorization": f"Basic {encoded}"}
+
+    return _make_headers

--- a/tests/functional/api/groups/test_create.py
+++ b/tests/functional/api/groups/test_create.py
@@ -1,30 +1,29 @@
 # -*- coding: utf-8 -*-
 
-import base64
-
 import pytest
-
-from h.models.auth_client import GrantType
 
 
 class TestCreateGroup:
     def test_it_returns_http_200_with_valid_payload(self, app, token_auth_header):
-        group = {"name": "My Group"}
-        res = app.post_json("/api/groups", group, headers=token_auth_header)
+        res = app.post_json(
+            "/api/groups", {"name": "My Group"}, headers=token_auth_header
+        )
 
         assert res.status_code == 200
 
     def test_it_ignores_non_whitelisted_fields_in_payload(self, app, token_auth_header):
-        group = {"name": "My Group", "organization": "foobar", "joinable_by": "whoever"}
-        res = app.post_json("/api/groups", group, headers=token_auth_header)
+        res = app.post_json(
+            "/api/groups",
+            {"name": "My Group", "organization": "foobar", "joinable_by": "whoever"},
+            headers=token_auth_header,
+        )
 
         assert res.status_code == 200
 
     def test_it_returns_http_400_with_invalid_payload(self, app, token_auth_header):
-        group = {}
 
         res = app.post_json(
-            "/api/groups", group, headers=token_auth_header, expect_errors=True
+            "/api/groups", {}, headers=token_auth_header, expect_errors=True
         )
 
         assert res.status_code == 400
@@ -32,122 +31,75 @@ class TestCreateGroup:
     def test_it_returns_http_400_if_groupid_set_on_default_authority(
         self, app, token_auth_header
     ):
-        group = {"name": "My Group", "groupid": "3434kjkjk"}
         res = app.post_json(
-            "/api/groups", group, headers=token_auth_header, expect_errors=True
+            "/api/groups",
+            {"name": "My Group", "groupid": "3434kjkjk"},
+            headers=token_auth_header,
+            expect_errors=True,
         )
 
         assert res.status_code == 400
 
-    def test_it_returns_http_404_if_no_authenticated_user(
-        self, app, auth_client_header
-    ):
+    def test_it_returns_http_404_if_no_authenticated_user(self, app, auth_header):
         # FIXME: This should return a 403
-        group = {"name": "My Group"}
         res = app.post_json(
-            "/api/groups", group, headers=auth_client_header, expect_errors=True
+            "/api/groups", {"name": "My Group"}, headers=auth_header, expect_errors=True
         )
 
         assert res.status_code == 404
 
     @pytest.mark.xfail
-    def test_it_returns_http_403_if_no_authenticated_user(
-        self, app, auth_client_header
-    ):
-        group = {"name": "My Group"}
+    def test_it_returns_http_403_if_no_authenticated_user(self, app, auth_header):
         res = app.post_json(
-            "/api/groups", group, headers=auth_client_header, expect_errors=True
+            "/api/groups", {"name": "My Group"}, headers=auth_header, expect_errors=True
         )
 
         assert res.status_code == 403
 
-    def test_it_allows_auth_client_with_forwarded_user(
-        self, app, auth_client_header, third_party_user
-    ):
-        headers = auth_client_header
-        headers["X-Forwarded-User"] = third_party_user.userid
-        group = {"name": "My Group"}
+    def test_it_allows_auth_client_with_forwarded_user(self, app, auth_header, user):
+        headers = auth_header
+        headers["X-Forwarded-User"] = user.userid
 
-        res = app.post_json("/api/groups", group, headers=headers)
+        res = app.post_json("/api/groups", {"name": "My Group"}, headers=headers)
 
         assert res.status_code == 200
 
     def test_it_allows_groupdid_from_auth_client_with_forwarded_user(
-        self, app, auth_client_header, third_party_user
+        self, app, auth_headers_3rd_party, user_3rd_party
     ):
-        headers = auth_client_header
-        headers["X-Forwarded-User"] = third_party_user.userid
-        group = {"name": "My Group", "groupid": "group:333vcdfkj~@thirdparty.com"}
-
-        res = app.post_json("/api/groups", group, headers=headers)
+        res = app.post_json(
+            "/api/groups",
+            {"name": "My Group", "groupid": "group:333vcdfkj~@thirdparty.example.com"},
+            headers=auth_headers_3rd_party,
+        )
         data = res.json
 
         assert res.status_code == 200
         assert "groupid" in data
-        assert data["groupid"] == "group:{groupid}@thirdparty.com".format(
-            groupid="333vcdfkj~"
-        )
+        assert data["groupid"] == "group:333vcdfkj~@thirdparty.example.com"
 
     def test_it_returns_HTTP_Conflict_if_groupid_is_duplicate(
-        self, app, auth_client_header, third_party_user
+        self, app, auth_headers_3rd_party, user_3rd_party
     ):
-        headers = auth_client_header
-        headers["X-Forwarded-User"] = third_party_user.userid
-        group = {"name": "My Group", "groupid": "group:333vcdfkj~@thirdparty.com"}
+        body = {
+            "name": "My Group",
+            "groupid": "group:333vcdfkj~@thirdparty.example.com",
+        }
 
-        res = app.post_json("/api/groups", group, headers=headers)
-        res = app.post_json("/api/groups", group, headers=headers, expect_errors=True)
+        app.post_json("/api/groups", body, headers=auth_headers_3rd_party)
+        res = app.post_json(
+            "/api/groups", body, headers=auth_headers_3rd_party, expect_errors=True
+        )
 
         assert res.status_code == 409
 
     def test_it_returns_http_404_with_invalid_forwarded_user_format(
-        self, app, auth_client_header
+        self, app, auth_header
     ):
         # FIXME: This should return a 403
-        headers = auth_client_header
+        headers = auth_header
         headers["X-Forwarded-User"] = "floopflarp"
-        group = {}
 
-        res = app.post_json("/api/groups", group, headers=headers, expect_errors=True)
+        res = app.post_json("/api/groups", {}, headers=headers, expect_errors=True)
 
         assert res.status_code == 404
-
-
-@pytest.fixture
-def third_party_user(db_session, factories):
-    user = factories.User(authority="thirdparty.com")
-    db_session.commit()
-    return user
-
-
-@pytest.fixture
-def auth_client(db_session, factories):
-    auth_client = factories.ConfidentialAuthClient(
-        authority="thirdparty.com", grant_type=GrantType.client_credentials
-    )
-    db_session.commit()
-    return auth_client
-
-
-@pytest.fixture
-def auth_client_header(auth_client):
-    user_pass = "{client_id}:{secret}".format(
-        client_id=auth_client.id, secret=auth_client.secret
-    )
-    encoded = base64.standard_b64encode(user_pass.encode("utf-8"))
-    return {"Authorization": "Basic {creds}".format(creds=encoded.decode("ascii"))}
-
-
-@pytest.fixture
-def user_with_token(db_session, factories):
-    user = factories.User()
-    token = factories.DeveloperToken(userid=user.userid)
-    db_session.add(token)
-    db_session.commit()
-    return (user, token)
-
-
-@pytest.fixture
-def token_auth_header(user_with_token):
-    user, token = user_with_token
-    return {"Authorization": "Bearer {}".format(token.value)}

--- a/tests/functional/api/groups/test_update.py
+++ b/tests/functional/api/groups/test_update.py
@@ -1,20 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import base64
-
-import pytest
-
-from h.models.auth_client import GrantType
-
 
 class TestUpdateGroup:
     def test_it_returns_http_200_with_valid_payload_and_user_token(
-        self, app, token_auth_header, first_party_group
+        self, app, token_auth_header, group
     ):
-        group = {"name": "Rename My Group"}
         res = app.patch_json(
-            "/api/groups/{id}".format(id=first_party_group.pubid),
-            group,
+            f"/api/groups/{group.pubid}",
+            {"name": "Rename My Group"},
             headers=token_auth_header,
         )
 
@@ -23,13 +16,11 @@ class TestUpdateGroup:
         assert res.json_body["groupid"] is None
 
     def test_it_does_not_update_group_if_empty_payload_and_user_token(
-        self, app, token_auth_header, first_party_group
+        self, app, token_auth_header, group
     ):
-        payload = {}
+
         res = app.patch_json(
-            "/api/groups/{id}".format(id=first_party_group.pubid),
-            payload,
-            headers=token_auth_header,
+            f"/api/groups/{group.pubid}", {}, headers=token_auth_header,
         )
 
         assert res.status_code == 200
@@ -37,34 +28,33 @@ class TestUpdateGroup:
         assert res.json_body["groupid"] is None
 
     def test_it_ignores_non_whitelisted_fields_in_payload_and_user_token(
-        self, app, token_auth_header, first_party_group
+        self, app, token_auth_header, group
     ):
-        group = {
-            "id": "fbdzzz",
-            "name": "My Group",
-            "organization": "foobar",
-            "joinable_by": "whoever",
-        }
+        new_id = "fbdzzz"
+
         res = app.patch_json(
-            "/api/groups/{id}".format(id=first_party_group.pubid),
-            group,
+            f"/api/groups/{group.pubid}",
+            {
+                "id": new_id,
+                "name": "My Group",
+                "organization": "foobar",
+                "joinable_by": "whoever",
+            },
             headers=token_auth_header,
         )
 
         assert res.status_code == 200
-        assert res.json_body["id"] != group["id"]
+        assert res.json_body["id"] != new_id
         assert res.json_body["organization"] is None
 
     def test_it_returns_http_400_with_invalid_payload_and_user_token(
-        self, app, token_auth_header, first_party_group
+        self, app, token_auth_header, group
     ):
-        group = {
-            "name": "Oooopoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
-        }
-
         res = app.patch_json(
-            "/api/groups/{id}".format(id=first_party_group.pubid),
-            group,
+            f"/api/groups/{group.pubid}",
+            {
+                "name": "Oooopoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            },
             headers=token_auth_header,
             expect_errors=True,
         )
@@ -72,24 +62,20 @@ class TestUpdateGroup:
         assert res.status_code == 400
 
     def test_it_returns_http_400_if_groupid_set_on_default_authority_and_user_token(
-        self, app, token_auth_header, first_party_group
+        self, app, token_auth_header, group
     ):
-        group = {"groupid": "3434kjkjk"}
         res = app.patch_json(
-            "/api/groups/{id}".format(id=first_party_group.pubid),
-            group,
+            f"/api/groups/{group.pubid}",
+            {"groupid": "3434kjkjk"},
             headers=token_auth_header,
             expect_errors=True,
         )
 
         assert res.status_code == 400
 
-    def test_it_returns_http_404_if_no_authenticated_user(self, app, first_party_group):
-        group = {"name": "My Group"}
+    def test_it_returns_http_404_if_no_authenticated_user(self, app, group):
         res = app.patch_json(
-            "/api/groups/{id}".format(id=first_party_group.pubid),
-            group,
-            expect_errors=True,
+            f"/api/groups/{group.pubid}", {"name": "My Group"}, expect_errors=True,
         )
 
         assert res.status_code == 404
@@ -101,10 +87,9 @@ class TestUpdateGroup:
         group = factories.Group()
         db_session.commit()
 
-        group_payload = {"name": "My Group"}
         res = app.patch_json(
-            "/api/groups/{id}".format(id=group.pubid),
-            group_payload,
+            f"/api/groups/{group.pubid}",
+            {"name": "My Group"},
             headers=token_auth_header,
             expect_errors=True,
         )
@@ -112,158 +97,94 @@ class TestUpdateGroup:
         assert res.status_code == 404
 
     def test_it_allows_auth_client_with_valid_forwarded_user(
-        self, app, auth_client_header, third_party_user, factories, db_session
+        self, app, auth_headers_3rd_party, user_3rd_party, factories, db_session
     ):
         group = factories.Group(
-            creator=third_party_user, authority=third_party_user.authority
+            creator=user_3rd_party, authority=user_3rd_party.authority
         )
         db_session.commit()
 
-        headers = auth_client_header
-        headers["X-Forwarded-User"] = third_party_user.userid
-        group_payload = {"name": "My Group"}
-
-        path = "/api/groups/{id}".format(id=group.pubid)
-        res = app.patch_json(path, group_payload, headers=headers)
+        res = app.patch_json(
+            f"/api/groups/{group.pubid}",
+            {"name": "My Group"},
+            headers=auth_headers_3rd_party,
+        )
 
         assert res.status_code == 200
         assert res.json_body["name"] == "My Group"
 
     def test_it_allows_auth_client_with_matching_authority(
-        self, app, auth_client_header, third_party_user, factories, db_session
+        self, app, auth_headers_3rd_party, user_3rd_party, factories, db_session
     ):
         group = factories.Group(
-            creator=third_party_user, authority=third_party_user.authority
+            creator=user_3rd_party, authority=user_3rd_party.authority
         )
         db_session.commit()
 
-        group_payload = {"name": "My Group"}
-
-        path = "/api/groups/{id}".format(id=group.pubid)
-        res = app.patch_json(path, group_payload, headers=auth_client_header)
+        res = app.patch_json(
+            f"/api/groups/{group.pubid}",
+            {"name": "My Group"},
+            headers=auth_headers_3rd_party,
+        )
 
         assert res.status_code == 200
         assert res.json_body["name"] == "My Group"
 
     def test_it_does_not_allow_auth_client_with_mismatched_authority(
-        self, app, auth_client_header, factories, db_session
+        self, app, auth_header, factories, db_session
     ):
         group = factories.Group(authority="rando.biz")
         db_session.commit()
 
-        group_payload = {"name": "My Group"}
-
-        path = "/api/groups/{id}".format(id=group.pubid)
         res = app.patch_json(
-            path, group_payload, headers=auth_client_header, expect_errors=True
+            f"/api/groups/{group.pubid}",
+            {"name": "My Group"},
+            headers=auth_header,
+            expect_errors=True,
         )
 
         assert res.status_code == 404
 
     def test_it_allows_groupid_from_auth_client_with_forwarded_user(
-        self, app, auth_client_header, third_party_user, factories, db_session
+        self, app, auth_headers_3rd_party, user_3rd_party, factories, db_session
     ):
         group = factories.Group(
-            creator=third_party_user, authority=third_party_user.authority
+            creator=user_3rd_party, authority=user_3rd_party.authority
         )
         db_session.commit()
 
-        headers = auth_client_header
-        headers["X-Forwarded-User"] = third_party_user.userid
-        group_payload = {
-            "name": "My Group",
-            "groupid": "group:333vcdfkj~@thirdparty.com",
-        }
-
-        path = "/api/groups/{id}".format(id=group.pubid)
-        res = app.patch_json(path, group_payload, headers=headers)
+        res = app.patch_json(
+            f"/api/groups/{group.pubid}",
+            {"name": "My Group", "groupid": "group:333vcdfkj~@thirdparty.example.com"},
+            headers=auth_headers_3rd_party,
+        )
 
         assert res.status_code == 200
         assert "groupid" in res.json_body
-        assert res.json_body["groupid"] == "group:{groupid}@thirdparty.com".format(
-            groupid="333vcdfkj~"
-        )
+        assert res.json_body["groupid"] == "group:333vcdfkj~@thirdparty.example.com"
 
     def test_it_returns_HTTP_Conflict_if_groupid_is_duplicate(
-        self, app, auth_client_header, third_party_user, factories, db_session
+        self, app, auth_headers_3rd_party, user_3rd_party, factories, db_session
     ):
         group1 = factories.Group(
-            creator=third_party_user,
-            authority=third_party_user.authority,
-            groupid="group:one@thirdparty.com",
+            creator=user_3rd_party,
+            authority=user_3rd_party.authority,
+            groupid="group:one@thirdparty.example.com",
         )
         group2 = factories.Group(
-            creator=third_party_user,
-            authority=third_party_user.authority,
-            groupid="group:two@thirdparty.com",
+            creator=user_3rd_party,
+            authority=user_3rd_party.authority,
+            groupid="group:two@thirdparty.example.com",
         )
         db_session.commit()
 
-        headers = auth_client_header
-        headers["X-Forwarded-User"] = third_party_user.userid
-        group_payload = {"groupid": "group:one@thirdparty.com"}
-
         # Attempting to set group2's `groupid` to one already taken by group1
-        path = "/api/groups/{id}".format(id=group2.pubid)
-        res = app.patch_json(path, group_payload, headers=headers, expect_errors=True)
+        res = app.patch_json(
+            f"/api/groups/{group2.pubid}",
+            {"groupid": "group:one@thirdparty.example.com"},
+            headers=auth_headers_3rd_party,
+            expect_errors=True,
+        )
 
         assert group1.groupid in res.json_body["reason"]
         assert res.status_code == 409
-
-
-@pytest.fixture
-def first_party_user(db_session, factories):
-    user = factories.User()
-    db_session.commit()
-    return user
-
-
-@pytest.fixture
-def first_party_group(db_session, factories, first_party_user):
-    group = factories.Group(
-        name="My First Group",
-        description="Original description",
-        creator=first_party_user,
-        authority=first_party_user.authority,
-    )
-    db_session.commit()
-    return group
-
-
-@pytest.fixture
-def user_with_token(db_session, factories, first_party_user):
-    token = factories.DeveloperToken(userid=first_party_user.userid)
-    db_session.add(token)
-    db_session.commit()
-    return (first_party_user, token)
-
-
-@pytest.fixture
-def token_auth_header(user_with_token):
-    user, token = user_with_token
-    return {"Authorization": "Bearer {}".format(token.value)}
-
-
-@pytest.fixture
-def third_party_user(factories, db_session):
-    user = factories.User(authority="thirdparty.com")
-    db_session.commit()
-    return user
-
-
-@pytest.fixture
-def auth_client(db_session, factories):
-    auth_client = factories.ConfidentialAuthClient(
-        authority="thirdparty.com", grant_type=GrantType.client_credentials
-    )
-    db_session.commit()
-    return auth_client
-
-
-@pytest.fixture
-def auth_client_header(auth_client):
-    user_pass = "{client_id}:{secret}".format(
-        client_id=auth_client.id, secret=auth_client.secret
-    )
-    encoded = base64.standard_b64encode(user_pass.encode("utf-8"))
-    return {"Authorization": "Basic {creds}".format(creds=encoded.decode("ascii"))}

--- a/tests/functional/api/groups/test_upsert.py
+++ b/tests/functional/api/groups/test_upsert.py
@@ -1,30 +1,20 @@
 # -*- coding: utf-8 -*-
 
-import base64
-
-import pytest
-
-from h.models.auth_client import GrantType
-
 
 class TestUpsertGroupUpdate:
-    def test_it_returns_http_404_if_no_authenticated_user(self, app, first_party_group):
-        group = {"name": "My Group"}
+    def test_it_returns_http_404_if_no_authenticated_user(self, app, group):
         res = app.put_json(
-            "/api/groups/{id}".format(id=first_party_group.pubid),
-            group,
-            expect_errors=True,
+            f"/api/groups/{group.pubid}", {"name": "My Group"}, expect_errors=True,
         )
 
         assert res.status_code == 404
 
     def test_it_returns_http_200_with_valid_payload_and_user_token(
-        self, app, token_auth_header, first_party_group
+        self, app, token_auth_header, group
     ):
-        group = {"name": "Rename My Group"}
         res = app.put_json(
-            "/api/groups/{id}".format(id=first_party_group.pubid),
-            group,
+            f"/api/groups/{group.pubid}",
+            {"name": "Rename My Group"},
             headers=token_auth_header,
         )
 
@@ -33,16 +23,11 @@ class TestUpsertGroupUpdate:
         assert res.json_body["groupid"] is None
 
     def test_it_ignores_non_whitelisted_fields_in_payload(
-        self, app, token_auth_header, first_party_group
+        self, app, token_auth_header, group
     ):
-        group = {
-            "name": "Rename Me",
-            "organization": "foobar",
-            "joinable_by": "whoever",
-        }
         res = app.put_json(
-            "/api/groups/{id}".format(id=first_party_group.pubid),
-            group,
+            f"/api/groups/{group.pubid}",
+            {"name": "Rename Me", "organization": "foobar", "joinable_by": "whoever"},
             headers=token_auth_header,
         )
 
@@ -50,13 +35,11 @@ class TestUpsertGroupUpdate:
         assert res.json_body["organization"] is None
 
     def test_it_returns_http_400_with_invalid_payload(
-        self, app, token_auth_header, first_party_group
+        self, app, token_auth_header, group
     ):
-        group = {}
-
         res = app.put_json(
-            "/api/groups/{id}".format(id=first_party_group.pubid),
-            group,
+            f"/api/groups/{group.pubid}",
+            {},
             headers=token_auth_header,
             expect_errors=True,
         )
@@ -64,12 +47,11 @@ class TestUpsertGroupUpdate:
         assert res.status_code == 400
 
     def test_it_returns_http_400_if_groupid_set_on_default_authority(
-        self, app, token_auth_header, first_party_group
+        self, app, token_auth_header, group
     ):
-        group = {"name": "Egghead", "groupid": "3434kjkjk"}
         res = app.put_json(
-            "/api/groups/{id}".format(id=first_party_group.pubid),
-            group,
+            f"/api/groups/{group.pubid}",
+            {"name": "Egghead", "groupid": "3434kjkjk"},
             headers=token_auth_header,
             expect_errors=True,
         )
@@ -83,10 +65,9 @@ class TestUpsertGroupUpdate:
         group = factories.Group()
         db_session.commit()
 
-        group_payload = {"name": "My Group"}
         res = app.put_json(
-            "/api/groups/{id}".format(id=group.pubid),
-            group_payload,
+            f"/api/groups/{group.pubid}",
+            {"name": "My Group"},
             headers=token_auth_header,
             expect_errors=True,
         )
@@ -94,113 +75,103 @@ class TestUpsertGroupUpdate:
         assert res.status_code == 404
 
     def test_it_allows_auth_client_with_valid_forwarded_user(
-        self, app, auth_client_header, third_party_user, factories, db_session
+        self, app, auth_headers_3rd_party, user_3rd_party, factories, db_session
     ):
         group = factories.Group(
-            creator=third_party_user, authority=third_party_user.authority
+            creator=user_3rd_party, authority=user_3rd_party.authority
         )
         db_session.commit()
 
-        headers = auth_client_header
-        headers["X-Forwarded-User"] = third_party_user.userid
-        group_payload = {"name": "My Group"}
-
-        path = "/api/groups/{id}".format(id=group.pubid)
-        res = app.put_json(path, group_payload, headers=headers)
+        res = app.put_json(
+            f"/api/groups/{group.pubid}",
+            {"name": "My Group"},
+            headers=auth_headers_3rd_party,
+        )
 
         assert res.status_code == 200
         assert res.json_body["name"] == "My Group"
 
     def test_it_returns_404_if_forwarded_user_is_not_authorized_to_update(
-        self, app, auth_client_header, third_party_user, factories, db_session
+        self, app, auth_header, user_3rd_party, factories, db_session
     ):
-        # Not created by `third_party_user`
-        group = factories.Group(authority=third_party_user.authority)
+        # Not created by `user`
+        group = factories.Group(authority=user_3rd_party.authority)
         db_session.commit()
 
-        headers = auth_client_header
-        headers["X-Forwarded-User"] = third_party_user.userid
-        group_payload = {"name": "My Group"}
+        headers = auth_header
+        headers["X-Forwarded-User"] = user_3rd_party.userid
 
-        path = "/api/groups/{id}".format(id=group.pubid)
-        res = app.put_json(path, group_payload, headers=headers, expect_errors=True)
+        res = app.put_json(
+            f"/api/groups/{group.pubid}",
+            {"name": "My Group"},
+            headers=headers,
+            expect_errors=True,
+        )
 
         assert res.status_code == 404
 
     def test_it_allows_groupid_from_auth_client_with_forwarded_user(
-        self, app, auth_client_header, third_party_user, factories, db_session
+        self, app, auth_headers_3rd_party, user_3rd_party, factories, db_session
     ):
         group = factories.Group(
-            creator=third_party_user, authority=third_party_user.authority
+            creator=user_3rd_party, authority=user_3rd_party.authority
         )
         db_session.commit()
 
-        headers = auth_client_header
-        headers["X-Forwarded-User"] = third_party_user.userid
-        group_payload = {
-            "name": "My Group",
-            "groupid": "group:333vcdfkj~@thirdparty.com",
-        }
-
-        path = "/api/groups/{id}".format(id=group.pubid)
-        res = app.put_json(path, group_payload, headers=headers)
+        res = app.put_json(
+            f"/api/groups/{group.pubid}",
+            {"name": "My Group", "groupid": "group:333vcdfkj~@thirdparty.example.com"},
+            headers=auth_headers_3rd_party,
+        )
 
         assert res.status_code == 200
         assert "groupid" in res.json_body
-        assert res.json_body["groupid"] == "group:{groupid}@thirdparty.com".format(
-            groupid="333vcdfkj~"
-        )
+        assert res.json_body["groupid"] == "group:333vcdfkj~@thirdparty.example.com"
 
     def test_it_supersedes_groupid_with_value_in_payload(
-        self, app, auth_client_header, third_party_user, factories, db_session
+        self, app, auth_headers_3rd_party, user_3rd_party, factories, db_session
     ):
         # In this test, the ``groupid`` in the path param is different than that
         # indicated in the payload. This allows a caller to change the ``groupid``
         group = factories.Group(
-            creator=third_party_user,
-            authority=third_party_user.authority,
+            creator=user_3rd_party,
+            authority=user_3rd_party.authority,
             authority_provided_id="doodad",
         )
         db_session.commit()
 
-        headers = auth_client_header
-        headers["X-Forwarded-User"] = third_party_user.userid
-        group_payload = {
-            "name": "My Group",
-            "groupid": "group:ice-cream@thirdparty.com",
-        }
-
-        path = "/api/groups/{id}".format(id=group.groupid)
-        res = app.put_json(path, group_payload, headers=headers)
+        res = app.put_json(
+            f"/api/groups/{group.groupid}",
+            {"name": "My Group", "groupid": "group:ice-cream@thirdparty.example.com"},
+            headers=auth_headers_3rd_party,
+        )
 
         assert res.status_code == 200
         assert "groupid" in res.json_body
-        assert res.json_body["groupid"] == "group:{groupid}@thirdparty.com".format(
-            groupid="ice-cream"
-        )
+        assert res.json_body["groupid"] == "group:ice-cream@thirdparty.example.com"
 
     def test_it_returns_HTTP_Conflict_if_groupid_is_duplicate(
-        self, app, auth_client_header, third_party_user, factories, db_session
+        self, app, auth_headers_3rd_party, user_3rd_party, factories, db_session
     ):
         group1 = factories.Group(
-            creator=third_party_user,
-            authority=third_party_user.authority,
-            groupid="group:one@thirdparty.com",
+            creator=user_3rd_party,
+            authority=user_3rd_party.authority,
+            groupid="group:one@thirdparty.example.com",
         )
         group2 = factories.Group(
-            creator=third_party_user,
-            authority=third_party_user.authority,
-            groupid="group:two@thirdparty.com",
+            creator=user_3rd_party,
+            authority=user_3rd_party.authority,
+            groupid="group:two@thirdparty.example.com",
         )
         db_session.commit()
 
-        headers = auth_client_header
-        headers["X-Forwarded-User"] = third_party_user.userid
-        group_payload = {"name": "Whatnot", "groupid": "group:one@thirdparty.com"}
-
         # Attempting to set group2's `groupid` to one already taken by group1
-        path = "/api/groups/{id}".format(id=group2.pubid)
-        res = app.put_json(path, group_payload, headers=headers, expect_errors=True)
+        res = app.put_json(
+            f"/api/groups/{group2.groupid}",
+            {"name": "Whatnot", "groupid": "group:one@thirdparty.example.com"},
+            headers=auth_headers_3rd_party,
+            expect_errors=True,
+        )
 
         assert group1.groupid in res.json_body["reason"]
         assert res.status_code == 409
@@ -208,85 +179,28 @@ class TestUpsertGroupUpdate:
 
 class TestUpsertGroupCreate:
     def test_it_allows_auth_client_with_forwarded_user(
-        self, app, auth_client_header, third_party_user
+        self, app, auth_headers_3rd_party, user_3rd_party
     ):
-        headers = auth_client_header
-        headers["X-Forwarded-User"] = third_party_user.userid
-        group = {
-            "name": "My Group",
-            "groupid": "group:foothold@{auth}".format(auth=third_party_user.authority),
-        }
-
-        res = app.put_json("/api/groups/somepubid", group, headers=headers)
+        res = app.put_json(
+            "/api/groups/somepubid",
+            {
+                "name": "My Group",
+                "groupid": f"group:foothold@{user_3rd_party.authority}",
+            },
+            headers=auth_headers_3rd_party,
+        )
 
         assert res.status_code == 200
         assert res.json_body["name"] == "My Group"
-        assert res.json_body["groupid"] == "group:foothold@{auth}".format(
-            auth=third_party_user.authority
-        )
+        assert res.json_body["groupid"] == f"group:foothold@{user_3rd_party.authority}"
 
     def test_it_allows_user_with_token(self, app, token_auth_header):
-        group = {"name": "This is my group"}
-        res = app.put_json("/api/groups/randompubid", group, headers=token_auth_header)
+        res = app.put_json(
+            "/api/groups/randompubid",
+            {"name": "This is my group"},
+            headers=token_auth_header,
+        )
 
         assert res.status_code == 200
         assert res.json_body["name"] == "This is my group"
         assert res.json_body["groupid"] is None
-
-
-@pytest.fixture
-def first_party_user(db_session, factories):
-    user = factories.User()
-    db_session.commit()
-    return user
-
-
-@pytest.fixture
-def first_party_group(db_session, factories, first_party_user):
-    group = factories.Group(
-        name="My First Group",
-        description="Original description",
-        creator=first_party_user,
-        authority=first_party_user.authority,
-    )
-    db_session.commit()
-    return group
-
-
-@pytest.fixture
-def user_with_token(db_session, factories, first_party_user):
-    token = factories.DeveloperToken(userid=first_party_user.userid)
-    db_session.add(token)
-    db_session.commit()
-    return (first_party_user, token)
-
-
-@pytest.fixture
-def token_auth_header(user_with_token):
-    user, token = user_with_token
-    return {"Authorization": "Bearer {}".format(token.value)}
-
-
-@pytest.fixture
-def third_party_user(factories, db_session):
-    user = factories.User(authority="thirdparty.com")
-    db_session.commit()
-    return user
-
-
-@pytest.fixture
-def auth_client(db_session, factories):
-    auth_client = factories.ConfidentialAuthClient(
-        authority="thirdparty.com", grant_type=GrantType.client_credentials
-    )
-    db_session.commit()
-    return auth_client
-
-
-@pytest.fixture
-def auth_client_header(auth_client):
-    user_pass = "{client_id}:{secret}".format(
-        client_id=auth_client.id, secret=auth_client.secret
-    )
-    encoded = base64.standard_b64encode(user_pass.encode("utf-8"))
-    return {"Authorization": "Basic {creds}".format(creds=encoded.decode("ascii"))}


### PR DESCRIPTION
**Refactor**

 * Use f-strings
 * Remove duplicated fixtures
 * Try and resolve horrible mess around users, 1st party, 3rd party and all the auth
 * We now have consistent user, auth_header, user_3rd_party, auth_header_3rd_party etc.

**Bug**

 * Fixed a bug revealed by fixing the tests where adding a member to groups with invalid ids will cause a 500, instead of 404.