### PR TITLE
Partially pre-compile the filter clause

### DIFF
--- a/h/streamer/filter.py
+++ b/h/streamer/filter.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unicodedata
+from operator import attrgetter
 
 from h.util.uri import normalize as normalize_uri
 
@@ -29,6 +30,12 @@ SCHEMA = {
 
 
 class FilterHandler:
+    FIELD_GETTERS = {
+        "/uri": attrgetter("target_uri"),
+        "/references": attrgetter("references"),
+        "/id": attrgetter("id"),
+    }
+
     def __init__(self, filter_json):
         self.filter = filter_json
 
@@ -65,56 +72,54 @@ class FilterHandler:
 
     @classmethod
     def _get_filter(cls, clause):
-        def clause_filter(annotation):
-            field_path = clause["field"]
+        """Get a filter function for a given clause.
 
-            # Extract the annotation property that corresponds to the "field"
-            # path in the filter. This only supports a small set of paths
-            # which are actually used by the Hypothesis client.
-            field_value = None
+        :param clause: The decoded JSON clause
+        :return: A function which accepts an annotation and returns a truth
+            value depending on whether the value applies
+        """
+        field_path = clause["field"]
+
+        try:
+            field_getter = cls.FIELD_GETTERS[field_path]
+        except KeyError:
+            return
+
+        def normalize(term, known_term=False):
+            if not known_term and isinstance(term, list):
+                return [normalize(sub_term, known_term=True) for sub_term in term]
+
+            # Notice closure around field_path here
             if field_path == "/uri":
-                field_value = annotation.target_uri
-            elif field_path == "/references":
-                field_value = annotation.references
-            elif field_path == "/id":
-                field_value = annotation.id
+                # Apply field-specific normalization.
+                return normalize_uri(term)
+
+            # Apply generic normalization.
+            return uni_fold(term)
+
+        filter_term = normalize(clause["value"])
+
+        def clause_filter(annotation):
+            # Extract the annotation property that corresponds to the "field"
+            # path in the filter.
+            field_value = field_getter(annotation)
 
             if field_value is None:
                 return False
 
-            filter_term = clause["value"]
-
-            def normalize(term):
-                # Apply generic normalization.
-                normalized = uni_fold(term)
-
-                # Apply field-specific normalization.
-                if field_path == "/uri":
-                    normalized = normalize_uri(term)
-
-                return normalized
-
-            if isinstance(filter_term, list):
-                filter_term = [normalize(t) for t in filter_term]
-            else:
-                filter_term = normalize(filter_term)
-
-            if isinstance(field_value, list):
-                field_value = [normalize(v) for v in field_value]
-            else:
-                field_value = normalize(field_value)
+            field_value = normalize(field_value)
 
             if clause["operator"] == "one_of":
-                # The `one_of` operator behaves differently depending on whether
-                # the annotation's field value is a list (eg. tags) or atom (eg. id).
-                #
-                # This is not ideal but the client currently relies on it.
+                # The `one_of` operator behaves differently depending on
+                # whether the annotation's field value is a list (eg. tags)
+                # or atom (eg. id). This is not ideal but the client currently
+                # relies on it.
                 if isinstance(field_value, list):
                     return filter_term in field_value
-                else:
-                    return field_value in filter_term
-            else:
-                return field_value == filter_term
+
+                return field_value in filter_term
+
+            return field_value == filter_term
 
         return clause_filter
 

--- a/h/streamer/filter.py
+++ b/h/streamer/filter.py
@@ -49,26 +49,15 @@ class FilterHandler:
             if clause_filter
         ]
 
-    def evaluate_clause(self, clause, annotation):
-        clause_filter = self._get_filter(clause)
+    def match(self, annotation):
+        if not self._clause_filters:
+            return True
 
-        if clause_filter is None:
-            return None
-
-        return clause_filter(annotation)
-
-    def include_any(self, annotation):
         for clause_filter in self._clause_filters:
             if clause_filter(annotation):
                 return True
 
         return False
-
-    def match(self, annotation):
-        if not self._clause_filters:
-            return True
-
-        return self.include_any(annotation)
 
     @classmethod
     def _get_filter(cls, clause):

--- a/h/streamer/filter.py
+++ b/h/streamer/filter.py
@@ -32,68 +32,91 @@ class FilterHandler:
     def __init__(self, filter_json):
         self.filter = filter_json
 
+        # Pre-compile as much as is sensible about our filters, so we can do
+        # this work once, and then apply it over and over
+        self._clause_filters = [
+            clause_filter
+            for clause_filter in (
+                self._get_filter(clause) for clause in self.filter.get("clauses", [])
+            )
+            if clause_filter
+        ]
+
     def evaluate_clause(self, clause, annotation):
-        field_path = clause["field"]
+        clause_filter = self._get_filter(clause)
 
-        # Extract the annotation property that corresponds to the "field"
-        # path in the filter. This only supports a small set of paths
-        # which are actually used by the Hypothesis client.
-        field_value = None
-        if field_path == "/uri":
-            field_value = annotation.target_uri
-        elif field_path == "/references":
-            field_value = annotation.references
-        elif field_path == "/id":
-            field_value = annotation.id
+        if clause_filter is None:
+            return None
 
-        if field_value is None:
-            return False
-
-        filter_term = clause["value"]
-
-        def normalize(term):
-            # Apply generic normalization.
-            normalized = uni_fold(term)
-
-            # Apply field-specific normalization.
-            if field_path == "/uri":
-                normalized = normalize_uri(term)
-
-            return normalized
-
-        if isinstance(filter_term, list):
-            filter_term = [normalize(t) for t in filter_term]
-        else:
-            filter_term = normalize(filter_term)
-
-        if isinstance(field_value, list):
-            field_value = [normalize(v) for v in field_value]
-        else:
-            field_value = normalize(field_value)
-
-        if clause["operator"] == "one_of":
-            # The `one_of` operator behaves differently depending on whether
-            # the annotation's field value is a list (eg. tags) or atom (eg. id).
-            #
-            # This is not ideal but the client currently relies on it.
-            if isinstance(field_value, list):
-                return filter_term in field_value
-            else:
-                return field_value in filter_term
-        else:
-            return field_value == filter_term
+        return clause_filter(annotation)
 
     def include_any(self, annotation):
-        for clause in self.filter["clauses"]:
-            if self.evaluate_clause(clause, annotation):
+        for clause_filter in self._clause_filters:
+            if clause_filter(annotation):
                 return True
+
         return False
 
     def match(self, annotation):
-        if len(self.filter["clauses"]) > 0:
-            return self.include_any(annotation)
-        else:
+        if not self._clause_filters:
             return True
+
+        return self.include_any(annotation)
+
+    @classmethod
+    def _get_filter(cls, clause):
+        def clause_filter(annotation):
+            field_path = clause["field"]
+
+            # Extract the annotation property that corresponds to the "field"
+            # path in the filter. This only supports a small set of paths
+            # which are actually used by the Hypothesis client.
+            field_value = None
+            if field_path == "/uri":
+                field_value = annotation.target_uri
+            elif field_path == "/references":
+                field_value = annotation.references
+            elif field_path == "/id":
+                field_value = annotation.id
+
+            if field_value is None:
+                return False
+
+            filter_term = clause["value"]
+
+            def normalize(term):
+                # Apply generic normalization.
+                normalized = uni_fold(term)
+
+                # Apply field-specific normalization.
+                if field_path == "/uri":
+                    normalized = normalize_uri(term)
+
+                return normalized
+
+            if isinstance(filter_term, list):
+                filter_term = [normalize(t) for t in filter_term]
+            else:
+                filter_term = normalize(filter_term)
+
+            if isinstance(field_value, list):
+                field_value = [normalize(v) for v in field_value]
+            else:
+                field_value = normalize(field_value)
+
+            if clause["operator"] == "one_of":
+                # The `one_of` operator behaves differently depending on whether
+                # the annotation's field value is a list (eg. tags) or atom (eg. id).
+                #
+                # This is not ideal but the client currently relies on it.
+                if isinstance(field_value, list):
+                    return filter_term in field_value
+                else:
+                    return field_value in filter_term
+            else:
+                return field_value == filter_term
+
+        return clause_filter
 
 
 def uni_fold(text):

--- a/tests/h/streamer/filter_test.py
+++ b/tests/h/streamer/filter_test.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 
 from h.streamer.filter import FilterHandler
@@ -74,3 +76,30 @@ class TestFilterHandler:
             target_uri="https://example.com", references=[other_ann.id]
         )
         assert handler.match(ann) is False
+
+    @pytest.mark.skip(reason="For dev purposes only")
+    def test_speed(self, factories):
+        query = {
+            "match_policy": "include_any",
+            "actions": {},
+            "clauses": [
+                {
+                    "field": "/uri",
+                    "operator": "one_of",
+                    "value": ["https://example.com", "https://example.org"],
+                }
+            ],
+        }
+
+        ann = factories.Annotation(target_uri="https://example.org")
+        handler = FilterHandler(query)
+
+        start = datetime.utcnow()
+
+        # I think the max number connected at once is 4096
+        for _ in range(4096):
+            handler.match(ann)
+
+        diff = datetime.utcnow() - start
+        ms = diff.seconds * 1000 + diff.microseconds / 1000
+        print(ms, "ms")

--- a/tests/h/streamer/filter_test.py
+++ b/tests/h/streamer/filter_test.py
@@ -78,7 +78,7 @@ class TestFilterHandler:
         assert handler.match(ann) is False
 
     @pytest.mark.skip(reason="For dev purposes only")
-    def test_speed(self, factories):
+    def test_speed(self, factories):  # pragma: no cover
         query = {
             "match_policy": "include_any",
             "actions": {},


### PR DESCRIPTION
This PR operates on the assumption that the filter is created once, and applied many times. This front loads a lot of the work to filter creation time, to benefit filter application time.

This should be roughly cost neutral over-all, but improves the time to apply the filter by about 3.4x on my machine. I was assuming 4096 (maximum websocket connections) and saw the filter compare time drop from around 340ms to 100ms.

This is a pure refactor, and shouldn't effect the behavior in anyway.