### PR TITLE
Search tests refactor

### DIFF
--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -8,6 +8,7 @@ import factory
 from sqlalchemy import orm
 
 from h import models
+from h.db.types import URLSafeUUID
 from h.models.document import update_document_metadata
 
 from .base import FAKER, ModelFactory
@@ -127,7 +128,8 @@ class Annotation(ModelFactory):
         if getattr(self, "id", None):
             return
 
-        self.id = uuid.uuid4().hex
+        # Ids in the DB are in hex, but in the code they should be URL safe
+        self.id = URLSafeUUID().process_result_value(uuid.uuid4().hex, None)
 
     @factory.post_generation
     def timestamps(self, create, extracted, **kwargs):

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -27,7 +27,7 @@ def moderation_service(pyramid_config):
 
 
 @pytest.fixture
-def Annotation(factories, index):
+def Annotation(factories, index_annotations):
     """Create and index an annotation.
 
     Looks like factories.Annotation() but automatically uses the build()
@@ -37,18 +37,19 @@ def Annotation(factories, index):
 
     def _Annotation(**kwargs):
         annotation = factories.Annotation.build(**kwargs)
-        index(annotation)
+        index_annotations(annotation)
         return annotation
 
     return _Annotation
 
 
 @pytest.fixture
-def index(es_client, pyramid_request, moderation_service):
+def index_annotations(es_client, pyramid_request, moderation_service):
     def _index(*annotations):
         """Index the given annotation(s) into Elasticsearch."""
         for annotation in annotations:
             h.search.index.index(es_client, annotation, pyramid_request)
+
         es_client.conn.indices.refresh(index=es_client.index)
 
     return _index

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -703,7 +703,7 @@ class TestHiddenFilter:
     )
     def test_visibility_of_moderated_and_nipsaed_annotations(
         self,
-        index,
+        index_annotations,
         Annotation,
         pyramid_request,
         search,


### PR DESCRIPTION
A couple of small changes to help some work in this area:

 * Renamed `index` fixture to `index_annotation` to help with grepping
 * Fixed a bug with annotation factory id generation, which made misleading ids