### PR TITLE
#2 Convert Bulk API library users upsert to use a query as the id is gone

### DIFF
--- a/h/h_api/bulk_api/model/data_body.py
+++ b/h/h_api/bulk_api/model/data_body.py
@@ -19,8 +19,17 @@ class UpsertUser(JSONAPIData):
         :param attributes: User attributes
         :return:
         """
+
+        authority = attributes.pop("authority", None)
+        username = attributes.pop("username", None)
+
         return super().create(
-            DataType.USER, attributes=attributes, meta={"$anchor": id_reference}
+            DataType.USER,
+            attributes=attributes,
+            meta={
+                "query": {"authority": authority, "username": username},
+                "$anchor": id_reference,
+            },
         )
 
 

--- a/h/h_api/resources/schema/bulk_api/command/upsert_group.json
+++ b/h/h_api/resources/schema/bulk_api/command/upsert_group.json
@@ -42,11 +42,11 @@
                 "meta": {
                     "$anchor": "my_group_1",
                     "query": {
-                        "groupid": "group:somegroup@example.com"
+                        "groupid": "group:name@example.com"
                     }
                 },
                 "attributes": {
-                    "name": "group name"
+                    "name": "name"
                 }
             }
         }

--- a/h/h_api/resources/schema/bulk_api/command/upsert_user.json
+++ b/h/h_api/resources/schema/bulk_api/command/upsert_user.json
@@ -15,8 +15,16 @@
                         "meta": {
                             "additionalProperties": false,
                             "properties": {
+                                "query": {
+                                    "type": "object",
+                                    "properties": {
+                                        "username": {"$ref": "../../core.json#/$defs/userName"},
+                                        "authority": {"$ref": "../../core.json#/$defs/authority"}
+                                    }
+                                },
                                 "$anchor": {"$ref": "../../core.json#/$defs/anchor"}
-                            }
+                            },
+                            "required": ["query"]
                         }
                     },
                     "required": ["type", "attributes", "meta"]
@@ -31,12 +39,14 @@
             "data": {
                 "type": "user",
                 "meta": {
-                    "$anchor": "my_user_ref"
+                    "$anchor": "my_user_ref",
+                    "query": {
+                        "username": "username",
+                        "authority": "example.com"
+                    }
                 },
                 "attributes": {
-                    "username": "user",
                     "display_name": "display name",
-                    "authority": "example.com",
                     "identities": [
                         {
                             "provider": "provider string",

--- a/h/h_api/resources/schema/bulk_api/command/upsert_user.json
+++ b/h/h_api/resources/schema/bulk_api/command/upsert_user.json
@@ -17,10 +17,12 @@
                             "properties": {
                                 "query": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "username": {"$ref": "../../core.json#/$defs/userName"},
                                         "authority": {"$ref": "../../core.json#/$defs/authority"}
-                                    }
+                                    },
+                                    "required": ["username", "authority"]
                                 },
                                 "$anchor": {"$ref": "../../core.json#/$defs/anchor"}
                             },

--- a/h/h_api/resources/schema/core.json
+++ b/h/h_api/resources/schema/core.json
@@ -50,23 +50,27 @@
             ]
         },
 
+        "userName": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 30,
+            "pattern": "^[A-Za-z0-9._]+$"
+        },
+
+        "authority": {
+            "type": "string"
+        },
+
         "user": {
             "type": "object",
             "additionalProperties": false,
 
             "properties": {
-                "username": {
-                    "type": "string",
-                    "minLength": 3,
-                    "maxLength": 30,
-                    "pattern": "^[A-Za-z0-9._]+$"
-                },
+                "username": {"$ref": "#/$defs/userName"},
+                "authority": {"$ref": "#/$defs/authority"},
                 "display_name": {
                     "type": "string",
                     "maxLength": 30
-                },
-                "authority": {
-                    "type": "string"
                 },
                 "identities": {
                     "type": "array",
@@ -90,7 +94,7 @@
                 }
             },
             "required": [
-                "username", "display_name", "authority", "identities"
+                "display_name", "identities"
             ],
             "examples": [
                 {

--- a/h/views/api/bulk.py
+++ b/h/views/api/bulk.py
@@ -66,6 +66,7 @@ class AuthorityCheckingExecutor(AutomaticReportExecutor):
             self._assert_authority(
                 "authority", body.attributes["authority"], embedded=False
             )
+            self._assert_authority("query authority", body.meta["query"]["authority"])
 
         elif data_type == DataType.GROUP:
             self._assert_authority("groupid", body.attributes["groupid"])

--- a/tests/h/h_api/bulk_api/model/data_body_test.py
+++ b/tests/h/h_api/bulk_api/model/data_body_test.py
@@ -16,7 +16,7 @@ class TestUpsertUser:
                 "type": "user",
                 "meta": {
                     "$anchor": "user_ref",
-                    "query": {"authority": "example.com", "username": "username",},
+                    "query": {"authority": "example.com", "username": "username"},
                 },
                 "attributes": {
                     "identities": [

--- a/tests/h/h_api/bulk_api/model/data_body_test.py
+++ b/tests/h/h_api/bulk_api/model/data_body_test.py
@@ -13,19 +13,20 @@ class TestUpsertUser:
         data = UpsertUser.create(user_attributes, "user_ref")
         assert data.raw == {
             "data": {
+                "type": "user",
+                "meta": {
+                    "$anchor": "user_ref",
+                    "query": {"authority": "example.com", "username": "username",},
+                },
                 "attributes": {
-                    "authority": "example.com",
-                    "display_name": "display name",
                     "identities": [
                         {
                             "provider": "provider string",
-                            "provider_unique_id": "provider " "unique id",
+                            "provider_unique_id": "provider unique id",
                         }
                     ],
-                    "username": "user",
+                    "display_name": "display name",
                 },
-                "meta": {"$anchor": "user_ref"},
-                "type": "user",
             }
         }
 

--- a/tests/h/h_api/conftest.py
+++ b/tests/h/h_api/conftest.py
@@ -59,12 +59,18 @@ def create_group_membership_body():
 
 @pytest.fixture
 def user_attributes(upsert_user_body):
-    return upsert_user_body["data"]["attributes"]
+    return dict(
+        upsert_user_body["data"]["attributes"],
+        **upsert_user_body["data"]["meta"]["query"]
+    )
 
 
 @pytest.fixture
-def group_attributes():
-    return {"name": "name", "groupid": "group:name@example.com"}
+def group_attributes(upsert_group_body):
+    return dict(
+        upsert_group_body["data"]["attributes"],
+        **upsert_group_body["data"]["meta"]["query"]
+    )
 
 
 @pytest.fixture

--- a/tests/h/h_api/fixtures/bulk_api.ndjson
+++ b/tests/h/h_api/fixtures/bulk_api.ndjson
@@ -2,9 +2,9 @@
 
 ["configure", {"view": null, "user": {"effective": "acct:user@example.com"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
 
+["upsert", {"data": {"type": "user", "attributes": {"display_name": "display name", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id"}]}, "meta": {"query": {"authority": "example.com", "username": "user"}, "$anchor": "user_ref"}}}]
 
-["upsert", {"data": {"type": "user", "attributes": {"username": "user", "display_name": "display name", "authority": "example.com", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id"}]}, "meta": {"$anchor": "user_ref"}}}]
-["upsert", {"data": {"type": "group", "attributes": {"name": "name"}, "meta": {"query": {"groupid": "group:name@example.com"}, "$anchor": "group_ref"}}}]
 
+["upsert", {"data": {"type": "group", "attributes": {"name": "group name"}, "meta": {"query": {"groupid": "group:somegroup@example.com"}, "$anchor": "group_ref"}}}]
 ["create", {"data": {"type": "group_membership", "relationships": {"member": {"data": {"type": "user", "id": {"$ref": "user_ref"}}}, "group": {"data": {"type": "group", "id": {"$ref": "group_ref"}}}}}}]
 

--- a/tests/h/views/api/bulk_test.py
+++ b/tests/h/views/api/bulk_test.py
@@ -16,7 +16,24 @@ def make_group_command(groupid, query_groupid):
         {"name": "name", "groupid": query_groupid}, "id_ref"
     )
 
+    # Fake the effect of merging in the query
     command.body.attributes["groupid"] = groupid
+
+    return command
+
+
+def make_user_commmand(authority, query_authority):
+    attributes = {
+        "username": "username",
+        "display_name": "display_name",
+        "authority": query_authority,
+        "identities": [{"provider": "p", "provider_unique_id": "pid"}],
+    }
+
+    command = CommandBuilder.user.upsert(attributes, "id_ref")
+
+    # Fake the effect of merging in the query
+    command.body.attributes["authority"] = authority
 
     return command
 
@@ -42,8 +59,11 @@ class TestAuthorityCheckingExecutor:
     @pytest.mark.parametrize(
         "command",
         (
-            CommandBuilder.user.upsert(
-                dict(good_user_attrs, authority="bad_authority"), "id_ref"
+            make_user_commmand(
+                authority="bad_authority", query_authority=good_authority
+            ),
+            make_user_commmand(
+                authority=good_authority, query_authority="bad_authority"
             ),
             make_group_command(
                 groupid=good_groupid, query_groupid="group:name@bad_authority"


### PR DESCRIPTION
Now we don't have an id for the user, just saying "upsert" doesn't really make any sense. We need to state _what_ we are upserting by. This now follows the pattern laid out by the group which is to separate fields sufficient to uniquely identify the object into `query` (which are automatically folded into the attributes for insertion).

The difference is most easily seen in the schema examples:

 * https://github.com/hypothesis/h/pull/5982/files#diff-7c170d7c5bcaaee382c64aab2d33c9b0

In short:

 * "username" and "authority" are now part of the "query" rather than attributes for transit
 * As we have "merge_queries" enabled, this will get copied into the attributes for convenience on the other side
 * This lets us specify how we want to find the user to update
 * This correspondingly lets us check on the other side that the query is what we expect (this is the only mechanism we support)