### PR TITLE
Add WebSocket connection metrics

### DIFF
--- a/h/websocket.py
+++ b/h/websocket.py
@@ -38,6 +38,7 @@ license distributed with the ws4py project. Such code remains copyright (c)
 import logging
 import os
 
+import newrelic.agent
 import pyramid
 from gevent.pool import Pool
 from gunicorn.workers.ggevent import GeventPyWSGIWorker, PyWSGIHandler, PyWSGIServer
@@ -45,6 +46,7 @@ from ws4py import format_addresses
 
 from h.config import configure
 from h.sentry_filters import SENTRY_FILTERS
+from h.streamer.websocket import websocket_metrics
 
 log = logging.getLogger(__name__)
 
@@ -205,5 +207,8 @@ def create_app(_global_config, **settings):
     # Add support for logging exceptions whenever they arise
     config.include("pyramid_exclog")
     config.add_settings({"exclog.extra_info": True})
+
+    # Set up metrics collection
+    newrelic.agent.register_data_source(websocket_metrics)
 
     return config.make_wsgi_app()


### PR DESCRIPTION
Add a New Relic custom metrics data source [1] to the WebSocket server which
exposes metrics about active WebSocket connections to New Relic.

The initial metrics include:

 - The number of active connections
 - The number of authenticated and anonymous connections (ie.
   connections from logged-in and logged-out users)
 - The number of messages received from and sent to WebSocket clients

[1] See https://docs.newrelic.com/docs/agents/python-agent/supported-features/python-custom-metrics. Data sources are generators that are called by the New Relic Python agent on a periodic basis to retrieve the current values of the metrics. These are then dispatched to the NR backend.

Part of https://github.com/hypothesis/h/issues/6236.

**TODO**

- [ ] Look into the cause of a warning when starting the WebSocket process locally with New Relic activated and also check whether it is currently happening in production
 
----

**Manual testing**

1. Sign up for a free New Relic personal account and log in
2. Go to the "APM" section and follow the setup link
3. You should see instructions which include a link to download a configuration file. This file is a `.ini` file which contains, amongst other things, a license key
4. Set the New Relic environment variables in your shell:
   ```
    export NEW_RELIC_LICENSE_KEY=<license key>
    export NEW_RELIC_APP_NAME=h
   ```
5. Modify `conf/supervisord-dev.conf` to launch the WebSocket with New Relic:
   ```diff
   diff --git a/conf/supervisord-dev.conf b/conf/supervisord-dev.conf
   index fe92ea5c5..6e387dff3 100644
   --- a/conf/supervisord-dev.conf
   +++ b/conf/supervisord-dev.conf
   @@ -10,7 +10,7 @@ stopsignal = KILL
    stopasgroup = true
 
    [program:websocket]
   -command = pserve --reload conf/development-websocket.ini
   +command = newrelic-admin run-program pserve --reload conf/development-websocket.ini
    stdout_events_enabled=true
    stderr_events_enabled=true
    stopsignal = KILL
   ```
6. Run `make dev`. You may see a warning on startup containing `[newrelic.core.agent:WARNING] Attempt to activate application in a process different...`. **In my testing, the metrics are apparently collected and reported despite this warning.**
7. Do some actions that result in connections to the WebSocket server, such as opening a page containing the local client
8. Go to New Relic => APM => Select "h" application => Scroll all the way down the left side bar to "More views" => Metric Explorer
9. In the metrics list you should see several "Custom/WebSocket/"-prefixed metrics appear.

When you click on the metrics in step 9 you should see recent metrics, but be aware that the default New Relic view of those metrics will scale them by a factor of 1000 (see the query above the metric graph). When this lands in production we would build up a dashboard containing the metrics in some useful graph form without this scaling factor.