### PR TITLE
Move indexing functions to a service (as is)

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -77,6 +77,7 @@ def includeme(config):
     config.register_service_factory(
         ".rename_user.rename_user_factory", name="rename_user"
     )
+    config.register_service_factory(".search_index.factory", name="search_index")
     config.register_service_factory(".settings.settings_factory", name="settings")
     config.register_service_factory(".user.user_service_factory", name="user")
     config.register_service_factory(

--- a/h/services/search_index/__init__.py
+++ b/h/services/search_index/__init__.py
@@ -1,1 +1,1 @@
-from h.services.search_index.service import add_annotation, delete_annotation, factory
+from h.services.search_index.service import factory  # noqa: F401

--- a/h/services/search_index/__init__.py
+++ b/h/services/search_index/__init__.py
@@ -1,0 +1,1 @@
+from h.services.search_index.service import add_annotation, delete_annotation

--- a/h/services/search_index/__init__.py
+++ b/h/services/search_index/__init__.py
@@ -1,1 +1,1 @@
-from h.services.search_index.service import add_annotation, delete_annotation
+from h.services.search_index.service import add_annotation, delete_annotation, factory

--- a/h/services/search_index/service.py
+++ b/h/services/search_index/service.py
@@ -1,0 +1,66 @@
+from h.events import AnnotationTransformEvent
+from h.presenters import AnnotationSearchIndexPresenter
+
+
+def add_annotation(es, annotation, request, target_index=None):
+    """
+    Index an annotation into the search index.
+
+    A new annotation document will be created in the search index or,
+    if the index already contains an annotation document with the same ID as
+    the given annotation then it will be updated.
+
+    :param es: the Elasticsearch client object to use
+    :type es: h.search.Client
+
+    :param annotation: the annotation to index
+    :type annotation: h.models.Annotation
+
+    :param target_index: the index name, uses default index if not given
+    :type target_index: unicode
+    """
+    as_dict = AnnotationSearchIndexPresenter(annotation, request).asdict()
+
+    request.registry.notify(AnnotationTransformEvent(request, annotation, as_dict))
+
+    if target_index is None:
+        target_index = es.index
+
+    es.conn.index(
+        index=target_index, doc_type=es.mapping_type, body=as_dict, id=annotation.id
+    )
+
+
+def delete_annotation(es, annotation_id, target_index=None, refresh=False):
+    """
+    Mark an annotation as deleted in the search index.
+
+    This will write a new body that only contains the ``deleted`` boolean field
+    with the value ``true``. It allows us to rely on Elasticsearch to complain
+    about dubious operations while re-indexing when we use `op_type=create`.
+
+    :param es: the Elasticsearch client object to use
+    :type es: h.search.Client
+
+    :param annotation_id: the annotation id whose corresponding document to
+        delete from the search index
+    :type annotation_id: str
+
+    :param target_index: the index name, uses default index if not given
+    :type target_index: unicode
+
+    :param refresh: Force this deletion to be immediately visible to search operations
+    :type refresh: bool
+
+    """
+
+    if target_index is None:
+        target_index = es.index
+
+    es.conn.index(
+        index=target_index,
+        doc_type=es.mapping_type,
+        body={"deleted": True},
+        id=annotation_id,
+        refresh=refresh,
+    )

--- a/h/services/search_index/service.py
+++ b/h/services/search_index/service.py
@@ -2,6 +2,24 @@ from h.events import AnnotationTransformEvent
 from h.presenters import AnnotationSearchIndexPresenter
 
 
+class SearchIndexService:
+    def __init__(self, es_client, request):
+        self.es_client = es_client
+        self.request = request
+
+    def add_annotation(self, annotation, target_index=None):
+        return add_annotation(
+            self.es_client, annotation, self.request, target_index=target_index
+        )
+
+    def delete_annotation_by_id(self, annotation_id, target_index=None, refresh=False):
+        return delete_annotation(self.es_client, annotation_id, target_index, refresh)
+
+
+def factory(_context, request):
+    return SearchIndexService(request.es, request)
+
+
 def add_annotation(es, annotation, request, target_index=None):
     """
     Index an annotation into the search index.

--- a/h/services/search_index/service.py
+++ b/h/services/search_index/service.py
@@ -8,19 +8,19 @@ class SearchIndexService:
         self.request = request
 
     def add_annotation(self, annotation, target_index=None):
-        return add_annotation(
+        return _add_annotation(
             self.es_client, annotation, self.request, target_index=target_index
         )
 
     def delete_annotation_by_id(self, annotation_id, target_index=None, refresh=False):
-        return delete_annotation(self.es_client, annotation_id, target_index, refresh)
+        return _delete_annotation(self.es_client, annotation_id, target_index, refresh)
 
 
 def factory(_context, request):
     return SearchIndexService(request.es, request)
 
 
-def add_annotation(es, annotation, request, target_index=None):
+def _add_annotation(es, annotation, request, target_index=None):
     """
     Index an annotation into the search index.
 
@@ -49,7 +49,7 @@ def add_annotation(es, annotation, request, target_index=None):
     )
 
 
-def delete_annotation(es, annotation_id, target_index=None, refresh=False):
+def _delete_annotation(es, annotation_id, target_index=None, refresh=False):
     """
     Mark an annotation as deleted in the search index.
 

--- a/h/services/search_index/service.py
+++ b/h/services/search_index/service.py
@@ -8,77 +8,51 @@ class SearchIndexService:
         self.request = request
 
     def add_annotation(self, annotation, target_index=None):
-        return _add_annotation(
-            self.es_client, annotation, self.request, target_index=target_index
+        """
+        Index an annotation into the search index.
+
+        A new annotation document will be created in the search index or,
+        if the index already contains an annotation document with the same ID as
+        the given annotation then it will be updated.
+
+        :param annotation: the annotation to index
+        :param target_index: the index name, uses default index if not given
+        """
+        body = AnnotationSearchIndexPresenter(annotation, self.request).asdict()
+
+        self.request.registry.notify(
+            AnnotationTransformEvent(self.request, annotation, body)
         )
 
+        self._index_annotation_body(annotation.id, body, target_index)
+
     def delete_annotation_by_id(self, annotation_id, target_index=None, refresh=False):
-        return _delete_annotation(self.es_client, annotation_id, target_index, refresh)
+        """
+        Mark an annotation as deleted in the search index.
+
+        This will write a new body that only contains the ``deleted`` boolean field
+        with the value ``true``. It allows us to rely on Elasticsearch to complain
+        about dubious operations while re-indexing when we use `op_type=create`.
+
+        :param annotation_id: the annotation id whose corresponding document to
+            delete from the search index
+        :param target_index: the index name, uses default index if not given
+        :param refresh: Force this deletion to be immediately visible to search operations
+        """
+
+        self._index_annotation_body(
+            annotation_id, {"deleted": True}, target_index, refresh
+        )
+
+    def _index_annotation_body(self, annotation_id, body, target_index, refresh=False):
+        self.es_client.conn.index(
+            index=self.es_client.index if target_index is None else target_index,
+            doc_type=self.es_client.mapping_type,
+            body=body,
+            id=annotation_id,
+            refresh=refresh,
+        )
 
 
 def factory(_context, request):
     return SearchIndexService(request.es, request)
-
-
-def _add_annotation(es, annotation, request, target_index=None):
-    """
-    Index an annotation into the search index.
-
-    A new annotation document will be created in the search index or,
-    if the index already contains an annotation document with the same ID as
-    the given annotation then it will be updated.
-
-    :param es: the Elasticsearch client object to use
-    :type es: h.search.Client
-
-    :param annotation: the annotation to index
-    :type annotation: h.models.Annotation
-
-    :param target_index: the index name, uses default index if not given
-    :type target_index: unicode
-    """
-    as_dict = AnnotationSearchIndexPresenter(annotation, request).asdict()
-
-    request.registry.notify(AnnotationTransformEvent(request, annotation, as_dict))
-
-    if target_index is None:
-        target_index = es.index
-
-    es.conn.index(
-        index=target_index, doc_type=es.mapping_type, body=as_dict, id=annotation.id
-    )
-
-
-def _delete_annotation(es, annotation_id, target_index=None, refresh=False):
-    """
-    Mark an annotation as deleted in the search index.
-
-    This will write a new body that only contains the ``deleted`` boolean field
-    with the value ``true``. It allows us to rely on Elasticsearch to complain
-    about dubious operations while re-indexing when we use `op_type=create`.
-
-    :param es: the Elasticsearch client object to use
-    :type es: h.search.Client
-
-    :param annotation_id: the annotation id whose corresponding document to
-        delete from the search index
-    :type annotation_id: str
-
-    :param target_index: the index name, uses default index if not given
-    :type target_index: unicode
-
-    :param refresh: Force this deletion to be immediately visible to search operations
-    :type refresh: bool
-
-    """
-
-    if target_index is None:
-        target_index = es.index
-
-    es.conn.index(
-        index=target_index,
-        doc_type=es.mapping_type,
-        body={"deleted": True},
-        id=annotation_id,
-        refresh=refresh,
-    )

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -2,9 +2,9 @@ from unittest import mock
 
 import pytest
 
-import h.search.index
 from h.services.annotation_moderation import AnnotationModerationService
 from h.services.group import GroupService
+from h.services.search_index import add_annotation
 
 
 @pytest.fixture
@@ -47,8 +47,7 @@ def index_annotations(es_client, pyramid_request, moderation_service):
     def _index(*annotations):
         """Index the given annotation(s) into Elasticsearch."""
         for annotation in annotations:
-            h.search.index.index(es_client, annotation, pyramid_request)
-
+            add_annotation(es_client, annotation, pyramid_request)
         es_client.conn.indices.refresh(index=es_client.index)
 
     return _index

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 from h.services.annotation_moderation import AnnotationModerationService
 from h.services.group import GroupService
-from h.services.search_index import add_annotation
+from h.services.search_index.service import SearchIndexService
 
 
 @pytest.fixture
@@ -43,14 +43,20 @@ def Annotation(factories, index_annotations):
 
 
 @pytest.fixture
-def index_annotations(es_client, pyramid_request, moderation_service):
+def index_annotations(es_client, search_index):
     def _index(*annotations):
         """Index the given annotation(s) into Elasticsearch."""
         for annotation in annotations:
-            add_annotation(es_client, annotation, pyramid_request)
+            search_index.add_annotation(annotation)
+
         es_client.conn.indices.refresh(index=es_client.index)
 
     return _index
+
+
+@pytest.fixture
+def search_index(es_client, pyramid_request, moderation_service):
+    return SearchIndexService(es_client, pyramid_request)
 
 
 @pytest.fixture

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -2,100 +2,9 @@ import logging
 from unittest import mock
 
 import elasticsearch
-import elasticsearch_dsl
 import pytest
-from h_matchers import Any
 
 import h.search.index
-
-
-@pytest.mark.usefixtures("annotations")
-class TestIndex:
-    def test_annotation_ids_are_used_as_elasticsearch_ids(
-        self, es_client, factories, index_annotations
-    ):
-        annotation = factories.Annotation.build()
-
-        index_annotations(annotation)
-
-        result = es_client.conn.get(
-            index=es_client.index, doc_type=es_client.mapping_type, id=annotation.id
-        )
-        assert result["_id"] == annotation.id
-
-    def test_it_indexes_presented_annotation(
-        self,
-        factories,
-        get_indexed_ann,
-        index_annotations,
-        pyramid_request,
-        AnnotationSearchIndexPresenter,
-    ):
-        annotation = factories.Annotation.build()
-        presenter = AnnotationSearchIndexPresenter.return_value
-        presenter.asdict.return_value = {
-            "id": annotation.id,
-            "some_other_field": "a_value",
-        }
-
-        index_annotations(annotation)
-        indexed_ann = get_indexed_ann(annotation.id)
-
-        AnnotationSearchIndexPresenter.assert_called_once_with(
-            annotation, pyramid_request
-        )
-        assert indexed_ann == presenter.asdict.return_value
-
-    def test_it_notifies(
-        self,
-        AnnotationTransformEvent,
-        factories,
-        pyramid_request,
-        notify,
-        index_annotations,
-        search,
-    ):
-        annotation = factories.Annotation.build(userid="acct:someone@example.com")
-
-        index_annotations(annotation)
-
-        event = AnnotationTransformEvent.return_value
-
-        AnnotationTransformEvent.assert_called_once_with(
-            pyramid_request, annotation, Any()
-        )
-        notify.assert_called_once_with(event)
-
-    @pytest.fixture
-    def annotations(self, factories, index_annotations):
-        """
-        Add some annotations to Elasticsearch as "noise".
-
-        These are annotations that we *don't* expect to show up in search
-        results. We want some noise in the search index to make sure that the
-        test search queries are only returning the expected annotations and
-        not, for example, simply returning *all* annotations.
-
-        """
-        index_annotations(
-            factories.Annotation.build(),
-            factories.Annotation.build(),
-            factories.Annotation.build(),
-        )
-
-
-class TestDelete:
-    def test_annotation_is_marked_deleted(
-        self, es_client, factories, get_indexed_ann, index_annotations
-    ):
-        annotation = factories.Annotation.build(id="test_annotation_id")
-
-        index_annotations(annotation)
-
-        assert "deleted" not in get_indexed_ann(annotation.id)
-
-        h.search.index.delete(es_client, annotation.id)
-        assert get_indexed_ann(annotation.id).get("deleted") is True
 
 
 class TestBatchIndexer:
@@ -258,11 +167,6 @@ def AnnotationSearchIndexPresenter(patch):
     class_ = patch("h.search.index.presenters.AnnotationSearchIndexPresenter")
     class_.return_value.asdict.return_value = {"test": "val"}
     return class_
-
-
-@pytest.fixture
-def search(es_client, request):
-    return elasticsearch_dsl.Search(using=es_client.conn, index=es_client.index)
 
 
 @pytest.fixture

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -5,7 +5,6 @@ import pytest
 import webob
 
 from h.search import Search, query
-from h.services.search_index import delete_annotation
 
 MISSING = object()
 ES_VERSION = (1, 7, 0)
@@ -668,13 +667,15 @@ class TestUriCombinedWildcardFilter:
 
 
 class TestDeletedFilter:
-    def test_excludes_deleted_annotations(self, search, es_client, Annotation):
+    def test_excludes_deleted_annotations(
+        self, search, es_client, Annotation, search_index
+    ):
         deleted_ids = [Annotation(deleted=True).id]
         not_deleted_ids = [Annotation(deleted=False).id]
 
         # Deleted annotations need to be marked in the index using `h.search.index.delete`.
         for id_ in deleted_ids:
-            delete_annotation(es_client, id_, refresh=True)
+            search_index.delete_annotation_by_id(id_, refresh=True)
 
         result = search.run(webob.multidict.MultiDict({}))
 

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -1,0 +1,101 @@
+from unittest.mock import create_autospec, patch, sentinel
+
+import pytest
+from h_matchers import Any
+
+from h.search.client import Client
+from h.services.search_index import add_annotation, delete_annotation
+
+
+class TestAddAnnotation:
+    def test_it_serialises(
+        self,
+        add_one,
+        annotation,
+        pyramid_request,
+        es_client,
+        AnnotationSearchIndexPresenter,
+    ):
+        add_one(annotation)
+
+        AnnotationSearchIndexPresenter.assert_called_once_with(
+            annotation, pyramid_request
+        )
+        es_client.conn.index.assert_called_once_with(
+            index=Any(),
+            doc_type=Any(),
+            body=AnnotationSearchIndexPresenter.return_value.asdict.return_value,
+            id=annotation.id,
+        )
+
+    def test_it_notifies_of_annotation_transformation(
+        self,
+        add_one,
+        annotation,
+        pyramid_request,
+        AnnotationTransformEvent,
+        AnnotationSearchIndexPresenter,
+    ):
+        with patch.object(pyramid_request, "registry") as registry:
+            add_one(annotation)
+
+            AnnotationTransformEvent.assert_called_once_with(
+                pyramid_request,
+                annotation,
+                AnnotationSearchIndexPresenter.return_value.asdict.return_value,
+            )
+            registry.notify.assert_called_once_with(
+                AnnotationTransformEvent.return_value
+            )
+
+    @pytest.mark.parametrize("target_index", (None, "another"))
+    def test_it_calls_elasticsearch_as_expected(
+        self, add_one, annotation, target_index, es_client
+    ):
+        add_one(annotation, target_index=target_index)
+
+        es_client.conn.index.assert_called_once_with(
+            index=es_client.index if target_index is None else target_index,
+            doc_type=es_client.mapping_type,
+            body=Any(),
+            id=Any(),
+        )
+
+    @pytest.fixture
+    def add_one(self, factories, es_client, pyramid_request):
+        def add_one(annotation, target_index=None):
+            add_annotation(es_client, annotation, pyramid_request, target_index)
+
+        return add_one
+
+    @pytest.fixture
+    def annotation(self, factories):
+        return factories.Annotation.build()
+
+    @pytest.fixture(autouse=True)
+    def AnnotationTransformEvent(self, patch):
+        return patch("h.services.search_index.service.AnnotationTransformEvent")
+
+    @pytest.fixture(autouse=True)
+    def AnnotationSearchIndexPresenter(self, patch):
+        return patch("h.services.search_index.service.AnnotationSearchIndexPresenter")
+
+
+class TestDeleteAnnotation:
+    @pytest.mark.parametrize("target_index", (None, "another"))
+    @pytest.mark.parametrize("refresh", (True, False))
+    def test_delete_annotation(self, es_client, target_index, refresh):
+        delete_annotation(es_client, sentinel.annotation_id, target_index, refresh)
+
+        es_client.conn.index.assert_called_once_with(
+            index=es_client.index if target_index is None else target_index,
+            doc_type=es_client.mapping_type,
+            body={"deleted": True},
+            id=sentinel.annotation_id,
+            refresh=refresh,
+        )
+
+
+@pytest.fixture(autouse=True)
+def es_client():
+    return create_autospec(Client, instance=True)

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -26,6 +26,7 @@ class TestAddAnnotation:
             doc_type=Any(),
             body=AnnotationSearchIndexPresenter.return_value.asdict.return_value,
             id=annotation.id,
+            refresh=Any(),
         )
 
     def test_it_notifies_of_annotation_transformation(
@@ -59,6 +60,7 @@ class TestAddAnnotation:
             doc_type=es_client.mapping_type,
             body=Any(),
             id=Any(),
+            refresh=False,
         )
 
     @pytest.fixture


### PR DESCRIPTION
Prior to this PR there were two single indexing functions `index()` and `delete()`. This PR moves them with the functionality they currently have into a service.

This is in preparation to consolidate the indexing logic which is presently split between the indexing tasks and these functions into a single service which does both.