### PR TITLE
Add `chrome://` schema URLs to the badge block list

### DIFF
--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -35,6 +35,18 @@ class TestBlocklist:
     def test_it_allows_non_blocked_items(self, acceptable_url):
         assert not Blocklist.is_blocked(acceptable_url)
 
+    def test_regex_golden_master(self):
+
+        # This is a golden master test intended to facilitate refactoring
+        # It just states that the regex is what it last was, this allows you
+        # to change how it's generated and test if you have changed what is
+        # generated
+        assert Blocklist._PATTERN.pattern == (
+            r"^(?:(?:chrome)://)|(?:(?:http[sx]?:)?//"
+            r"(?:(?:facebook\.com)|(?:www\.facebook\.com)|(?:mail\.google\.com))"
+            r"(?:/|$))"
+        )
+
     def test_its_fast(self):
         # Check any modifications haven't made this significantly slower
         reps = 10000

--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -14,8 +14,13 @@ class TestBlocklist:
     @pytest.mark.parametrize("domain", Blocklist.BLOCKED_DOMAINS)
     @pytest.mark.parametrize("prefix", ("http://", "https://", "httpx://", "//"))
     @pytest.mark.parametrize("suffix", ("", "/", "/path?a=b"))
-    def test_it_blocks(self, domain, prefix, suffix):
+    def test_it_blocks_bad_domains(self, domain, prefix, suffix):
         assert Blocklist.is_blocked(f"{prefix}{domain}{suffix}")
+
+    @pytest.mark.parametrize("scheme", Blocklist.BLOCKED_SCHEMES)
+    @pytest.mark.parametrize("suffix", ("://about", "://newtab"))
+    def test_it_blocks_bad_schema(self, scheme, suffix):
+        assert Blocklist.is_blocked(f"{scheme}://{suffix}")
 
     @pytest.mark.parametrize(
         "acceptable_url",
@@ -23,6 +28,8 @@ class TestBlocklist:
             "http://example.com/this/is/fine",
             "http://example.com//facebook.com",
             "http://facebook.com.om.nom",
+            "file://c/my/magical_file.pdf",
+            "chrome-extension://blah",
         ),
     )
     def test_it_allows_non_blocked_items(self, acceptable_url):
@@ -43,10 +50,12 @@ class TestBlocklist:
 
         # Handy to know while tinkering
         # print(
-        #     f"Calls per second: {calls_per_second}, {1000000 / calls_per_second:.03f} μs/call"
+        #     f"Calls per second: {calls_per_second}, "
+        #     f"{1000000 / calls_per_second:.03f} μs/call"
         # )
 
-        # It should be above this number by quite a margin (20x), but we don't want flaky tests
+        # It should be above this number by quite a margin (20x), but we
+        # don't want flaky tests
         assert calls_per_second > 50000
 
 


### PR DESCRIPTION
This is mostly to ensure we aren't serving a lot of content for new tabs in chrome. This should:

 * Return 0
 * Return caching headers

For the moment we are allowing 'chrome-extension://' but I'm not sure if we want to.

To test:

 * `make dev`
 * Goto: http://localhost:5000/api/badge?uri=chrome://newtab
 *  This should return `{"count": 0}`
 * The header 'Cache-Control' should be set to public and have a max-age

This should mean browsers cache the response for a day and don't ask us for it again