### PR TITLE
Update link to point to proper roadmap

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -70,7 +70,7 @@ http {
     }
 
     location /roadmap {
-      return 302 "https://trello.com/b/2ajZ2dWe/public-roadmap";
+      return 302 "https://github.com/hypothesis/product-backlog/projects/6";
     }
 
     location @api_error_429 {


### PR DESCRIPTION
Before it was redirecting to the Trello board,
now it will redirect to the GitHub project.

fixes https://github.com/hypothesis/h/issues/5476