### PR TITLE
Add annotation.sequence_id to the model

### DIFF
--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -37,6 +37,26 @@ class Annotation(Base):
         types.URLSafeUUID, server_default=sa.func.uuid_generate_v1mc(), primary_key=True
     )
 
+    _sequence_id_sequence = sa.Sequence(
+        "annotation_sequence_id_seq", metadata=Base.metadata, start=15000000
+    )
+
+    #: A sequential ID for this annotation.
+    #:
+    #: This is a secondary ID that has the property that it always increments:
+    #: each new annotation that gets added to the DB will have a sequence_id
+    #: that's higher than all previous annotations. (Note that there may be
+    #: gaps in the sequence.)
+    #:
+    #: An ID with the property always incrementing is useful to have for
+    #: implementing certain tasks, and the UUID-based ID above lacks this
+    #: property.
+    sequence_id = sa.Column(
+        sa.Integer,
+        _sequence_id_sequence,
+        server_default=_sequence_id_sequence.next_value(),
+    )
+
     #: The timestamp when the annotation was created.
     created = sa.Column(
         sa.DateTime,


### PR DESCRIPTION
Depends on: https://github.com/hypothesis/h/pull/6253

Testing:

Create some new annotations and you should see that they get sequence_id
values in the DB starting from 15,000,000 and increasing:

    tox -qqe dockercompose -- exec postgres psql -U postgres -c "select sequence_id from annotation;"

For the reasoning behind the 15,000,000 start number see:
https://github.com/hypothesis/h/pull/6253/files