### PR TITLE
Optimize WebSocket message filtering

### DIFF
--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -129,8 +129,8 @@ def _generate_annotation_event(
     if message["src_client_id"] == socket.client_id:
         return None
 
-    # We don't send anything until we have received a filter from the client
-    if socket.filter is None:
+    # Don't send anything unless the client has configured a matching filter
+    if socket.filter is None or not socket.filter.match(annotation):
         return None
 
     # Don't sent annotations from NIPSA'd users to anyone other than that
@@ -149,9 +149,6 @@ def _generate_annotation_event(
 
     permissions = serialized.get("permissions")
     if not _authorized_to_read(socket.effective_principals, permissions):
-        return None
-
-    if not socket.filter.match(serialized, action):
         return None
 
     notification["payload"] = [serialized]

--- a/requirements/analyze.txt
+++ b/requirements/analyze.txt
@@ -38,7 +38,6 @@ iso8601==0.1.12           # via -r requirements/requirements.txt, colander, defo
 isort==5.5.1              # via pylint
 itsdangerous==1.1.0       # via -r requirements/requirements.txt
 jinja2==2.11.2            # via -r requirements/requirements.txt, pyramid-jinja2
-jsonpointer==2.0          # via -r requirements/requirements.txt
 jsonschema==3.2.0         # via -r requirements/requirements.txt, h-api
 kombu==4.6.11             # via -r requirements/requirements.txt, celery
 lazy-object-proxy==1.4.3  # via astroid

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -37,7 +37,6 @@ iso8601==0.1.12           # via -r requirements/requirements.txt, colander, defo
 itsdangerous==1.1.0       # via -r requirements/requirements.txt
 jedi==0.17.2              # via ipython
 jinja2==2.11.2            # via -r requirements/requirements.txt, pyramid-jinja2
-jsonpointer==2.0          # via -r requirements/requirements.txt
 jsonschema==3.2.0         # via -r requirements/requirements.txt, h-api
 kombu==4.6.11             # via -r requirements/requirements.txt, celery
 mako==1.1.3               # via -r requirements/requirements.txt, alembic

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -35,7 +35,6 @@ iniconfig==1.0.1          # via pytest
 iso8601==0.1.12           # via -r requirements/requirements.txt, colander, deform
 itsdangerous==1.1.0       # via -r requirements/requirements.txt
 jinja2==2.11.2            # via -r requirements/requirements.txt, pyramid-jinja2
-jsonpointer==2.0          # via -r requirements/requirements.txt
 jsonschema==3.2.0         # via -r requirements/requirements.txt, h-api
 kombu==4.6.11             # via -r requirements/requirements.txt, celery
 mako==1.1.3               # via -r requirements/requirements.txt, alembic

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -21,7 +21,6 @@ gevent >= 1.4.0
 gunicorn >= 19.9.0
 hkdf
 itsdangerous
-jsonpointer == 2.0
 jsonschema
 kombu >= 4.2.1
 mistune

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -31,7 +31,6 @@ importlib-metadata==1.7.0  # via jsonschema, kombu
 iso8601==0.1.12           # via colander, deform
 itsdangerous==1.1.0       # via -r requirements/requirements.in
 jinja2==2.11.2            # via pyramid-jinja2
-jsonpointer==2.0          # via -r requirements/requirements.in
 jsonschema==3.2.0         # via -r requirements/requirements.in, h-api
 kombu==4.6.11             # via -r requirements/requirements.in, celery
 mako==1.1.3               # via alembic

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -36,7 +36,6 @@ iniconfig==1.0.1          # via pytest
 iso8601==0.1.12           # via -r requirements/requirements.txt, colander, deform
 itsdangerous==1.1.0       # via -r requirements/requirements.txt
 jinja2==2.11.2            # via -r requirements/requirements.txt, pyramid-jinja2
-jsonpointer==2.0          # via -r requirements/requirements.txt
 jsonschema==3.2.0         # via -r requirements/requirements.txt, h-api
 kombu==4.6.11             # via -r requirements/requirements.txt, celery
 mako==1.1.3               # via -r requirements/requirements.txt, alembic

--- a/tests/h/streamer/filter_test.py
+++ b/tests/h/streamer/filter_test.py
@@ -37,18 +37,20 @@ class TestFilterHandler:
         assert handler.match(ann) is should_match
 
     def test_it_matches_id(self, factories):
-        ann_a = factories.Annotation(target_uri="https://example.com")
-        ann_b = factories.Annotation(target_uri="https://example.net")
+        ann_matching = factories.Annotation(target_uri="https://example.com")
+        ann_non_matching = factories.Annotation(target_uri="https://example.net")
 
         query = {
             "match_policy": "include_any",
             "actions": {},
-            "clauses": [{"field": "/id", "operator": "equals", "value": ann_a.id}],
+            "clauses": [
+                {"field": "/id", "operator": "equals", "value": ann_matching.id}
+            ],
         }
         handler = FilterHandler(query)
 
-        assert handler.match(ann_a) is True
-        assert handler.match(ann_b) is False
+        assert handler.match(ann_matching) is True
+        assert handler.match(ann_non_matching) is False
 
     def test_it_matches_parent_id(self, factories):
         parent_ann = factories.Annotation()

--- a/tests/h/streamer/filter_test.py
+++ b/tests/h/streamer/filter_test.py
@@ -3,6 +3,13 @@ import pytest
 from h.streamer.filter import FilterHandler
 
 
+class FakeAnnotation:
+    def __init__(self, id, uri, references=[]):
+        self.id = id
+        self.target_uri = uri
+        self.references = references
+
+
 class TestFilterHandler:
     @pytest.mark.parametrize(
         "query_uris,ann_uri,should_match",
@@ -33,7 +40,7 @@ class TestFilterHandler:
         }
         handler = FilterHandler(query)
 
-        ann = {"id": "123", "uri": ann_uri}
+        ann = FakeAnnotation("123", uri=ann_uri)
         assert handler.match(ann) is should_match
 
     def test_it_matches_id(self):
@@ -44,10 +51,10 @@ class TestFilterHandler:
         }
         handler = FilterHandler(query)
 
-        ann = {"id": "123", "uri": "https://example.com"}
+        ann = FakeAnnotation("123", uri="https://example.com")
         assert handler.match(ann) is True
 
-        ann = {"id": "456", "uri": "https://example.net"}
+        ann = FakeAnnotation("456", uri="https://example.net")
         assert handler.match(ann) is False
 
     def test_it_matches_parent_id(self):
@@ -58,8 +65,8 @@ class TestFilterHandler:
         }
         handler = FilterHandler(query)
 
-        ann = {"id": "abc", "uri": "https://example.com", "references": ["123"]}
+        ann = FakeAnnotation("abc", uri="https://example.com", references=["123"])
         assert handler.match(ann) is True
 
-        ann = {"id": "abc", "uri": "https://example.com", "references": ["456"]}
+        ann = FakeAnnotation("abc", uri="https://example.com", references=["456"])
         assert handler.match(ann) is False


### PR DESCRIPTION
This PR optimises the filtering of notifications against the configuration from WS clients indicating which annotations they are interested in. It should significantly reduce the amount of work that is done per (message x WS client) for clients that are not interested in the annotation (eg. because the client is on a different URL).

Previously, for every message that the WS received, the WS server would, separately for each connected client, serialize the message to a JSON representation and then match the serialized JSON against the filter.

This PR changes the filtering to match the _annotation_ against the filter rather than the JSON representation, avoiding the need to serialize it before calling `socket.filter.match(...)`. It also does the filtering earlier in the processing, skipping the NIPSA check and creation of various services if no connected clients will match the annotation. A side effect of the filtering changes is that the `jsonpointer` dependency is no longer used and so I have removed it.

Part of https://github.com/hypothesis/h/issues/6192