### PR TITLE
Up the internal streamer queue size as we seem to be hitting in live

### DIFF
--- a/h/streamer/streamer.py
+++ b/h/streamer/streamer.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 # The maxsize ensures that memory used by this queue is bounded. Producers
 # writing to the queue must consider their behaviour when the queue is full,
 # using .put(...) with a timeout or .put_nowait(...) as appropriate.
-WORK_QUEUE = gevent.queue.Queue(maxsize=4096)
+WORK_QUEUE = gevent.queue.Queue(maxsize=8192)
 
 # Message queues that the streamer processes messages from
 ANNOTATION_TOPIC = "annotation"


### PR DESCRIPTION
The current RAM situation in live is good (2GB out of 8GB) but we are hitting limits on this queue. This part of an investigation to see if this helps

In live we are seeing:
```Streamer work queue full! Unable to queue message from h.realtime having waited 0.1s: giving up.```

I believe this is internal queuing inside gevent Queues not Rabbit as first thought.

We _think_ this may help if we are getting compounding issues where waiting for a spot in the queue begins consuming CPU, which means we don't have time to empty the queue.

It's equally possible that we just aren't emptying the queue fast enough and having a larger queue just means we will have a slight pause before hitting the same issue.