### PR TITLE
Add a DB migration for the user comms_opt_in field

### DIFF
--- a/h/migrations/versions/64039842150a_add_user_comms_opt_in_column.py
+++ b/h/migrations/versions/64039842150a_add_user_comms_opt_in_column.py
@@ -1,0 +1,14 @@
+"""Add User.comms_opt_in column."""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "64039842150a"
+down_revision = "3359d7d8ec29"
+
+
+def upgrade():
+    op.add_column("user", sa.Column("comms_opt_in", sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("user", "comms_opt_in")


### PR DESCRIPTION
This is to record communication preferences for news etc.

This is for: https://github.com/hypothesis/product-backlog/issues/1086 and enables: https://github.com/hypothesis/h/pull/6136