### PR TITLE
Add Docker Compose healthcheck config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     image: postgres:11.5-alpine
     ports:
       - '127.0.0.1:5432:5432'
+    healthcheck:
+        test: ["CMD", "pg_isready", "-U", "postgres"]
+        interval: 1s
   elasticsearch:
     image: hypothesis/elasticsearch:latest
     ports:


### PR DESCRIPTION
The same as we previously [added to lms](https://github.com/hypothesis/lms/pull/1846).

This enables health-checking of the Postgres service to see whether
Postgres is up or not by using the `docker inspect` command. For
example:

    docker inspect -f {{.State.Health.Status}} h_postgres_1

We had previously supposed that, for h, healthchecks for Postgres,
Elasticsearch _and_ RabbitMQ would be needed. But I wonder if that's
true? h and lms will crash on startup if you run `make dev` without
Postgres being running. But will h crash if Elasticsearch and
RabbitMQ aren't running? Requests that require Elasticsearch or RabbitMQ
would fail of course. But I'm not sure whether dev server just starting
up is dependent on Elasticsearch and RabbitMQ already being running like
it is with Postgres.

If you're running `make test` this could certainly fail if it hits an
Elasticsearch-requiring test before Elasticsearch has finished starting
up. But that race condition may be such that Elasticsearch always wins
it (at least if you're not directly running only one of the search test
modules).