### PR TITLE
NewRelic - Configuration definition

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,7 +12,6 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:web]
-environment=NEW_RELIC_APP_NAME=h-web
 command=newrelic-admin run-program pserve conf/app.ini
 stdout_logfile=NONE
 stderr_logfile=NONE
@@ -20,7 +19,6 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:websocket]
-environment=NEW_RELIC_APP_NAME=h-websocket
 command=newrelic-admin run-program pserve conf/websocket.ini
 stdout_logfile=NONE
 stderr_logfile=NONE
@@ -28,7 +26,6 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:worker]
-environment=NEW_RELIC_APP_NAME=h-worker
 command=newrelic-admin run-program hypothesis celery worker --loglevel=INFO
 stdout_logfile=NONE
 stderr_logfile=NONE


### PR DESCRIPTION
Updated to remove the separate application name definitions. We will now
report it a single NEW_RELIC_APP_NAME.