### PR TITLE
Use a baseclass for root factories

### DIFF
--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -76,7 +76,7 @@ from h.traversal import contexts
 
 
 class RootFactory:
-    """Abstract interface for root resource factories."""
+    """Base class for all root resource factories."""
 
     def __init__(self, request):
         self.request = request

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -77,7 +77,7 @@ from h.traversal import contexts
 
 class RootFactory:
     """Abstract interface for root resource factories."""
-    
+
     def __init__(self, request):
         self.request = request
 


### PR DESCRIPTION
The `__init__` method is mandatory for root factories. This makes that clear and reduces repetition.