### PR TITLE
Add task to backfill annotation.sequence_id column

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ omit =
     h/debug.py
     h/migrations/*
     h/cli/commands/create_annotations.py
+    h/tasks.temp.py
 
 [report]
 show_missing = True

--- a/h/celery.py
+++ b/h/celery.py
@@ -30,7 +30,13 @@ celery.conf.update(
     task_acks_late=True,
     worker_disable_rate_limits=True,
     task_ignore_result=True,
-    imports=("h.tasks.admin", "h.tasks.cleanup", "h.tasks.indexer", "h.tasks.mailer"),
+    imports=(
+        "h.tasks.admin",
+        "h.tasks.cleanup",
+        "h.tasks.indexer",
+        "h.tasks.mailer",
+        "h.tasks.temp",
+    ),
     task_routes={
         "h.tasks.indexer.add_annotation": "indexer",
         "h.tasks.indexer.delete_annotation": "indexer",

--- a/h/tasks/temp.py
+++ b/h/tasks/temp.py
@@ -1,0 +1,57 @@
+"""Temporary Celery tasks that can be deleted once they're no longer needed."""
+
+import os
+
+from sqlalchemy.sql.expression import func
+
+from h.celery import celery, get_task_logger
+from h.models import Annotation
+
+log = get_task_logger(__name__)
+
+
+@celery.task
+def backfill_annotation_sequence_ids():
+    """
+    Temporary task to back-fill the annotation.sequence_id column.
+
+    This task can be deleted once the column has been back-filled in the
+    production DB.
+    """
+    db = celery.request.db
+    limit = os.environ.get("BACKFILL_ANNOTATIONS_LIMIT", 1000)
+
+    annotations = (
+        db.query(Annotation)
+        .filter_by(sequence_id=None)
+        .order_by(Annotation.created)
+        .limit(limit)
+    )
+
+    sequence_id = (
+        db.query(func.max(Annotation.sequence_id))
+        .filter(Annotation.sequence_id < 15000000)
+        .scalar()
+    )
+
+    if sequence_id is None:
+        sequence_id = 0
+    else:
+        sequence_id += 1
+
+    num_annotations = annotations.count()
+
+    if num_annotations:
+        log.info(
+            f"Backfilling sequence_id's for {annotations.count()} annotations "
+            f"starting from sequence_id {sequence_id} "
+            f"and created date {annotations.first().created}"
+        )
+    else:
+        # Once it starts logging this message it's time to delete this task
+        # from the code.
+        log.info("No more annotations to backfill")
+
+    for annotation in annotations:
+        annotation.sequence_id = sequence_id
+        sequence_id += 1

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ passenv =
     dev: NEW_RELIC_APP_NAME
     dev: NODE_ENV
     dev: KILL_SWITCH_WEBSOCKET
+    dev: BACKFILL_ANNOTATIONS_LIMIT
     {tests,functests}: TEST_DATABASE_URL
     {tests,functests}: ELASTICSEARCH_URL
     {tests,functests}: PYTEST_ADDOPTS


### PR DESCRIPTION
See also:

* h-periodic PR to make it run this task every minute: https://github.com/hypothesis/h-periodic/pull/13

Depends on:

* https://github.com/hypothesis/h/pull/6254

Add a Celery task (intended to be run periodically by h-periodic) to backfill the annotation.sequence_id column with incrementing integers, slowly without locking the DB for any long periods of time.

The task will no longer be needed once the column has been backfilled. At that time we can send a follow-up PR to delete it. We'll also need to delete the task from [the h-periodic schedule](https://github.com/hypothesis/h-periodic/pull/13).

The task logs some messages so that we can monitor what it's doing (andhow far it has gotten) in Papertrail. There's a special log message that it'll start logging once the backfill is complete. We can also monitor the sequence_id column in Metabase.

Celery task time to completion also gets logged in Papertrail so we can monitor that.

The speed of the task can be tuned in two ways:

1. In the Celery beat schedule over in https://github.com/hypothesis/h-periodic we can tune how frequently the task gets run. (Changing this requires committing a change to h-periodic and deploying it, but doesn't require changing or deploying h.)

   It's important that each run of the task completes before the next
   run begins. We don't want multiple instances of the task running at
   once, and nothing in particular prevents that from happening, we just
   have to avoid it by not setting the frequency too high.

2. We can set the `BACKFILL_ANNOTATIONS_LIMIT` envvar to control how
   many annotations the task backfills each time it's run. (Changing
   this requires changing an envvar in h's Elastic Beanstalk config,
   this takes some time but doesn't require a complete re-deploy of h.)

   It's important that each run of the task completes quickly so that it
   doesn't lock the DB (annotations table) for too long. The task should
   complete in a few hundred milliseconds.