### PR TITLE
Check to see if filter_rows have been added to sockets

### DIFF
--- a/h/streamer/filter.py
+++ b/h/streamer/filter.py
@@ -45,6 +45,11 @@ class SocketFilter:
         }
 
         for socket in sockets:
+            # Some sockets might not yet have the filter applied (or had a non
+            # parsable filter etc.)
+            if not hasattr(socket, "filter_rows"):
+                continue
+
             # Iterate over the filter_rows added by `set_filter()`
             for field, value in socket.filter_rows:
                 if value in values[field]:

--- a/tests/h/streamer/filter_test.py
+++ b/tests/h/streamer/filter_test.py
@@ -60,6 +60,14 @@ class TestFilterHandler:
         assert filter_matches(filter_, ann_matching)
         assert not filter_matches(filter_, ann_non_matching)
 
+    def test_it_does_not_crash_without_filter_rows(self, factories):
+        ann = factories.Annotation()
+
+        socket_no_rows = FakeSocket()
+
+        result = tuple(SocketFilter.matching([socket_no_rows], ann))
+        assert not result
+
     def test_it_matches_parent_id(self, factories, filter_matches):
         parent_ann = factories.Annotation()
         other_ann = factories.Annotation()


### PR DESCRIPTION
When sockets are new, or if the filter was malformed the rows have not
yet been added. This checks stops us from crashing.

The previous work had:

```
matching_sockets = [
    s for s in sockets if s.filter and s.filter.match(normalized_annotation)
]
```

I missed the `if s.filter` which does similar work.

----

We can see the instances of this in papertrail: https://my.papertrailapp.com/systems/h-prod_i-03161fef0bf92becd/events?focus=1243269601182224432&q=AttributeError%3A%20%27WebSocket%27&selected=1243269601182224432

Hopefully after deploying this will stop. Annoyingly my tests actually worked fine, so this clearly happens just _some_ of the time.