### PR TITLE
Enable New Relic monitoring of the websocket

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -20,7 +20,8 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:websocket]
-command=pserve conf/websocket.ini
+environment=NEW_RELIC_CONFIG_FILE=conf/websocket.ini
+command=newrelic-admin run-program pserve conf/websocket.ini
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true


### PR DESCRIPTION
This is to see if we can get any useful stats about where our time is going