### PR TITLE
Revert "Emit caching headers for blocked badge requests"

### DIFF
--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -63,13 +63,6 @@ def badge(request):
 
     if Blocklist.is_blocked(uri):
         count = 0
-
-        # Blocked things stay blocked, so we can calm down the traffic to us
-        cache_control = request.response.cache_control
-        cache_control.prevent_auto = True
-        cache_control.public = True
-        cache_control.max_age = 86400  # 1 day
-
     elif not _has_uri_ever_been_annotated(request.db, uri):
         # Do a cheap check to see if this URI has ever been annotated. If not,
         # and most haven't, then we can skip the costs of a blocklist lookup or

--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -61,17 +61,6 @@ class TestBadge:
         search_run.assert_not_called()
         assert result == {"total": 0}
 
-    def test_it_sets_cache_headers_if_blocked(
-        self, badge_request, Blocklist, pyramid_request
-    ):
-        badge_request("http://example.com", annotated=True, blocked=True)
-
-        cache_control = pyramid_request.response.cache_control
-
-        assert cache_control.prevent_auto
-        assert cache_control.public
-        assert cache_control.max_age > 0
-
     def test_it_returns_0_if_uri_never_annotated(self, badge_request, search_run):
         result = badge_request("http://example.com", annotated=False, blocked=False)
 


### PR DESCRIPTION
Reverts hypothesis/h#6210

I'm reverting this for now, we have a rogue Vary header which we need to track down which prevents Cloudflare caching. Without this, it won't really work.