### PR TITLE
Make WebSocket formatting of annotations consistent with API

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -337,6 +337,13 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
         :returns: the userid authenticated for the passed request or None
         :rtype: unicode or None
         """
+
+        if hasattr(request, "websocket_userid"):
+            # This is a dummy request created while generating a WebSocket
+            # notification message in response to an event. In this case return
+            # the userid that was determined when the WebSocket client connected.
+            return request.websocket_userid
+
         token_str = None
         if _is_ws_request(request):
             token_str = request.GET.get("access_token", None)

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -138,6 +138,13 @@ def _generate_annotation_event(message, socket, annotation):
             "options": {"action": action},
         }
         request = env["request"]
+
+        # Propagate the authenticated user from the WebSocket to the request.
+        #
+        # This relies on the auth policy to look for the `websocket_userid`
+        # attr when determining the userid for the request.
+        request.websocket_userid = socket.authenticated_userid
+
         nipsa_service = request.find_service(name="nipsa")
         user_nipsad = nipsa_service.is_flagged(annotation.userid)
 

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -171,6 +171,7 @@ def create_app(_global_config, **settings):
 
     config.include("pyramid_services")
 
+    config.include("h.accounts")
     config.include("h.auth")
     # Override the default authentication policy.
     config.set_authentication_policy("h.auth.WEBSOCKET_POLICY")


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/h/pull/6202**

The WebSocket process previously constructed the various services
involved in annotation formatting "manually" rather than re-using the
existing service factories that the web process uses via
`request.find_service`. As a result, there were inconsistencies in the
content of annotations delivered as WebSocket message payloads compared
to API responses to `GET /annotations/:id`.

This commit builds on the changes in https://github.com/hypothesis/h/pull/6202
by using the dummy request created by `pyramid.scripting.prepare` in
order to instantiate services in the same way they would be in the web
process using `request.find_service`. As a result, the serialized
annotation should contain the same information as a formatted API
request.

An additional benefit is that it simplifies the WebSocket code and
generally makes programming in this context more familiar.

Fixes https://github.com/hypothesis/h/issues/5487

**TODO:**

- [ ] Ensure that the `request` object has a correct `request.authenticated_userid`, since services may depend upon this
- [ ] Update the tests, which are quite dependent on the previous implementation
