### PR TITLE
Move group membership to a model we can import

### DIFF
--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -28,7 +28,7 @@ from h.models.document import Document, DocumentMeta, DocumentURI
 from h.models.feature import Feature
 from h.models.feature_cohort import FeatureCohort
 from h.models.flag import Flag
-from h.models.group import Group
+from h.models.group import Group, GroupMembership
 from h.models.group_scope import GroupScope
 from h.models.organization import Organization
 from h.models.setting import Setting
@@ -52,6 +52,7 @@ __all__ = (
     "FeatureCohort",
     "Flag",
     "Group",
+    "GroupMembership",
     "GroupScope",
     "Organization",
     "Setting",

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -34,6 +34,18 @@ class WriteableBy(enum.Enum):
     members = "members"
 
 
+class GroupMembership(Base):
+    __tablename__ = "user_group"
+
+    __table_args__ = (sa.UniqueConstraint("user_id", "group_id"),)
+
+    id = sa.Column("id", sa.Integer, autoincrement=True, primary_key=True)
+    user_id = sa.Column("user_id", sa.Integer, sa.ForeignKey("user.id"), nullable=False)
+    group_id = sa.Column(
+        "group_id", sa.Integer, sa.ForeignKey("group.id"), nullable=False
+    )
+
+
 class Group(Base, mixins.Timestamps):
     __tablename__ = "group"
 
@@ -320,14 +332,4 @@ PRIVATE_GROUP_TYPE_FLAGS = TypeFlags(
 
 RESTRICTED_GROUP_TYPE_FLAGS = TypeFlags(
     joinable_by=None, readable_by=ReadableBy.world, writeable_by=WriteableBy.members
-)
-
-
-USER_GROUP_TABLE = sa.Table(
-    "user_group",
-    Base.metadata,
-    sa.Column("id", sa.Integer, autoincrement=True, primary_key=True),
-    sa.Column("user_id", sa.Integer, sa.ForeignKey("user.id"), nullable=False),
-    sa.Column("group_id", sa.Integer, sa.ForeignKey("group.id"), nullable=False),
-    sa.UniqueConstraint("user_id", "group_id"),
 )


### PR DESCRIPTION
Previously we only modified group membership through the ORM layer, but to do it en-masse we will need to go one layer deeper in SQLAlchemy.

We still the the objects to specified the tables and column names etc. This separates out the GroupMembership object as a top level item. It's basically exactly the code that was there in a model shape.