### PR TITLE
Allow the LMS machine user to upsert all LMS groups

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -251,6 +251,17 @@ class Group(Base, mixins.Timestamps):
             # The creator may update this group in an upsert context
             terms.append((security.Allow, self.creator.userid, "upsert"))
 
+        # Temporary hack to allow the LMS app's machine user to upsert all LMS
+        # groups, even if the machine user isn't the group's creator.
+        # We can remove this once we've either:
+        #
+        # * Run a DB migration to change the creators of all LMS groups to the
+        #   LMS app's machine user: https://github.com/hypothesis/lms/issues/1401
+        # * Or changed the LMS app to use h's new bulk API instead of using the
+        #   group upsert API: https://github.com/hypothesis/lms/issues/1506
+        if self.authority == "lms.hypothes.is":
+            terms.append((security.Allow, "acct:lms@lms.hypothes.is", "upsert"))
+
         # This authority principal may be used to grant auth clients
         # permissions for groups within their authority
         authority_principal = "client_authority:{}".format(self.authority)

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -393,6 +393,11 @@ class TestGroupACL:
     def test_creator_has_upsert_permissions(self, group, authz_policy):
         assert authz_policy.permits(group, "acct:luke@example.com", "upsert")
 
+    def test_lms_machine_user_has_upsert_permissions(self, group, authz_policy):
+        group.authority = "lms.hypothes.is"
+
+        assert authz_policy.permits(group, "acct:lms@lms.hypothes.is", "upsert")
+
     def test_admin_allowed_only_for_authority_when_no_creator(
         self, group, authz_policy
     ):


### PR DESCRIPTION
Temporary hack until we can fix this properly with a DB migration. See:

https://hypothes-is.slack.com/archives/C4K6M7P5E/p1585929784086000

We're gonna have to hardcode the LMS app's machine user's ID
(acct:lms@lms.hypothes.is) into h's group upsert permissions. That'll
allow the machine user to upsert groups, while _still_ allowing the
teachers (who're the group's creators) to upsert them as well. So we can
deploy this.

Later we'll run a DB migration so that the LMS app's machine user _is_
the creator of all LMS groups. At that point the existing "group creator
can upsert group" rule will suffice, and we can remove this temporary
"also the LMS app's machine user can upsert all LMS groups" rule.