### PR TITLE
Catch exceptions which arise from duplicate groups

### DIFF
--- a/h/services/bulk_executor/_actions.py
+++ b/h/services/bulk_executor/_actions.py
@@ -122,7 +122,18 @@ class GroupUpsertAction(DBAction):
         ).returning(Group.id, Group.authority, Group.authority_provided_id)
 
         # Upsert the data
-        group_rows = self._execute_statement(stmt).fetchall()
+        try:
+            group_rows = self._execute_statement(stmt).fetchall()
+
+        except ProgrammingError as err:
+            # https://www.postgresql.org/docs/9.4/errcodes-appendix.html
+            # 21000 == cardinality violation
+            if err.orig.pgcode == "21000":
+                raise ConflictingDataError(
+                    "Attempted to create two groups with the same authority and id"
+                )
+
+            raise
 
         # Report back
         return [

--- a/h/services/bulk_executor/_actions.py
+++ b/h/services/bulk_executor/_actions.py
@@ -31,7 +31,7 @@ class DBAction:
         The commands are assumed to be appropriate for this action type.
         """
 
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
     @staticmethod
     def _check_upsert_queries(batch, expected_keys):

--- a/tests/h/services/bulk_executor/_actions_test.py
+++ b/tests/h/services/bulk_executor/_actions_test.py
@@ -158,6 +158,13 @@ class TestBulkGroupUpsert:
                 sentinel.batch, effective_user_id=None
             )
 
+    def test_it_fails_with_duplicate_groups(self, db_session, user):
+        command = group_upsert_command(0)
+        action = GroupUpsertAction(db_session)
+
+        with pytest.raises(ConflictingDataError):
+            action.execute([command, command], effective_user_id=user.id)
+
     @pytest.mark.parametrize("field", ["authority", "authority_provided_id"])
     def test_it_fails_with_mismatched_queries(self, db_session, field, user):
         command = group_upsert_command(**{field: "value"})

--- a/tests/h/services/bulk_executor/_actions_test.py
+++ b/tests/h/services/bulk_executor/_actions_test.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from operator import attrgetter
-from unittest.mock import sentinel
+from unittest.mock import Mock, patch, sentinel
 
 import pytest
 from h_api.bulk_api import Report
@@ -11,6 +11,7 @@ from h_api.exceptions import (
 )
 from h_matchers import Any
 from h_matchers.matcher.object import AnyObject
+from sqlalchemy.exc import IntegrityError, ProgrammingError
 
 from h.models import Group, GroupMembership, User, UserIdentity
 from h.models.group import PRIVATE_GROUP_TYPE_FLAGS
@@ -68,6 +69,19 @@ class TestBulkUserUpsert:
 
         with pytest.raises(ConflictingDataError):
             UserUpsertAction(db_session).execute(commands)
+
+    def test_other_db_errors_are_raised_directly(self, db_session, programming_error):
+        action = UserUpsertAction(db_session)
+
+        fake_execute_result = Mock(spec_set=["fetchall"])
+        fake_execute_result.fetchall.return_value = [["id", "authority", "username"]]
+
+        with patch.object(action, "_execute_statement") as _execute_statement:
+            # We need the second call to fail during _upsert_identities
+            _execute_statement.side_effect = [fake_execute_result, programming_error]
+
+            with pytest.raises(ProgrammingError):
+                action.execute([upsert_user_command(0)])
 
     def test_it_returns_in_the_same_order_as_the_commands(self, db_session, commands):
         # Insert the values to set db order, then update them in reverse
@@ -160,10 +174,21 @@ class TestBulkGroupUpsert:
 
     def test_it_fails_with_duplicate_groups(self, db_session, user):
         command = group_upsert_command(0)
-        action = GroupUpsertAction(db_session)
 
         with pytest.raises(ConflictingDataError):
-            action.execute([command, command], effective_user_id=user.id)
+            GroupUpsertAction(db_session).execute(
+                [command, command], effective_user_id=user.id
+            )
+
+    def test_other_db_errors_are_raised_directly(
+        self, db_session, user, programming_error
+    ):
+        action = GroupUpsertAction(db_session)
+        with patch.object(action, "_execute_statement") as _execute_statement:
+            _execute_statement.side_effect = programming_error
+
+            with pytest.raises(ProgrammingError):
+                action.execute([group_upsert_command(0)], effective_user_id=user.id)
 
     @pytest.mark.parametrize("field", ["authority", "authority_provided_id"])
     def test_it_fails_with_mismatched_queries(self, db_session, field, user):
@@ -263,6 +288,14 @@ class TestBulkGroupMembershipCreate:
                 [group_membership_create(user.id, 999999)]
             )
 
+    def test_other_db_errors_are_raised_directly(self, db_session, integrity_error):
+        action = GroupMembershipCreateAction(db_session)
+        with patch.object(action, "_execute_statement") as _execute_statement:
+            _execute_statement.side_effect = integrity_error
+
+            with pytest.raises(IntegrityError):
+                action.execute([group_membership_create(1, 2)])
+
     @staticmethod
     def assert_membership_matches_commands(db_session, commands):
         # Sort by `group_id` as these tests always use the same `user_id`
@@ -304,3 +337,13 @@ class TestBulkGroupMembershipCreate:
         db_session.flush()
 
         return groups
+
+
+@pytest.fixture
+def programming_error():
+    return ProgrammingError("statement", "params", orig=Mock())
+
+
+@pytest.fixture
+def integrity_error():
+    return IntegrityError("statement", "params", orig=Mock())


### PR DESCRIPTION
We're getting errors about this in Sentry. This doesn't really "fix" it but at least it means we don't emit 500's any more which might make debugging it a little swifter.

My best guess is that on occasion we are getting groups repeated from Canvas for some reason.