### PR TITLE
GitHub Actions: Build the result of merging the PR

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,5 +1,5 @@
 name: Continuous integration
-on: [push]
+on: pull_request
 env:
   TOX_PARALLEL_NO_SPINNER: 1
   PYTEST_ADDOPTS: --exitfirst


### PR DESCRIPTION
Build the result of merging the PR into master, instead of building the
HEAD commit of the PR branch.

If you expand the **Checkout git repo** step in the GitHub Actions build
log it shows you which commit was used.

Our GHA workflow on master just checks out the latest commit on the PR's
branch. Change it to check out the merge commit of the PR's branch into
master instead (GitHub automatically generates these merge commits for
all PRs).

It would be possible to build **both** the branch's HEAD commit and the
merge but I think that would be a waste of time: we only really need to
build the merge.

Since we use GitHub's **Rebase and merge** button instead of the
*Merge** button the merge commit never actually ends up on the master
branch. Rebased versions of the PR's branch's commits end up on master
instead. But GitHub disables the **Rebase and merge** button if the
rebase would produce a different result than a merge, see:
https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#rebase-and-merge-your-pull-request-commits