### PR TITLE
Bulk API - Byte stream - Make it the focus of tests and fix it

### DIFF
--- a/h/h_api/bulk_api/entry_point.py
+++ b/h/h_api/bulk_api/entry_point.py
@@ -110,7 +110,9 @@ class BulkAPI:
         :param string: A string to split
         :return: A generator of strings containing single lines
         """
-        return string.strip().split("\n")
+
+        lines = (line.strip() for line in string.strip().split("\n"))
+        return (line for line in lines if line)
 
     @staticmethod
     def _bytes_to_lines(stream, chunk_size=16384):
@@ -130,8 +132,9 @@ class BulkAPI:
             while b"\n" in block:
                 head, block = block.split(b"\n", 1)
 
+                line += head
                 if line:
-                    yield line + head
+                    yield line
 
                 line = b""
 

--- a/tests/h/h_api/bulk_api/entry_point_test.py
+++ b/tests/h/h_api/bulk_api/entry_point_test.py
@@ -43,6 +43,20 @@ class TestBulkAPI:
 
         self._assert_process_called_with_generator_of_commands(CommandProcessor)
 
+    def test__bytes_to_lines(self):
+        bytes = BytesIO(b"\nline_1\n\nlong_middle_line_2\nline_3")
+
+        lines = BulkAPI._bytes_to_lines(bytes, chunk_size=8)
+
+        assert isinstance(lines, GeneratorType)
+        assert list(lines) == [b"line_1", b"long_middle_line_2", b"line_3"]
+
+    def test__string_to_lines(self):
+        lines = BulkAPI._string_to_lines("\nline_1\n\nlong_middle_line_2\nline_3")
+
+        assert isinstance(lines, GeneratorType)
+        assert list(lines) == ["line_1", "long_middle_line_2", "line_3"]
+
     @pytest.mark.parametrize(
         "kwargs",
         (


### PR DESCRIPTION
This was pretty broke, because we were testing and old path and being hyper vague about what we expected out of the process.

This was relying on the functional tests to prove the actual contents were correct, but they used `from_strings` rather than `from_bytes` and so didn't prove it out.