### PR TITLE
NewRelic - Ignore badge transitions

### DIFF
--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import newrelic.agent
 from pyramid import httpexceptions
 from webob.multidict import MultiDict
 
@@ -31,6 +32,9 @@ def badge(request):
     that there are 0 annotations.
 
     """
+
+    # Disable NewRelic for this function.
+    newrelic.agent.ignore_transaction(flag=True)
     uri = request.params.get("uri")
 
     if not uri:


### PR DESCRIPTION
Here we have a branch that disables `badge` transactions being reported to NewRelic.

Badge transactions equate to a huge amount of the data we are reporting.  By ignoring, or potentially limiting how we handle this function will enable us to use other functionality provided by NewRelic without hitting data limits.

I understand this will leave a bit of a hole, but I am thinking we understand how the function works. So the benefit we get out of having it in NewRelic is limited. We will still see an increase in Papertrail logging if someone decides to maliciously attack the badge endpoint, and if required we can remove the `ignore` statement to test any updates we make in the future.  

What do you think? Any questions let me know.
