### PR TITLE
Remove an attempt to prevent the Vary: Cookie header that didn't work

### DIFF
--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -71,12 +71,9 @@ def badge(request):
         cache_control.max_age = 86400  # 1 day
 
         # `pyramid_authsanity` sets a response callback which adds Vary=Cookie
-        # which will totally break our caching. To get around this we add
-        # another callback which should be called after to disable it.
-        def disable_vary_header(_request, response):
-            response.vary = None
-
-        request.add_response_callback(disable_vary_header)
+        # which will totally break our caching. So far there doesn't seem to be
+        # much we can do about this, but browsers will still individually
+        # respect the caching headers.
 
     elif not _has_uri_ever_been_annotated(request.db, uri):
         # Do a cheap check to see if this URI has ever been annotated. If not,


### PR DESCRIPTION
This was an attempt to try and get around the fact that `pyramid_authsanity` seems to add a Vary header whether we like it or not. This prevents Cloudflare from serving this page for us. A look at the stats suggests that we actually are still getting benefit from browser caching respecting our Cache-Control header.

Best guess is `pyramid_authsanity` is triggering this after we add our callback. As the callbacks are executed in order this means we are too late.