### PR TITLE
Skip empty lines when decoding in `from_lines`

### DIFF
--- a/h/h_api/bulk_api/entry_point.py
+++ b/h/h_api/bulk_api/entry_point.py
@@ -93,6 +93,9 @@ class BulkAPI:
         :return: A generator of `Command` objects
         """
         for line_number, line in enumerate(lines):
+            if not line:
+                continue
+
             try:
                 data = json.loads(line)
             except JSONDecodeError as e:

--- a/tests/h/h_api/bulk_api/entry_point_test.py
+++ b/tests/h/h_api/bulk_api/entry_point_test.py
@@ -16,7 +16,7 @@ class TestBulkAPI:
     # This is a glue library, so there's not much to do here but test the
     # interfaces
 
-    def test_from_stream(self, lines, executor, CommandProcessor):
+    def test_from_lines(self, lines, executor, CommandProcessor):
         BulkAPI.from_lines(lines, executor)
 
         CommandProcessor.assert_called_once_with(


### PR DESCRIPTION
This was introduced by the combination of two different PRs. I think this happened as each worked alone, but upon merging them both it broke.