### PR TITLE
Fix pattern to allow to catch no slash and prevent Vary header

### DIFF
--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -11,12 +11,11 @@ from h.views.badge import Blocklist, badge
 
 
 class TestBlocklist:
-    @pytest.mark.parametrize("bad_part", Blocklist.BLOCKED_DOMAINS)
+    @pytest.mark.parametrize("domain", Blocklist.BLOCKED_DOMAINS)
     @pytest.mark.parametrize("prefix", ("http://", "https://", "httpx://", "//"))
-    def test_it_blocks(self, bad_part, prefix):
-        url = f"{prefix}{bad_part}/path?a=b"
-
-        assert Blocklist.is_blocked(url)
+    @pytest.mark.parametrize("suffix", ("", "/", "/path?a=b"))
+    def test_it_blocks(self, domain, prefix, suffix):
+        assert Blocklist.is_blocked(f"{prefix}{domain}{suffix}")
 
     @pytest.mark.parametrize(
         "acceptable_url",


### PR DESCRIPTION
I can't locally get the Vary header to be emitted in any way, so this
is difficult to test. It happens everytime in prod though, so I'm
hoping I can see this in QA.

## Testing notes

Getting this to occur in dev is tricky, but you can force the situation by:

Broken:

 * Adding `search.Search(request)` to the top of the badge view
 * Removing `request.add_response_callback(disable_vary_header)`
 * Visiting a blocked site like: http://localhost:5000/api/badge?uri=https%3A%2F%2Ffacebook.com%2F
 * You should see the Vary header

Fixed:

 * Add back the `request.add_response_callback(disable_vary_header)` line
 * Re-test
 * You should now see no Vary header

As for why this triggers at all, I don't know, but anything which triggers a call to `authenticated_userid` will create this situation.