### PR TITLE
A rough cut of a working Bulk API executor and return values

### DIFF
--- a/h/h_api/exceptions.py
+++ b/h/h_api/exceptions.py
@@ -46,6 +46,12 @@ class InvalidDeclarationError(SimpleJSONAPIError):
     http_status = 400
 
 
+class ConflictingDataError(SimpleJSONAPIError):
+    """The client has requested changes which conflict with existing data."""
+
+    http_status = 409
+
+
 class InvalidJSONError(SimpleJSONAPIError):
     """The client sent a string we cannot interpret as JSON."""
 

--- a/h/h_api/exceptions.py
+++ b/h/h_api/exceptions.py
@@ -63,6 +63,12 @@ class UnpopulatedReferenceError(SimpleJSONAPIError):
         )
 
 
+class UnsupportedOperationError(SimpleJSONAPIError):
+    """The client has a well formed request, but we cannot do what they ask."""
+
+    http_status = 422
+
+
 class SchemaValidationError(JSONAPIError):
     """The provided data did not match the schema."""
 

--- a/h/services/bulk_executor/__init__.py
+++ b/h/services/bulk_executor/__init__.py
@@ -1,0 +1,3 @@
+from h.services.bulk_executor._executor import BulkExecutor
+
+__all__ = ["BulkExecutor"]

--- a/h/services/bulk_executor/_actions.py
+++ b/h/services/bulk_executor/_actions.py
@@ -1,0 +1,156 @@
+"""Individual actions for modifying the DB in bulk."""
+from copy import deepcopy
+
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.exc import ProgrammingError
+from zope.sqlalchemy import mark_changed
+
+from h.h_api.bulk_api import Report
+from h.h_api.exceptions import ConflictingDataError, UnsupportedOperationError
+from h.models import User, UserIdentity
+
+
+class DBAction:
+    """Base class for all DB actions.
+
+    Provides an interface and a couple of useful methods.
+    """
+
+    def __init__(self, db):
+        self.db = db
+
+    def execute(self, batch, **kwargs):
+        """Process a series of commands.
+
+        The commands are assumed to be appropriate for this action type.
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def _check_upsert_queries(batch, expected_keys):
+        """Check that the query matches expectations and the attributes.
+
+        :param batch: A collection of command objects
+        :param expected_keys: The keys which must be in the query and match
+                              the attributes with the same name.
+        """
+
+        for command in batch:
+            query = command.body.query
+
+            # This is technically overkill as the schema should make sure we
+            # can't receive queries we aren't expecting
+            if set(query.keys()) != set(expected_keys):
+                raise UnsupportedOperationError(
+                    f"Upserting by query fields '{query.keys()}' is not supported"
+                )
+
+            # Checking that the values are the same is a bit more important, as
+            # this happens post schema, and could therefore be wrong
+            for key, expected in query.items():
+                if command.body.attributes[key] != expected:
+                    raise UnsupportedOperationError(
+                        "Upserting different values to the query is not supported. "
+                        f"Different value found in key '{key}'"
+                    )
+
+    def _execute_statement(self, stmt):
+        result = self.db.execute(stmt)
+
+        # Let SQL Alchemy know that something has changed, otherwise it will
+        # never commit the transaction we are working on and it will get rolled
+        # back
+        mark_changed(self.db)
+
+        return result
+
+
+class UserUpsertAction(DBAction):
+    """Perform a bulk user upsert.
+
+    :raises ConflictingDataError: If two users attempt to use the same identity
+    """
+
+    def execute(self, batch, **_):
+        # Check that we can actually process this batch
+        self._check_upsert_queries(batch, expected_keys=["authority", "username"])
+
+        # Split users and their embedded identity lists
+        users, identities = [], []
+
+        for command in batch:
+            attributes = deepcopy(command.body.attributes)
+
+            identities.append(attributes.pop("identities"))
+            users.append(attributes)
+
+        # Upsert the data
+        user_rows = self._upsert_user_table(users)
+        self._upsert_identities(identities, user_ids=[row[0] for row in user_rows])
+
+        # Report back
+        return [
+            Report(id_, public_id=User(authority=authority, _username=username).userid)
+            for id_, authority, username in user_rows
+        ]
+
+    def _upsert_user_table(self, users):
+        stmt = self._upsert_statement(
+            User,
+            users,
+            index=[
+                # The text wrapper here prevents SQLAlchemy from quoting the
+                # string, and we need it to be verbatim
+                text("lower(replace(username, '.'::text, ''::text)), authority")
+            ],
+            upsert=["display_name"],
+        ).returning(User.id, User.authority, User._username)
+
+        return self._execute_statement(stmt).fetchall()
+
+    def _upsert_identities(self, identities, user_ids):
+        flat_identities = []
+
+        # Flatten the nested lists into a single list with user ids
+        for id_, identity_list in zip(user_ids, identities):
+            for identity in identity_list:
+                identity["user_id"] = id_
+                flat_identities.append(identity)
+
+        try:
+            # We can't tell the difference between a constraint violation
+            # because the row we are trying to insert already exists, and
+            # because the identity belongs to another user.
+            # To get around this we attempt to 'upsert' after the conflict. If
+            # the values match, nothing happens. If they are different a
+            # cardinality violation is raised by Postgres.
+
+            self._execute_statement(
+                self._upsert_statement(
+                    UserIdentity,
+                    flat_identities,
+                    index=["provider", "provider_unique_id"],
+                    upsert=["user_id"],
+                ).returning(UserIdentity.id)
+            )
+
+        except ProgrammingError as err:
+            # https://www.postgresql.org/docs/9.4/errcodes-appendix.html
+            # 21000 == cardinality violation
+            # This indicates the identity belongs to another user
+            if err.orig.pgcode == "21000":
+                raise ConflictingDataError(
+                    "Attempted to assign existing identity to a different user"
+                )
+
+            raise
+
+    @staticmethod
+    def _upsert_statement(table, values, index, upsert):
+        stmt = insert(table).values(values)
+
+        return stmt.on_conflict_do_update(
+            index_elements=index,
+            set_={field: getattr(stmt.excluded, field) for field in upsert},
+        )

--- a/h/services/bulk_executor/_actions.py
+++ b/h/services/bulk_executor/_actions.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 
 from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.exc import IntegrityError, ProgrammingError
 from zope.sqlalchemy import mark_changed
 
 from h.h_api.bulk_api import Report
@@ -12,7 +12,7 @@ from h.h_api.exceptions import (
     ConflictingDataError,
     UnsupportedOperationError,
 )
-from h.models import Group, User, UserIdentity
+from h.models import Group, GroupMembership, User, UserIdentity
 
 
 class DBAction:
@@ -109,6 +109,48 @@ class GroupUpsertAction(DBAction):
             )
             for id_, authority, authority_provided_id in group_rows
         ]
+
+
+class GroupMembershipCreateAction(DBAction):
+    def execute(self, batch, on_duplicate="continue", **_):
+        if on_duplicate != "continue":
+            raise UnsupportedOperationError(
+                "Create modes other than 'continue' have not been implemented"
+            )
+
+        values = [
+            {"user_id": command.body.member.id, "group_id": command.body.group.id}
+            for command in batch
+        ]
+
+        stmt = insert(GroupMembership).values(values)
+
+        if on_duplicate == "continue":
+            # This update doesn't change the row, but it does count as it being
+            # 'updated' which means we can get the values in the "RETURNING"
+            # clause and do the select in one go
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["user_id", "group_id"],
+                set_={"user_id": stmt.excluded.user_id},
+            )
+
+        stmt = stmt.returning(GroupMembership.id)
+
+        try:
+            membership_rows = self._execute_statement(stmt).fetchall()
+
+        except IntegrityError as err:
+            # https://www.postgresql.org/docs/9.1/errcodes-appendix.html
+            # 23503	= foreign_key_violation
+            if err.orig.pgcode == "23503":
+                raise ConflictingDataError(
+                    "Cannot insert group membership as either the user or "
+                    f"group specified does not exist: {err.params}"
+                )
+
+            raise
+
+        return [Report(id_) for (id_,) in membership_rows]
 
 
 class UserUpsertAction(DBAction):

--- a/h/services/bulk_executor/_executor.py
+++ b/h/services/bulk_executor/_executor.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from h.h_api.bulk_api.executor import AutomaticReportExecutor
 from h.h_api.enums import CommandType, DataType
 from h.h_api.exceptions import InvalidDeclarationError, UnsupportedOperationError
-from h.models import User
+from h.services.bulk_executor._actions import UserUpsertAction
 
 
 class BulkExecutor(AutomaticReportExecutor):
@@ -22,7 +22,7 @@ class BulkExecutor(AutomaticReportExecutor):
         self.authority = authority
 
         self.handlers = {
-            (CommandType.UPSERT, DataType.USER): self.FAKE,
+            (CommandType.UPSERT, DataType.USER): UserUpsertAction(self.db),
             (CommandType.UPSERT, DataType.GROUP): self.FAKE,
             (CommandType.CREATE, DataType.GROUP_MEMBERSHIP): self.FAKE,
         }
@@ -55,7 +55,13 @@ class BulkExecutor(AutomaticReportExecutor):
                 f"No implementation for {command_type.value} {data_type.value}"
             )
 
-        return super().execute_batch(command_type, data_type, default_config, batch)
+        if handler is self.FAKE:
+            return super().execute_batch(command_type, data_type, default_config, batch)
+
+        # Do it
+        return handler.execute(
+            batch, effective_user_id=self.effective_user_id, **default_config
+        )
 
     def _assert_authority(self, field, value, embedded=False):
         if embedded and value.endswith(f"@{self.authority}"):

--- a/h/services/bulk_executor/_executor.py
+++ b/h/services/bulk_executor/_executor.py
@@ -5,7 +5,8 @@ from sqlalchemy.orm.exc import NoResultFound
 from h.h_api.bulk_api.executor import AutomaticReportExecutor
 from h.h_api.enums import CommandType, DataType
 from h.h_api.exceptions import InvalidDeclarationError, UnsupportedOperationError
-from h.services.bulk_executor._actions import UserUpsertAction
+from h.models import User
+from h.services.bulk_executor._actions import GroupUpsertAction, UserUpsertAction
 
 
 class BulkExecutor(AutomaticReportExecutor):
@@ -23,7 +24,7 @@ class BulkExecutor(AutomaticReportExecutor):
 
         self.handlers = {
             (CommandType.UPSERT, DataType.USER): UserUpsertAction(self.db),
-            (CommandType.UPSERT, DataType.GROUP): self.FAKE,
+            (CommandType.UPSERT, DataType.GROUP): GroupUpsertAction(self.db),
             (CommandType.CREATE, DataType.GROUP_MEMBERSHIP): self.FAKE,
         }
 
@@ -32,7 +33,18 @@ class BulkExecutor(AutomaticReportExecutor):
     def configure(self, config):
         """Process a configuration instruction."""
         self._assert_authority("effective user", config.effective_user, embedded=True)
-        self.effective_user_id = config.effective_user
+
+        try:
+            user = (
+                self.db.query(User).filter(User.userid == config.effective_user).one()
+            )
+
+        except NoResultFound:
+            raise InvalidDeclarationError(
+                f"No user found for effective user: '{config.effective_user}'"
+            )
+
+        self.effective_user_id = user.id
 
     def execute_batch(self, command_type, data_type, default_config, batch):
         """Execute a batch of instructions of the same type."""

--- a/h/services/bulk_executor/_executor.py
+++ b/h/services/bulk_executor/_executor.py
@@ -1,0 +1,69 @@
+"""Bulk executor for use with h.h_api.bulk_api."""
+
+from sqlalchemy.orm.exc import NoResultFound
+
+from h.h_api.bulk_api.executor import AutomaticReportExecutor
+from h.h_api.enums import CommandType, DataType
+from h.h_api.exceptions import InvalidDeclarationError, UnsupportedOperationError
+from h.models import User
+
+
+class BulkExecutor(AutomaticReportExecutor):
+    """Executor of command objects which will modify the database in bulk."""
+
+    FAKE = object()
+
+    def __init__(self, db, authority="lms.hypothes.is"):
+        """
+        :param db: DB session object
+        :param authority: Restrict all request to this authority
+        """
+        self.db = db
+        self.authority = authority
+
+        self.handlers = {
+            (CommandType.UPSERT, DataType.USER): self.FAKE,
+            (CommandType.UPSERT, DataType.GROUP): self.FAKE,
+            (CommandType.CREATE, DataType.GROUP_MEMBERSHIP): self.FAKE,
+        }
+
+        self.effective_user_id = None
+
+    def configure(self, config):
+        """Process a configuration instruction."""
+        self._assert_authority("effective user", config.effective_user, embedded=True)
+        self.effective_user_id = config.effective_user
+
+    def execute_batch(self, command_type, data_type, default_config, batch):
+        """Execute a batch of instructions of the same type."""
+
+        # Check the commands for the correct authority
+        for command in batch:
+            if data_type in (DataType.USER, DataType.GROUP):
+                self._assert_authority(
+                    "authority", command.body.attributes["authority"]
+                )
+                self._assert_authority(
+                    "query authority", command.body.query["authority"]
+                )
+
+        # Get a handler for this action
+        handler = self.handlers.get((command_type, data_type), None)
+
+        if handler is None:
+            raise UnsupportedOperationError(
+                f"No implementation for {command_type.value} {data_type.value}"
+            )
+
+        return super().execute_batch(command_type, data_type, default_config, batch)
+
+    def _assert_authority(self, field, value, embedded=False):
+        if embedded and value.endswith(f"@{self.authority}"):
+            return
+
+        if value == self.authority:
+            return
+
+        raise InvalidDeclarationError(
+            f"The {field} '{value}' does not match the expected authority"
+        )

--- a/h/services/bulk_executor/_executor.py
+++ b/h/services/bulk_executor/_executor.py
@@ -6,7 +6,11 @@ from h.h_api.bulk_api.executor import AutomaticReportExecutor
 from h.h_api.enums import CommandType, DataType
 from h.h_api.exceptions import InvalidDeclarationError, UnsupportedOperationError
 from h.models import User
-from h.services.bulk_executor._actions import GroupUpsertAction, UserUpsertAction
+from h.services.bulk_executor._actions import (
+    GroupMembershipCreateAction,
+    GroupUpsertAction,
+    UserUpsertAction,
+)
 
 
 class BulkExecutor(AutomaticReportExecutor):
@@ -25,7 +29,10 @@ class BulkExecutor(AutomaticReportExecutor):
         self.handlers = {
             (CommandType.UPSERT, DataType.USER): UserUpsertAction(self.db),
             (CommandType.UPSERT, DataType.GROUP): GroupUpsertAction(self.db),
-            (CommandType.CREATE, DataType.GROUP_MEMBERSHIP): self.FAKE,
+            (
+                CommandType.CREATE,
+                DataType.GROUP_MEMBERSHIP,
+            ): GroupMembershipCreateAction(self.db),
         }
 
         self.effective_user_id = None

--- a/h/views/api/bulk.py
+++ b/h/views/api/bulk.py
@@ -1,70 +1,14 @@
+import json
 from itertools import chain
 from logging import getLogger
 
 from pyramid.response import Response
 
 from h.h_api.bulk_api import BulkAPI
-from h.h_api.bulk_api.executor import AutomaticReportExecutor
-from h.h_api.enums import DataType
-from h.h_api.exceptions import InvalidDeclarationError
+from h.services.bulk_executor import BulkExecutor
 from h.views.api.config import api_config
 
 LOG = getLogger(__name__)
-
-
-class FakeBulkAPI(BulkAPI):
-    """Temporary stub for return values.
-
-    When this work is complete, BulkAPI will return values for us. But right
-    now it doesn't and we need something to prove we can build a return value.
-    """
-
-    return_content = True
-
-    @classmethod
-    def from_byte_stream(cls, byte_stream, executor, observer=None):
-        super().from_byte_stream(byte_stream, executor, observer=None)
-
-        if cls.return_content:
-            yield b'["Line 1"]\n'
-            yield b'["Line 2"]\n'
-        else:
-            return None
-
-
-class AuthorityCheckingExecutor(AutomaticReportExecutor):
-    """A bulk executor which checks the authority."""
-
-    def __init__(self, authority="lms.hypothes.is"):
-        self.effective_user = None
-        self.authority = authority
-
-    def configure(self, config):
-        self._assert_authority("effective user", config.effective_user, embedded=True)
-
-        self.effective_user = config.effective_user
-
-    def execute_batch(self, command_type, data_type, default_config, batch):
-        for command in batch:
-            self._check_authority(data_type, command.body)
-
-        return super().execute_batch(command_type, data_type, default_config, batch)
-
-    def _assert_authority(self, field, value, embedded=False):
-        if embedded and value.endswith(f"@{self.authority}"):
-            return
-
-        if value == self.authority:
-            return
-
-        raise InvalidDeclarationError(
-            f"The {field} '{value}' does not match the expected authority"
-        )
-
-    def _check_authority(self, data_type, body):
-        if data_type in (DataType.USER, DataType.GROUP):
-            self._assert_authority("authority", body.attributes["authority"])
-            self._assert_authority("query authority", body.query["authority"])
 
 
 @api_config(
@@ -90,21 +34,25 @@ def bulk(request):
     `h.h_api.bulk_api`.
     """
 
-    results = FakeBulkAPI.from_byte_stream(
-        request.body_file, executor=AuthorityCheckingExecutor()
+    results = BulkAPI.from_byte_stream(
+        request.body_file, executor=BulkExecutor(request.db)
     )
 
-    # No return view is required
     if results is None:
         return Response(status=204)
 
-    # An NDJSON response is required
-    if results:
-        # When we get an iterator we must force the first return value to be
-        # created to be sure input validation has occurred. Otherwise we might
-        # raise errors outside of the view
-        results = chain([next(results)], results)
+    # When we get an iterator we must force the first return value to be
+    # created to be sure input validation has occurred. Otherwise we might
+    # raise errors outside of the view when called
 
-        return Response(
-            app_iter=results, status=200, content_type="application/x-ndjson"
-        )
+    try:
+        results = chain([next(results)], results)
+    except StopIteration:
+        results = []
+
+    # An NDJSON response is required
+    return Response(
+        app_iter=((json.dumps(result) + "\n").encode("utf-8") for result in results),
+        status=200,
+        content_type="application/x-ndjson",
+    )

--- a/tests/functional/api/test_bulk.py
+++ b/tests/functional/api/test_bulk.py
@@ -5,7 +5,7 @@ from h_matchers import Any
 
 from h.h_api.bulk_api import CommandBuilder
 from h.h_api.enums import ViewType
-from h.models import User
+from h.models import Group, User
 
 
 class TestBulk:
@@ -56,9 +56,9 @@ class TestBulk:
 
         assert lines == [
             {"data": {"id": "acct:user2@lms.hypothes.is", "type": "user"}},
-            {"data": {"id": Any(), "type": "group"}},
-            {"data": {"id": Any(), "type": "group"}},
-            {"data": {"id": Any(), "type": "group"}},
+            {"data": {"id": "group:id_0@lms.hypothes.is", "type": "group"}},
+            {"data": {"id": "group:id_1@lms.hypothes.is", "type": "group"}},
+            {"data": {"id": "group:id_2@lms.hypothes.is", "type": "group"}},
             {"data": {"id": Any(), "type": "group_membership"}},
             {"data": {"id": Any(), "type": "group_membership"}},
             {"data": {"id": Any(), "type": "group_membership"}},
@@ -73,6 +73,14 @@ class TestBulk:
         )
         assert len(users) == 1
         assert users[0].userid == "acct:user2@lms.hypothes.is"
+
+        groups = list(db_session.query(Group).filter(Group.authority == cls.AUTHORITY))
+        assert len(groups) == 3
+        assert [group.groupid for group in groups] == [
+            "group:id_0@lms.hypothes.is",
+            "group:id_1@lms.hypothes.is",
+            "group:id_2@lms.hypothes.is",
+        ]
 
     @pytest.fixture
     def commands(self, user):

--- a/tests/functional/api/test_bulk.py
+++ b/tests/functional/api/test_bulk.py
@@ -5,7 +5,7 @@ from h_matchers import Any
 
 from h.h_api.bulk_api import CommandBuilder
 from h.h_api.enums import ViewType
-from h.models import Group, User
+from h.models import Group, GroupMembership, User
 
 
 class TestBulk:
@@ -81,6 +81,12 @@ class TestBulk:
             "group:id_1@lms.hypothes.is",
             "group:id_2@lms.hypothes.is",
         ]
+
+        memberships = list(db_session.query(GroupMembership))
+        assert len(memberships) == 3
+
+        memberships = [(rel.user_id, rel.group_id) for rel in memberships]
+        assert memberships == [(users[0].id, group.id) for group in groups]
 
     @pytest.fixture
     def commands(self, user):

--- a/tests/functional/api/test_bulk.py
+++ b/tests/functional/api/test_bulk.py
@@ -47,6 +47,7 @@ class TestBulk:
         )
 
         self._assert_response_has_expected_values(response)
+        self._assert_db_has_expected_rows(db_session)
 
     @staticmethod
     def _assert_response_has_expected_values(response):
@@ -54,7 +55,7 @@ class TestBulk:
         lines = [json.loads(line) for line in lines if line]
 
         assert lines == [
-            {"data": {"id": Any(), "type": "user"}},
+            {"data": {"id": "acct:user2@lms.hypothes.is", "type": "user"}},
             {"data": {"id": Any(), "type": "group"}},
             {"data": {"id": Any(), "type": "group"}},
             {"data": {"id": Any(), "type": "group"}},
@@ -62,6 +63,16 @@ class TestBulk:
             {"data": {"id": Any(), "type": "group_membership"}},
             {"data": {"id": Any(), "type": "group_membership"}},
         ]
+
+    @classmethod
+    def _assert_db_has_expected_rows(cls, db_session):
+        users = list(
+            db_session.query(User).filter(
+                User.authority == cls.AUTHORITY, User.username == "user2"
+            )
+        )
+        assert len(users) == 1
+        assert users[0].userid == "acct:user2@lms.hypothes.is"
 
     @pytest.fixture
     def commands(self, user):

--- a/tests/functional/api/test_bulk.py
+++ b/tests/functional/api/test_bulk.py
@@ -4,25 +4,19 @@ import pytest
 from h_matchers import Any
 
 from h.h_api.bulk_api import CommandBuilder
+from h.h_api.enums import ViewType
+from h.models import User
 
 
 class TestBulk:
+    AUTHORITY = "lms.hypothes.is"
+
     def test_it_requires_authentication(self, app, bad_header):
         response = app.post(
             "/api/bulk", b"dummy", headers=bad_header, expect_errors=True
         )
 
         assert response.status_int == 404
-
-    def test_it_accepts_a_valid_request(self, app, nd_json, lms_auth_header):
-        response = app.post("/api/bulk", nd_json, headers=lms_auth_header)
-
-        assert response.status_int == 200
-        assert response.content_type == "application/x-ndjson"
-        assert (
-            response.headers["Hypothesis-Media-Type"]
-            == "application/vnd.hypothesis.v1+x-ndjson"
-        )
 
     def test_it_raises_errors_for_invalid_request(self, app, lms_auth_header):
         response = app.post(
@@ -38,17 +32,50 @@ class TestBulk:
             )
         }
 
-    @pytest.fixture
-    def commands(self):
-        authority = "lms.hypothes.is"
+    def test_it_accepts_a_valid_request(
+        self, app, nd_json, lms_auth_header, db_session
+    ):
+        app.post("/api/bulk", nd_json, headers=lms_auth_header)
 
-        return [
-            CommandBuilder.configure(f"acct:user1@{authority}", total_instructions=4),
+        response = app.post("/api/bulk", nd_json, headers=lms_auth_header)
+
+        assert response.status_int == 200
+        assert response.content_type == "application/x-ndjson"
+        assert (
+            response.headers["Hypothesis-Media-Type"]
+            == "application/vnd.hypothesis.v1+x-ndjson"
+        )
+
+        self._assert_response_has_expected_values(response)
+
+    @staticmethod
+    def _assert_response_has_expected_values(response):
+        lines = response.body.decode("utf-8").split("\n")
+        lines = [json.loads(line) for line in lines if line]
+
+        assert lines == [
+            {"data": {"id": Any(), "type": "user"}},
+            {"data": {"id": Any(), "type": "group"}},
+            {"data": {"id": Any(), "type": "group"}},
+            {"data": {"id": Any(), "type": "group"}},
+            {"data": {"id": Any(), "type": "group_membership"}},
+            {"data": {"id": Any(), "type": "group_membership"}},
+            {"data": {"id": Any(), "type": "group_membership"}},
+        ]
+
+    @pytest.fixture
+    def commands(self, user):
+        group_count = 3
+
+        commands = [
+            CommandBuilder.configure(
+                user.userid, total_instructions=group_count * 2 + 2, view=ViewType.BASIC
+            ),
             CommandBuilder.user.upsert(
                 {
                     "username": "user2",
                     "display_name": "display_name",
-                    "authority": authority,
+                    "authority": self.AUTHORITY,
                     "identities": [
                         {
                             "provider": "provider",
@@ -58,16 +85,34 @@ class TestBulk:
                 },
                 "user_ref",
             ),
-            CommandBuilder.group.upsert(
-                {
-                    "authority": authority,
-                    "authority_provided_id": "name",
-                    "name": "name",
-                },
-                "group_ref",
-            ),
-            CommandBuilder.group_membership.create("user_ref", "group_ref"),
         ]
+
+        for i in range(group_count):
+            commands.append(
+                CommandBuilder.group.upsert(
+                    {
+                        "authority": self.AUTHORITY,
+                        "authority_provided_id": f"id_{i}",
+                        "name": f"name_{i}",
+                    },
+                    f"group_ref_{i}",
+                )
+            )
+
+        for i in range(group_count):
+            commands.append(
+                CommandBuilder.group_membership.create("user_ref", f"group_ref_{i}")
+            )
+
+        return commands
+
+    @pytest.fixture
+    def user(self, db_session):
+        user = User(authority=self.AUTHORITY, _username="username")
+        db_session.add(user)
+        db_session.flush()
+
+        return user
 
     @pytest.fixture
     def nd_json(self, commands):

--- a/tests/h/h_api/bulk_api/functional_test.py
+++ b/tests/h/h_api/bulk_api/functional_test.py
@@ -51,6 +51,7 @@ class TestBulkAPIFunctional:
         This is a happy path check. We expect this to work."""
 
         ndjson = BulkAPI.to_string(commands)
+        print(ndjson)
         lines = ndjson.strip().split("\n")
         command_data = [json.loads(line) for line in lines]
 
@@ -92,7 +93,7 @@ class TestBulkAPIFunctional:
     @pytest.fixture
     def commands(self, user_command, group_command, membership_command):
         return (
-            CommandBuilder.configure("acct:user@example.com", total_instructions=4),
+            CommandBuilder.configure("acct:user@lms.hypothes.is", total_instructions=4),
             user_command,
             group_command,
             membership_command,

--- a/tests/h/services/bulk_executor/_actions_test.py
+++ b/tests/h/services/bulk_executor/_actions_test.py
@@ -1,12 +1,17 @@
 from copy import deepcopy
+from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
 
 from h.h_api.bulk_api import Report
-from h.h_api.exceptions import ConflictingDataError, UnsupportedOperationError
-from h.models import User
-from h.services.bulk_executor._actions import UserUpsertAction
+from h.h_api.exceptions import (
+    CommandSequenceError,
+    ConflictingDataError,
+    UnsupportedOperationError,
+)
+from h.models import Group, User
+from h.services.bulk_executor._actions import GroupUpsertAction, UserUpsertAction
 from tests.h.services.bulk_executor.conftest import CommandFactory
 
 
@@ -110,3 +115,84 @@ class TestBulkUserUpsert:
     @pytest.fixture
     def commands(self):
         return [CommandFactory.user_upsert(i) for i in range(3)]
+
+
+class TestBulkGroupUpsert:
+    def test_it_can_insert_new_records(self, db_session, commands, user):
+        reports = GroupUpsertAction(db_session).execute(
+            commands, effective_user_id=user.id
+        )
+
+        assert reports == Any.iterable.comprised_of(Any.instance_of(Report)).of_size(3)
+
+        self.assert_groups_match_commands(db_session, commands)
+
+    def test_it_can_update_records(self, db_session, commands, user):
+        update_commands = [
+            CommandFactory.group_upsert(i, extras={"name": f"changed_{i}"})
+            for i in range(3)
+        ]
+
+        GroupUpsertAction(db_session).execute(commands, effective_user_id=user.id)
+        reports = GroupUpsertAction(db_session).execute(
+            update_commands, effective_user_id=user.id
+        )
+
+        assert reports == Any.iterable.comprised_of(Any.instance_of(Report)).of_size(3)
+
+        self.assert_groups_match_commands(db_session, update_commands)
+
+    def test_it_returns_in_the_same_order_as_the_commands(
+        self, db_session, commands, user
+    ):
+        # Insert the values to set db order, then update them in reverse
+        action = GroupUpsertAction(db_session)
+        reports = action.execute(commands, effective_user_id=user.id)
+        reversed_reports = action.execute(
+            list(reversed(deepcopy(commands))), effective_user_id=user.id
+        )
+
+        ids = [report.id for report in reports]
+        reversed_ids = [report.id for report in reversed_reports]
+
+        assert reversed_ids == list(reversed(ids))
+
+    def test_it_fails_with_no_effective_user(self, db_session):
+        with pytest.raises(CommandSequenceError):
+            GroupUpsertAction(db_session).execute(
+                sentinel.batch, effective_user_id=None
+            )
+
+    @pytest.mark.parametrize("field", ["authority", "authority_provided_id"])
+    def test_it_fails_with_mismatched_queries(self, db_session, field, user):
+        command = CommandFactory.group_upsert(extras={field: "value"})
+        command.body.query[field] = "DIFFERENT"
+
+        with pytest.raises(UnsupportedOperationError):
+            GroupUpsertAction(db_session).execute([command], effective_user_id=user.id)
+
+    def test_if_fails_with_unsupported_queries(self, db_session, user):
+        command = CommandFactory.group_upsert()
+        command.body.query["something_new"] = "foo"
+
+        with pytest.raises(UnsupportedOperationError):
+            GroupUpsertAction(db_session).execute([command], effective_user_id=user.id)
+
+    def assert_groups_match_commands(self, db_session, commands):
+        attrs_by_name = {
+            command.body.attributes["name"]: command.body.attributes
+            for command in commands
+        }
+
+        models_by_name = {
+            group.name: group
+            for group in db_session.query(Group).filter(
+                Group.authority == CommandFactory.AUTHORITY
+            )
+        }
+
+        assert_models_match_data(models_by_name, attrs_by_name)
+
+    @pytest.fixture
+    def commands(self):
+        return [CommandFactory.group_upsert(i) for i in range(3)]

--- a/tests/h/services/bulk_executor/_actions_test.py
+++ b/tests/h/services/bulk_executor/_actions_test.py
@@ -1,0 +1,112 @@
+from copy import deepcopy
+
+import pytest
+from h_matchers import Any
+
+from h.h_api.bulk_api import Report
+from h.h_api.exceptions import ConflictingDataError, UnsupportedOperationError
+from h.models import User
+from h.services.bulk_executor._actions import UserUpsertAction
+from tests.h.services.bulk_executor.conftest import CommandFactory
+
+
+def assert_models_match_data(models_by_name, attrs_by_name, handlers=None):
+    assert set(models_by_name.keys()) == set(attrs_by_name.keys())
+
+    for name, model in models_by_name.items():
+        expected_attrs = attrs_by_name[name]
+
+        for field, value in expected_attrs.items():
+            found = getattr(model, field)
+
+            if handlers and field in handlers:
+                found = handlers[field](found)
+
+            assert found == value
+
+
+class TestBulkUserUpsert:
+    def test_it_can_insert_new_records(self, db_session, commands):
+        reports = UserUpsertAction(db_session).execute(commands)
+
+        assert reports == Any.iterable.comprised_of(Any.instance_of(Report)).of_size(3)
+
+        self.assert_users_match_commands(db_session, commands)
+
+    def test_it_can_update_records(self, db_session, commands):
+        update_commands = [
+            CommandFactory.user_upsert(i, extras={"display_name": f"changed_{i}"})
+            for i in range(3)
+        ]
+
+        action = UserUpsertAction(db_session)
+        action.execute(commands)
+        reports = action.execute(update_commands)
+
+        assert reports == Any.iterable.comprised_of(Any.instance_of(Report)).of_size(3)
+
+        self.assert_users_match_commands(db_session, update_commands)
+
+    def test_if_tails_with_duplicate_identities(self, db_session):
+        command_1 = CommandFactory.user_upsert(1)
+        command_2 = CommandFactory.user_upsert(2)
+        commands = [command_1, command_2]
+
+        command_2.body.attributes["identities"] = command_1.body.attributes[
+            "identities"
+        ]
+
+        with pytest.raises(ConflictingDataError):
+            UserUpsertAction(db_session).execute(commands)
+
+    def test_it_returns_in_the_same_order_as_the_commands(self, db_session, commands):
+        # Insert the values to set db order, then update them in reverse
+        action = UserUpsertAction(db_session)
+        reports = action.execute(commands)
+        reversed_reports = action.execute(list(reversed(deepcopy(commands))))
+
+        ids = [report.id for report in reports]
+        reversed_ids = [report.id for report in reversed_reports]
+
+        assert reversed_ids == list(reversed(ids))
+
+    @pytest.mark.parametrize("field", ["username", "authority"])
+    def test_it_fails_with_mismatched_queries(self, db_session, field):
+        command = CommandFactory.user_upsert(extras={field: "value"})
+        command.body.query[field] = "DIFFERENT"
+
+        with pytest.raises(UnsupportedOperationError):
+            UserUpsertAction(db_session).execute([command])
+
+    def test_if_fails_with_unsupported_queries(self, db_session):
+        command = CommandFactory.user_upsert()
+        command.body.query["something_new"] = "foo"
+
+        with pytest.raises(UnsupportedOperationError):
+            UserUpsertAction(db_session).execute([command])
+
+    def assert_users_match_commands(self, db_session, commands):
+        attrs_by_name = {
+            command.body.attributes["username"]: command.body.attributes
+            for command in commands
+        }
+
+        models_by_name = {user.username: user for user in db_session.query(User)}
+
+        assert_models_match_data(
+            models_by_name,
+            attrs_by_name,
+            {
+                "identities": lambda found: [
+                    {
+                        "provider": identity.provider,
+                        "provider_unique_id": identity.provider_unique_id,
+                    }
+                    for identity in found
+                ]
+            },
+        )
+
+    @pytest.fixture
+    def commands(self):
+        return [CommandFactory.user_upsert(i) for i in range(3)]

--- a/tests/h/services/bulk_executor/_executor_test.py
+++ b/tests/h/services/bulk_executor/_executor_test.py
@@ -14,12 +14,7 @@ class TestDBExecutor:
     @pytest.mark.parametrize(
         "command_type,data_type,handler",
         (
-            param(
-                CommandType.UPSERT,
-                DataType.USER,
-                "UserUpsertAction",
-                marks=pytest.mark.xfail(reason="Not implemented"),
-            ),
+            (CommandType.UPSERT, DataType.USER, "UserUpsertAction"),
             param(
                 CommandType.UPSERT,
                 DataType.GROUP,

--- a/tests/h/services/bulk_executor/_executor_test.py
+++ b/tests/h/services/bulk_executor/_executor_test.py
@@ -1,0 +1,108 @@
+from unittest.mock import sentinel
+
+import pytest
+from pytest import param
+
+from h.h_api.bulk_api.model.config_body import Configuration
+from h.h_api.enums import CommandType, DataType
+from h.h_api.exceptions import InvalidDeclarationError, UnsupportedOperationError
+from h.services.bulk_executor._executor import BulkExecutor
+from tests.h.services.bulk_executor.conftest import CommandFactory
+
+
+class TestDBExecutor:
+    @pytest.mark.parametrize(
+        "command_type,data_type,handler",
+        (
+            param(
+                CommandType.UPSERT,
+                DataType.USER,
+                "UserUpsertAction",
+                marks=pytest.mark.xfail(reason="Not implemented"),
+            ),
+            param(
+                CommandType.UPSERT,
+                DataType.GROUP,
+                "GroupUpsertAction",
+                marks=pytest.mark.xfail(reason="Not implemented"),
+            ),
+            param(
+                CommandType.CREATE,
+                DataType.GROUP_MEMBERSHIP,
+                "GroupMembershipCreateAction",
+                marks=pytest.mark.xfail(reason="Not implemented"),
+            ),
+        ),
+        indirect=["handler"],
+    )
+    def test_it_calls_correct_db_handler(
+        self, db_session, command_type, data_type, handler, commands
+    ):
+        executor = BulkExecutor(db_session)
+        handler.assert_called_once_with(db_session)
+
+        executor.effective_user_id = 1
+
+        # These commands aren't actually the right type, but it doesn't
+        # matter for this test
+        executor.execute_batch(
+            command_type, data_type, {"config_option": 2}, commands,
+        )
+
+        bulk_upsert = handler.return_value
+        bulk_upsert.execute.assert_called_once_with(
+            commands, effective_user_id=1, config_option=2
+        )
+
+    @pytest.mark.parametrize(
+        "command_type,data_type",
+        (
+            (CommandType.CREATE, DataType.USER),
+            (CommandType.CREATE, DataType.GROUP),
+            (CommandType.UPSERT, DataType.GROUP_MEMBERSHIP),
+        ),
+    )
+    def test_it_raises_UnsupportedOperationError_for_invalid_actions(
+        self, db_session, command_type, data_type, commands
+    ):
+        executor = BulkExecutor(db_session)
+
+        with pytest.raises(UnsupportedOperationError):
+            executor.execute_batch(command_type, data_type, commands, {})
+
+    def test_it_raises_InvalidDeclarationError_with_non_lms_authority(self):
+        config = Configuration.create(
+            effective_user="acct:user@bad_authority.com", total_instructions=2
+        )
+
+        with pytest.raises(InvalidDeclarationError):
+            BulkExecutor(sentinel.db).configure(config)
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            param(CommandFactory.user_upsert(authority="bad"), id="bad user attr"),
+            param(
+                CommandFactory.user_upsert(query_authority="bad"), id="bad user query"
+            ),
+            param(CommandFactory.group_upsert(authority="bad"), id="bad group attr"),
+            param(
+                CommandFactory.group_upsert(query_authority="bad"), id="bad group query"
+            ),
+        ),
+    )
+    def test_it_raises_InvalidDeclarationError_with_called_with_non_lms_authority(
+        self, command
+    ):
+        with pytest.raises(InvalidDeclarationError):
+            BulkExecutor(sentinel.db).execute_batch(
+                command.type, command.body.type, {}, [command]
+            )
+
+    @pytest.fixture
+    def handler(self, patch, request):
+        return patch(f"h.services.bulk_executor._executor.{request.param}")
+
+    @pytest.fixture
+    def commands(self):
+        return [CommandFactory.user_upsert()]

--- a/tests/h/services/bulk_executor/conftest.py
+++ b/tests/h/services/bulk_executor/conftest.py
@@ -1,0 +1,58 @@
+from h.h_api.bulk_api import CommandBuilder
+
+
+class CommandFactory:
+    """Create commands for the bulk tests."""
+
+    AUTHORITY = "lms.hypothes.is"
+
+    @classmethod
+    def user_upsert(
+        cls, number=0, authority=AUTHORITY, query_authority=AUTHORITY, extras=None
+    ):
+        attrs = cls._add_extras(
+            {
+                "username": f"user_{number}",
+                "display_name": f"display_name_{number}",
+                "authority": query_authority,
+                "identities": [
+                    {"provider": "provider", "provider_unique_id": f"pid_{number}"}
+                ],
+            },
+            extras,
+        )
+
+        return cls._merge_query(
+            CommandBuilder.user.upsert(attrs, f"user_ref_{number}"), authority
+        )
+
+    @classmethod
+    def group_upsert(
+        cls, number=0, authority=AUTHORITY, query_authority=AUTHORITY, extras=None
+    ):
+        attrs = cls._add_extras(
+            {
+                "name": f"name_{number}",
+                "authority": query_authority,
+                "authority_provided_id": f"ap_id_{number}",
+            },
+            extras,
+        )
+
+        return cls._merge_query(
+            CommandBuilder.group.upsert(attrs, f"group_ref_{number}",), authority,
+        )
+
+    @staticmethod
+    def _add_extras(base, extras):
+        if extras:
+            base.update(extras)
+
+        return base
+
+    @staticmethod
+    def _merge_query(command, authority):
+        command.body.attributes.update(command.body.query)
+        command.body.attributes["authority"] = authority
+
+        return command

--- a/tests/h/views/api/bulk_test.py
+++ b/tests/h/views/api/bulk_test.py
@@ -1,100 +1,37 @@
+import json
 from io import BytesIO
 from unittest.mock import create_autospec
 
 import pytest
-from h_matchers import Any
-from pytest import param
 from webob import Response
 
-from h.h_api.bulk_api import CommandBuilder
-from h.h_api.bulk_api.model.config_body import Configuration
-from h.h_api.exceptions import InvalidDeclarationError, SchemaValidationError
-from h.views.api.bulk import AuthorityCheckingExecutor, bulk
-
-AUTHORITY = "lms.hypothes.is"
-
-
-def make_group_command(authority=AUTHORITY, query_authority=AUTHORITY):
-    command = CommandBuilder.group.upsert(
-        {
-            "name": "name",
-            "authority": query_authority,
-            "authority_provided_id": "authority_provided_id",
-        },
-        "id_ref",
-    )
-
-    # Fake the effect of merging in the query
-    command.body.attributes["authority"] = authority
-
-    return command
-
-
-def make_user_commmand(authority=AUTHORITY, query_authority=AUTHORITY):
-    command = CommandBuilder.user.upsert(
-        {
-            "username": "username",
-            "display_name": "display_name",
-            "authority": query_authority,
-            "identities": [{"provider": "p", "provider_unique_id": "pid"}],
-        },
-        "id_ref",
-    )
-
-    # Fake the effect of merging in the query
-    command.body.attributes["authority"] = authority
-
-    return command
-
-
-class TestAuthorityCheckingExecutor:
-    def test_it_raises_InvalidDeclarationError_with_non_lms_authority(self):
-        config = Configuration.create(
-            effective_user="acct:user@bad_authority.com", total_instructions=2
-        )
-
-        with pytest.raises(InvalidDeclarationError):
-            AuthorityCheckingExecutor().configure(config)
-
-    @pytest.mark.parametrize(
-        "command",
-        (
-            param(make_user_commmand(authority="bad"), id="bad user attr"),
-            param(make_user_commmand(query_authority="bad"), id="bad user query"),
-            param(make_group_command(authority="bad"), id="bad group attr"),
-            param(make_group_command(query_authority="bad"), id="bad group query"),
-        ),
-    )
-    def test_it_raises_InvalidDeclarationError_with_called_with_non_lms_authority(
-        self, command
-    ):
-        with pytest.raises(InvalidDeclarationError):
-            AuthorityCheckingExecutor().execute_batch(
-                command.type, command.body.type, {}, [command]
-            )
+from h.h_api.exceptions import SchemaValidationError
+from h.views.api.bulk import bulk
 
 
 class TestBulk:
-    def test_it_calls_bulk_api_correctly(self, pyramid_request, BulkAPI):
+    def test_it_calls_bulk_api_correctly(self, pyramid_request, BulkAPI, bulk_executor):
         bulk(pyramid_request)
 
         BulkAPI.from_byte_stream.assert_called_once_with(
-            pyramid_request.body_file,
-            executor=Any.instance_of(AuthorityCheckingExecutor),
+            pyramid_request.body_file, executor=bulk_executor.return_value,
         )
 
-    def test_it_formats_responses_correctly(self, pyramid_request, return_lines):
+        bulk_executor.assert_called_once_with(pyramid_request.db)
+
+    def test_it_formats_responses_correctly(self, pyramid_request, return_values):
         result = bulk(pyramid_request)
 
         assert isinstance(result, Response)
         assert result.status == "200 OK"
         assert result.content_type == "application/x-ndjson"
-        assert result.body == b"".join(return_lines)
+
+        lines = result.body.decode("utf-8").split("\n")
+        lines = [json.loads(line) for line in lines if line]
+        assert lines == return_values
 
     @pytest.mark.usefixtures("no_return_content")
-    def test_it_returns_204_if_no_content_is_to_be_returned(
-        self, pyramid_request, return_lines
-    ):
+    def test_it_returns_204_if_no_content_is_to_be_returned(self, pyramid_request):
         result = bulk(pyramid_request)
 
         assert result.status == "204 No Content"
@@ -105,7 +42,7 @@ class TestBulk:
             # Looks like this doesn't do anything, but it turns this into a
             # generator. Unless the first item is retrieved the above is not
             # executed.
-            yield "good!"
+            yield {}
 
         BulkAPI.from_byte_stream.side_effect = bad_generator
 
@@ -119,16 +56,20 @@ class TestBulk:
         return pyramid_request
 
     @pytest.fixture
-    def return_lines(self):
-        return [b"line_1\n", b"line_2\n"]
+    def return_values(self):
+        return [{f"row_{i}": "value"} for i in range(3)]
 
     @pytest.fixture(autouse=True)
-    def BulkAPI(self, patch, return_lines):
-        BulkAPI = patch("h.views.api.bulk.FakeBulkAPI")
-        BulkAPI.from_byte_stream.return_value = (line for line in return_lines)
+    def BulkAPI(self, patch, return_values):
+        BulkAPI = patch("h.views.api.bulk.BulkAPI")
+        BulkAPI.from_byte_stream.return_value = (value for value in return_values)
 
         return BulkAPI
 
     @pytest.fixture
     def no_return_content(self, BulkAPI):
         BulkAPI.from_byte_stream.return_value = None
+
+    @pytest.fixture(autouse=True)
+    def bulk_executor(self, patch):
+        return patch("h.views.api.bulk.BulkExecutor")


### PR DESCRIPTION
### What's in this PR?

 * This adds implementation guts for actually writing all of the required changes to the database for the Bulk API
    * A call to this end-point should really upsert and create everything
    * It's very happy path though
 * This is done with 'action' classes that each concentrate on doing one thing (like `UserUpsertAction`). This is mostly to prevent the executor from becoming crazy long. These are in `h.services.bulk_executor.actions`.
 * A return data path has been implemented with a new view type "basic". This will return the data type and the public id of an object. This is for debugging and comfort only. We'll use view type `None` when we are doing this for real
 * All fakery has been stripped out of the classes

### What's not in this PR?

 * Some totally separable things have already been split out into: https://github.com/hypothesis/h/pull/5987
 * Incomplete doc strings
 * Probably quite a bit of missing error handing and edge-cases (do we actually abort the transaction if something fails etc?)
 * Lots of un-implemented tests (and general coverage gaps)

----

### Reviewing notes

This PR is intended as a way to check in on the general direction, and therefore:

 * This is far too big to actually review properly (it is intended to be chopped up soon)
 * The diff might not be worth reading in detail
 * The files as they are laid out are probably more useful

Things which are mostly noise here:

 * The service has been split into multiple files to make it easier to read
 * Lots of places changing from `example.com` to `lms.hypothes.is` for the authority, as it's the only one we accept

A working call with dev data:

```
curl --request POST \
  --url http://localhost:5000/api/bulk \
  --header 'authorization: Basic ZjVhZGE5NzItNzMyZC0xMWU5LTk2NzUtNzMyNjhlYjlkNzYxOjQ1dHZlZF8ya3NnZlNMYjFEUlYzWktNbHo1c2tWVFRQaXJyQ3lKaUlUam8=' \
  --data '["configure", {"view": "basic", "user": {"effective": "acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
["upsert", {"data": {"type": "user", "attributes": {"display_name": "display name2", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id2"}]}, "meta": {"query": {"authority": "lms.hypothes.is", "username": "username2"}, "$anchor": "user_ref"}}}]
["upsert", {"data": {"type": "group", "attributes": {"name": "name"}, "meta": {"query": {"authority": "lms.hypothes.is", "authority_provided_id": "authority_provided_id"}, "$anchor": "group_ref"}}}]
["create", {"data": {"type": "group_membership", "relationships": {"member": {"data": {"type": "user", "id": {"$ref": "user_ref"}}}, "group": {"data": {"type": "group", "id": {"$ref": "group_ref"}}}}}}]
```