### PR TITLE
Fix some broken tests

### DIFF
--- a/tests/functional/test_client_login.py
+++ b/tests/functional/test_client_login.py
@@ -72,7 +72,7 @@ class TestLoginFlow:
         result = response.form.submit()
         js_settings = result.html.find("script", class_="js-hypothesis-settings")
 
-        return json.loads(js_settings.text)
+        return json.loads(js_settings.string)
 
     @classmethod
     def _parse_url(cls, url):


### PR DESCRIPTION
A new release of beautifulsoup contained a breaking change that broke
these tests: `js_settings.text` no longer contains the contents of the
`<script class="js-hypothesis-settings" type="application/json">`
object. Instead, `js_settings.text` is now an empty string.

`.string` seems to be what you have to use instead.

See:

* The beautifulsoup changelog:

  https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/CHANGELOG

  The breaking change was introduced in version 4.9.0 on 5th April 2020,
  the changelog entry for it was:

  > Embedded CSS and Javascript is now stored in distinct Stylesheet and
  > Script tags, which are ignored by methods like get_text(). This
  > feature is not supported by the html5lib treebuilder. [bug=1868861]

* The beautifulsoup bug report that inspired the breaking change:
  https://bugs.launchpad.net/beautifulsoup/+bug/1868861

* The beautifulsoup commit that introduced the breaking change:
  https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/revision/564