### PR TITLE
#4 Convert Bulk API library groups to remove groupid in favour of the underlying parts

### DIFF
--- a/h/h_api/bulk_api/model/data_body.py
+++ b/h/h_api/bulk_api/model/data_body.py
@@ -40,7 +40,7 @@ class UpsertGroup(UpsertBody):
 
     validator = Schema.get_validator("bulk_api/command/upsert_group.json")
     data_type = DataType.GROUP
-    query_fields = ["groupid"]
+    query_fields = ["authority", "authority_provided_id"]
 
 
 class CreateGroupMembership(JSONAPIData):

--- a/h/h_api/resources/schema/bulk_api/command/upsert_group.json
+++ b/h/h_api/resources/schema/bulk_api/command/upsert_group.json
@@ -21,7 +21,8 @@
                                 "query": {
                                     "type": "object",
                                     "properties": {
-                                        "groupid": {"$ref":  "../../core.json#/$defs/groupGroupId"}
+                                        "authority_provided_id": {"$ref": "../../core.json#/$defs/authorityProvidedId"},
+                                        "authority": {"$ref": "../../core.json#/$defs/authority"}
                                     }
                                 },
                                 "$anchor": {"$ref": "../../core.json#/$defs/anchor"}
@@ -42,7 +43,8 @@
                 "meta": {
                     "$anchor": "my_group_1",
                     "query": {
-                        "groupid": "group:name@example.com"
+                        "authority_provided_id": "authority_provided_id",
+                        "authority": "example.com"
                     }
                 },
                 "attributes": {

--- a/h/h_api/resources/schema/bulk_api/command/upsert_group.json
+++ b/h/h_api/resources/schema/bulk_api/command/upsert_group.json
@@ -44,7 +44,7 @@
                     "$anchor": "my_group_1",
                     "query": {
                         "authority_provided_id": "authority_provided_id",
-                        "authority": "example.com"
+                        "authority": "lms.hypothes.is"
                     }
                 },
                 "attributes": {

--- a/h/h_api/resources/schema/bulk_api/command/upsert_user.json
+++ b/h/h_api/resources/schema/bulk_api/command/upsert_user.json
@@ -44,7 +44,7 @@
                     "$anchor": "my_user_ref",
                     "query": {
                         "username": "username",
-                        "authority": "example.com"
+                        "authority": "lms.hypothes.is"
                     }
                 },
                 "attributes": {

--- a/h/h_api/resources/schema/core.json
+++ b/h/h_api/resources/schema/core.json
@@ -34,14 +34,6 @@
             ]
         },
 
-        "groupGroupId": {
-            "type": "string",
-            "pattern": "group:[a-zA-Z0-9._\\-+!~*()']{1,1024}@.*$",
-            "examples": [
-                "group:group_name@example.com"
-            ]
-        },
-
         "userId": {
             "type": "string",
             "pattern": "^acct:.+$",
@@ -59,6 +51,11 @@
 
         "authority": {
             "type": "string"
+        },
+
+        "authorityProvidedId": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9._\\-+!~*()']{1,1024}$"
         },
 
         "user": {
@@ -116,14 +113,16 @@
             "additionalProperties": false,
             "properties": {
                 "name": {"type": "string"},
-                "groupid": {"$ref":  "#/$defs/groupGroupId"}
+                "authority_provided_id": {"$ref": "#/$defs/authorityProvidedId"},
+                "authority": {"$ref": "#/$defs/authority"}
             },
             "required": ["name"],
 
             "examples": [
                 {
                     "name": "group_name",
-                    "groupid": "group:group_name@example.com"
+                    "authority_provided_id": "authority_provided_id",
+                    "authority": "example.com"
                 }
             ]
         }

--- a/h/h_api/resources/schema/core.json
+++ b/h/h_api/resources/schema/core.json
@@ -38,7 +38,7 @@
             "type": "string",
             "pattern": "^acct:.+$",
             "examples": [
-                "acct:user@example.com"
+                "acct:user@lms.hypothes.is"
             ]
         },
 
@@ -97,11 +97,11 @@
                 {
                     "username": "username",
                     "display_name": "my name",
-                    "authority": "example.com",
+                    "authority": "lms.hypothes.is",
                     "identities": [
                         {
                             "provider": "provider name",
-                            "provider_unique_id": "provider@example.com"
+                            "provider_unique_id": "provider_unique_id"
                         }
                     ]
                 }
@@ -122,7 +122,7 @@
                 {
                     "name": "group_name",
                     "authority_provided_id": "authority_provided_id",
-                    "authority": "example.com"
+                    "authority": "lms.hypothes.is"
                 }
             ]
         }

--- a/h/views/api/bulk.py
+++ b/h/views/api/bulk.py
@@ -40,7 +40,7 @@ class AuthorityCheckingExecutor(AutomaticReportExecutor):
         self.authority = authority
 
     def configure(self, config):
-        self._assert_authority("effective user", config.effective_user)
+        self._assert_authority("effective user", config.effective_user, embedded=True)
 
         self.effective_user = config.effective_user
 
@@ -50,7 +50,7 @@ class AuthorityCheckingExecutor(AutomaticReportExecutor):
 
         return super().execute_batch(command_type, data_type, default_config, batch)
 
-    def _assert_authority(self, field, value, embedded=True):
+    def _assert_authority(self, field, value, embedded=False):
         if embedded and value.endswith(f"@{self.authority}"):
             return
 
@@ -62,15 +62,9 @@ class AuthorityCheckingExecutor(AutomaticReportExecutor):
         )
 
     def _check_authority(self, data_type, body):
-        if data_type == DataType.USER:
-            self._assert_authority(
-                "authority", body.attributes["authority"], embedded=False
-            )
-            self._assert_authority("query authority", body.meta["query"]["authority"])
-
-        elif data_type == DataType.GROUP:
-            self._assert_authority("groupid", body.attributes["groupid"])
-            self._assert_authority("query groupid", body.meta["query"]["groupid"])
+        if data_type in (DataType.USER, DataType.GROUP):
+            self._assert_authority("authority", body.attributes["authority"])
+            self._assert_authority("query authority", body.query["authority"])
 
 
 @api_config(

--- a/tests/functional/api/test_bulk.py
+++ b/tests/functional/api/test_bulk.py
@@ -59,7 +59,12 @@ class TestBulk:
                 "user_ref",
             ),
             CommandBuilder.group.upsert(
-                {"groupid": f"group:name@{authority}", "name": "name"}, "group_ref"
+                {
+                    "authority": authority,
+                    "authority_provided_id": "name",
+                    "name": "name",
+                },
+                "group_ref",
             ),
             CommandBuilder.group_membership.create("user_ref", "group_ref"),
         ]

--- a/tests/h/h_api/bulk_api/model/data_body_test.py
+++ b/tests/h/h_api/bulk_api/model/data_body_test.py
@@ -75,7 +75,10 @@ class TestUpsertGroup:
                 "attributes": {"name": "name"},
                 "meta": {
                     "$anchor": "reference",
-                    "query": {"groupid": "group:name@example.com"},
+                    "query": {
+                        "authority": "example.com",
+                        "authority_provided_id": "authority_provided_id",
+                    },
                 },
                 "type": "group",
             }

--- a/tests/h/h_api/bulk_api/model/data_body_test.py
+++ b/tests/h/h_api/bulk_api/model/data_body_test.py
@@ -47,7 +47,7 @@ class TestUpsertUser:
                 "type": "user",
                 "meta": {
                     "$anchor": "user_ref",
-                    "query": {"authority": "example.com", "username": "username"},
+                    "query": {"authority": "lms.hypothes.is", "username": "username"},
                 },
                 "attributes": {
                     "identities": [
@@ -76,7 +76,7 @@ class TestUpsertGroup:
                 "meta": {
                     "$anchor": "reference",
                     "query": {
-                        "authority": "example.com",
+                        "authority": "lms.hypothes.is",
                         "authority_provided_id": "authority_provided_id",
                     },
                 },

--- a/tests/h/h_api/fixtures/bulk_api.ndjson
+++ b/tests/h/h_api/fixtures/bulk_api.ndjson
@@ -1,9 +1,10 @@
 
 
-["configure", {"view": null, "user": {"effective": "acct:user@example.com"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
+["configure", {"view": null, "user": {"effective": "acct:user@lms.hypothes.is"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
 
-["upsert", {"data": {"type": "user", "attributes": {"display_name": "display name", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id"}]}, "meta": {"query": {"authority": "example.com", "username": "username"}, "$anchor": "user_ref"}}}]
+["upsert", {"data": {"type": "user", "attributes": {"display_name": "display name", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id"}]}, "meta": {"query": {"authority": "lms.hypothes.is", "username": "username"}, "$anchor": "user_ref"}}}]
 
-["upsert", {"data": {"type": "group", "attributes": {"name": "name"}, "meta": {"query": {"authority": "name@example.com", "authority_provided_id": "authority_provided_id"}, "$anchor": "group_ref"}}}]
+["upsert", {"data": {"type": "group", "attributes": {"name": "name"}, "meta": {"query": {"authority": "lms.hypothes.is", "authority_provided_id": "authority_provided_id"}, "$anchor": "group_ref"}}}]
 ["create", {"data": {"type": "group_membership", "relationships": {"member": {"data": {"type": "user", "id": {"$ref": "user_ref"}}}, "group": {"data": {"type": "group", "id": {"$ref": "group_ref"}}}}}}]
+
 

--- a/tests/h/h_api/fixtures/bulk_api.ndjson
+++ b/tests/h/h_api/fixtures/bulk_api.ndjson
@@ -2,9 +2,8 @@
 
 ["configure", {"view": null, "user": {"effective": "acct:user@example.com"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
 
-["upsert", {"data": {"type": "user", "attributes": {"display_name": "display name", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id"}]}, "meta": {"query": {"authority": "example.com", "username": "user"}, "$anchor": "user_ref"}}}]
+["upsert", {"data": {"type": "user", "attributes": {"display_name": "display name", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id"}]}, "meta": {"query": {"authority": "example.com", "username": "username"}, "$anchor": "user_ref"}}}]
 
-
-["upsert", {"data": {"type": "group", "attributes": {"name": "group name"}, "meta": {"query": {"groupid": "group:somegroup@example.com"}, "$anchor": "group_ref"}}}]
+["upsert", {"data": {"type": "group", "attributes": {"name": "name"}, "meta": {"query": {"authority": "name@example.com", "authority_provided_id": "authority_provided_id"}, "$anchor": "group_ref"}}}]
 ["create", {"data": {"type": "group_membership", "relationships": {"member": {"data": {"type": "user", "id": {"$ref": "user_ref"}}}, "group": {"data": {"type": "group", "id": {"$ref": "group_ref"}}}}}}]
 

--- a/tests/h/h_api/schema_test.py
+++ b/tests/h/h_api/schema_test.py
@@ -52,7 +52,7 @@ class TestSchema:
 
         # Modify one value which proves we configured the Validator to load
         # chained schema
-        upsert_group_body["data"]["meta"]["query"]["groupid"] = "wrong_pattern"
+        upsert_group_body["data"]["attributes"]["NOT A KEY"] = "WRONG"
 
         with pytest.raises(SchemaValidationError):
             validator.validate_all(upsert_group_body)


### PR DESCRIPTION
The change here is not to use groupid (which isn't really a column) in favour of "authority" and "authority_provided_id". This is for a few reasons:

 * When doing the level down in SQLAlchemy we must use real fields
 * It adds code on both sides to pack, then unpack the fields into a string and back
 * It complicates checking the authority