### PR TITLE
Fix annotation read permission checking in WebSocket server

### DIFF
--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -52,22 +52,6 @@ def principals_for_user(user):
     return list(principals)
 
 
-def translate_annotation_principals(principals):
-    """
-    Translate a list of annotation principals to a list of pyramid principals.
-    """
-    result = set([])
-    for principal in principals:
-        # Ignore suspicious principals from annotations
-        if principal.startswith("system."):
-            continue
-        if principal == "group:__world__":
-            result.add(security.Everyone)
-        else:
-            result.add(principal)
-    return list(result)
-
-
 def default_authority(request):
     """
     Return the value of the h.authority config settings.

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -4,7 +4,6 @@ import hmac
 import re
 
 import sqlalchemy as sa
-from pyramid import security
 
 from h.auth import role
 from h.models.auth_client import AuthClient, GrantType

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -9,7 +9,6 @@ from gevent.queue import Full
 from pyramid.security import principals_allowed_by_permission
 
 from h import presenters, realtime, storage
-from h.auth.util import translate_annotation_principals
 from h.formatters import AnnotationUserInfoFormatter
 from h.realtime import Consumer
 from h.services.groupfinder import GroupfinderService

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -92,30 +92,6 @@ def test_principals_for_user(user, principals):
         assert set(principals) == set(result)
 
 
-@pytest.mark.parametrize(
-    "p_in,p_out",
-    [
-        # The basics
-        ([], []),
-        (["acct:donna@example.com"], ["acct:donna@example.com"]),
-        (["group:foo"], ["group:foo"]),
-        # Remove pyramid principals
-        (["system.Everyone"], []),
-        # Remap annotatator principal names
-        (["group:__world__"], [security.Everyone]),
-        # Normalise multiple principals
-        (
-            ["me", "myself", "me", "group:__world__", "group:foo", "system.Admins"],
-            ["me", "myself", security.Everyone, "group:foo"],
-        ),
-    ],
-)
-def test_translate_annotation_principals(p_in, p_out):
-    result = util.translate_annotation_principals(p_in)
-
-    assert set(result) == set(p_out)
-
-
 class TestClientAuthority:
     @pytest.mark.parametrize(
         "principals",

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -5,7 +5,6 @@ from unittest import mock
 
 import pytest
 import sqlalchemy as sa
-from pyramid import security
 
 from h.auth import role, util
 from h.models import AuthClient


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/h/pull/6201**~~

The logic to determine whether a connected WebSocket client had permission to
read a particular annotation was broken because the `AnnotationContext.__acl__`
method has an implicit dependency on the current Pyramid registry and this
registry was never set in the WS server. As a result, the call to
`principals_allowed_by_permission` in `AnnotationContext.__acl__` ended up using
the default authorization policy which always returns `[system.Everyone]` - ie.
as if any connected WS client could read the annotation.

This commit fixes the issue by using a helper from `pyramid.scripting` to set
the active registry while generating the notification. It also simplifies the
logic to determine the principals (groups, users etc.) that can read the
annotation and compare them to the principals of the WebSocket client.

Fixes https://github.com/hypothesis/support/issues/137.