### PR TITLE
Handle overflow code block

### DIFF
--- a/h/static/styles/core/_typography.scss
+++ b/h/static/styles/core/_typography.scss
@@ -168,6 +168,7 @@ $touch-input-font-size: 16px;
     display: block;
     background-color: color.$grey-1;
     border-radius: 2px;
+    white-space: pre-wrap;
   }
 }
 


### PR DESCRIPTION
The code block in the annotation card does not handle properly when it overflows

Example: https://hypothes.is/users/katuo

![image](https://user-images.githubusercontent.com/8580008/89388770-ab433f80-d72e-11ea-9203-b697ccabc663.png)

My solution is to use the `white-space: pre-wrap` to handle it.

![image](https://user-images.githubusercontent.com/8580008/89388915-df1e6500-d72e-11ea-9afb-56c1bfa7794d.png)
