### PR TITLE
#5 - Bulk API - Add a "basic" view type which returns data type and id

### DIFF
--- a/h/h_api/bulk_api/command_builder.py
+++ b/h/h_api/bulk_api/command_builder.py
@@ -11,7 +11,7 @@ from h.h_api.bulk_api.model.data_body import (
     UpsertGroup,
     UpsertUser,
 )
-from h.h_api.enums import CommandType
+from h.h_api.enums import CommandType, ViewType
 
 
 class CommandBuilder:
@@ -37,7 +37,7 @@ class CommandBuilder:
             return UpsertCommand(raw)
 
     @classmethod
-    def configure(cls, effective_user, total_instructions):
+    def configure(cls, effective_user, total_instructions, view=ViewType.NONE):
         """
         Create a configuration command.
 
@@ -46,7 +46,7 @@ class CommandBuilder:
         :rtype: ConfigCommand
         """
         return ConfigCommand.create(
-            Configuration.create(effective_user, total_instructions),
+            Configuration.create(effective_user, total_instructions, view=view),
         )
 
     class user:

--- a/h/h_api/bulk_api/command_processor.py
+++ b/h/h_api/bulk_api/command_processor.py
@@ -182,13 +182,13 @@ This may cause the CommandBatcher to call the on_flush() callback that we passed
             self.reports[data_type].extend(reports)
 
     def _report_back(self):
-        if not self.reports:
+        if not self.reports or self.config.view is ViewType.NONE:
             # Nothing to report!
             return
 
         if self.config.view is not ViewType.BASIC:
-            # TODO! Implement reporting back
-            raise NotImplementedError()
+            # This shouldn't be possible, but belt and braces
+            raise ValueError(f"Unknown configuration view type {self.config.view}")
 
         for data_type, reports in self.reports.items():
             for report in reports:

--- a/h/h_api/bulk_api/entry_point.py
+++ b/h/h_api/bulk_api/entry_point.py
@@ -32,7 +32,7 @@ class BulkAPI:
         if not isinstance(executor, Executor):
             raise TypeError(f"Expected 'Executor' instance not '{type(executor)}'")
 
-        CommandProcessor(executor=executor, observer=observer).process(
+        return CommandProcessor(executor=executor, observer=observer).process(
             cls._commands_from_ndjson(lines)
         )
 
@@ -54,7 +54,7 @@ class BulkAPI:
         Convenience wrapper for `from_lines`.
         """
 
-        cls.from_lines(cls._bytes_to_lines(byte_stream), executor, observer)
+        return cls.from_lines(cls._bytes_to_lines(byte_stream), executor, observer)
 
     @classmethod
     def to_stream(cls, handle, commands):

--- a/h/h_api/bulk_api/entry_point.py
+++ b/h/h_api/bulk_api/entry_point.py
@@ -44,7 +44,7 @@ class BulkAPI:
         Convenience wrapper for `from_lines`.
         """
 
-        cls.from_lines(cls._string_to_lines(string), executor, observer)
+        return cls.from_lines(cls._string_to_lines(string), executor, observer)
 
     @classmethod
     def from_byte_stream(cls, byte_stream, executor, observer=None):

--- a/h/h_api/bulk_api/executor.py
+++ b/h/h_api/bulk_api/executor.py
@@ -1,6 +1,6 @@
 """Implementations of an 'Executor' responsible for running bulk commands."""
 from h.h_api.bulk_api.model.report import Report
-from h.h_api.enums import CommandResult, CommandType
+from h.h_api.enums import CommandType
 
 
 class Executor:
@@ -69,10 +69,4 @@ class AutomaticReportExecutor(Executor):
     def execute_batch(self, command_type, data_type, default_config, batch):
         """Return fake ids for all items in the batch with id references."""
 
-        fake_status = (
-            CommandResult.CREATED
-            if command_type is CommandType.CREATE
-            else CommandResult.UPDATED
-        )
-
-        return [Report(fake_status, id_=index) for index in range(len(batch))]
+        return [Report(id_=index) for index in range(len(batch))]

--- a/h/h_api/bulk_api/executor.py
+++ b/h/h_api/bulk_api/executor.py
@@ -1,6 +1,5 @@
 """Implementations of an 'Executor' responsible for running bulk commands."""
 from h.h_api.bulk_api.model.report import Report
-from h.h_api.enums import CommandType
 
 
 class Executor:

--- a/h/h_api/bulk_api/model/config_body.py
+++ b/h/h_api/bulk_api/model/config_body.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from functools import lru_cache
 
-from h.h_api.enums import CommandType, DataType
+from h.h_api.enums import CommandType, DataType, ViewType
 from h.h_api.model.base import Model
 from h.h_api.schema import Schema
 
@@ -14,7 +14,7 @@ class Configuration(Model):
     WILD_CARD = "*"
 
     @classmethod
-    def create(cls, effective_user, total_instructions):
+    def create(cls, effective_user, total_instructions, view=None):
         """
         Create a configuration object.
 
@@ -23,7 +23,7 @@ class Configuration(Model):
         """
         return cls(
             {
-                "view": None,
+                "view": ViewType(view).value,
                 "user": {"effective": effective_user},
                 "instructions": {"total": int(total_instructions)},
                 "defaults": [
@@ -36,7 +36,7 @@ class Configuration(Model):
     @property
     def view(self):
         """The return type of view requested by the user."""
-        return self.raw["view"]
+        return ViewType(self.raw["view"])
 
     @property
     def effective_user(self):

--- a/h/h_api/bulk_api/model/report.py
+++ b/h/h_api/bulk_api/model/report.py
@@ -1,26 +1,19 @@
 """A value object for returning database modification results."""
 
-from h.h_api.enums import CommandResult
-
 
 class Report:
     """A model for reporting the result of database modification."""
 
-    # Attach this here for the convenience of the consuming library
-    CommandResult = CommandResult
-
-    def __init__(self, outcome, id_, public_id=None):
+    def __init__(self, id_, public_id=None):
         """
-        :param outcome: An instance of CommandResult
         :param id_: The id of the updated resource
         :param public_id: The user friendly id of the resource
         """
         if id_ is None:
             raise ValueError("id_ is required for successful outcomes")
 
-        self.outcome = self.CommandResult(outcome)
         self.id = id_
         self.public_id = id_ if public_id is None else public_id
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} {self.outcome.value}: '{self.id}' ({self.public_id})>"
+        return f"<{self.__class__.__name__}: '{self.id}' ({self.public_id})>"

--- a/h/h_api/bulk_api/model/report.py
+++ b/h/h_api/bulk_api/model/report.py
@@ -9,13 +9,18 @@ class Report:
     # Attach this here for the convenience of the consuming library
     CommandResult = CommandResult
 
-    def __init__(self, outcome, id_):
+    def __init__(self, outcome, id_, public_id=None):
         """
         :param outcome: An instance of CommandResult
-        :param id_: The id of the resource update
+        :param id_: The id of the updated resource
+        :param public_id: The user friendly id of the resource
         """
         if id_ is None:
             raise ValueError("id_ is required for successful outcomes")
 
         self.outcome = self.CommandResult(outcome)
         self.id = id_
+        self.public_id = id_ if public_id is None else public_id
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self.outcome.value}: '{self.id}' ({self.public_id})>"

--- a/h/h_api/enums.py
+++ b/h/h_api/enums.py
@@ -29,3 +29,10 @@ class CommandStatus(Enum):
 
     AS_RECEIVED = "as_received"
     POST_EXECUTE = "post_execute"
+
+
+class ViewType(Enum):
+    """Type of view of the data requested."""
+
+    NONE = None
+    BASIC = "basic"

--- a/h/h_api/enums.py
+++ b/h/h_api/enums.py
@@ -19,11 +19,6 @@ class CommandType(Enum):
     CREATE = "create"
 
 
-class CommandResult(Enum):
-    CREATED = "created"
-    UPDATED = "updated"
-
-
 class CommandStatus(Enum):
     """BulkAPI command processing statuses."""
 

--- a/h/h_api/resources/schema/bulk_api/command/configuration.json
+++ b/h/h_api/resources/schema/bulk_api/command/configuration.json
@@ -7,7 +7,7 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
-        "view": {"enum": [null]},
+        "view": {"enum": [null, "basic"]},
 
         "user": {
             "type": "object",
@@ -64,7 +64,7 @@
             "view": null,
 
             "user": {
-                "effective": "acct:user@example.com"
+                "effective": "acct:user@lms.hypothes.is"
             },
 
             "instructions": {

--- a/tests/h/h_api/bulk_api/command_builder_test.py
+++ b/tests/h/h_api/bulk_api/command_builder_test.py
@@ -8,7 +8,7 @@ from h.h_api.bulk_api.model.data_body import (
     UpsertGroup,
     UpsertUser,
 )
-from h.h_api.enums import CommandType
+from h.h_api.enums import CommandType, ViewType
 from h.h_api.exceptions import SchemaValidationError
 
 UPSERT = CommandType.UPSERT.value
@@ -69,12 +69,13 @@ class TestCommandBuilderFromData:
 
 class TestCommandBuilderCreation:
     def test_configure(self):
-        command = CommandBuilder.configure("acct:user@example.com", 2)
+        command = CommandBuilder.configure("acct:user@example.com", 2, "basic")
 
         assert isinstance(command, ConfigCommand)
         assert isinstance(command.body, Configuration)
         assert command.body.effective_user == "acct:user@example.com"
         assert command.body.total_instructions == 2
+        assert command.body.view == ViewType.BASIC
 
     def test_user_upsert(self, user_attributes):
         command = CommandBuilder.user.upsert(user_attributes, "user_ref")

--- a/tests/h/h_api/bulk_api/command_processor_test.py
+++ b/tests/h/h_api/bulk_api/command_processor_test.py
@@ -8,7 +8,7 @@ from h.h_api.bulk_api.command_builder import CommandBuilder
 from h.h_api.bulk_api.command_processor import CommandProcessor
 from h.h_api.bulk_api.model.report import Report
 from h.h_api.bulk_api.observer import Observer
-from h.h_api.enums import CommandResult, CommandStatus, CommandType, DataType
+from h.h_api.enums import CommandResult, CommandStatus, CommandType, DataType, ViewType
 from h.h_api.exceptions import CommandSequenceError, InvalidDeclarationError
 
 
@@ -160,11 +160,10 @@ class TestCommandProcessor:
         with pytest.raises(exception):
             command_processor.process(commands)
 
-    @pytest.mark.xfail
     def test_reports_are_stored_if_view_is_not_None(
         self, command_processor, commands, config_command
     ):
-        config_command.body.raw["view"] = "to_be_decided"
+        config_command.body.raw["view"] = ViewType.BASIC
 
         command_processor.process(commands)
 
@@ -175,11 +174,15 @@ class TestCommandProcessor:
     def test_reports_are_not_stored_if_view_is_None(
         self, command_processor, commands, config_command
     ):
-        assert config_command.body.view is None
+        assert config_command.body.view is ViewType.NONE
 
         command_processor.process(commands)
 
         assert not command_processor.reports
+
+    @pytest.mark.xfail
+    def test_it_generates_basic_reports(self):
+        raise NotImplementedError()
 
     @pytest.fixture
     def commands(self, config_command, user_command):

--- a/tests/h/h_api/bulk_api/command_processor_test.py
+++ b/tests/h/h_api/bulk_api/command_processor_test.py
@@ -9,7 +9,7 @@ from h.h_api.bulk_api.command_builder import CommandBuilder
 from h.h_api.bulk_api.command_processor import CommandProcessor
 from h.h_api.bulk_api.model.report import Report
 from h.h_api.bulk_api.observer import Observer
-from h.h_api.enums import CommandResult, CommandStatus, CommandType, DataType, ViewType
+from h.h_api.enums import CommandStatus, CommandType, DataType, ViewType
 from h.h_api.exceptions import CommandSequenceError, InvalidDeclarationError
 
 
@@ -143,13 +143,7 @@ class TestCommandProcessor:
             ("string", TypeError),
             (["not_a_report_class"], TypeError),
             ([], IndexError),
-            (
-                [
-                    Report(CommandResult.CREATED, id_="foo"),
-                    Report(CommandResult.CREATED, id_="foo"),
-                ],
-                IndexError,
-            ),
+            ([Report(id_="foo"), Report(id_="foo"),], IndexError,),
         ),
     )
     def test_we_require_a_report_for_each_object(

--- a/tests/h/h_api/bulk_api/command_processor_test.py
+++ b/tests/h/h_api/bulk_api/command_processor_test.py
@@ -143,7 +143,7 @@ class TestCommandProcessor:
             ("string", TypeError),
             (["not_a_report_class"], TypeError),
             ([], IndexError),
-            ([Report(id_="foo"), Report(id_="foo"),], IndexError,),
+            ([Report(id_="foo"), Report(id_="foo")], IndexError),
         ),
     )
     def test_we_require_a_report_for_each_object(

--- a/tests/h/h_api/bulk_api/command_processor_test.py
+++ b/tests/h/h_api/bulk_api/command_processor_test.py
@@ -1,3 +1,4 @@
+from types import GeneratorType
 from unittest.mock import call, create_autospec
 
 import pytest
@@ -180,9 +181,15 @@ class TestCommandProcessor:
 
         assert not command_processor.reports
 
-    @pytest.mark.xfail
-    def test_it_generates_basic_reports(self):
-        raise NotImplementedError()
+    def test_it_generates_basic_reports(
+        self, command_processor, commands, config_command
+    ):
+        config_command.body.raw["view"] = "basic"
+        results = command_processor.process(commands)
+
+        assert isinstance(results, GeneratorType)
+        # Our commands below only include a user object
+        assert list(results) == [{"data": {"id": Any(), "type": "user"}}]
 
     @pytest.fixture
     def commands(self, config_command, user_command):

--- a/tests/h/h_api/bulk_api/executor_test.py
+++ b/tests/h/h_api/bulk_api/executor_test.py
@@ -5,26 +5,19 @@ from h_matchers import Any
 
 from h.h_api.bulk_api.executor import AutomaticReportExecutor
 from h.h_api.bulk_api.model.report import Report
-from h.h_api.enums import CommandResult, CommandType
+from h.h_api.enums import CommandType
 
 
 class TestAutomaticReportExecutor:
     @pytest.mark.parametrize(
-        "command_type,command_result",
-        (
-            (CommandType.CREATE, CommandResult.CREATED),
-            (CommandType.UPSERT, CommandResult.UPDATED),
-        ),
+        "command_type", (CommandType.CREATE, CommandType.UPSERT),
     )
-    def test_execute_batch_returns_an_appropriate_type(
-        self, command_type, command_result
-    ):
+    def test_execute_batch_returns_an_appropriate_type(self, command_type):
         results = AutomaticReportExecutor().execute_batch(
             command_type, sentinel.data_type, sentinel.config, batch=[sentinel.command]
         )
 
         assert results == [Any.instance_of(Report)]
-        assert results[0].outcome == command_result
 
     def test_execute_batch_generates_fake_ids(self):
         results = AutomaticReportExecutor().execute_batch(

--- a/tests/h/h_api/bulk_api/model/config_body_test.py
+++ b/tests/h/h_api/bulk_api/model/config_body_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from h.h_api.bulk_api.model.config_body import Configuration
-from h.h_api.enums import CommandType, DataType
+from h.h_api.enums import CommandType, DataType, ViewType
 from h.h_api.exceptions import SchemaValidationError
 
 
@@ -38,7 +38,7 @@ class TestConfiguration:
             effective_user="acct:user@example.com", total_instructions=100
         )
 
-        assert config.view is None
+        assert config.view is ViewType.NONE
         assert config.effective_user == "acct:user@example.com"
         assert config.total_instructions == 100
 

--- a/tests/h/h_api/bulk_api/model/report_test.py
+++ b/tests/h/h_api/bulk_api/model/report_test.py
@@ -11,3 +11,10 @@ class TestReport:
 
         assert report.outcome == CommandResult.UPDATED
         assert report.id == "id"
+        assert report.public_id == "id"
+
+    def test_different_ids(self):
+        report = Report(CommandResult.UPSERTED, "private_id", "public_id")
+
+        assert report.id == "private_id"
+        assert report.public_id == "public_id"

--- a/tests/h/h_api/bulk_api/model/report_test.py
+++ b/tests/h/h_api/bulk_api/model/report_test.py
@@ -1,20 +1,17 @@
 import pytest
 
 from h.h_api.bulk_api.model.report import Report
-from h.h_api.enums import CommandResult
 
 
 class TestReport:
-    @pytest.mark.parametrize("outcome", [CommandResult.UPDATED, "updated"])
-    def test_it(self, outcome):
-        report = Report(outcome, "id")
+    def test_it(self):
+        report = Report("id")
 
-        assert report.outcome == CommandResult.UPDATED
         assert report.id == "id"
         assert report.public_id == "id"
 
     def test_different_ids(self):
-        report = Report(CommandResult.CREATED, "private_id", "public_id")
+        report = Report("private_id", "public_id")
 
         assert report.id == "private_id"
         assert report.public_id == "public_id"

--- a/tests/h/h_api/bulk_api/model/report_test.py
+++ b/tests/h/h_api/bulk_api/model/report_test.py
@@ -1,5 +1,3 @@
-import pytest
-
 from h.h_api.bulk_api.model.report import Report
 
 

--- a/tests/h/h_api/bulk_api/model/report_test.py
+++ b/tests/h/h_api/bulk_api/model/report_test.py
@@ -14,7 +14,7 @@ class TestReport:
         assert report.public_id == "id"
 
     def test_different_ids(self):
-        report = Report(CommandResult.UPSERTED, "private_id", "public_id")
+        report = Report(CommandResult.CREATED, "private_id", "public_id")
 
         assert report.id == "private_id"
         assert report.public_id == "public_id"

--- a/tests/h/h_api/fixtures/bulk_api.ndjson
+++ b/tests/h/h_api/fixtures/bulk_api.ndjson
@@ -1,6 +1,6 @@
 
 
-["configure", {"view": null, "user": {"effective": "acct:user@lms.hypothes.is"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
+["configure", {"view": "basic", "user": {"effective": "acct:user@lms.hypothes.is"}, "instructions": {"total": 4}, "defaults": [["create", "*", {"on_duplicate": "continue"}], ["upsert", "*", {"merge_query": true}]]}]
 
 ["upsert", {"data": {"type": "user", "attributes": {"display_name": "display name", "identities": [{"provider": "provider string", "provider_unique_id": "provider unique id"}]}, "meta": {"query": {"authority": "lms.hypothes.is", "username": "username"}, "$anchor": "user_ref"}}}]
 


### PR DESCRIPTION
To facilitate debugging it's very handy to get some feedback about what went on. As we already return the ids for internal purposes we can have a basic view that returns them to the user.

The only wrinkle is that most of our ids are private and not suitable for showing to the user.

This PR:

 * Adds a public id to the report object (suitable for showing the user)
 * Builds minimal return values to send back when things are working well
 * Removes the outcome (`CommandResult`) from the report as we don't use it for anything