### PR TITLE
#3 Unify the user and group models now they are so similar

### DIFF
--- a/h/h_api/bulk_api/model/data_body.py
+++ b/h/h_api/bulk_api/model/data_body.py
@@ -5,55 +5,42 @@ from h.h_api.model.json_api import JSONAPIData
 from h.h_api.schema import Schema
 
 
-class UpsertUser(JSONAPIData):
+class UpsertBody(JSONAPIData):
+    data_type = None
+    query_fields = []
+
+    @classmethod
+    def create(cls, attributes, id_reference):
+        query = {field: attributes.pop(field, None) for field in cls.query_fields}
+
+        return super().create(
+            data_type=cls.data_type,
+            attributes=attributes,
+            meta={"query": query},
+            id_reference=id_reference,
+        )
+
+    @property
+    def query(self):
+        """The query used to select which item to update."""
+
+        return self.meta["query"]
+
+
+class UpsertUser(UpsertBody):
     """The data to upsert a user."""
 
     validator = Schema.get_validator("bulk_api/command/upsert_user.json")
-
-    @classmethod
-    def create(cls, attributes, id_reference):
-        """
-        Create an upsert user body.
-
-        :param _id: User id
-        :param attributes: User attributes
-        :return:
-        """
-
-        authority = attributes.pop("authority", None)
-        username = attributes.pop("username", None)
-
-        return super().create(
-            DataType.USER,
-            attributes=attributes,
-            meta={
-                "query": {"authority": authority, "username": username},
-                "$anchor": id_reference,
-            },
-        )
+    data_type = DataType.USER
+    query_fields = ["authority", "username"]
 
 
-class UpsertGroup(JSONAPIData):
+class UpsertGroup(UpsertBody):
     """The data to upsert a group."""
 
     validator = Schema.get_validator("bulk_api/command/upsert_group.json")
-
-    @classmethod
-    def create(cls, attributes, id_reference):
-        """
-        Create an upsert group body.
-
-        :param attributes: Group attributes
-        :param id_reference: A custom reference for this group
-        :return:
-        """
-        group_id = attributes.pop("groupid", None)
-
-        return super().create(
-            DataType.GROUP,
-            attributes=attributes,
-            meta={"query": {"groupid": group_id}, "$anchor": id_reference},
-        )
+    data_type = DataType.GROUP
+    query_fields = ["groupid"]
 
 
 class CreateGroupMembership(JSONAPIData):

--- a/h/h_api/model/json_api.py
+++ b/h/h_api/model/json_api.py
@@ -44,8 +44,20 @@ class JSONAPIData(Model):
 
     @classmethod
     def create(
-        cls, data_type, _id=None, attributes=None, meta=None, relationships=None
+        cls,
+        data_type,
+        _id=None,
+        attributes=None,
+        meta=None,
+        relationships=None,
+        id_reference=None,
     ):
+        if id_reference is not None:
+            if meta is None:
+                meta = {}
+
+            meta["$anchor"] = id_reference
+
         return cls(
             {
                 "data": cls.dict_from_populated(

--- a/tests/h/h_api/model/json_api_test.py
+++ b/tests/h/h_api/model/json_api_test.py
@@ -47,7 +47,7 @@ class TestJSONAPIError:
 class TestJSONAPIData:
     def test_create(self):
         attributes = {"attrs": 1}
-        meta = {"$anchor": "my_ref"}
+        meta = {"some_meta": "value"}
         relationships = {"rel_type": {"data": {"type": "foo", "id": "1"}}}
 
         data = JSONAPIData.create(
@@ -55,6 +55,7 @@ class TestJSONAPIData:
             "my_id",
             attributes=attributes,
             meta=meta,
+            id_reference="my_ref",
             relationships=relationships,
         )
 
@@ -71,7 +72,7 @@ class TestJSONAPIData:
 
         assert data.id == "my_id"
         assert data.type == DataType.GROUP
-        assert data.meta == meta
+        assert data.meta == {"some_meta": "value", "$anchor": "my_ref"}
         assert data.attributes == attributes
         assert data.relationships == relationships
         assert data.id_reference == "my_ref"


### PR DESCRIPTION
Previously the user and group upsert commands were quite different:

 * The user had an id, and attributes
 * The group had no id, a query, and attributes which contained anything not in the query

Now the user and the group both look like the group did before, and can be based on the same code.