### PR TITLE
Suppress error formatting for log lines containing certain strings

### DIFF
--- a/bin/logger
+++ b/bin/logger
@@ -152,9 +152,9 @@ def _log_payload(payload, err=False):
     prefix = "{name:{width}} | ".format(name=name, width=WIDTH)
 
     for line in data.splitlines():
-        format_as_error = err
-        for marker in NON_ERROR_MARKERS:
-            format_as_error = format_as_error and (marker not in line)
+        format_as_error = err and all(
+            [marker not in line for marker in NON_ERROR_MARKERS]
+        )
 
         output_line = prefix + line + "\n"
 

--- a/bin/logger
+++ b/bin/logger
@@ -116,17 +116,17 @@ colors = Colors()
 
 def main():
     while True:
-        _write('READY\n')
+        _write("READY\n")
         header = _parse_header(sys.stdin.readline())
-        payload = sys.stdin.read(int(header['len']))
+        payload = sys.stdin.read(int(header["len"]))
 
         # Only handle PROCESS_LOG_* events and just ACK anything else.
-        if header['eventname'] == 'PROCESS_LOG_STDOUT':
+        if header["eventname"] == "PROCESS_LOG_STDOUT":
             _log_payload(payload)
-        elif header['eventname'] == 'PROCESS_LOG_STDERR':
+        elif header["eventname"] == "PROCESS_LOG_STDERR":
             _log_payload(payload, err=True)
 
-        _write('RESULT 2\nOK')
+        _write("RESULT 2\nOK")
 
 
 def _write(s):
@@ -135,25 +135,36 @@ def _write(s):
 
 
 def _parse_header(data):
-    return dict([x.split(':') for x in data.split()])
+    return dict([x.split(":") for x in data.split()])
+
+
+# Patterns in log lines that identify them as not being errors, even if the
+# log line was written to stderr.
+NON_ERROR_MARKERS = ["[gunicorn.error:INFO]", "Starting monitor"]
 
 
 def _log_payload(payload, err=False):
-    headerdata, data = payload.split('\n', 1)
+    headerdata, data = payload.split("\n", 1)
     header = _parse_header(headerdata)
-    name = header['processname']
+    name = header["processname"]
     if err:
-        name += ' (stderr)'
-    prefix = '{name:{width}} | '.format(name=name, width=WIDTH)
-    for line in data.splitlines():
-        output_line = prefix + line + '\n'
+        name += " (stderr)"
+    prefix = "{name:{width}} | ".format(name=name, width=WIDTH)
 
-        if '--dev' in sys.argv:
-            output_line = colors.color(name, output_line, error=err)
+    for line in data.splitlines():
+        format_as_error = err
+        for marker in NON_ERROR_MARKERS:
+            format_as_error = format_as_error and (marker not in line)
+
+        output_line = prefix + line + "\n"
+
+        if "--dev" in sys.argv:
+            output_line = colors.color(name, output_line, error=format_as_error)
 
         sys.stderr.write(output_line)
+
     sys.stderr.flush()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Adjust the formatting of output from `make dev` to avoid using the bold
red "error" formatting for log lines that contain certain strings, even
if they were written to stderr.

There are some other minor changes in this commit as a result of
formatting the file with Black.

Slack context: https://hypothes-is.slack.com/archives/C1MA4E9B9/p1595931093420100

An alternative way to avoid the problem here would be to change the services producing the offending log lines to write them to stdout instead.

**Before:**

<img width="600" alt="before" src="https://user-images.githubusercontent.com/2458/88683158-6ba3a480-d0eb-11ea-8798-e98cd374a534.png">

**After:**

<img width="600" alt="Screenshot 2020-07-28 at 15 58 21" src="https://user-images.githubusercontent.com/2458/88682980-36975200-d0eb-11ea-84fc-0c765d2ac23b.png">
