### PR TITLE
Don't reindex the entire DB if a user has no annotatoins

### DIFF
--- a/h/search/index.py
+++ b/h/search/index.py
@@ -126,7 +126,7 @@ class BatchIndexer:
         :returns: a set of errored ids
         :rtype: set
         """
-        if not annotation_ids:
+        if annotation_ids is None:
             annotations = _all_annotations(session=self.session, windowsize=windowsize)
         else:
             annotations = _filtered_annotations(


### PR DESCRIPTION
When NIPSA'ing or un-NIPSA'ing a user who has no annotations, don't reindex the entire annotations table into Elasticsearch.