### PR TITLE
Add a kill switch for the websocket based on an environment variable

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,4 +11,4 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 96.75
+fail_under = 96.76

--- a/h/streamer/kill_switch_views.py
+++ b/h/streamer/kill_switch_views.py
@@ -1,0 +1,13 @@
+"""Routes registered when the kill switch is enabled."""
+from pyramid.response import Response
+from pyramid.view import notfound_view_config
+
+
+@notfound_view_config()
+def not_found(_exc, _request):
+    """Handle any request we get with the shortest possible response."""
+    return Response(status="429 Offline", headerlist=[])
+
+
+def includeme(config):
+    config.scan(__name__)

--- a/tests/h/streamer/kill_switch_views_test.py
+++ b/tests/h/streamer/kill_switch_views_test.py
@@ -1,0 +1,8 @@
+from h.streamer.kill_switch_views import not_found
+
+
+def test_not_found_view(pyramid_request):
+    response = not_found(Exception(), pyramid_request)
+
+    assert response.status_code == 429
+    assert response.content_type is None

--- a/tests/h/streamer/views_test.py
+++ b/tests/h/streamer/views_test.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-import pytest
-
 from h.streamer import streamer, views
 
 
@@ -32,8 +28,3 @@ def test_websocket_view_adds_work_queue_to_environ(pyramid_request):
     env = pyramid_request.environ
 
     assert env["h.ws.streamer_work_queue"] == streamer.WORK_QUEUE
-
-
-@pytest.fixture
-def pyramid_request(pyramid_request):
-    return pyramid_request

--- a/tests/h/websocket_test.py
+++ b/tests/h/websocket_test.py
@@ -18,6 +18,22 @@ class TestIncludeMe:
             }
         )
 
+    @pytest.mark.usefixtures("with_kill_switch_on")
+    def test_it_respects_the_kill_switch(self, configure, config):
+        create_app(None)
+
+        config.add_settings.assert_not_called()
+        config.add_tween.assert_not_called()
+        config.set_authentication_policy.assert_not_called()
+        config.add_route.assert_not_called()
+
+        config.include.assert_called_once_with("h.streamer.kill_switch_views")
+
+    @pytest.fixture
+    def with_kill_switch_on(self, patch):
+        os = patch("h.websocket.os")
+        os.environ.get.side_effect = {"KILL_SWITCH_WEBSOCKET": 1}.get
+
     @pytest.fixture
     def config(self):
         return mock.create_autospec(Configurator, instance=True)

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,7 @@ passenv =
     dev: NEW_RELIC_LICENSE_KEY
     dev: NEW_RELIC_APP_NAME
     dev: NODE_ENV
+    dev: KILL_SWITCH_WEBSOCKET
     {tests,functests}: TEST_DATABASE_URL
     {tests,functests}: ELASTICSEARCH_URL
     {tests,functests}: PYTEST_ADDOPTS


### PR DESCRIPTION
 * The kill switch is 'KILL_SWITCH_WEBSOCKET'
 * This will abort all normal config and route registration
 * A single route returning 429 is configured instead

To test:

 * Run: `KILL_SWITCH_WEBSOCKET make dev`
 * The log output on start up should contain a message about the kill switch
 * Go to anything at: http://localhost:5001/
 * You should get a 429 response (429 = Too Many Requests)
 * Start the client and via
 * Open the client on a page and observe failing websocket connections in the console with 429