### PR TITLE
Add variable mime sub-type to api decorators

### DIFF
--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -34,6 +34,7 @@ def add_api_view(
     link_name=None,
     description=None,
     enable_preflight=True,
+    subtype="json",
     **settings
 ):
 
@@ -66,7 +67,7 @@ def add_api_view(
     :param dict settings: Arguments to pass on to ``config.add_view``
     """
     settings.setdefault("renderer", "json")
-    settings.setdefault("decorator", (cors_policy, version_media_type_header))
+    settings.setdefault("decorator", (cors_policy, version_media_type_header(subtype)))
 
     if link_name:
         link = links.ServiceLink(
@@ -92,7 +93,7 @@ def add_api_view(
 
         # config.add_view only allows one, string value for `accept`, so we
         # have to re-invoke it to add additional accept headers
-        settings["accept"] = media_type_for_version(version)
+        settings["accept"] = media_type_for_version(version, subtype=subtype)
         config.add_view(view=view, **settings)
 
     if enable_preflight:

--- a/h/views/api/decorators/response.py
+++ b/h/views/api/decorators/response.py
@@ -5,23 +5,28 @@ from h.views.api import API_VERSION_DEFAULT
 from h.views.api.helpers.media_types import media_type_for_version, version_media_types
 
 
-def version_media_type_header(wrapped):
+def version_media_type_header(subtype="json"):
     """View decorator to add response header indicating API version"""
 
-    def wrapper(context, request):
-        response = wrapped(context, request)
-        # Assume default version...
-        version_media_type = media_type_for_version(API_VERSION_DEFAULT)
-        # ...Unless we can determine otherwise from the Accept header
-        if request.accept:
-            version_accepts = [t for t in request.accept if t in version_media_types()]
-            if any(version_accepts):
-                # If the Accept header contains any values that match a known version
-                # media type, that's the version that would have been matched
-                # and used
-                version_media_type = version_accepts[0]
+    def deco(wrapped):
+        def wrapper(context, request):
+            response = wrapped(context, request)
+            # Assume default version...
+            version_media_type = media_type_for_version(API_VERSION_DEFAULT, subtype)
+            # ...Unless we can determine otherwise from the Accept header
+            if request.accept:
+                version_accepts = [
+                    t for t in request.accept if t in version_media_types()
+                ]
+                if any(version_accepts):
+                    # If the Accept header contains any values that match a known version
+                    # media type, that's the version that would have been matched
+                    # and used
+                    version_media_type = version_accepts[0]
 
-        response.headers["Hypothesis-Media-Type"] = version_media_type
-        return response
+            response.headers["Hypothesis-Media-Type"] = version_media_type
+            return response
 
-    return wrapper
+        return wrapper
+
+    return deco

--- a/tests/h/views/api/config_test.py
+++ b/tests/h/views/api/config_test.py
@@ -5,7 +5,6 @@ from unittest import mock
 import pytest
 
 from h.views.api import config as api_config
-from h.views.api.decorators.response import version_media_type_header
 
 
 @pytest.mark.usefixtures("cors")
@@ -57,14 +56,17 @@ class TestAddApiView:
         (_, kwargs) = pyramid_config.add_view.call_args_list[0]
         assert kwargs["renderer"] == "xml"
 
-    def test_it_sets_default_decorators(self, pyramid_config, view):
+    def test_it_sets_default_decorators(
+        self, pyramid_config, view, version_media_type_header
+    ):
         api_config.add_api_view(
             pyramid_config, view, versions=["v1"], route_name="thing.read"
         )
-        (_, kwargs) = pyramid_config.add_view.call_args_list[0]
+        _, kwargs = pyramid_config.add_view.call_args_list[0]
+
         assert kwargs["decorator"] == (
             api_config.cors_policy,
-            version_media_type_header,
+            version_media_type_header("json"),
         )
 
     def test_it_adds_cors_preflight_view(self, pyramid_config, view, cors):
@@ -107,7 +109,7 @@ class TestAddApiView:
         )
         (_, kwargs) = pyramid_config.add_view.call_args_list[1]
 
-        media_type_for_version.assert_called_once_with("v1")
+        media_type_for_version.assert_called_once_with("v1", subtype="json")
         assert kwargs["accept"] == media_type_for_version.return_value
 
     def test_it_raises_ValueError_on_unrecognized_version(self, pyramid_config, view):
@@ -183,3 +185,7 @@ class TestAddApiView:
     @pytest.fixture
     def view(self):
         return mock.Mock()
+
+    @pytest.fixture
+    def version_media_type_header(self, patch):
+        return patch("h.views.api.config.version_media_type_header")

--- a/tests/h/views/api/decorators/response_test.py
+++ b/tests/h/views/api/decorators/response_test.py
@@ -10,16 +10,18 @@ from h.views.api.decorators.response import version_media_type_header
 
 class TestVersionMediaTypeHeader:
     def test_it_calls_wrapped_view_function(self, pyramid_request, testview):
-        version_media_type_header(testview)(None, pyramid_request)
+        version_media_type_header("json")(testview)(None, pyramid_request)
 
         assert testview.called
 
+    @pytest.mark.parametrize("subtype", ("json", "x-ndjson"))
     def test_it_sets_response_header_to_default_media_type_if_accept_not_set(
-        self, pyramid_request, testview
+        self, pyramid_request, testview, subtype
     ):
-        res = version_media_type_header(testview)(None, pyramid_request)
+        res = version_media_type_header(subtype)(testview)(None, pyramid_request)
         assert (
-            res.headers["Hypothesis-Media-Type"] == "application/vnd.hypothesis.v1+json"
+            res.headers["Hypothesis-Media-Type"]
+            == f"application/vnd.hypothesis.v1+{subtype}"
         )
 
     @pytest.mark.parametrize(
@@ -44,7 +46,7 @@ class TestVersionMediaTypeHeader:
     ):
         pyramid_request.accept = create_accept_header(accept)
 
-        res = version_media_type_header(testview)(None, pyramid_request)
+        res = version_media_type_header("json")(testview)(None, pyramid_request)
 
         assert res.headers["Hypothesis-Media-Type"] == expected_header
 


### PR DESCRIPTION
Currently our mime type is always `application/vnd.hypothesis.v1+json`, but the correct type for the new Bulk API is `application/vnd.hypothesis.v1+ndjson`.

This adds the ability to specify the mime sub-type with the existing API decorators.