### PR TITLE
Add pyramid-sanity to h and fix the tests

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -154,3 +154,6 @@ def includeme(config):
     )
 
     config.include("h_pyramid_sentry")
+
+    # pyramid-sanity should be activated as late as possible
+    config.include("pyramid_sanity")

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,10 @@
+# Hypothesis packages
 h_pyramid_sentry
 h_matchers
 h-api
+pyramid-sanity
 
+# 3rd-party packages
 PyJWT
 SQLAlchemy >= 1.1.4
 alembic

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,9 +56,10 @@ pyramid-jinja2==2.8       # via -r requirements.in
 pyramid-layout==1.0       # via -r requirements.in
 pyramid-mailer==0.15.1    # via -r requirements.in
 pyramid-retry==2.1.1      # via -r requirements.in
+pyramid-sanity==1.0.1     # via -r requirements.in
 pyramid-services==2.2     # via -r requirements.in, pyramid-authsanity
 pyramid-tm==2.4           # via -r requirements.in
-pyramid==1.10.4           # via -r requirements.in, h-pyramid-sentry, pyramid-authsanity, pyramid-exclog, pyramid-jinja2, pyramid-layout, pyramid-mailer, pyramid-retry, pyramid-services, pyramid-tm
+pyramid==1.10.4           # via -r requirements.in, h-pyramid-sentry, pyramid-authsanity, pyramid-exclog, pyramid-jinja2, pyramid-layout, pyramid-mailer, pyramid-retry, pyramid-sanity, pyramid-services, pyramid-tm
 pyrsistent==0.16.0        # via jsonschema
 python-dateutil==2.8.1    # via -r requirements.in, alembic, elasticsearch-dsl
 python-editor==1.0.4      # via alembic

--- a/tests/functional/api/test_bulk.py
+++ b/tests/functional/api/test_bulk.py
@@ -13,14 +13,22 @@ class TestBulk:
 
     def test_it_requires_authentication(self, app, bad_header):
         response = app.post(
-            "/api/bulk", b"dummy", headers=bad_header, expect_errors=True
+            "/api/bulk",
+            b"dummy",
+            headers=bad_header,
+            expect_errors=True,
+            content_type="application/x-ndjson",
         )
 
         assert response.status_int == 404
 
     def test_it_raises_errors_for_invalid_request(self, app, lms_auth_header):
         response = app.post(
-            "/api/bulk", '["some-mince"]', headers=lms_auth_header, expect_errors=True
+            "/api/bulk",
+            '["some-mince"]',
+            headers=lms_auth_header,
+            expect_errors=True,
+            content_type="application/x-ndjson",
         )
 
         assert response.status_int == 400
@@ -35,9 +43,12 @@ class TestBulk:
     def test_it_accepts_a_valid_request(
         self, app, nd_json, lms_auth_header, db_session
     ):
-        app.post("/api/bulk", nd_json, headers=lms_auth_header)
-
-        response = app.post("/api/bulk", nd_json, headers=lms_auth_header)
+        response = app.post(
+            "/api/bulk",
+            nd_json,
+            headers=lms_auth_header,
+            content_type="application/x-ndjson",
+        )
 
         assert response.status_int == 200
         assert response.content_type == "application/x-ndjson"


### PR DESCRIPTION
This adds Pyramid-sanity for https://github.com/hypothesis/h/issues/6157 to prevent certain malformed requests from crashing us.

This also includes a fix to send the correct Content-Type for the Bulk API tests. This was originally part of fixing a bug with `pyramid-sanity`, but the library has since moved on and it's not technically required. So it seems very disconnected, and is now but :shrug: 

~This requires the fix in https://github.com/hypothesis/pyramid-sanity/pull/11, and so an update to the version number once that is done.~

Some example URLs to show it kicking in:

 * http://localhost:5000/foo/?f%FC=123
 * http://localhost:5000/foo/f%FC