### PR TITLE
A collection of un-related changes which are pre-conditions for the POC

### DIFF
--- a/h/h_api/bulk_api/command_builder.py
+++ b/h/h_api/bulk_api/command_builder.py
@@ -11,7 +11,7 @@ from h.h_api.bulk_api.model.data_body import (
     UpsertGroup,
     UpsertUser,
 )
-from h.h_api.enums import CommandType
+from h.h_api.enums import CommandType, ViewType
 
 
 class CommandBuilder:
@@ -37,7 +37,7 @@ class CommandBuilder:
             return UpsertCommand(raw)
 
     @classmethod
-    def configure(cls, effective_user, total_instructions):
+    def configure(cls, effective_user, total_instructions, view=ViewType.NONE):
         """
         Create a configuration command.
 
@@ -46,7 +46,7 @@ class CommandBuilder:
         :rtype: ConfigCommand
         """
         return ConfigCommand.create(
-            Configuration.create(effective_user, total_instructions),
+            Configuration.create(effective_user, total_instructions, view=view),
         )
 
     class user:

--- a/h/h_api/bulk_api/entry_point.py
+++ b/h/h_api/bulk_api/entry_point.py
@@ -32,7 +32,7 @@ class BulkAPI:
         if not isinstance(executor, Executor):
             raise TypeError(f"Expected 'Executor' instance not '{type(executor)}'")
 
-        CommandProcessor(executor=executor, observer=observer).process(
+        return CommandProcessor(executor=executor, observer=observer).process(
             cls._commands_from_ndjson(lines)
         )
 
@@ -54,7 +54,7 @@ class BulkAPI:
         Convenience wrapper for `from_lines`.
         """
 
-        cls.from_lines(cls._bytes_to_lines(byte_stream), executor, observer)
+        return cls.from_lines(cls._bytes_to_lines(byte_stream), executor, observer)
 
     @classmethod
     def to_stream(cls, handle, commands):

--- a/h/h_api/bulk_api/model/config_body.py
+++ b/h/h_api/bulk_api/model/config_body.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from functools import lru_cache
 
-from h.h_api.enums import CommandType, DataType
+from h.h_api.enums import CommandType, DataType, ViewType
 from h.h_api.model.base import Model
 from h.h_api.schema import Schema
 
@@ -14,7 +14,7 @@ class Configuration(Model):
     WILD_CARD = "*"
 
     @classmethod
-    def create(cls, effective_user, total_instructions):
+    def create(cls, effective_user, total_instructions, view=None):
         """
         Create a configuration object.
 
@@ -23,7 +23,7 @@ class Configuration(Model):
         """
         return cls(
             {
-                "view": None,
+                "view": ViewType(view).value,
                 "user": {"effective": effective_user},
                 "instructions": {"total": int(total_instructions)},
                 "defaults": [
@@ -36,7 +36,7 @@ class Configuration(Model):
     @property
     def view(self):
         """The return type of view requested by the user."""
-        return self.raw["view"]
+        return ViewType(self.raw["view"])
 
     @property
     def effective_user(self):

--- a/h/h_api/bulk_api/model/data_body.py
+++ b/h/h_api/bulk_api/model/data_body.py
@@ -40,7 +40,7 @@ class UpsertGroup(UpsertBody):
 
     validator = Schema.get_validator("bulk_api/command/upsert_group.json")
     data_type = DataType.GROUP
-    query_fields = ["groupid"]
+    query_fields = ["authority", "authority_provided_id"]
 
 
 class CreateGroupMembership(JSONAPIData):

--- a/h/h_api/bulk_api/model/data_body.py
+++ b/h/h_api/bulk_api/model/data_body.py
@@ -5,55 +5,42 @@ from h.h_api.model.json_api import JSONAPIData
 from h.h_api.schema import Schema
 
 
-class UpsertUser(JSONAPIData):
+class UpsertBody(JSONAPIData):
+    data_type = None
+    query_fields = []
+
+    @classmethod
+    def create(cls, attributes, id_reference):
+        query = {field: attributes.pop(field, None) for field in cls.query_fields}
+
+        return super().create(
+            data_type=cls.data_type,
+            attributes=attributes,
+            meta={"query": query},
+            id_reference=id_reference,
+        )
+
+    @property
+    def query(self):
+        """The query used to select which item to update."""
+
+        return self.meta["query"]
+
+
+class UpsertUser(UpsertBody):
     """The data to upsert a user."""
 
     validator = Schema.get_validator("bulk_api/command/upsert_user.json")
-
-    @classmethod
-    def create(cls, attributes, id_reference):
-        """
-        Create an upsert user body.
-
-        :param _id: User id
-        :param attributes: User attributes
-        :return:
-        """
-
-        authority = attributes.pop("authority", None)
-        username = attributes.pop("username", None)
-
-        return super().create(
-            DataType.USER,
-            attributes=attributes,
-            meta={
-                "query": {"authority": authority, "username": username},
-                "$anchor": id_reference,
-            },
-        )
+    data_type = DataType.USER
+    query_fields = ["authority", "username"]
 
 
-class UpsertGroup(JSONAPIData):
+class UpsertGroup(UpsertBody):
     """The data to upsert a group."""
 
     validator = Schema.get_validator("bulk_api/command/upsert_group.json")
-
-    @classmethod
-    def create(cls, attributes, id_reference):
-        """
-        Create an upsert group body.
-
-        :param attributes: Group attributes
-        :param id_reference: A custom reference for this group
-        :return:
-        """
-        group_id = attributes.pop("groupid", None)
-
-        return super().create(
-            DataType.GROUP,
-            attributes=attributes,
-            meta={"query": {"groupid": group_id}, "$anchor": id_reference},
-        )
+    data_type = DataType.GROUP
+    query_fields = ["groupid"]
 
 
 class CreateGroupMembership(JSONAPIData):

--- a/h/h_api/bulk_api/model/report.py
+++ b/h/h_api/bulk_api/model/report.py
@@ -9,13 +9,18 @@ class Report:
     # Attach this here for the convenience of the consuming library
     CommandResult = CommandResult
 
-    def __init__(self, outcome, id_):
+    def __init__(self, outcome, id_, public_id=None):
         """
         :param outcome: An instance of CommandResult
-        :param id_: The id of the resource update
+        :param id_: The id of the updated resource
+        :param public_id: The user friendly id of the resource
         """
         if id_ is None:
             raise ValueError("id_ is required for successful outcomes")
 
         self.outcome = self.CommandResult(outcome)
         self.id = id_
+        self.public_id = id_ if public_id is None else public_id
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self.outcome.value}: '{self.id}' ({self.public_id})>"

--- a/h/h_api/enums.py
+++ b/h/h_api/enums.py
@@ -29,3 +29,10 @@ class CommandStatus(Enum):
 
     AS_RECEIVED = "as_received"
     POST_EXECUTE = "post_execute"
+
+
+class ViewType(Enum):
+    """Type of view of the data requested."""
+
+    NONE = None
+    BASIC = "basic"

--- a/h/h_api/model/json_api.py
+++ b/h/h_api/model/json_api.py
@@ -44,8 +44,20 @@ class JSONAPIData(Model):
 
     @classmethod
     def create(
-        cls, data_type, _id=None, attributes=None, meta=None, relationships=None
+        cls,
+        data_type,
+        _id=None,
+        attributes=None,
+        meta=None,
+        relationships=None,
+        id_reference=None,
     ):
+        if id_reference is not None:
+            if meta is None:
+                meta = {}
+
+            meta["$anchor"] = id_reference
+
         return cls(
             {
                 "data": cls.dict_from_populated(

--- a/h/h_api/resources/schema/bulk_api/command/configuration.json
+++ b/h/h_api/resources/schema/bulk_api/command/configuration.json
@@ -7,7 +7,7 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
-        "view": {"enum": [null]},
+        "view": {"enum": [null, "basic"]},
 
         "user": {
             "type": "object",
@@ -64,7 +64,7 @@
             "view": null,
 
             "user": {
-                "effective": "acct:user@example.com"
+                "effective": "acct:user@lms.hypothes.is"
             },
 
             "instructions": {

--- a/h/h_api/resources/schema/bulk_api/command/upsert_group.json
+++ b/h/h_api/resources/schema/bulk_api/command/upsert_group.json
@@ -21,7 +21,8 @@
                                 "query": {
                                     "type": "object",
                                     "properties": {
-                                        "groupid": {"$ref":  "../../core.json#/$defs/groupGroupId"}
+                                        "authority_provided_id": {"$ref": "../../core.json#/$defs/authorityProvidedId"},
+                                        "authority": {"$ref": "../../core.json#/$defs/authority"}
                                     }
                                 },
                                 "$anchor": {"$ref": "../../core.json#/$defs/anchor"}
@@ -42,7 +43,8 @@
                 "meta": {
                     "$anchor": "my_group_1",
                     "query": {
-                        "groupid": "group:name@example.com"
+                        "authority_provided_id": "authority_provided_id",
+                        "authority": "example.com"
                     }
                 },
                 "attributes": {

--- a/h/h_api/resources/schema/bulk_api/command/upsert_group.json
+++ b/h/h_api/resources/schema/bulk_api/command/upsert_group.json
@@ -44,7 +44,7 @@
                     "$anchor": "my_group_1",
                     "query": {
                         "authority_provided_id": "authority_provided_id",
-                        "authority": "example.com"
+                        "authority": "lms.hypothes.is"
                     }
                 },
                 "attributes": {

--- a/h/h_api/resources/schema/bulk_api/command/upsert_user.json
+++ b/h/h_api/resources/schema/bulk_api/command/upsert_user.json
@@ -44,7 +44,7 @@
                     "$anchor": "my_user_ref",
                     "query": {
                         "username": "username",
-                        "authority": "example.com"
+                        "authority": "lms.hypothes.is"
                     }
                 },
                 "attributes": {

--- a/h/h_api/resources/schema/core.json
+++ b/h/h_api/resources/schema/core.json
@@ -34,14 +34,6 @@
             ]
         },
 
-        "groupGroupId": {
-            "type": "string",
-            "pattern": "group:[a-zA-Z0-9._\\-+!~*()']{1,1024}@.*$",
-            "examples": [
-                "group:group_name@example.com"
-            ]
-        },
-
         "userId": {
             "type": "string",
             "pattern": "^acct:.+$",
@@ -59,6 +51,11 @@
 
         "authority": {
             "type": "string"
+        },
+
+        "authorityProvidedId": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9._\\-+!~*()']{1,1024}$"
         },
 
         "user": {
@@ -116,14 +113,16 @@
             "additionalProperties": false,
             "properties": {
                 "name": {"type": "string"},
-                "groupid": {"$ref":  "#/$defs/groupGroupId"}
+                "authority_provided_id": {"$ref": "#/$defs/authorityProvidedId"},
+                "authority": {"$ref": "#/$defs/authority"}
             },
             "required": ["name"],
 
             "examples": [
                 {
                     "name": "group_name",
-                    "groupid": "group:group_name@example.com"
+                    "authority_provided_id": "authority_provided_id",
+                    "authority": "example.com"
                 }
             ]
         }

--- a/h/h_api/resources/schema/core.json
+++ b/h/h_api/resources/schema/core.json
@@ -38,7 +38,7 @@
             "type": "string",
             "pattern": "^acct:.+$",
             "examples": [
-                "acct:user@example.com"
+                "acct:user@lms.hypothes.is"
             ]
         },
 
@@ -97,11 +97,11 @@
                 {
                     "username": "username",
                     "display_name": "my name",
-                    "authority": "example.com",
+                    "authority": "lms.hypothes.is",
                     "identities": [
                         {
                             "provider": "provider name",
-                            "provider_unique_id": "provider@example.com"
+                            "provider_unique_id": "provider_unique_id"
                         }
                     ]
                 }
@@ -122,7 +122,7 @@
                 {
                     "name": "group_name",
                     "authority_provided_id": "authority_provided_id",
-                    "authority": "example.com"
+                    "authority": "lms.hypothes.is"
                 }
             ]
         }

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -34,6 +34,18 @@ class WriteableBy(enum.Enum):
     members = "members"
 
 
+class GroupMembership(Base):
+    __tablename__ = "user_group"
+
+    __table_args__ = (sa.UniqueConstraint("user_id", "group_id"),)
+
+    id = sa.Column("id", sa.Integer, autoincrement=True, primary_key=True)
+    user_id = sa.Column("user_id", sa.Integer, sa.ForeignKey("user.id"), nullable=False)
+    group_id = sa.Column(
+        "group_id", sa.Integer, sa.ForeignKey("group.id"), nullable=False
+    )
+
+
 class Group(Base, mixins.Timestamps):
     __tablename__ = "group"
 
@@ -320,14 +332,4 @@ PRIVATE_GROUP_TYPE_FLAGS = TypeFlags(
 
 RESTRICTED_GROUP_TYPE_FLAGS = TypeFlags(
     joinable_by=None, readable_by=ReadableBy.world, writeable_by=WriteableBy.members
-)
-
-
-USER_GROUP_TABLE = sa.Table(
-    "user_group",
-    Base.metadata,
-    sa.Column("id", sa.Integer, autoincrement=True, primary_key=True),
-    sa.Column("user_id", sa.Integer, sa.ForeignKey("user.id"), nullable=False),
-    sa.Column("group_id", sa.Integer, sa.ForeignKey("group.id"), nullable=False),
-    sa.UniqueConstraint("user_id", "group_id"),
 )

--- a/h/views/api/bulk.py
+++ b/h/views/api/bulk.py
@@ -40,7 +40,7 @@ class AuthorityCheckingExecutor(AutomaticReportExecutor):
         self.authority = authority
 
     def configure(self, config):
-        self._assert_authority("effective user", config.effective_user)
+        self._assert_authority("effective user", config.effective_user, embedded=True)
 
         self.effective_user = config.effective_user
 
@@ -50,7 +50,7 @@ class AuthorityCheckingExecutor(AutomaticReportExecutor):
 
         return super().execute_batch(command_type, data_type, default_config, batch)
 
-    def _assert_authority(self, field, value, embedded=True):
+    def _assert_authority(self, field, value, embedded=False):
         if embedded and value.endswith(f"@{self.authority}"):
             return
 
@@ -62,15 +62,9 @@ class AuthorityCheckingExecutor(AutomaticReportExecutor):
         )
 
     def _check_authority(self, data_type, body):
-        if data_type == DataType.USER:
-            self._assert_authority(
-                "authority", body.attributes["authority"], embedded=False
-            )
-            self._assert_authority("query authority", body.meta["query"]["authority"])
-
-        elif data_type == DataType.GROUP:
-            self._assert_authority("groupid", body.attributes["groupid"])
-            self._assert_authority("query groupid", body.meta["query"]["groupid"])
+        if data_type in (DataType.USER, DataType.GROUP):
+            self._assert_authority("authority", body.attributes["authority"])
+            self._assert_authority("query authority", body.query["authority"])
 
 
 @api_config(

--- a/tests/functional/api/test_bulk.py
+++ b/tests/functional/api/test_bulk.py
@@ -59,7 +59,12 @@ class TestBulk:
                 "user_ref",
             ),
             CommandBuilder.group.upsert(
-                {"groupid": f"group:name@{authority}", "name": "name"}, "group_ref"
+                {
+                    "authority": authority,
+                    "authority_provided_id": "name",
+                    "name": "name",
+                },
+                "group_ref",
             ),
             CommandBuilder.group_membership.create("user_ref", "group_ref"),
         ]

--- a/tests/h/h_api/bulk_api/command_builder_test.py
+++ b/tests/h/h_api/bulk_api/command_builder_test.py
@@ -8,7 +8,7 @@ from h.h_api.bulk_api.model.data_body import (
     UpsertGroup,
     UpsertUser,
 )
-from h.h_api.enums import CommandType
+from h.h_api.enums import CommandType, ViewType
 from h.h_api.exceptions import SchemaValidationError
 
 UPSERT = CommandType.UPSERT.value
@@ -69,12 +69,13 @@ class TestCommandBuilderFromData:
 
 class TestCommandBuilderCreation:
     def test_configure(self):
-        command = CommandBuilder.configure("acct:user@example.com", 2)
+        command = CommandBuilder.configure("acct:user@example.com", 2, "basic")
 
         assert isinstance(command, ConfigCommand)
         assert isinstance(command.body, Configuration)
         assert command.body.effective_user == "acct:user@example.com"
         assert command.body.total_instructions == 2
+        assert command.body.view == ViewType.BASIC
 
     def test_user_upsert(self, user_attributes):
         command = CommandBuilder.user.upsert(user_attributes, "user_ref")

--- a/tests/h/h_api/bulk_api/command_processor_test.py
+++ b/tests/h/h_api/bulk_api/command_processor_test.py
@@ -8,7 +8,7 @@ from h.h_api.bulk_api.command_builder import CommandBuilder
 from h.h_api.bulk_api.command_processor import CommandProcessor
 from h.h_api.bulk_api.model.report import Report
 from h.h_api.bulk_api.observer import Observer
-from h.h_api.enums import CommandResult, CommandStatus, CommandType, DataType
+from h.h_api.enums import CommandResult, CommandStatus, CommandType, DataType, ViewType
 from h.h_api.exceptions import CommandSequenceError, InvalidDeclarationError
 
 
@@ -160,11 +160,10 @@ class TestCommandProcessor:
         with pytest.raises(exception):
             command_processor.process(commands)
 
-    @pytest.mark.xfail
     def test_reports_are_stored_if_view_is_not_None(
         self, command_processor, commands, config_command
     ):
-        config_command.body.raw["view"] = "to_be_decided"
+        config_command.body.raw["view"] = ViewType.BASIC
 
         command_processor.process(commands)
 
@@ -175,11 +174,15 @@ class TestCommandProcessor:
     def test_reports_are_not_stored_if_view_is_None(
         self, command_processor, commands, config_command
     ):
-        assert config_command.body.view is None
+        assert config_command.body.view is ViewType.NONE
 
         command_processor.process(commands)
 
         assert not command_processor.reports
+
+    @pytest.mark.xfail
+    def test_it_generates_basic_reports(self):
+        raise NotImplementedError()
 
     @pytest.fixture
     def commands(self, config_command, user_command):

--- a/tests/h/h_api/bulk_api/model/config_body_test.py
+++ b/tests/h/h_api/bulk_api/model/config_body_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from h.h_api.bulk_api.model.config_body import Configuration
-from h.h_api.enums import CommandType, DataType
+from h.h_api.enums import CommandType, DataType, ViewType
 from h.h_api.exceptions import SchemaValidationError
 
 
@@ -38,7 +38,7 @@ class TestConfiguration:
             effective_user="acct:user@example.com", total_instructions=100
         )
 
-        assert config.view is None
+        assert config.view is ViewType.NONE
         assert config.effective_user == "acct:user@example.com"
         assert config.total_instructions == 100
 

--- a/tests/h/h_api/bulk_api/model/data_body_test.py
+++ b/tests/h/h_api/bulk_api/model/data_body_test.py
@@ -75,7 +75,10 @@ class TestUpsertGroup:
                 "attributes": {"name": "name"},
                 "meta": {
                     "$anchor": "reference",
-                    "query": {"groupid": "group:name@example.com"},
+                    "query": {
+                        "authority": "example.com",
+                        "authority_provided_id": "authority_provided_id",
+                    },
                 },
                 "type": "group",
             }

--- a/tests/h/h_api/bulk_api/model/data_body_test.py
+++ b/tests/h/h_api/bulk_api/model/data_body_test.py
@@ -47,7 +47,7 @@ class TestUpsertUser:
                 "type": "user",
                 "meta": {
                     "$anchor": "user_ref",
-                    "query": {"authority": "example.com", "username": "username"},
+                    "query": {"authority": "lms.hypothes.is", "username": "username"},
                 },
                 "attributes": {
                     "identities": [
@@ -76,7 +76,7 @@ class TestUpsertGroup:
                 "meta": {
                     "$anchor": "reference",
                     "query": {
-                        "authority": "example.com",
+                        "authority": "lms.hypothes.is",
                         "authority_provided_id": "authority_provided_id",
                     },
                 },

--- a/tests/h/h_api/bulk_api/model/report_test.py
+++ b/tests/h/h_api/bulk_api/model/report_test.py
@@ -11,3 +11,10 @@ class TestReport:
 
         assert report.outcome == CommandResult.UPDATED
         assert report.id == "id"
+        assert report.public_id == "id"
+
+    def test_different_ids(self):
+        report = Report(CommandResult.UPSERTED, "private_id", "public_id")
+
+        assert report.id == "private_id"
+        assert report.public_id == "public_id"

--- a/tests/h/h_api/fixtures/bulk_api.ndjson
+++ b/tests/h/h_api/fixtures/bulk_api.ndjson
@@ -1,9 +1,10 @@
 
 
-["configure", {"view": null, "user": {"effective": "acct:user@example.com"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
+["configure", {"view": null, "user": {"effective": "acct:user@lms.hypothes.is"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
 
-["upsert", {"data": {"type": "user", "attributes": {"display_name": "display name", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id"}]}, "meta": {"query": {"authority": "example.com", "username": "username"}, "$anchor": "user_ref"}}}]
+["upsert", {"data": {"type": "user", "attributes": {"display_name": "display name", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id"}]}, "meta": {"query": {"authority": "lms.hypothes.is", "username": "username"}, "$anchor": "user_ref"}}}]
 
-["upsert", {"data": {"type": "group", "attributes": {"name": "name"}, "meta": {"query": {"authority": "name@example.com", "authority_provided_id": "authority_provided_id"}, "$anchor": "group_ref"}}}]
+["upsert", {"data": {"type": "group", "attributes": {"name": "name"}, "meta": {"query": {"authority": "lms.hypothes.is", "authority_provided_id": "authority_provided_id"}, "$anchor": "group_ref"}}}]
 ["create", {"data": {"type": "group_membership", "relationships": {"member": {"data": {"type": "user", "id": {"$ref": "user_ref"}}}, "group": {"data": {"type": "group", "id": {"$ref": "group_ref"}}}}}}]
+
 

--- a/tests/h/h_api/fixtures/bulk_api.ndjson
+++ b/tests/h/h_api/fixtures/bulk_api.ndjson
@@ -2,9 +2,8 @@
 
 ["configure", {"view": null, "user": {"effective": "acct:user@example.com"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
 
-["upsert", {"data": {"type": "user", "attributes": {"display_name": "display name", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id"}]}, "meta": {"query": {"authority": "example.com", "username": "user"}, "$anchor": "user_ref"}}}]
+["upsert", {"data": {"type": "user", "attributes": {"display_name": "display name", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id"}]}, "meta": {"query": {"authority": "example.com", "username": "username"}, "$anchor": "user_ref"}}}]
 
-
-["upsert", {"data": {"type": "group", "attributes": {"name": "group name"}, "meta": {"query": {"groupid": "group:somegroup@example.com"}, "$anchor": "group_ref"}}}]
+["upsert", {"data": {"type": "group", "attributes": {"name": "name"}, "meta": {"query": {"authority": "name@example.com", "authority_provided_id": "authority_provided_id"}, "$anchor": "group_ref"}}}]
 ["create", {"data": {"type": "group_membership", "relationships": {"member": {"data": {"type": "user", "id": {"$ref": "user_ref"}}}, "group": {"data": {"type": "group", "id": {"$ref": "group_ref"}}}}}}]
 

--- a/tests/h/h_api/model/json_api_test.py
+++ b/tests/h/h_api/model/json_api_test.py
@@ -47,7 +47,7 @@ class TestJSONAPIError:
 class TestJSONAPIData:
     def test_create(self):
         attributes = {"attrs": 1}
-        meta = {"$anchor": "my_ref"}
+        meta = {"some_meta": "value"}
         relationships = {"rel_type": {"data": {"type": "foo", "id": "1"}}}
 
         data = JSONAPIData.create(
@@ -55,6 +55,7 @@ class TestJSONAPIData:
             "my_id",
             attributes=attributes,
             meta=meta,
+            id_reference="my_ref",
             relationships=relationships,
         )
 
@@ -71,7 +72,7 @@ class TestJSONAPIData:
 
         assert data.id == "my_id"
         assert data.type == DataType.GROUP
-        assert data.meta == meta
+        assert data.meta == {"some_meta": "value", "$anchor": "my_ref"}
         assert data.attributes == attributes
         assert data.relationships == relationships
         assert data.id_reference == "my_ref"

--- a/tests/h/h_api/schema_test.py
+++ b/tests/h/h_api/schema_test.py
@@ -52,7 +52,7 @@ class TestSchema:
 
         # Modify one value which proves we configured the Validator to load
         # chained schema
-        upsert_group_body["data"]["meta"]["query"]["groupid"] = "wrong_pattern"
+        upsert_group_body["data"]["attributes"]["NOT A KEY"] = "WRONG"
 
         with pytest.raises(SchemaValidationError):
             validator.validate_all(upsert_group_body)


### PR DESCRIPTION
These are here mostly as a first stab at chopping up the POC into bits. This PR isn't intended to be actually reviewed and merged.

The changes contained here:

 * Move group membership to a model we can import
 * Extend reports to have a public and private id
 * Add a new "basic" view type for returning data type and id
 * Standardise on "lms.hypothes.is" as the authority for examples