### PR TITLE
Fix isort (make format and make checkformatting)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -108,9 +108,9 @@ commands =
     lint: flake8 tests
     analyze: pylint {posargs:h tests}
     format: black h tests
-    format: isort --recursive --quiet --atomic h tests
+    format: isort --quiet --atomic h tests
     checkformatting: black --check h tests
-    checkformatting: isort --recursive --quiet --check-only h tests
+    checkformatting: isort --quiet --check-only h tests
     {tests,functests}: sh bin/create-testdb
     tests: coverage run -m pytest {posargs:tests/h/}
     functests: pytest {posargs:tests/functional/}


### PR DESCRIPTION
isort 5.0 removed the `--recursive` option, it's now just always
recursive:

https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md#500-penny---july-4-2020# Please enter the commit message for your changes. Lines starting