### PR TITLE
Remove quotation marks from returned `search.tag` link

### DIFF
--- a/h/views/api/links.py
+++ b/h/views/api/links.py
@@ -17,8 +17,9 @@ from h.views.api.helpers.angular import AngularRouteTemplater
 def links(context, request):
     templater = AngularRouteTemplater(request.route_url, params=["user"])
 
-    tag_search_url = request.route_url("activity.search", _query={"q": "_query_"})
-    tag_search_url = tag_search_url.replace("_query_", 'tag:":tag"')
+
+    tag_search_url = request.route_url("activity.search", _query={"q": 'tag:"__tag__"'})
+    tag_search_url = tag_search_url.replace("__tag__", ':tag')
 
     oauth_authorize_url = request.route_url("oauth_authorize")
     oauth_revoke_url = request.route_url("oauth_revoke")

--- a/h/views/api/links.py
+++ b/h/views/api/links.py
@@ -17,9 +17,8 @@ from h.views.api.helpers.angular import AngularRouteTemplater
 def links(context, request):
     templater = AngularRouteTemplater(request.route_url, params=["user"])
 
-
     tag_search_url = request.route_url("activity.search", _query={"q": 'tag:"__tag__"'})
-    tag_search_url = tag_search_url.replace("__tag__", ':tag')
+    tag_search_url = tag_search_url.replace("__tag__", ":tag")
 
     oauth_authorize_url = request.route_url("oauth_authorize")
     oauth_revoke_url = request.route_url("oauth_revoke")

--- a/tests/h/views/api/links_test.py
+++ b/tests/h/views/api/links_test.py
@@ -27,7 +27,7 @@ class TestLinks:
             "help": host + "/docs/help",
             "oauth.authorize": host + "/oauth/authorize",
             "oauth.revoke": host + "/oauth/revoke",
-            "search.tag": host + '/search?q=tag%3A%22:tag%22',
+            "search.tag": host + "/search?q=tag%3A%22:tag%22",
             "signup": host + "/signup",
             "user": host + "/u/:user",
         }

--- a/tests/h/views/api/links_test.py
+++ b/tests/h/views/api/links_test.py
@@ -27,7 +27,7 @@ class TestLinks:
             "help": host + "/docs/help",
             "oauth.authorize": host + "/oauth/authorize",
             "oauth.revoke": host + "/oauth/revoke",
-            "search.tag": host + '/search?q=tag:":tag"',
+            "search.tag": host + '/search?q=tag%3A%22:tag%22',
             "signup": host + "/signup",
             "user": host + "/u/:user",
         }


### PR DESCRIPTION
The presence of quotation marks here makes parameter replacement
by clients problematic and results in malformed URLs/links

Fixes https://github.com/hypothesis/client/issues/2073

See slack conversation here (authentication required): https://hypothes-is.slack.com/archives/C1M8NH76X/p1588336303257000