### PR TITLE
Set the Celery worker log levels to INFO

### DIFF
--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -17,7 +17,7 @@ stopsignal = KILL
 stopasgroup = true
 
 [program:worker]
-command = sh bin/hypothesis --dev celery worker
+command = sh bin/hypothesis --dev celery worker --loglevel=INFO
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -27,7 +27,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:worker]
-command=newrelic-admin run-program hypothesis celery worker
+command=newrelic-admin run-program hypothesis celery worker --loglevel=INFO
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true


### PR DESCRIPTION
So that we can see log messages from Celery tasks (e.g. search reindexing).