### PR TITLE
Remove uni_fold normalisation and cache url normalisation on annotations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,5 +11,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 96.76
+fail_under = 96.77
 skip_covered = True


### PR DESCRIPTION
 * This removes the uni_fold normalisation as it was only being applied to ids
 * This adds a caching version of the annotation which keeps normalised results
 * This results in a >5x speed up on my machine (140ms -> 25ms)