### PR TITLE
Update `redoc` 2.0-rc27 to fix Chrome scrolling issue in API docs

### DIFF
--- a/docs/_extra/api-reference/index.html
+++ b/docs/_extra/api-reference/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <redoc spec-url="hypothesis-v1.yaml" expand-responses="200,201"></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.4/bundles/redoc.standalone.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.27/bundles/redoc.standalone.js"></script>
   </body>
 </html>

--- a/docs/_extra/api-reference/v1/index.html
+++ b/docs/_extra/api-reference/v1/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <redoc spec-url="../hypothesis-v1.yaml" expand-responses="200,201"></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.4/bundles/redoc.standalone.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.27/bundles/redoc.standalone.js"></script>
   </body>
 </html>

--- a/docs/_extra/api-reference/v2/index.html
+++ b/docs/_extra/api-reference/v2/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <redoc spec-url="../hypothesis-v2.yaml" expand-responses="200,201"></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.4/bundles/redoc.standalone.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.27/bundles/redoc.standalone.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Updating the `redoc` version and building docs locally makes the reported issue go away for me in Chrome, so this should fix #1103.

Fixes https://github.com/hypothesis/product-backlog/issues/1103