### PR TITLE
Pin pytest to version 5.x

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,8 @@ setenv =
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 deps =
     tests: coverage
-    {tests,functests,analyze}: pytest
+    # Some tests currently fail with pytest 6.x
+    {tests,functests,analyze}: pytest<6
     {tests,functests,analyze}: factory-boy
     {tests,analyze}: hypothesis
     lint: flake8


### PR DESCRIPTION
Some tests currently fail with pytest 6.x.