### PR TITLE
Fix account activation and password reset flows

### DIFF
--- a/h/static/styles/components/_flash-messages.scss
+++ b/h/static/styles/components/_flash-messages.scss
@@ -12,6 +12,7 @@
   padding-left: 10px;
   padding-right: 10px;
   margin-bottom: 15px;
+  margin-top: 15px;
 }
 
 .flash-message *:first-child {

--- a/h/static/styles/components/_flash-messages.scss
+++ b/h/static/styles/components/_flash-messages.scss
@@ -1,0 +1,31 @@
+@use "core/color";
+@use "core/typography";
+
+.flash-message {
+  @include typography.font-big;
+
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  padding-bottom: 15px;
+  padding-top: 15px;
+  padding-left: 10px;
+  padding-right: 10px;
+  margin-bottom: 15px;
+}
+
+.flash-message *:first-child {
+  margin-top: 0;
+}
+
+.flash-message *:last-child {
+  margin-bottom: 0;
+}
+
+.flash-message__success {
+  @include color.success;
+}
+
+.flash-message__error {
+  @include color.error;
+}

--- a/h/static/styles/core/_color.scss
+++ b/h/static/styles/core/_color.scss
@@ -20,6 +20,22 @@ $brand: #d00032;
 $highlight: #58cef4;
 $group-organization-color: #6d676d;
 
+$success-bg: #d4edda;
+$success-border: #c3e6cb;
+
+$error-bg: #fff3cd;
+$error-border: #ffeeba;
+
+@mixin success {
+  background-color: $success-bg;
+  border-color: $success-border;
+}
+
+@mixin error {
+  background-color: $error-bg;
+  border-color: $error-border;
+}
+
 // Functions
 // ----------------------------------------------------------------------------
 

--- a/h/static/styles/core/_typography.scss
+++ b/h/static/styles/core/_typography.scss
@@ -13,6 +13,9 @@ $mono-font-family: Open Sans Mono, Menlo, DejaVu Sans Mono, monospace !default;
 $normal-font-size: 13px;
 $normal-line-height: 15px;
 
+$big-font-size: 17px;
+$big-line-height: 22px;
+
 $small-font-size: 11px;
 $small-line-height: 12px;
 
@@ -40,6 +43,11 @@ $touch-input-font-size: 16px;
   font-size: $normal-font-size;
   line-height: $normal-line-height;
   font-weight: 400;
+}
+
+@mixin font-big {
+  font-size: $big-font-size;
+  line-height: $big-line-height;
 }
 
 @mixin styled-text() {

--- a/h/static/styles/site.scss
+++ b/h/static/styles/site.scss
@@ -19,6 +19,7 @@
 @use 'components/brand';
 @use 'components/btn';
 @use 'components/dropdown-menu';
+@use 'components/flash-messages';
 @use 'components/footer';
 @use 'components/form';
 @use 'components/form-actions';

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -8,6 +8,8 @@
 
 {% block content %}
   <div class="form-container content">
+    {% include "h:templates/includes/flash-messages.html.jinja2" %}
+
     <h1 class="form-header">Log in</h1>
 
     {{ form }}

--- a/h/templates/includes/flash-messages.html.jinja2
+++ b/h/templates/includes/flash-messages.html.jinja2
@@ -1,0 +1,26 @@
+{#
+  Flash messages component.
+
+  This will display any current flash messages in any of the flash queues that
+  we use.
+
+  It will render nothing if there are no flash messages.
+
+  Usage:
+
+    {% include "h:templates/includes/flash-messages.html.jinja2" %}
+
+  Flash messages are a way to display a one-time message to the user on the
+  next page load, see:
+
+  https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/sessions.html#flash-messages
+#}
+{% for queue in ["success", "error"] %}
+  {% if request.session.peek_flash(queue) %}
+    {% for message in request.session.pop_flash(queue) %}
+      <div class="flash-message flash-message__{{ queue }}">
+        {{ message }}
+      </div>
+    {% endfor %}
+  {% endif %}
+{% endfor %}

--- a/h/templates/layouts/account.html.jinja2
+++ b/h/templates/layouts/account.html.jinja2
@@ -28,13 +28,7 @@
           {% endfor %}
         </ul>
       </nav>
-      {% if request.session.peek_flash('success') -%}
-        <div class="form-flash">
-          {% for message in request.session.pop_flash('success') %}
-            <p>{{ message }}</p>
-          {%- endfor %}
-        </div>
-      {%- endif %}
+      {% include "h:templates/includes/flash-messages.html.jinja2" %}
       {{ self.page_content() }}
 
       <footer class="form-footer--no-border">

--- a/h/templates/layouts/group.html.jinja2
+++ b/h/templates/layouts/group.html.jinja2
@@ -9,13 +9,7 @@
 {% block content %}
   <div class="content paper">
     <div class="form-container">
-      {% if request.session.peek_flash('success') -%}
-        <div class="form-flash">
-          {% for message in request.session.pop_flash('success') %}
-            <p>{{ message }}</p>
-          {%- endfor %}
-        </div>
-      {%- endif %}
+      {% include "h:templates/includes/flash-messages.html.jinja2" %}
       {{ self.page_content() }}
     </div>
   </div>

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -294,7 +294,7 @@ class ResetController:
         self.request.session.flash(
             jinja2.Markup(
                 _(
-                    "Your password has been reset. You can now login with "
+                    "Your password has been reset. You can now log in with "
                     "your new password."
                 )
             ),

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -111,7 +111,11 @@ class AuthController:
         """Render the login page, including the login form."""
         self._redirect_if_logged_in()
 
-        return {"form": self.form.render()}
+        return {
+            "form": self.form.render(
+                {"username": self.request.params.get("username", "")}
+            )
+        }
 
     @view_config(request_method="POST")
     @view_config(
@@ -329,7 +333,7 @@ class ActivateController:
                 ),
                 "error",
             )
-            return httpexceptions.HTTPFound(location=self.request.route_url("index"))
+            return httpexceptions.HTTPFound(location=self.request.route_url("login"))
 
         user = models.User.get_by_activation(self.request.db, activation)
         if user is None or user.id != id_:
@@ -350,7 +354,9 @@ class ActivateController:
 
         self.request.registry.notify(ActivationEvent(self.request, user))
 
-        return httpexceptions.HTTPFound(location=self.request.route_url("index"))
+        return httpexceptions.HTTPFound(
+            location=self.request.route_url("login", _query={"username": user.username})
+        )
 
     @view_config(request_method="GET", effective_principals=security.Authenticated)
     def get_when_logged_in(self):

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -294,10 +294,9 @@ class ResetController:
         self.request.session.flash(
             jinja2.Markup(
                 _(
-                    "Your password has been reset. "
-                    'You can now <a href="{url}">login</a> with your new '
-                    "password."
-                ).format(url=self.request.route_url("login"))
+                    "Your password has been reset. You can now login with "
+                    "your new password."
+                )
             ),
             "success",
         )
@@ -333,9 +332,9 @@ class ActivateController:
                     _(
                         "We didn't recognize that activation link. "
                         "Have you already activated your account? "
-                        'If so, try <a href="{url}">logging in</a> using the username '
+                        "If so, try logging in using the username "
                         "and password that you provided."
-                    ).format(url=self.request.route_url("login"))
+                    ),
                 ),
                 "error",
             )
@@ -351,9 +350,8 @@ class ActivateController:
             jinja2.Markup(
                 _(
                     "Your account has been activated! "
-                    'You can now <a href="{url}">log in</a> using the password you '
-                    "provided."
-                ).format(url=self.request.route_url("login"))
+                    "You can now log in using the password you provided."
+                ),
             ),
             "success",
         )

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -273,9 +273,15 @@ class ResetController:
                 self.form.set_widgets({"user": deform.widget.HiddenWidget()})
             return {"form": self.form.render()}
 
-        self._reset_password(appstruct["user"], appstruct["password"])
+        user = appstruct["user"]
 
-        return httpexceptions.HTTPFound(location=self.request.route_path("index"))
+        self._reset_password(user, appstruct["password"])
+
+        return httpexceptions.HTTPFound(
+            location=self.request.route_path(
+                "login", _query={"username": user.username}
+            )
+        )
 
     def _redirect_if_logged_in(self):
         if self.request.authenticated_userid is not None:

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -111,11 +111,7 @@ class AuthController:
         """Render the login page, including the login form."""
         self._redirect_if_logged_in()
 
-        return {
-            "form": self.form.render(
-                {"username": self.request.params.get("username", "")}
-            )
-        }
+        return {"form": self.form.render(LoginSchema.default_values(self.request))}
 
     @view_config(request_method="POST")
     @view_config(

--- a/tests/h/schemas/forms/accounts/login_test.py
+++ b/tests/h/schemas/forms/accounts/login_test.py
@@ -90,6 +90,25 @@ class TestLoginSchema:
         assert "password" in errors
         assert "Wrong password" in errors["password"]
 
+    @pytest.mark.parametrize(
+        "params,value",
+        [
+            # If a ?username=foobob query param is given then the username field in
+            # the login form is pre-filled with "foobob".
+            ({"username": "foobob"}, "foobob"),
+            # If the foobob query param is missing or has no value then the
+            # username field isn't pre-filled.
+            ({"username": ""}, ""),
+            ({}, ""),
+        ],
+    )
+    def test_default_values_prefills_username_from_username_query_param(
+        self, pyramid_request, params, value
+    ):
+        pyramid_request.params = params
+
+        assert LoginSchema.default_values(pyramid_request)["username"] == value
+
 
 @pytest.fixture
 def user_service(db_session, pyramid_config):

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -475,11 +475,14 @@ class TestActivateController:
         activation_model.get_by_code.return_value = None
 
         result = views.ActivateController(pyramid_request).get_when_not_logged_in()
-        error_flash = pyramid_request.session.peek_flash("error")
 
         assert isinstance(result, httpexceptions.HTTPFound)
-        assert error_flash
-        assert error_flash[0].startswith("We didn't recognize that activation link.")
+        assert result.location == "http://example.com/login"
+        assert pyramid_request.session.peek_flash("error") == [
+            Any.string.containing(
+                "We didn't recognize that activation link. Have you already activated "
+            ),
+        ]
 
     def test_get_when_not_logged_in_looks_up_user_by_activation(
         self, activation_model, pyramid_request, user_model
@@ -537,10 +540,10 @@ class TestActivateController:
         user_model.get_by_activation.return_value.id = 123
 
         views.ActivateController(pyramid_request).get_when_not_logged_in()
-        success_flash = pyramid_request.session.peek_flash("success")
 
-        assert success_flash
-        assert success_flash[0].startswith("Your account has been activated")
+        assert pyramid_request.session.peek_flash("success") == [
+            Any.string.containing("Your account has been activated")
+        ]
 
     def test_get_when_not_logged_in_successful_creates_ActivationEvent(
         self, pyramid_request, user_model, ActivationEvent

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -88,23 +88,9 @@ class TestAuthController:
         form = pyramid_request.create_form.return_value
 
         # It returns the rendered form.
-        form.render.assert_called_once_with(
-            {
-                # The username form field is not pre-filled by default.
-                "username": ""
-            }
-        )
+        LoginSchema.default_values.assert_called_once_with(pyramid_request)
+        form.render.assert_called_once_with(LoginSchema.default_values.return_value)
         assert template_vars == {"form": form.render.return_value}
-
-    def test_get_prefills_the_username_field(self, pyramid_request, LoginSchema):
-        # If there's a ?username=example_username query param then the username
-        # form field gets pre-filled with "example_username".
-        pyramid_request.params["username"] = "example_username"
-
-        views.AuthController(pyramid_request).get()
-
-        form = pyramid_request.create_form.return_value
-        form.render.assert_called_once_with({"username": "example_username"})
 
     def test_post_redirects_when_logged_in(self, pyramid_config, pyramid_request):
         pyramid_config.testing_securitypolicy("acct:jane@doe.org")


### PR DESCRIPTION
Fixes https://github.com/hypothesis/product-backlog/issues/1094

When a user activates their account (by clicking on an activation link from an email) or when they reset their password (either by entering a code that we emailed them into the <https://hypothes.is/account/reset> form or by clicking on a password reset link in the same email):

1. Redirect them to the login page, not the index page. The next thing they need to do is log in, so the login page is the right place to send them. Also, on production the index URL gets redirected (by NGINX) to the WordPress instance at https://web.hypothes.is/ which is super unhelpful in these flows.

2. Display a flash message above the login form explaining that their account has been activated or their password has been reset and they can now login (or that activation failed, in the case of an invalid activation link).

3. Pre-fill the username field in the login form with their username.

We didn't actually have a Jinja2/HTML template or SASS for flash messages, so this PR adds that as well, using a basic but functional design.

## Background on "flash messages" in Pyramid

See: https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/sessions.html#flash-messages

"Flash messages" are notifications that get displayed to the user on the next full page load and then disappear. The way it works is:

* Anywhere in the Python code something calls `request.session.flash(" ... ")` to set a flash message

* Anywhere in the templates something calls `request.session.pop_flash()` to read and display any and all flash messages that have been set (`pop_flash()` returns a list of all the messages in the queue, not just one)

* If the page's template does not do `pop_flash()` then the messages will still be in the queue when the _next_ page loads. If the next page (or the page after that) does `pop_flash()` it will get all the messages that have been set since the last time `pop_flash()` was done. (The messages are stored in the session.)

  This can be a hazard because if a page that should be popping flash messages does not, the flash messages can end up all piling up later on some other page where they don't make any sense. (This could probably be dealt with by using page-specific queues, or by discarding all messages at the beginning of each new request.)

### Flash message queues

`flash()` and `pop_flash()` use the default queue whose name is the empty string. You can also do `flash(message, "foo_queue")` and `pop_flash("foo_queue")` to use a separate, named queue.

We never use the default queue in h. We always use either the `"success"` or `"error"` queue.

## Out of scope

Fixing all the flash messages in h. The Python code in h sets lots of flash messages before rendering pages that do not display them. These pages used to display the flash messages, but when all the page templates were redesigned flash message support was left out of the templates. So now the flash messages are being written but never read.

In some cases the new UX makes the flash messages unnecessary and they shouldn't be written anymore. In other cases workflows have become confusing due to the pages no longer displaying important flash messages.

I've limited this PR to fixing the flash messages on the login page.

## Testing

### Successful account activation

Go to <http://localhost:5000/signup> and sign up for an account. Get the account activation link from the email (in the `h/mail/` folder) and open it. You should see:

![Screenshot from 2020-03-19 15-44-51](https://user-images.githubusercontent.com/22498/77085696-9c1a5a00-69f8-11ea-8711-f05ce747263a.png)

### Invalid activation link

If you try to open the same activation link again you should see an error. The same thing would happen if you try to open an activation link with an invalid code (e.g. <http://localhost:5000/activate/1/foo>) (the way activations work in h, there's no way to tell the difference between an already-used and a completely invalid activation link).

![Screenshot from 2020-03-19 15-47-32](https://user-images.githubusercontent.com/22498/77085957-f87d7980-69f8-11ea-9bf4-3449c24cce58.png)

### Password reset code

Go to <http://localhost:5000/forgot-password> and enter your email address. You'll be redirected to <http://localhost:5000/account/reset>. Get the password reset code from the email (in the `h/mail/` folder) and enter it into the form along with a new password. You should see:

![Screenshot from 2020-03-19 15-50-40](https://user-images.githubusercontent.com/22498/77086238-6aee5980-69f9-11ea-8c6e-948860c1dcb3.png)

### Password reset link

Go to <http://localhost:5000/forgot-password> and enter your email address. You'll be redirected to <http://localhost:5000/account/reset>. Get the password reset **link** from the email (in the `h/mail/` folder) and open it. After going through the new password page you should see:

![Screenshot from 2020-03-19 15-50-40](https://user-images.githubusercontent.com/22498/77086238-6aee5980-69f9-11ea-8c6e-948860c1dcb3.png)

## Details

### Browsers

I've tested in Firefox and Chrome and the new HTML & CSS looks fine in both of those.

### Mobile

Look fine when testing on mobile just using dev tools:

![Screenshot from 2020-03-19 16-32-53](https://user-images.githubusercontent.com/22498/77090709-717fcf80-69ff-11ea-9331-882f5fc0171d.png)

![Screenshot from 2020-03-19 16-33-46](https://user-images.githubusercontent.com/22498/77090723-7775b080-69ff-11ea-97ab-d8b044c409ab.png)

### Multi-paragraph flash messages

We don't have any in the code currently, but technically a single flash message can contain multiple paragraphs and the flash message CSS is able to handle this, spacing them out properly:

![Screenshot from 2020-03-19 17-35-08](https://user-images.githubusercontent.com/22498/77097053-1a322d00-6a08-11ea-93c7-75b05320e7b7.png)

### HTML in flash messages

We don't have any in the code currently, but technically a flash message can contain arbitrary HTML and links, not just text, and the flash message CSS can handle that:

![Screenshot from 2020-03-19 17-41-46](https://user-images.githubusercontent.com/22498/77097607-f3c0c180-6a08-11ea-96f9-bd6e6b9fb6c5.png)

### Multiple flash messages at once

In some cases multiple flash messages can appear on one page at once. And the flash messages might come from different queues. The CSS handles this, spacing them out nicely:

![Screenshot from 2020-03-19 17-39-31](https://user-images.githubusercontent.com/22498/77097426-af352600-6a08-11ea-84f3-672555c61391.png)
