### PR TITLE
Add a script to generating annotations in the dev DB

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ source =
 omit =
     h/debug.py
     h/migrations/*
+    h/cli/commands/create_annotations.py
 
 [report]
 show_missing = True

--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -22,6 +22,7 @@ SUBCOMMANDS = (
     "h.cli.commands.search.search",
     "h.cli.commands.shell.shell",
     "h.cli.commands.user.user",
+    "h.cli.commands.create_annotations.create_annotations",
 )
 
 

--- a/h/cli/commands/create_annotations.py
+++ b/h/cli/commands/create_annotations.py
@@ -1,0 +1,30 @@
+import datetime
+import random
+
+import click
+
+from tests.common import factories
+
+
+@click.command()
+@click.pass_context
+@click.option("--number", default=100)
+def create_annotations(ctx, number):
+    request = ctx.obj["bootstrap"]()
+    db = request.db
+    tm = request.tm
+
+    for _ in range(number):
+        created = updated = datetime.datetime(
+            year=random.randint(2015, 2020),
+            month=random.randint(1, 12),
+            day=random.randint(1, 27),
+            hour=random.randint(1, 12),
+            minute=random.randint(0, 59),
+            second=random.randint(0, 59),
+        )
+        db.add(
+            factories.Annotation.build(created=created, updated=updated, shared=True)
+        )
+
+    tm.commit()

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -99,6 +99,7 @@ zope.deprecation==4.1.2   # via -r requirements/requirements.txt, deform, pyrami
 zope.event==4.4           # via -r requirements/requirements.txt, gevent
 zope.interface==5.1.0     # via -r requirements/requirements.txt, gevent, pyramid, pyramid-authsanity, pyramid-retry, pyramid-services, repoze.sendmail, transaction, wired, zope.sqlalchemy
 zope.sqlalchemy==1.1      # via -r requirements/requirements.txt
+factory_boy
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -25,7 +25,7 @@ class Annotation(ModelFactory):
     text = factory.Faker("paragraph")
     userid = factory.LazyFunction(
         lambda: "acct:{username}@{authority}".format(
-            username=FAKER.user_name(), authority=FAKER.domain_name(levels=1)
+            username=FAKER.user_name(), authority="localhost"
         )
     )
     document = factory.SubFactory(Document)


### PR DESCRIPTION
Usage:

    tox -qe dev -- sh bin/hypothesis --dev create-annotations --number 10

This will add 10 randomly generated annotations to your dev DB each time
you run it.

The new annotations won't be in Elasticsearch. You can add them to
Elasticsearch like this:

    tox -qe dev -- sh bin/hypothesis --dev search reindex

The generated annotations aren't very good yet. For example each
annotation belongs to a randomly generated document and user. It'd be
better to generate fewer documents and users, and multiple annotations
belonging to each. We can make these sorts of improvements later.