### PR TITLE
Move to a much simpler and faster socket filtering mechanism

### DIFF
--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections import namedtuple
+from itertools import chain
 
 from gevent.queue import Full
 
@@ -14,7 +15,7 @@ from h.services.links import LinksService
 from h.services.nipsa import NipsaService
 from h.services.user import UserService
 from h.streamer import websocket
-from h.streamer.filter import NormalizedAnnotation
+from h.streamer.filter import SocketFilter
 from h.traversal import AnnotationContext
 
 log = logging.getLogger(__name__)
@@ -85,17 +86,18 @@ def handle_annotation_event(message, sockets, settings, session):
         log.warning("received annotation event for missing annotation: %s", id_)
         return
 
-    # Create a version of the annotation which compiles and caches normalised
-    # versions of the fields for speed
-    normalized_annotation = NormalizedAnnotation(annotation)
-
     # Find connected clients which are interested in this annotation.
-    # This is done early to minimize the work done if there are no such clients.
-    matching_sockets = [
-        s for s in sockets if s.filter and s.filter.match(normalized_annotation)
-    ]
-    if not matching_sockets:
+    matching_sockets = SocketFilter.matching(sockets, annotation)
+
+    try:
+        # Check to see if the generator has any items
+        first_socket = next(matching_sockets)
+    except StopIteration:
+        # Nothing matched
         return
+
+    # Create a generator which has the first socket back again
+    matching_sockets = chain((first_socket,), matching_sockets)
 
     nipsa_service = NipsaService(session)
     user_nipsad = nipsa_service.is_flagged(annotation.userid)

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -11,7 +11,7 @@ from gevent.queue import Full
 from ws4py.websocket import WebSocket as _WebSocket
 
 from h import storage
-from h.streamer import filter
+from h.streamer.filter import FILTER_SCHEMA, SocketFilter
 
 log = logging.getLogger(__name__)
 
@@ -151,9 +151,10 @@ def handle_filter_message(message, session=None):
             ok=False,
         )
         return
+
     filter_ = message.payload["filter"]
     try:
-        jsonschema.validate(filter_, filter.SCHEMA)
+        jsonschema.validate(filter_, FILTER_SCHEMA)
     except jsonschema.ValidationError:
         message.reply(
             {
@@ -166,10 +167,12 @@ def handle_filter_message(message, session=None):
             ok=False,
         )
         return
+
     if session is not None:
         # Add backend expands for clauses
         _expand_clauses(session, filter_)
-    message.socket.filter = filter.FilterHandler(filter_)
+
+    SocketFilter.set_filter(message.socket, filter_)
 
 
 MESSAGE_HANDLERS["filter"] = handle_filter_message  # noqa: E305

--- a/tests/h/streamer/filter_test.py
+++ b/tests/h/streamer/filter_test.py
@@ -1,13 +1,18 @@
 from datetime import datetime
+from random import random
 
 import pytest
 
-from h.streamer.filter import FilterHandler, NormalizedAnnotation
+from h.streamer.filter import SocketFilter
+
+
+class FakeSocket:
+    ...
 
 
 class TestFilterHandler:
     @pytest.mark.parametrize(
-        "query_uris,ann_uri,should_match",
+        "filter_uris,ann_uri,should_match",
         [
             # Test cases that require only exact comparisons.
             (
@@ -27,114 +32,109 @@ class TestFilterHandler:
             (["http://example.com"], "https://example.com/?", True),
         ],
     )
-    def test_it_matches_uri(self, make_annotation, query_uris, ann_uri, should_match):
-        ann = make_annotation(target_uri=ann_uri)
+    def test_it_matches_uri(
+        self, factories, filter_uris, ann_uri, should_match, filter_matches
+    ):
+        ann = factories.Annotation(target_uri=ann_uri)
 
-        query = {
+        filter_ = {
             "match_policy": "include_any",
             "actions": {},
-            "clauses": [{"field": "/uri", "operator": "one_of", "value": query_uris}],
+            "clauses": [{"field": "/uri", "operator": "one_of", "value": filter_uris}],
         }
-        handler = FilterHandler(query)
 
-        assert handler.match(ann) is should_match
+        assert filter_matches(filter_, ann) is should_match
 
-    def test_it_matches_id(self, make_annotation):
-        ann_matching = make_annotation()
-        ann_non_matching = make_annotation()
+    def test_it_matches_id(self, factories, filter_matches):
+        ann_matching = factories.Annotation()
+        ann_non_matching = factories.Annotation()
 
-        query = {
+        filter_ = {
             "match_policy": "include_any",
             "actions": {},
             "clauses": [
                 {"field": "/id", "operator": "equals", "value": ann_matching.id}
             ],
         }
-        handler = FilterHandler(query)
 
-        assert handler.match(ann_matching) is True
-        assert handler.match(ann_non_matching) is False
+        assert filter_matches(filter_, ann_matching)
+        assert not filter_matches(filter_, ann_non_matching)
 
-    def test_it_matches_parent_id(self, make_annotation):
-        parent_ann = make_annotation()
-        other_ann = make_annotation()
+    def test_it_matches_parent_id(self, factories, filter_matches):
+        parent_ann = factories.Annotation()
+        other_ann = factories.Annotation()
 
-        query = {
+        filter_ = {
             "match_policy": "include_any",
             "actions": {},
             "clauses": [
                 {"field": "/references", "operator": "one_of", "value": parent_ann.id}
             ],
         }
-        handler = FilterHandler(query)
 
-        ann = make_annotation(
+        ann = factories.Annotation(
             target_uri="https://example.com", references=[parent_ann.id]
         )
-        assert handler.match(ann) is True
+        assert filter_matches(filter_, ann)
 
-        ann = make_annotation(
+        ann = factories.Annotation(
             target_uri="https://example.com", references=[other_ann.id]
         )
-        assert handler.match(ann) is False
+        assert not filter_matches(filter_, ann)
 
     @pytest.mark.skip(reason="For dev purposes only")
-    def test_speed(self, make_annotation):  # pragma: no cover
-        query = {
+    def test_speed(self, factories):  # pragma: no cover
+        # I think the max number connected at once is 4096
+        sockets = [FakeSocket() for _ in range(4096)]
+
+        for socket in sockets:
+            SocketFilter.set_filter(socket, self.get_randomized_filter())
+
+        ann = factories.Annotation(target_uri="https://example.org")
+
+        start = datetime.utcnow()
+        # This returns a generator, we need to force it to produce answers
+        tuple(SocketFilter.matching(sockets, ann))
+
+        diff = datetime.utcnow() - start
+        ms = diff.seconds * 1000 + diff.microseconds / 1000
+        print(ms, "ms")
+
+    def get_randomized_filter(self):
+        return {
             "match_policy": "include_any",
             "actions": {},
             "clauses": [
                 {
                     "field": "/id",
                     "operator": "equals",
-                    "value": "3jgSANNlEeebpLMf36MACw",
+                    "value": "3jgSANNlEeebpLMf36MACw" + str(random()),
                 },
                 {
                     "field": "/references",
                     "operator": "one_of",
-                    "value": ["3jgSANNlEeebpLMf36MACw", "3jgSANNlEeebpLMf36MACw"],
+                    "value": [
+                        "3jgSANNlEeebpLMf36MACw" + str(random()),
+                        "3jgSANNlEeebpLMf36MACw" + str(random()),
+                    ],
                 },
                 {
                     "field": "/uri",
                     "operator": "one_of",
-                    "value": ["https://example.com", "https://example.org"],
+                    "value": [
+                        "https://example.com",
+                        "https://example.org" + str(random()),
+                    ],
                 },
             ],
         }
 
-        ann = make_annotation(target_uri="https://example.org")
-        handler = FilterHandler(query)
-
-        start = datetime.utcnow()
-
-        # I think the max number connected at once is 4096
-        for _ in range(4096):
-            handler.match(ann)
-
-        diff = datetime.utcnow() - start
-        ms = diff.seconds * 1000 + diff.microseconds / 1000
-        print(ms, "ms")
-
     @pytest.fixture
-    def make_annotation(self, factories):
-        def make_annotation(**kwargs):
-            return NormalizedAnnotation(factories.Annotation(**kwargs))
+    def filter_matches(self):
+        def filter_matches(filter, annotation):
+            socket = FakeSocket()
+            SocketFilter.set_filter(socket, filter)
 
-        return make_annotation
+            return bool(tuple(SocketFilter.matching([socket], annotation)))
 
-
-class TestNormalizedAnnotation:
-    @pytest.mark.parametrize(
-        "field,value,expected",
-        (
-            ("id", "3jgSANNlEeebpLMf36MACw", "3jgSANNlEeebpLMf36MACw"),
-            ("target_uri", "http://example.com", "httpx://example.com"),
-            ("references", ["3jgSANNlEeebpLMf36MACw"], ["3jgSANNlEeebpLMf36MACw"]),
-        ),
-    )
-    def test_it(self, factories, field, value, expected):
-        annotation = NormalizedAnnotation(factories.Annotation(**{field: value}))
-
-        result = getattr(annotation, field)
-
-        assert result == expected
+        return filter_matches


### PR DESCRIPTION
 * We first convert a given filter JSON into a list of key value pairs
 * We then compare these values against those of the annotation
 * This is a lot less code and about 12x faster on my machine

Previously this was taking about 350ms for 4096 sockets, recent work got this down to 25ms. This reduces it again to about 2ms.

### How this works

First we take a filter query like this:

```json
{
    "actions": {},
    "match_policy": "include_any",
    "clauses": [
        {
            "field": "/uri",
            "operator": "equals",
            "value": "http://example.com",
        },
        {
            "field": "/references",
            "operator": "one_of",
            "value": ["id1", "id2"],
        }
    ],
}
```

And convert it to a list of key value pairs like this and attach it to the socket:
```
[
    ("/uri", "httpx://example.com"),
    ("/references", "id1"),
    ("/references", "id2"),
]
```

Later on in `SocketFilter` we prepare each of the possible values for an annotation, and then just loop through the sockets looking for any matching value. Any hit is a match.