### PR TITLE
Allow any object instead of an integer in the document log messages

### DIFF
--- a/h/models/document.py
+++ b/h/models/document.py
@@ -298,8 +298,8 @@ def create_or_update_document_uri(
         session.add(docuri)
     elif not docuri.document == document:
         log.warning(
-            "Found DocumentURI (id: %d)'s document_id (%d) doesn't match "
-            "given Document's id (%d)",
+            "Found DocumentURI (id: %s)'s document_id (%s) doesn't match "
+            "given Document's id (%s)",
             docuri.id,
             docuri.document_id,
             document.id,
@@ -381,8 +381,8 @@ def create_or_update_document_meta(
         existing_dm.updated = updated
         if not existing_dm.document == document:
             log.warning(
-                "Found DocumentMeta (id: %d)'s document_id (%d) doesn't "
-                "match given Document's id (%d)",
+                "Found DocumentMeta (id: %s)'s document_id (%s) doesn't "
+                "match given Document's id (%s)",
                 existing_dm.id,
                 existing_dm.document_id,
                 document.id,

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ setenv =
 deps =
     tests: coverage
     # Some tests currently fail with pytest 6.x
-    {tests,functests,analyze}: pytest<6
+    {tests,functests,analyze}: pytest
     {tests,functests,analyze}: factory-boy
     {tests,analyze}: hypothesis
     lint: flake8


### PR DESCRIPTION
We don't want to crash because one of the values is None while we are trying to log a warning.

This fixes the tests, but I'd be lying if I knew exactly why this has changed between `pytest` 5.x and 6.