### PR TITLE
Don't import the test factories in prod

### DIFF
--- a/h/cli/commands/create_annotations.py
+++ b/h/cli/commands/create_annotations.py
@@ -3,13 +3,13 @@ import random
 
 import click
 
-from tests.common import factories
-
 
 @click.command()
 @click.pass_context
 @click.option("--number", default=100)
 def create_annotations(ctx, number):
+    from tests.common import factories
+
     request = ctx.obj["bootstrap"]()
     db = request.db
     tm = request.tm


### PR DESCRIPTION
Even though `create_annotations.py` isn't used in prod it does get
imported in prod when `bin/hypothesis` is used to start Celery workers.
This causes `create_annotations.py` to try to import the test factories
which crashes because the test factories try to import dependencies such
as factory_boy that aren't installed in prod. The result is that
starting Celery workers fails.

Try to fix this by inlining the import