### PR TITLE
Move the existing bulk executor to be provided by a service

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -94,6 +94,10 @@ def includeme(config):
         ".user_update.user_update_factory", name="user_update"
     )
 
+    config.register_service_factory(
+        ".bulk_executor.BulkExecutorService", name="bulk_executor"
+    )
+
     config.add_directive(
         "add_annotation_link_generator", ".links.add_annotation_link_generator"
     )

--- a/h/services/bulk_executor.py
+++ b/h/services/bulk_executor.py
@@ -1,0 +1,57 @@
+from h.h_api.bulk_api.executor import AutomaticReportExecutor
+from h.h_api.enums import DataType
+from h.h_api.exceptions import InvalidDeclarationError
+
+
+class BulkExecutorService:
+    def __init__(self, context, request):
+        self.db = request.db
+
+    def get_executor(self):
+        return AuthorityCheckingExecutor()
+
+
+class AuthorityCheckingExecutor(AutomaticReportExecutor):
+    """A bulk executor which checks the authority."""
+
+    def __init__(self, authority="lms.hypothes.is"):
+        self.effective_user = None
+        self.authority = authority
+
+    def configure(self, config):
+        self._assert_authority("effective user", config.effective_user)
+
+        self.effective_user = config.effective_user
+
+    def execute_batch(self, command_type, data_type, default_config, batch):
+        for command in batch:
+            self._check_authority(data_type, command.body)
+
+        return super().execute_batch(command_type, data_type, default_config, batch)
+
+    def _assert_authority(self, field, value, embedded=True):
+        if embedded and value.endswith(f"@{self.authority}"):
+            return
+
+        if value == self.authority:
+            return
+
+        raise InvalidDeclarationError(
+            f"The {field} '{value}' does not match the expected authority"
+        )
+
+    def _check_authority(self, data_type, body):
+        if data_type == DataType.USER:
+            self._assert_authority("id", body.id)
+            self._assert_authority(
+                "authority", body.attributes["authority"], embedded=False
+            )
+
+        elif data_type == DataType.GROUP:
+            self._assert_authority("groupid", body.attributes["groupid"])
+            self._assert_authority("query groupid", body.meta["query"]["groupid"])
+
+        elif data_type == DataType.GROUP_MEMBERSHIP:
+            self._assert_authority(
+                "member id", body.relationships["member"]["data"]["id"]
+            )

--- a/h/views/api/bulk.py
+++ b/h/views/api/bulk.py
@@ -4,9 +4,6 @@ from logging import getLogger
 from pyramid.response import Response
 
 from h.h_api.bulk_api import BulkAPI
-from h.h_api.bulk_api.executor import AutomaticReportExecutor
-from h.h_api.enums import DataType
-from h.h_api.exceptions import InvalidDeclarationError
 from h.views.api.config import api_config
 
 LOG = getLogger(__name__)
@@ -32,52 +29,6 @@ class FakeBulkAPI(BulkAPI):
             return None
 
 
-class AuthorityCheckingExecutor(AutomaticReportExecutor):
-    """A bulk executor which checks the authority."""
-
-    def __init__(self, authority="lms.hypothes.is"):
-        self.effective_user = None
-        self.authority = authority
-
-    def configure(self, config):
-        self._assert_authority("effective user", config.effective_user)
-
-        self.effective_user = config.effective_user
-
-    def execute_batch(self, command_type, data_type, default_config, batch):
-        for command in batch:
-            self._check_authority(data_type, command.body)
-
-        return super().execute_batch(command_type, data_type, default_config, batch)
-
-    def _assert_authority(self, field, value, embedded=True):
-        if embedded and value.endswith(f"@{self.authority}"):
-            return
-
-        if value == self.authority:
-            return
-
-        raise InvalidDeclarationError(
-            f"The {field} '{value}' does not match the expected authority"
-        )
-
-    def _check_authority(self, data_type, body):
-        if data_type == DataType.USER:
-            self._assert_authority("id", body.id)
-            self._assert_authority(
-                "authority", body.attributes["authority"], embedded=False
-            )
-
-        elif data_type == DataType.GROUP:
-            self._assert_authority("groupid", body.attributes["groupid"])
-            self._assert_authority("query groupid", body.meta["query"]["groupid"])
-
-        elif data_type == DataType.GROUP_MEMBERSHIP:
-            self._assert_authority(
-                "member id", body.relationships["member"]["data"]["id"]
-            )
-
-
 @api_config(
     versions=["v1", "v2"],
     route_name="api.bulk",
@@ -101,9 +52,9 @@ def bulk(request):
     `h.h_api.bulk_api`.
     """
 
-    results = FakeBulkAPI.from_byte_stream(
-        request.body_file, executor=AuthorityCheckingExecutor()
-    )
+    executor = request.find_service(name="bulk_executor").get_executor()
+
+    results = FakeBulkAPI.from_byte_stream(request.body_file, executor=executor)
 
     # No return view is required
     if results is None:

--- a/tests/h/services/bulk_executor_test.py
+++ b/tests/h/services/bulk_executor_test.py
@@ -1,0 +1,62 @@
+import pytest
+
+from h.h_api.bulk_api import CommandBuilder
+from h.h_api.bulk_api.model.config_body import Configuration
+from h.h_api.exceptions import InvalidDeclarationError
+from h.services.bulk_executor import AuthorityCheckingExecutor
+
+
+def make_group_command(groupid, query_groupid):
+    command = CommandBuilder.group.upsert(
+        {"name": "name", "groupid": query_groupid}, "id_ref"
+    )
+
+    command.body.attributes["groupid"] = groupid
+
+    return command
+
+
+class TestAuthorityCheckingExecutor:
+    good_user_id = "acct:user@lms.hypothes.is"
+    good_groupid = "group:name@lms.hypothes.is"
+    good_authority = "lms.hypothes.is"
+    good_user_attrs = {
+        "username": "username",
+        "display_name": "display_name",
+        "authority": good_authority,
+        "identities": [{"provider": "p", "provider_unique_id": "pid"}],
+    }
+
+    def test_it_raises_InvalidDeclarationError_when_configured_with_non_lms_authority(
+        self,
+    ):
+        config = Configuration.create(
+            effective_user="acct:user@bad_authority.com", total_instructions=2
+        )
+
+        with pytest.raises(InvalidDeclarationError):
+            AuthorityCheckingExecutor().configure(config)
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            CommandBuilder.user.upsert("acct:user@bad_authority", good_user_attrs),
+            CommandBuilder.user.upsert(
+                good_user_id, dict(good_user_attrs, authority="bad_authority")
+            ),
+            make_group_command(
+                groupid=good_groupid, query_groupid="group:name@bad_authority"
+            ),
+            make_group_command(
+                groupid="group:name@bad_authority", query_groupid=good_groupid
+            ),
+            CommandBuilder.group_membership.create("acct:user@bad_authority", "id_ref"),
+        ),
+    )
+    def test_it_raises_InvalidDeclarationError_with_called_with_non_lms_authority(
+        self, command
+    ):
+        with pytest.raises(InvalidDeclarationError):
+            AuthorityCheckingExecutor().execute_batch(
+                command.type, command.body.type, {}, [command]
+            )

--- a/tests/h/views/api/bulk_test.py
+++ b/tests/h/views/api/bulk_test.py
@@ -2,79 +2,25 @@ from io import BytesIO
 from unittest.mock import create_autospec
 
 import pytest
-from h_matchers import Any
 from webob import Response
 
-from h.h_api.bulk_api import CommandBuilder
-from h.h_api.bulk_api.model.config_body import Configuration
-from h.h_api.exceptions import InvalidDeclarationError, SchemaValidationError
-from h.views.api.bulk import AuthorityCheckingExecutor, bulk
-
-
-def make_group_command(groupid, query_groupid):
-    command = CommandBuilder.group.upsert(
-        {"name": "name", "groupid": query_groupid}, "id_ref"
-    )
-
-    command.body.attributes["groupid"] = groupid
-
-    return command
-
-
-class TestAuthorityCheckingExecutor:
-    good_user_id = "acct:user@lms.hypothes.is"
-    good_groupid = "group:name@lms.hypothes.is"
-    good_authority = "lms.hypothes.is"
-    good_user_attrs = {
-        "username": "username",
-        "display_name": "display_name",
-        "authority": good_authority,
-        "identities": [{"provider": "p", "provider_unique_id": "pid"}],
-    }
-
-    def test_it_raises_InvalidDeclarationError_when_configured_with_non_lms_authority(
-        self,
-    ):
-        config = Configuration.create(
-            effective_user="acct:user@bad_authority.com", total_instructions=2
-        )
-
-        with pytest.raises(InvalidDeclarationError):
-            AuthorityCheckingExecutor().configure(config)
-
-    @pytest.mark.parametrize(
-        "command",
-        (
-            CommandBuilder.user.upsert("acct:user@bad_authority", good_user_attrs),
-            CommandBuilder.user.upsert(
-                good_user_id, dict(good_user_attrs, authority="bad_authority")
-            ),
-            make_group_command(
-                groupid=good_groupid, query_groupid="group:name@bad_authority"
-            ),
-            make_group_command(
-                groupid="group:name@bad_authority", query_groupid=good_groupid
-            ),
-            CommandBuilder.group_membership.create("acct:user@bad_authority", "id_ref"),
-        ),
-    )
-    def test_it_raises_InvalidDeclarationError_with_called_with_non_lms_authority(
-        self, command
-    ):
-        with pytest.raises(InvalidDeclarationError):
-            AuthorityCheckingExecutor().execute_batch(
-                command.type, command.body.type, {}, [command]
-            )
+from h.h_api.exceptions import SchemaValidationError
+from h.services.bulk_executor import BulkExecutorService
+from h.views.api.bulk import bulk
 
 
 class TestBulk:
-    def test_it_calls_bulk_api_correctly(self, pyramid_request, BulkAPI):
+    def test_it_calls_bulk_api_correctly(
+        self, pyramid_request, BulkAPI, bulk_executor_service
+    ):
         bulk(pyramid_request)
 
         BulkAPI.from_byte_stream.assert_called_once_with(
             pyramid_request.body_file,
-            executor=Any.instance_of(AuthorityCheckingExecutor),
+            executor=bulk_executor_service.get_executor.return_value,
         )
+
+        bulk_executor_service.get_executor.assert_called_once_with()
 
     def test_it_formats_responses_correctly(self, pyramid_request, return_lines):
         result = bulk(pyramid_request)
@@ -125,3 +71,10 @@ class TestBulk:
     @pytest.fixture
     def no_return_content(self, BulkAPI):
         BulkAPI.from_byte_stream.return_value = None
+
+    @pytest.fixture(autouse=True)
+    def bulk_executor_service(self, pyramid_config):
+        service = create_autospec(BulkExecutorService, spec_set=True, instance=True)
+        pyramid_config.register_service(service, name="bulk_executor")
+
+        return service


### PR DESCRIPTION
This moves the existing `AuthorityCheckingExecutor` into a service file and makes the view access it by looking up a service.

The code itself hasn't changed, but it has some knock on effects for the tests.