### PR TITLE
Revert "Add the Google `authuser` to the list of banned params."

### DIFF
--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -91,11 +91,6 @@ BLACKLISTED_QUERY_PARAMS = [
         #    https://support.google.com/analytics/answer/1033867?hl=en
         #
         r"^utm_(campaign|content|medium|source|term)$",
-        # Google authuser, use across a number of services. See ticket:
-        #
-        #    https://github.com/hypothesis/h/issues/6033
-        #
-        "^authuser$",
         # WebTrends Analytics query params. Reference:
         #
         #    http://help.webtrends.com/en/analytics10/#qpr_about.html

--- a/tests/h/util/uri_test.py
+++ b/tests/h/util/uri_test.py
@@ -279,7 +279,6 @@ class TestURINormalise:
                 "http://example.com?x-amz-security-token-foo=abcde",
                 "httpx://example.com?x-amz-security-token-foo=abcde",
             ),
-            ("http://example.com?authuser=0", "httpx://example.com"),
         ),
     )
     def test_it_black_lists_invalid_params(self, url_in, url_out):


### PR DESCRIPTION
This reverts commit 84d56ca68e1f5fe17d711c577503ea0b6d966acc.

I think this commit is dangerous in it's present state as users on pages without a "canonical" link, but with a "authuser" will lose access to their annotations.

We'll have to think about this a bit more carefully before deploying.