### PR TITLE
#1 Convert Bulk API library to use references for the user id

### DIFF
--- a/h/h_api/bulk_api/command_builder.py
+++ b/h/h_api/bulk_api/command_builder.py
@@ -53,16 +53,16 @@ class CommandBuilder:
         """User commands."""
 
         @classmethod
-        def upsert(cls, user_id, attributes):
+        def upsert(cls, attributes, id_reference):
             """
             Create a user upsert command.
 
-            :param user_id: Users id (e.g. 'acct:user@example.com')
             :param attributes: Dict of user fields and values
+            :param id_reference: Custom reference to this user
             :rtype: UpsertCommand
             """
             return UpsertCommand.create(
-                CommandType.UPSERT, UpsertUser.create(user_id, attributes)
+                CommandType.UPSERT, UpsertUser.create(attributes, id_reference)
             )
 
     class group:
@@ -85,18 +85,18 @@ class CommandBuilder:
         """Group membership commands."""
 
         @classmethod
-        def create(cls, user_id, group_ref):
+        def create(cls, user_ref, group_ref):
             """
             Create a group membership create.
 
-            As the group id is not known at command creation time, a custom
-            reference can be supplied to the group which is then used here to
-            link the two.
+            As the group and user ids are not known at command creation time,
+            a custom reference can be supplied to the group which is then used
+            here to link the two.
 
-            :param user_id: The user id
+            :param user_ref: Custom reference to the user
             :param group_ref: Custom reference to the group
             :rtype: CreateCommand
             """
             return CreateCommand.create(
-                CommandType.CREATE, CreateGroupMembership.create(user_id, group_ref)
+                CommandType.CREATE, CreateGroupMembership.create(user_ref, group_ref)
             )

--- a/h/h_api/bulk_api/model/data_body.py
+++ b/h/h_api/bulk_api/model/data_body.py
@@ -74,47 +74,27 @@ class CreateGroupMembership(JSONAPIData):
         )
 
     @property
-    def member_id(self):
-        """The user which is a member of this group."""
+    def member(self):
+        """The user which is a member of this group.
 
-        _member_id = self._member_id
-        if isinstance(_member_id, dict) and "$ref" in _member_id:
-            return None
-
-        return _member_id
-
-    @property
-    def group_id(self):
-        """The group the user is a member of."""
-
-        _group_id = self._group_id
-        if isinstance(_group_id, dict) and "$ref" in _group_id:
-            return None
-
-        return _group_id
-
-    @property
-    def group_ref(self):
+        :return: A value object with `id` and `ref` properties.
         """
-        A client provided reference for this group.
-
-        If you don't know the group id yet, you can use your own reference.
-        """
-        return self._group_id.get("$ref")
+        return _IdRef(self.relationships["member"]["data"]["id"])
 
     @property
-    def member_ref(self):
+    def group(self):
+        """The group which this user is a member of.
+
+        :return: A value object with `id` and `ref` properties.
         """
-        A client provided reference for this member.
+        return _IdRef(self.relationships["group"]["data"]["id"])
 
-        If you don't know the member id yet, you can use your own reference.
-        """
-        return self._member_id.get("$ref")
 
-    @property
-    def _member_id(self):
-        return self.relationships["member"]["data"]["id"]
+class _IdRef:
+    """A value object which represents an id reference or concrete id."""
 
-    @property
-    def _group_id(self):
-        return self.relationships["group"]["data"]["id"]
+    def __init__(self, value):
+        if isinstance(value, dict):
+            self.id, self.ref = None, value.get("$ref")
+        else:
+            self.id, self.ref = value, None

--- a/h/h_api/bulk_api/model/data_body.py
+++ b/h/h_api/bulk_api/model/data_body.py
@@ -78,7 +78,7 @@ class CreateGroupMembership(JSONAPIData):
         """The user which is a member of this group."""
 
         _member_id = self._member_id
-        if "$ref" in _member_id:
+        if isinstance(_member_id, dict) and "$ref" in _member_id:
             return None
 
         return _member_id
@@ -88,7 +88,7 @@ class CreateGroupMembership(JSONAPIData):
         """The group the user is a member of."""
 
         _group_id = self._group_id
-        if "$ref" in _group_id:
+        if isinstance(_group_id, dict) and "$ref" in _group_id:
             return None
 
         return _group_id

--- a/h/h_api/resources/schema/bulk_api/command/create_group_membership.json
+++ b/h/h_api/resources/schema/bulk_api/command/create_group_membership.json
@@ -20,7 +20,7 @@
                                 "member": {"properties": {
                                     "data": {"properties": {
                                         "type": {"const": "user"},
-                                        "id": {"$ref": "../../core.json#/$defs/userId"}
+                                        "id": {"required": ["$ref"]}
                                     }}
                                 }},
                                 "group": {"properties": {

--- a/h/h_api/resources/schema/bulk_api/command/create_group_membership.json
+++ b/h/h_api/resources/schema/bulk_api/command/create_group_membership.json
@@ -46,10 +46,10 @@
                 "type": "group_membership",
                 "relationships": {
                     "member": {
-                        "data": {"type": "user", "id": "acct:user@example.com"}
+                        "data": {"type": "user", "id": {"$ref": "user_ref"}}
                     },
                     "group": {
-                        "data": {"type": "group", "id": {"$ref": "thing"}}
+                        "data": {"type": "group", "id": {"$ref": "group_ref"}}
                     }
                 }
             }

--- a/h/h_api/resources/schema/bulk_api/command/upsert_user.json
+++ b/h/h_api/resources/schema/bulk_api/command/upsert_user.json
@@ -11,10 +11,15 @@
                 "data": {
                     "properties": {
                         "type": {"const": "user"},
-                        "id": {"$ref": "../../core.json#/$defs/userId"},
-                        "attributes": {"$ref": "../../core.json#/$defs/user"}
+                        "attributes": {"$ref": "../../core.json#/$defs/user"},
+                        "meta": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "$anchor": {"$ref": "../../core.json#/$defs/anchor"}
+                            }
+                        }
                     },
-                    "required": ["type", "id", "attributes"]
+                    "required": ["type", "attributes", "meta"]
                 },
                 "additionalProperties": false
             }
@@ -25,7 +30,9 @@
         {
             "data": {
                 "type": "user",
-                "id": "acct:user@example.com",
+                "meta": {
+                    "$anchor": "my_user_ref"
+                },
                 "attributes": {
                     "username": "user",
                     "display_name": "display name",

--- a/h/views/api/bulk.py
+++ b/h/views/api/bulk.py
@@ -63,7 +63,6 @@ class AuthorityCheckingExecutor(AutomaticReportExecutor):
 
     def _check_authority(self, data_type, body):
         if data_type == DataType.USER:
-            self._assert_authority("id", body.id)
             self._assert_authority(
                 "authority", body.attributes["authority"], embedded=False
             )
@@ -71,11 +70,6 @@ class AuthorityCheckingExecutor(AutomaticReportExecutor):
         elif data_type == DataType.GROUP:
             self._assert_authority("groupid", body.attributes["groupid"])
             self._assert_authority("query groupid", body.meta["query"]["groupid"])
-
-        elif data_type == DataType.GROUP_MEMBERSHIP:
-            self._assert_authority(
-                "member id", body.relationships["member"]["data"]["id"]
-            )
 
 
 @api_config(

--- a/tests/functional/api/test_bulk.py
+++ b/tests/functional/api/test_bulk.py
@@ -45,7 +45,6 @@ class TestBulk:
         return [
             CommandBuilder.configure(f"acct:user1@{authority}", total_instructions=4),
             CommandBuilder.user.upsert(
-                f"acct:user2@{authority}",
                 {
                     "username": "user2",
                     "display_name": "display_name",
@@ -57,13 +56,12 @@ class TestBulk:
                         }
                     ],
                 },
+                "user_ref",
             ),
             CommandBuilder.group.upsert(
                 {"groupid": f"group:name@{authority}", "name": "name"}, "group_ref"
             ),
-            CommandBuilder.group_membership.create(
-                f"acct:user2@{authority}", "group_ref"
-            ),
+            CommandBuilder.group_membership.create("user_ref", "group_ref"),
         ]
 
     @pytest.fixture

--- a/tests/h/h_api/bulk_api/command_builder_test.py
+++ b/tests/h/h_api/bulk_api/command_builder_test.py
@@ -97,5 +97,8 @@ class TestCommandBuilderCreation:
 
         assert isinstance(command, CreateCommand)
         assert isinstance(command.body, CreateGroupMembership)
-        assert command.body.member_ref == "user_ref"
-        assert command.body.group_ref == "group_ref"
+
+        assert command.body.member.id is None
+        assert command.body.member.ref == "user_ref"
+        assert command.body.group.id is None
+        assert command.body.group.ref == "group_ref"

--- a/tests/h/h_api/bulk_api/command_processor_test.py
+++ b/tests/h/h_api/bulk_api/command_processor_test.py
@@ -64,8 +64,8 @@ class TestCommandProcessor:
 
         command_processor.process([config_command, membership_command])
 
-        assert membership_command.body.group_id == "group_id"
-        assert membership_command.body.member_id == "user_id"
+        assert membership_command.body.group.id == "group_id"
+        assert membership_command.body.member.id == "user_id"
 
     def test_it_passes_commands_to_the_observer(
         self, command_processor, observer, config_command, user_command

--- a/tests/h/h_api/bulk_api/command_processor_test.py
+++ b/tests/h/h_api/bulk_api/command_processor_test.py
@@ -44,10 +44,18 @@ class TestCommandProcessor:
             command_processor.process(commands)
 
     def test_id_references_are_dereferenced(
-        self, command_processor, config_command, membership_command, group_command
+        self,
+        command_processor,
+        config_command,
+        membership_command,
+        group_command,
+        user_command,
     ):
         command_processor.id_refs.add_concrete_id(
-            DataType.GROUP, group_command.body.id_reference, "concrete_id"
+            DataType.GROUP, group_command.body.id_reference, "group_id"
+        )
+        command_processor.id_refs.add_concrete_id(
+            DataType.USER, user_command.body.id_reference, "user_id"
         )
 
         assert membership_command.body.relationships["group"]["data"]["id"] == {
@@ -56,10 +64,8 @@ class TestCommandProcessor:
 
         command_processor.process([config_command, membership_command])
 
-        assert (
-            membership_command.body.relationships["group"]["data"]["id"]
-            == "concrete_id"
-        )
+        assert membership_command.body.group_id == "group_id"
+        assert membership_command.body.member_id == "user_id"
 
     def test_it_passes_commands_to_the_observer(
         self, command_processor, observer, config_command, user_command

--- a/tests/h/h_api/bulk_api/id_references_test.py
+++ b/tests/h/h_api/bulk_api/id_references_test.py
@@ -16,13 +16,18 @@ class TestIdReferences:
 
     def test_we_can_fill_out_a_reference(self, group_membership_body):
         id_refs = IdReferences()
-        id_refs.add_concrete_id(DataType.GROUP, "group_ref", "real_id")
+        id_refs.add_concrete_id(DataType.GROUP, "group_ref", "real_group_id")
+        id_refs.add_concrete_id(DataType.USER, "user_ref", "real_user_id")
 
         id_refs.fill_out(group_membership_body)
 
         group_id = group_membership_body["data"]["relationships"]["group"]["data"]["id"]
+        member_id = group_membership_body["data"]["relationships"]["member"]["data"][
+            "id"
+        ]
 
-        assert group_id == "real_id"
+        assert group_id == "real_group_id"
+        assert member_id == "real_user_id"
 
     def test_with_missing_references_we_raise_UnpopulatedReferenceError(
         self, group_membership_body
@@ -34,8 +39,6 @@ class TestIdReferences:
 
     @pytest.fixture
     def group_membership_body(self):
-        group_membership = CreateGroupMembership.create(
-            "acct:user@example.com", "group_ref"
-        )
+        group_membership = CreateGroupMembership.create("user_ref", "group_ref")
 
         return group_membership.raw

--- a/tests/h/h_api/bulk_api/model/data_body_test.py
+++ b/tests/h/h_api/bulk_api/model/data_body_test.py
@@ -88,8 +88,9 @@ class TestCreateGroupMembership:
             )
 
     def test_accessors(self, create_group_membership_body):
-        data = CreateGroupMembership(create_group_membership_body)
+        body = CreateGroupMembership(create_group_membership_body)
 
-        assert data.member_id == "acct:user@example.com"
-        assert data.group_id is None
-        assert data.group_ref == "thing"
+        assert body.member_id is None
+        assert body.member_ref == "user_ref"
+        assert body.group_id is None
+        assert body.group_ref == "group_ref"

--- a/tests/h/h_api/bulk_api/model/data_body_test.py
+++ b/tests/h/h_api/bulk_api/model/data_body_test.py
@@ -90,7 +90,7 @@ class TestCreateGroupMembership:
     def test_accessors(self, create_group_membership_body):
         body = CreateGroupMembership(create_group_membership_body)
 
-        assert body.member_id is None
-        assert body.member_ref == "user_ref"
-        assert body.group_id is None
-        assert body.group_ref == "group_ref"
+        assert body.member.id is None
+        assert body.member.ref == "user_ref"
+        assert body.group.id is None
+        assert body.group.ref == "group_ref"

--- a/tests/h/h_api/bulk_api/model/data_body_test.py
+++ b/tests/h/h_api/bulk_api/model/data_body_test.py
@@ -10,7 +10,7 @@ from h.h_api.exceptions import SchemaValidationError
 
 class TestUpsertUser:
     def test_create_ok(self, user_attributes):
-        data = UpsertUser.create("acct:user@example.com", user_attributes)
+        data = UpsertUser.create(user_attributes, "user_ref")
         assert data.raw == {
             "data": {
                 "attributes": {
@@ -24,14 +24,14 @@ class TestUpsertUser:
                     ],
                     "username": "user",
                 },
-                "id": "acct:user@example.com",
+                "meta": {"$anchor": "user_ref"},
                 "type": "user",
             }
         }
 
     def test_create_can_fail(self):
         with pytest.raises(SchemaValidationError):
-            UpsertUser.create("bad", {})
+            UpsertUser.create({}, "id_ref")
 
 
 class TestUpsertGroup:
@@ -56,13 +56,13 @@ class TestUpsertGroup:
 
 class TestCreateGroupMembership:
     def test_create_ok(self):
-        data = CreateGroupMembership.create("acct:user@example.com", "reference")
+        data = CreateGroupMembership.create("user_ref", "group_ref")
 
         assert data.raw == {
             "data": {
                 "relationships": {
-                    "group": {"data": {"id": {"$ref": "reference"}, "type": "group"}},
-                    "member": {"data": {"id": "acct:user@example.com", "type": "user"}},
+                    "member": {"data": {"id": {"$ref": "user_ref"}, "type": "user"}},
+                    "group": {"data": {"id": {"$ref": "group_ref"}, "type": "group"}},
                 },
                 "type": "group_membership",
             }

--- a/tests/h/h_api/conftest.py
+++ b/tests/h/h_api/conftest.py
@@ -21,18 +21,19 @@ def config_command():
 
 @pytest.fixture
 def group_command(group_attributes):
-    return CommandBuilder.group.upsert(group_attributes, "id_ref")
+    return CommandBuilder.group.upsert(group_attributes, "group_ref")
 
 
 @pytest.fixture
 def user_command(user_attributes):
-    return CommandBuilder.user.upsert("acct:user@example.com", user_attributes)
+    return CommandBuilder.user.upsert(user_attributes, "user_ref")
 
 
 @pytest.fixture
 def membership_command(user_command, group_command):
     return CommandBuilder.group_membership.create(
-        user_id=user_command.body.id, group_ref=group_command.body.id_reference
+        user_ref=user_command.body.id_reference,
+        group_ref=group_command.body.id_reference,
     )
 
 

--- a/tests/h/h_api/fixtures/bulk_api.ndjson
+++ b/tests/h/h_api/fixtures/bulk_api.ndjson
@@ -1,8 +1,10 @@
 
+
 ["configure", {"view": null, "user": {"effective": "acct:user@example.com"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
 
 
-["upsert", {"data": {"type": "user", "id": "acct:user@wat.com", "attributes": {"username": "username", "display_name": "display name", "authority": "authority", "identities": [{"provider": "provider", "provider_unique_id": "provider_unique_id"}]}}}]
-["upsert", {"data": {"type": "group", "attributes": {"name": "group:name@example.com"}, "meta": {"query": {"groupid": "group:groupid@example.com"}, "$anchor": "group_ref"}}}]
-["create", {"data": {"type": "group_membership", "relationships": {"member": {"data": {"type": "user", "id": "acct:user@wat.com"}}, "group": {"data": {"type": "group", "id": {"$ref": "group_ref"}}}}}}]
+["upsert", {"data": {"type": "user", "attributes": {"username": "user", "display_name": "display name", "authority": "example.com", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id"}]}, "meta": {"$anchor": "user_ref"}}}]
+["upsert", {"data": {"type": "group", "attributes": {"name": "name"}, "meta": {"query": {"groupid": "group:name@example.com"}, "$anchor": "group_ref"}}}]
+
+["create", {"data": {"type": "group_membership", "relationships": {"member": {"data": {"type": "user", "id": {"$ref": "user_ref"}}}, "group": {"data": {"type": "group", "id": {"$ref": "group_ref"}}}}}}]
 

--- a/tests/h/views/api/bulk_test.py
+++ b/tests/h/views/api/bulk_test.py
@@ -22,7 +22,6 @@ def make_group_command(groupid, query_groupid):
 
 
 class TestAuthorityCheckingExecutor:
-    good_user_id = "acct:user@lms.hypothes.is"
     good_groupid = "group:name@lms.hypothes.is"
     good_authority = "lms.hypothes.is"
     good_user_attrs = {
@@ -32,9 +31,7 @@ class TestAuthorityCheckingExecutor:
         "identities": [{"provider": "p", "provider_unique_id": "pid"}],
     }
 
-    def test_it_raises_InvalidDeclarationError_when_configured_with_non_lms_authority(
-        self,
-    ):
+    def test_it_raises_InvalidDeclarationError_with_non_lms_authority(self,):
         config = Configuration.create(
             effective_user="acct:user@bad_authority.com", total_instructions=2
         )
@@ -45,9 +42,8 @@ class TestAuthorityCheckingExecutor:
     @pytest.mark.parametrize(
         "command",
         (
-            CommandBuilder.user.upsert("acct:user@bad_authority", good_user_attrs),
             CommandBuilder.user.upsert(
-                good_user_id, dict(good_user_attrs, authority="bad_authority")
+                dict(good_user_attrs, authority="bad_authority"), "id_ref"
             ),
             make_group_command(
                 groupid=good_groupid, query_groupid="group:name@bad_authority"
@@ -55,7 +51,6 @@ class TestAuthorityCheckingExecutor:
             make_group_command(
                 groupid="group:name@bad_authority", query_groupid=good_groupid
             ),
-            CommandBuilder.group_membership.create("acct:user@bad_authority", "id_ref"),
         ),
     )
     def test_it_raises_InvalidDeclarationError_with_called_with_non_lms_authority(


### PR DESCRIPTION
 * The 'user.userid' != 'user.id'
 * This normally isn't a problem, but it's a pain for bulk inserting group membership
 * As group membership relies on the integer group and user ids
 * Without these we have to look up both groups and users first for each one
 * We could probably do that en-masse, but it still means loads of extra lookups

Previously we would send the userid in two places:

 * As the 'id' field on the user (which we then ignore)
 * As the member id to the group membership (which we would then have to translate)

Instead this PR changes it so we follow the pattern set by the group:

 * Don't bother sending the id at all with the user, but send an id reference instead
 * Specify the reference in the group membership instead of the concrete id
 * The system will then translate one to the other for us (it was sufficiently general that it just did this for us, no extra coding required)

## Examples 

The reference here can be anything you want pretty much. You could use the `userid` if you really wanted to, but anything that is unique within this request will do.

Old user
```
{
    "data": {
         "id": "user:blah@example.com",
         ....
     }
}
```

New user
```
{
    "data": {
        "meta": {
            "$anchor": "anything_you_like"        
        },
        ...
    }
}
```

Old membership
```
{

    "data": {
        "relationships": {
            "member": {
                "id": "user:blah@example.com"
            },
            ...
        },
        ...
    }
}
```

New membership
```
{

    "data": {
        "relationships": {
            "member": {
                "id": {"$ref": "anything_you_like"}
            },
            ...
        },
        ...
    }
}