### PR TITLE
Set the badge to use a completely internal blocklist

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,3 +12,4 @@ omit =
 show_missing = True
 precision = 2
 fail_under = 96.76
+skip_covered = True

--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-
-import newrelic.agent
+# import newrelic.agent
 from pyramid import httpexceptions
 from webob.multidict import MultiDict
 
-from h import models, search
+from h import search
 from h.util.uri import normalize
 from h.util.view import json_view
 
@@ -21,6 +20,29 @@ def _has_uri_ever_been_annotated(db, uri):
     return result[0] is True
 
 
+class Blocklist:
+    """Block URLs which we know are not worth replying to for the badge."""
+
+    BLOCKED_URL_PARTS = (
+        "//facebook.com",
+        "//mail.google.com",
+        "//www.facebook.com",
+    )
+
+    @classmethod
+    def is_blocked(cls, url):
+        """Check if a URL is blocked."""
+
+        # Dumb is fast here. I can't find a better way of doing this for now
+        url = url.lower()
+
+        for part in cls.BLOCKED_URL_PARTS:
+            if part in url:
+                return True
+
+        return False
+
+
 @json_view(route_name="badge")
 def badge(request):
     """Return the number of public annotations on a given page.
@@ -30,24 +52,23 @@ def badge(request):
     Certain pages are blocklisted so that the badge never shows a number on
     those pages. The Chrome extension is oblivious to this, we just tell it
     that there are 0 annotations.
-
     """
-
     # Disable NewRelic for this function.
-    newrelic.agent.ignore_transaction(flag=True)
+    # newrelic.agent.ignore_transaction(flag=True)
+
     uri = request.params.get("uri")
 
     if not uri:
         raise httpexceptions.HTTPBadRequest()
 
-    # Do a cheap check to see if this URI has ever been annotated. If not,
-    # and most haven't, then we can skip the costs of a blocklist lookup or
-    # search request. In addition to the Elasticsearch query, the search request
-    # involves several DB queries to expand URIs and enumerate group IDs
-    # readable by the current user.
-    if not _has_uri_ever_been_annotated(request.db, uri):
+    if Blocklist.is_blocked(uri):
         count = 0
-    elif models.Blocklist.is_blocked(request.db, uri):
+    elif not _has_uri_ever_been_annotated(request.db, uri):
+        # Do a cheap check to see if this URI has ever been annotated. If not,
+        # and most haven't, then we can skip the costs of a blocklist lookup or
+        # search request. In addition to the Elasticsearch query, the search request
+        # involves several DB queries to expand URIs and enumerate group IDs
+        # readable by the current user.
         count = 0
     else:
         query = MultiDict({"uri": uri, "limit": 0})


### PR DESCRIPTION
 * Also apply this blocklist before asking Postgres about annotations
 * This should be faster and reduce load on Postgres
 * Also hid files with 100% coverage
 * Re-enables New-Relic logging so we can see if this helps any

Previously we made calls in a pyramid like this:

 * Filter by ever annotated (2.72ms, filters ~90%, makes a query)
 * Filter by blocked (0.195ms, filters ~55%, make a query)
 * Return query from elastic (0.539ms)

Average time on this: 2.72 + 0.9 * 0.194 + 0.9 * 0.55 * 0.539 = 3.162 ms (~20% call time)

Now we **theoretically**:

 * Filter by blocked (0.001ms, filters ~55%, no query)
 * Filter by ever annotated (2.72ms, filters ~90%, makes a query)
 * Return query from elastic (0.539ms)

Average time on this: 0.001 + 0.55 * 2.72 + 0.55 * 0.9 * 0.539 = 1.763 ms (~10% saving)

At a rate of 20.6k/minutes, we should hopefully avoid ~13k/min requests to Postgres as well.

----

## Notes

This doesn't remove any of the blocklist architecture. If we decide this is a keeper we should:

 * Remove the db table
 * Remove the model code
 * Remove the admin page and friends