### PR TITLE
Add feature flag for testing changes to annotation loading in the client

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -14,6 +14,9 @@ FEATURES = {
         "using a cached version?"
     ),
     "client_display_names": "Render display names instead of user names in the client",
+    "client_do_not_separate_replies": (
+        "Disable separating replies when loading annotations in the client"
+    ),
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.


### PR DESCRIPTION
This PR adds a feature flag we can use in the client to test turning off `_separate_replies` when loading annotations and replies in the sidebar (the `stream` view will continue to set `_separate_replies` to `true`). 

Part of https://github.com/hypothesis/private-issues/issues/41