### PR TITLE
Add the Google `authuser` to the list of banned params.

### DIFF
--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -91,6 +91,11 @@ BLACKLISTED_QUERY_PARAMS = [
         #    https://support.google.com/analytics/answer/1033867?hl=en
         #
         r"^utm_(campaign|content|medium|source|term)$",
+        # Google authuser, use across a number of services. See ticket:
+        #
+        #    https://github.com/hypothesis/h/issues/6033
+        #
+        "^authuser$",
         # WebTrends Analytics query params. Reference:
         #
         #    http://help.webtrends.com/en/analytics10/#qpr_about.html

--- a/tests/h/util/uri_test.py
+++ b/tests/h/util/uri_test.py
@@ -279,6 +279,7 @@ class TestURINormalise:
                 "http://example.com?x-amz-security-token-foo=abcde",
                 "httpx://example.com?x-amz-security-token-foo=abcde",
             ),
+            ("http://example.com?authuser=0", "httpx://example.com"),
         ),
     )
     def test_it_black_lists_invalid_params(self, url_in, url_out):


### PR DESCRIPTION
This is to address: https://github.com/hypothesis/h/issues/6033