### PR TITLE
Add a periodic Postges -> Elasticsearch sync task

### DIFF
--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -29,6 +29,7 @@ from h.models.feature_cohort import FeatureCohort
 from h.models.flag import Flag
 from h.models.group import Group, GroupMembership
 from h.models.group_scope import GroupScope
+from h.models.job import Job
 from h.models.organization import Organization
 from h.models.setting import Setting
 from h.models.subscriptions import Subscriptions
@@ -53,6 +54,7 @@ __all__ = (
     "Group",
     "GroupMembership",
     "GroupScope",
+    "Job",
     "Organization",
     "Setting",
     "Subscriptions",

--- a/h/models/job.py
+++ b/h/models/job.py
@@ -1,0 +1,54 @@
+"""
+A simple transactional job queue.
+
+This home-grown job queue differs from our Celery task queue in a few ways:
+
+1. The job queue is stored in Postgres so jobs can be added as part of a
+   Postgres transaction.
+
+   For example a new annotation can be added to the annotations table and a job
+   to synchronize that annotation into Elasticsearch can be added to the job
+   queue as part of the same Postgres transaction. This way it's not possible
+   to add an annotation to Postgres and fail to add it to the job queue or
+   vice-versa. The two can't get out of sync because they're part of a single
+   Postgres transaction.
+
+2. The job queue is less immediate.
+
+   Jobs are processed in batch by periodic Celery tasks that run every N
+   minutes so a job added to the job queue might not get processed until N
+   minutes later (or even longer: if the job queue is currently long then the
+   periodic task may have to run multiple times before it gets to your job).
+
+   Tasks added to Celery can be processed by a worker almost immediately.
+
+3. The job queue is very simple and has far fewer features than Celery.
+
+   Celery should be the default task queue for almost all tasks, and only jobs
+   that really need Postgres transactionality should use this custom job queue.
+"""
+from sqlalchemy import Column, DateTime, Integer, Sequence, UnicodeText, func, text
+from sqlalchemy.dialects.postgresql import JSONB
+
+from h.db import Base
+
+
+class Job(Base):
+    """A job in the job queue."""
+
+    __tablename__ = "job"
+
+    id = Column(Integer, Sequence("job_id_seq", cycle=True), primary_key=True)
+    name = Column(UnicodeText, nullable=False)
+    enqueued_at = Column(DateTime, nullable=False, server_default=func.now())
+    scheduled_at = Column(DateTime, nullable=False, server_default=func.now())
+    expires_at = Column(
+        DateTime, nullable=False, server_default=text("now() + interval '30 days'")
+    )
+    priority = Column(Integer, nullable=False)
+    tag = Column(UnicodeText, nullable=False)
+    kwargs = Column(
+        JSONB,
+        server_default=text("'{}'::jsonb"),
+        nullable=False,
+    )

--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -8,6 +8,12 @@ from h.models import Annotation, Job
 
 logger = get_task_logger(__name__)
 
+# Strings used in log messages.
+DELETED_FROM_DB = "Jobs deleted because annotations were deleted from the DB"
+MISSING = "Annotations synced because they were not in Elasticsearch"
+OUT_OF_DATE = "Annotations synced because they were outdated in Elasticsearch"
+UP_TO_DATE = "Jobs deleted because annotations were up to date in Elasticsearch"
+
 
 class Queue:
     """A job queue for synchronizing annotations from Postgres to Elastic."""
@@ -141,10 +147,3 @@ class Queue:
             hit["_source"]["updated"] = updated
 
         return {hit["_id"]: hit["_source"] for hit in hits}
-
-
-# Strings used in log messages.
-DELETED_FROM_DB = "Jobs deleted because annotations were deleted from the DB"
-MISSING = "Annotations synced because they were not in Elasticsearch"
-OUT_OF_DATE = "Annotations synced because they were outdated in Elasticsearch"
-UP_TO_DATE = "Jobs deleted because annotations were up to date in Elasticsearch"

--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -1,0 +1,150 @@
+from collections import Counter
+from datetime import datetime
+
+from celery.utils.log import get_task_logger
+from dateutil.parser import isoparse
+
+from h.models import Annotation, Job
+
+logger = get_task_logger(__name__)
+
+
+class Queue:
+    """A job queue for synchronizing annotations from Postgres to Elastic."""
+
+    def __init__(self, db, es, batch_indexer):
+        self._db = db
+        self._es = es
+        self._batch_indexer = batch_indexer
+
+    def add(self, annotation_id, tag, schedule_in=None):
+        """Queue an annotation to be synced to Elasticsearch."""
+        self.add_all([annotation_id], tag, schedule_in)
+
+    def add_all(self, annotation_ids, tag, schedule_in=None):
+        """Queue a list of annotations to be synced to Elasticsearch."""
+
+        scheduled_at = (datetime.utcnow() + schedule_in) if schedule_in else None
+
+        # Jobs with a lower number for their priority get processed before jobs
+        # with a higher number. Make large batches of jobs added all at once
+        # get processed *after* small batches added a few at a time, so that
+        # large batches don't hold up small ones for a long time.
+        priority = len(annotation_ids)
+
+        self._db.add_all(
+            Job(
+                tag=tag,
+                name="sync_annotation",
+                scheduled_at=scheduled_at,
+                priority=priority,
+                kwargs={"annotation_id": annotation_id},
+            )
+            for annotation_id in annotation_ids
+        )
+
+    def sync(self, limit):
+        """
+        Synchronize a batch of annotations from Postgres to Elasticsearch.
+
+        Called periodically by a Celery task (see h-periodic).
+
+        Each time this method runs it considers a fixed number of sync
+        annotation jobs from the queue and for each job:
+
+        * If the annotation is already the same in Elastic as in the DB then
+          remove the job from the queue
+
+        * If the annotation is missing from Elastic or different in Elastic
+          than in the DB then re-sync the annotation into Elastic. Leave the
+          job on the queue to be re-checked and removed the next time the
+          method runs.
+        """
+        jobs = self._get_jobs_from_queue(limit)
+
+        if not jobs:
+            return
+
+        annotation_ids = {job.kwargs["annotation_id"] for job in jobs}
+        annotations_from_db = self._get_annotations_from_db(annotation_ids)
+        annotations_from_es = self._get_annotations_from_es(annotation_ids)
+
+        # Completed jobs that can be removed from the queue.
+        job_complete = []
+
+        # IDs of annotations to (re-)add to Elasticsearch because they're
+        # either missing from Elasticsearch or are different in Elasticsearch
+        # than in the DB.
+        annotation_ids_to_sync = set()
+
+        counts = Counter()
+
+        for job in jobs:
+            annotation_id = job.kwargs["annotation_id"]
+            annotation_from_db = annotations_from_db.get(annotation_id)
+            annotation_from_es = annotations_from_es.get(annotation_id)
+
+            if not annotation_from_db:
+                job_complete.append(job)
+                counts[DELETED_FROM_DB] += 1
+            elif not annotation_from_es:
+                annotation_ids_to_sync.add(annotation_id)
+                counts[MISSING] += 1
+            elif annotation_from_es["updated"] != annotation_from_db.updated:
+                annotation_ids_to_sync.add(annotation_id)
+                counts[OUT_OF_DATE] += 1
+            else:
+                job_complete.append(job)
+                counts[UP_TO_DATE] += 1
+
+        for job in job_complete:
+            self._db.delete(job)
+
+        if annotation_ids_to_sync:
+            self._batch_indexer.index(list(annotation_ids_to_sync))
+
+        logger.info(dict(counts))
+
+    def _get_jobs_from_queue(self, limit):
+        return (
+            self._db.query(Job)
+            .filter(
+                Job.name == "sync_annotation",
+                Job.scheduled_at < datetime.utcnow(),
+            )
+            .order_by(Job.priority, Job.enqueued_at)
+            .limit(limit)
+            .with_for_update(skip_locked=True)
+            .all()
+        )
+
+    def _get_annotations_from_db(self, annotation_ids):
+        return {
+            annotation.id: annotation
+            for annotation in self._db.query(Annotation.id, Annotation.updated)
+            .filter_by(deleted=False)
+            .filter(Annotation.id.in_(annotation_ids))
+        }
+
+    def _get_annotations_from_es(self, annotation_ids):
+        hits = self._es.conn.search(
+            body={
+                "_source": ["updated"],
+                "query": {"ids": {"values": list(annotation_ids)}},
+                "size": len(annotation_ids),
+            }
+        )["hits"]["hits"]
+
+        for hit in hits:
+            updated = hit["_source"].get("updated")
+            updated = isoparse(updated).replace(tzinfo=None) if updated else None
+            hit["_source"]["updated"] = updated
+
+        return {hit["_id"]: hit["_source"] for hit in hits}
+
+
+# Strings used in log messages.
+DELETED_FROM_DB = "Jobs deleted because annotations were deleted from the DB"
+MISSING = "Annotations synced because they were not in Elasticsearch"
+OUT_OF_DATE = "Annotations synced because they were outdated in Elasticsearch"
+UP_TO_DATE = "Jobs deleted because annotations were up to date in Elasticsearch"

--- a/h/services/search_index/service_factory.py
+++ b/h/services/search_index/service_factory.py
@@ -1,3 +1,5 @@
+from h.search.index import BatchIndexer
+from h.services.search_index._queue import Queue
 from h.services.search_index.service import SearchIndexService
 
 
@@ -9,4 +11,9 @@ def factory(_context, request):
         es_client=request.es,
         session=request.db,
         settings=request.find_service(name="settings"),
+        queue=Queue(
+            db=request.db,
+            es=request.es,
+            batch_indexer=BatchIndexer(request.db, request.es, request),
+        ),
     )

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -2,7 +2,6 @@ from celery import Task
 
 from h import models
 from h.celery import celery, get_task_logger
-from h.models import Annotation
 from h.search.index import BatchIndexer
 
 log = get_task_logger(__name__)
@@ -44,26 +43,5 @@ def reindex_user_annotations(userid):
 
 
 @celery.task
-def reindex_annotations_in_date_range(start_date, end_date, max_annotations=250000):
-    """Re-index annotations from Postgres to Elasticsearch in a date range.
-
-    :param start_date: Begin at this time (greater or equal)
-    :param end_date: End at this time (less than or equal)
-    :param max_annotations: Maximum number of items to process overall
-
-    """
-    log.info(f"Re-indexing from {start_date} to {end_date}...")
-
-    indexer = BatchIndexer(celery.request.db, celery.request.es, celery.request)
-    errored = indexer.index(
-        annotation.id
-        for annotation in celery.request.db.query(Annotation.id)
-        .filter(Annotation.updated >= start_date)
-        .filter(Annotation.updated <= end_date)
-        .limit(max_annotations)
-    )
-
-    if errored:
-        log.warning("Failed to re-index annotations into ES6 %s", errored)
-
-    log.info("Re-index from %s to %s complete.", start_date, end_date)
+def sync_annotations(limit):
+    celery.request.find_service(name="search_index").sync(limit)

--- a/h/templates/admin/search.html.jinja2
+++ b/h/templates/admin/search.html.jinja2
@@ -3,15 +3,6 @@
 {% set page_id = 'search' %}
 {% set page_title = 'Search index' %}
 
-{% macro indexing_warnings() %}
-  <p>
-    This operation can be very expensive, so ensure it is not run twice at once.
-  </p>
-  <p>
-    The background worker will refuse to process any items after 250,000.
-  </p>
-{% endmacro %}
-
 {% macro panel(heading) %}
   <div class="panel panel-default">
     <div class="panel-heading">
@@ -27,36 +18,25 @@
 {% block content %}
   <p>This is the search index admin page.</p>
 
-  {% if indexing %}
-    {% call panel(heading="⚠️Indexing is in progress... ⚠") %}
-      {{ indexing_warnings() }}
+  {% call panel(heading="Reindex all annotations between two dates") %}
+    <form method="POST" class="form-inline">
+      <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
 
-      <p>Celery task id: <pre>{{ task_id }}</pre></p>
-    {% endcall %}
+      <div class="form-group">
+        <label for="start">Start date</label>
+        <input type="datetime-local" class="form-control" name="start" id="start">
+      </div>
 
-  {% else %}
-    {% call panel(heading="Reindex all annotations between two dates") %}
-      {{ indexing_warnings() }}
+      <div class="form-group">
+        <label for="end">End date</label>
+        <input type="datetime-local" class="form-control" name="end" id="end">
+      </div>
 
-      <form method="POST" class="form-inline">
-        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
-
-        <div class="form-group">
-          <label for="start">Start date</label>
-          <input type="datetime-local" class="form-control" name="start" id="start">
-        </div>
-
-        <div class="form-group">
-          <label for="end">End date</label>
-          <input type="datetime-local" class="form-control" name="end" id="end">
-        </div>
-
-        <div class="form-group">
-          <input type="submit" class="btn btn-default" name="reindex_date" value="Reindex">
-        </div>
-      </form>
-    {% endcall %}
-  {% endif %}
+      <div class="form-group">
+        <input type="submit" class="btn btn-default" name="reindex_date" value="Reindex">
+      </div>
+    </form>
+  {% endcall %}
 
 
 {% endblock %}

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 from h.services.group import GroupService
 from h.services.search_index import SearchIndexService
+from h.services.search_index._queue import Queue
 
 
 @pytest.fixture
@@ -46,7 +47,11 @@ def index_annotations(es_client, search_index):
 @pytest.fixture
 def search_index(es_client, pyramid_request, moderation_service):
     return SearchIndexService(
-        pyramid_request, es_client, session=pyramid_request.db, settings={}
+        pyramid_request,
+        es_client,
+        session=pyramid_request.db,
+        settings={},
+        queue=mock.create_autospec(Queue, spec_set=True, instance=True),
     )
 
 

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -16,6 +16,10 @@ from h.services.search_index._queue import (
     Queue,
 )
 
+LIMIT = 10
+ONE_WEEK = datetime_.timedelta(weeks=1)
+MINUS_FIVE_MINUTES = datetime_.timedelta(minutes=-5)
+
 
 class TestAddSyncAnnotationJob:
     def test_it(self, db_session, queue, now):
@@ -226,15 +230,6 @@ class TestSyncAnnotations:
             es_client.conn.indices.refresh(index=es_client.index)
 
         return index
-
-
-LIMIT = 10
-
-
-ONE_WEEK = datetime_.timedelta(weeks=1)
-
-
-MINUS_FIVE_MINUTES = datetime_.timedelta(minutes=-5)
 
 
 @pytest.fixture

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -1,0 +1,259 @@
+import datetime as datetime_
+import logging
+from unittest import mock
+
+import pytest
+from h_matchers import Any
+
+from h.models import Job
+from h.search.index import BatchIndexer
+from h.services.search_index import SearchIndexService
+from h.services.search_index._queue import (
+    DELETED_FROM_DB,
+    MISSING,
+    OUT_OF_DATE,
+    UP_TO_DATE,
+    Queue,
+)
+
+
+class TestAddSyncAnnotationJob:
+    def test_it(self, db_session, queue, now):
+        queue.add("test_annotation_id", "test_tag", schedule_in=ONE_WEEK)
+
+        assert db_session.query(Job).all() == [
+            Any.instance_of(Job).with_attrs(
+                dict(
+                    enqueued_at=Any.instance_of(datetime_.datetime),
+                    scheduled_at=now + ONE_WEEK,
+                    tag="test_tag",
+                    priority=1,
+                    kwargs={"annotation_id": "test_annotation_id"},
+                )
+            ),
+        ]
+
+
+class TestSyncAnnotations:
+    def test_it_does_nothing_if_the_queue_is_empty(self, batch_indexer, caplog, queue):
+        queue.sync(LIMIT)
+
+        batch_indexer.index.assert_not_called()
+        # If it didn't do anything then it shouldn't have logged that it did anything.
+        assert DELETED_FROM_DB not in caplog.records
+        assert MISSING not in caplog.records
+        assert OUT_OF_DATE not in caplog.records
+        assert UP_TO_DATE not in caplog.records
+
+    def test_it_ignores_jobs_that_arent_scheduled_yet(
+        self, annotation_ids, batch_indexer, caplog, queue
+    ):
+        queue.add_all(annotation_ids, tag="test_tag", schedule_in=ONE_WEEK)
+
+        queue.sync(LIMIT)
+
+        batch_indexer.index.assert_not_called()
+        # If it didn't do anything then it shouldn't have logged that it did anything.
+        assert DELETED_FROM_DB not in caplog.records
+        assert MISSING not in caplog.records
+        assert OUT_OF_DATE not in caplog.records
+        assert UP_TO_DATE not in caplog.records
+
+    def test_it_ignores_jobs_beyond_limit(
+        self, all_annotation_ids, batch_indexer, queue
+    ):
+        queue.add_all(
+            all_annotation_ids, tag="test_tag", schedule_in=MINUS_FIVE_MINUTES
+        )
+
+        queue.sync(LIMIT)
+
+        for annotation_id in all_annotation_ids[LIMIT:]:
+            assert annotation_id not in batch_indexer.index.call_args[0][0]
+
+    def test_if_the_annotation_isnt_in_the_DB_it_deletes_the_job_from_the_queue(
+        self, annotations, annotation_ids, caplog, db_session, queue
+    ):
+        for annotation in annotations:
+            db_session.delete(annotation)
+
+        queue.add_all(annotation_ids, tag="test_tag", schedule_in=MINUS_FIVE_MINUTES)
+
+        queue.sync(LIMIT)
+
+        assert str({DELETED_FROM_DB: 10}) in caplog.text
+        assert db_session.query(Job).all() == []
+
+    def test_if_the_annotation_is_marked_as_deleted_in_the_DB_it_deletes_the_job_from_the_queue(
+        self, annotations, annotation_ids, caplog, db_session, queue
+    ):
+        for annotation in annotations:
+            annotation.deleted = True
+
+        queue.add_all(annotation_ids, tag="test_tag", schedule_in=MINUS_FIVE_MINUTES)
+
+        queue.sync(LIMIT)
+
+        assert str({DELETED_FROM_DB: 10}) in caplog.text
+        assert db_session.query(Job).all() == []
+
+    def test_if_the_annotation_is_missing_from_Elastic_it_indexes_it(
+        self, annotation_ids, batch_indexer, caplog, queue
+    ):
+        queue.add_all(annotation_ids, tag="test_tag", schedule_in=MINUS_FIVE_MINUTES)
+
+        queue.sync(LIMIT)
+
+        assert str({MISSING: 10}) in caplog.text
+        batch_indexer.index.assert_called_once_with(
+            Any.list.containing(annotation_ids).only()
+        )
+
+    def test_if_the_annotation_is_already_in_Elastic_it_removes_the_job_from_the_queue(
+        self,
+        annotations,
+        annotation_ids,
+        batch_indexer,
+        caplog,
+        db_session,
+        index,
+        queue,
+    ):
+        index(annotations)
+        queue.add_all(annotation_ids, tag="test_tag", schedule_in=MINUS_FIVE_MINUTES)
+
+        queue.sync(LIMIT)
+
+        assert str({UP_TO_DATE: 10}) in caplog.text
+        assert db_session.query(Job).all() == []
+        batch_indexer.index.assert_not_called()
+
+    def test_if_the_annotation_has_a_different_updated_time_in_Elastic_it_indexes_it(
+        self, annotations, annotation_ids, batch_indexer, caplog, index, now, queue
+    ):
+        index(annotations)
+        queue.add_all(annotation_ids, tag="test_tag", schedule_in=MINUS_FIVE_MINUTES)
+        # Simulate the annotations having been updated in the DB after they
+        # were indexed.
+        for annotation in annotations:
+            annotation.updated = now
+
+        queue.sync(LIMIT)
+
+        assert str({OUT_OF_DATE: 10}) in caplog.text
+        batch_indexer.index.assert_called_once_with(
+            Any.list.containing(annotation_ids).only()
+        )
+
+    def test_if_there_are_multiple_jobs_with_the_same_annotation_id(
+        self, annotation_ids, batch_indexer, caplog, queue
+    ):
+        queue.add_all(
+            [annotation_ids[0], annotation_ids[0], annotation_ids[0]],
+            tag="test_tag",
+            schedule_in=MINUS_FIVE_MINUTES,
+        )
+
+        queue.sync(LIMIT)
+
+        # It only syncs the annotation to Elasticsearch once.
+        assert str({MISSING: 3}) in caplog.text
+        batch_indexer.index.assert_called_once_with(
+            Any.list.containing([annotation_ids[0]]).only()
+        )
+
+    def test_deleting_multiple_jobs_with_the_same_annotation_id(
+        self, annotations, batch_indexer, caplog, db_session, index, queue
+    ):
+        queue.add_all(
+            [annotations[0].id, annotations[0].id, annotations[0].id],
+            tag="test_tag",
+            schedule_in=MINUS_FIVE_MINUTES,
+        )
+        index([annotations[0]])
+
+        queue.sync(LIMIT)
+
+        assert str({UP_TO_DATE: 3}) in caplog.text
+        assert db_session.query(Job).all() == []
+        batch_indexer.index.assert_not_called()
+
+    @pytest.fixture
+    def annotations(self, factories, now):
+        return factories.Annotation.create_batch(
+            size=20,
+            created=now - datetime_.timedelta(minutes=1),
+            updated=now - datetime_.timedelta(minutes=1),
+        )
+
+    @pytest.fixture
+    def all_annotation_ids(self, annotations):
+        return [annotation.id for annotation in annotations]
+
+    @pytest.fixture
+    def annotation_ids(self, all_annotation_ids):
+        return all_annotation_ids[:LIMIT]
+
+    @pytest.fixture
+    def caplog(self, caplog):
+        # Filter out log messages from any other module.
+        caplog.set_level(logging.CRITICAL + 1)
+        # Filter in log messages from the module under test only.
+        caplog.set_level(logging.INFO, "h.services.search_index._queue")
+        return caplog
+
+    @pytest.fixture
+    def search_index(
+        self, es_client, pyramid_request, moderation_service, nipsa_service
+    ):
+        return SearchIndexService(
+            pyramid_request,
+            es_client,
+            session=pyramid_request.db,
+            settings={},
+            queue=queue,
+        )
+
+    @pytest.fixture
+    def index(self, es_client, search_index, nipsa_service):
+        """A function for adding annotations to Elasticsearch."""
+
+        def index(annotations):
+            """Add `annotations` to the Elasticsearch index."""
+            for annotation in annotations:
+                search_index.add_annotation(annotation)
+
+            es_client.conn.indices.refresh(index=es_client.index)
+
+        return index
+
+
+LIMIT = 10
+
+
+ONE_WEEK = datetime_.timedelta(weeks=1)
+
+
+MINUS_FIVE_MINUTES = datetime_.timedelta(minutes=-5)
+
+
+@pytest.fixture
+def batch_indexer():
+    return mock.create_autospec(BatchIndexer, spec_set=True, instance=True)
+
+
+@pytest.fixture(autouse=True)
+def datetime(patch, now):
+    datetime = patch("h.services.search_index._queue.datetime")
+    datetime.utcnow.return_value = now
+    return datetime
+
+
+@pytest.fixture
+def now():
+    return datetime_.datetime.utcnow()
+
+
+@pytest.fixture
+def queue(batch_indexer, db_session, es_client):
+    return Queue(db_session, es_client, batch_indexer)

--- a/tests/h/services/search_index/service_factory_test.py
+++ b/tests/h/services/search_index/service_factory_test.py
@@ -6,16 +6,26 @@ from h.services.search_index.service_factory import factory
 
 
 class TestFactory:
-    def test_it(self, pyramid_request, SearchIndexService, settings):
+    def test_it(
+        self, pyramid_request, SearchIndexService, settings, BatchIndexer, Queue
+    ):
         result = factory(sentinel.context, pyramid_request)
 
+        BatchIndexer.assert_called_once_with(
+            pyramid_request.db, pyramid_request.es, pyramid_request
+        )
+        Queue.assert_called_once_with(
+            db=pyramid_request.db,
+            es=pyramid_request.es,
+            batch_indexer=BatchIndexer.return_value,
+        )
         SearchIndexService.assert_called_once_with(
             request=pyramid_request,
             es_client=pyramid_request.es,
             session=pyramid_request.db,
             settings=settings,
+            queue=Queue.return_value,
         )
-
         assert result == SearchIndexService.return_value
 
     @pytest.fixture
@@ -29,6 +39,17 @@ class TestFactory:
         pyramid_request.es = sentinel.es
         return pyramid_request
 
-    @pytest.fixture
-    def SearchIndexService(self, patch):
-        return patch("h.services.search_index.service_factory.SearchIndexService")
+
+@pytest.fixture(autouse=True)
+def BatchIndexer(patch):
+    return patch("h.services.search_index.service_factory.BatchIndexer")
+
+
+@pytest.fixture(autouse=True)
+def Queue(patch):
+    return patch("h.services.search_index.service_factory.Queue")
+
+
+@pytest.fixture(autouse=True)
+def SearchIndexService(patch):
+    return patch("h.services.search_index.service_factory.SearchIndexService")

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest.mock import call, create_autospec, patch, sentinel
 
 import pytest
@@ -5,6 +6,7 @@ from h_matchers import Any
 
 from h.events import AnnotationEvent
 from h.search.client import Client
+from h.services.search_index._queue import Queue
 from h.services.search_index.service import SearchIndexService
 from h.services.settings import SettingsService
 
@@ -141,6 +143,40 @@ class TestAddAnnotation:
         return patch("h.services.search_index.service.AnnotationSearchIndexPresenter")
 
 
+class TestAddAnnotationsBetweenTimes:
+    def test_it(self, annotation_ids, search_index, queue):
+        search_index.add_annotations_between_times(
+            datetime.datetime(2020, 9, 9),
+            datetime.datetime(2020, 9, 11),
+            "test_tag",
+        )
+
+        queue.add_all.assert_called_once_with(
+            Any.list.containing(annotation_ids).only(), tag="test_tag"
+        )
+
+    @pytest.fixture
+    def annotations(self, factories):
+        return factories.Annotation.create_batch(
+            size=10, updated=datetime.datetime(year=2020, month=9, day=10)
+        )
+
+    @pytest.fixture(autouse=True)
+    def non_matching_annotations(self, factories):
+        """Annotations from outside the date range that we're reindexing."""
+        before_annotations = factories.Annotation.create_batch(
+            size=3, updated=datetime.datetime(year=2020, month=9, day=8)
+        )
+        after_annotations = factories.Annotation.create_batch(
+            size=3, updated=datetime.datetime(year=2020, month=9, day=12)
+        )
+        return before_annotations + after_annotations
+
+    @pytest.fixture
+    def annotation_ids(self, annotations):
+        return [annotation.id for annotation in annotations]
+
+
 class TestDeleteAnnotationById:
     @pytest.mark.parametrize("refresh", (True, False))
     def test_delete_annotation(self, search_index, es_client, refresh):
@@ -252,6 +288,13 @@ class TestHandleAnnotationEvent:
             yield delete_annotation_by_id
 
 
+class TestSync:
+    def test_it(self, search_index, queue):
+        search_index.sync(10)
+
+        queue.sync.assert_called_once_with(10)
+
+
 @pytest.fixture
 def with_reindex_in_progress(settings_service):
     settings_service.get.side_effect = {
@@ -269,12 +312,18 @@ def settings_service(pyramid_config):
 
 
 @pytest.fixture
-def search_index(es_client, pyramid_request, settings_service):
+def queue():
+    return create_autospec(Queue, spec_set=True, instance=True)
+
+
+@pytest.fixture
+def search_index(es_client, pyramid_request, settings_service, queue):
     return SearchIndexService(
         session=pyramid_request.db,
         es_client=es_client,
         request=pyramid_request,
         settings=settings_service,
+        queue=queue,
     )
 
 

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -5,6 +5,8 @@ import pytest
 
 from h.tasks import indexer
 
+pytestmark = pytest.mark.usefixtures("search_index")
+
 
 class TestSearchIndexServicesWrapperTasks:
     """Tests for tasks that just wrap SearchIndexServices functions."""
@@ -64,9 +66,6 @@ class TestSyncAnnotations:
         indexer.sync_annotations("test_queue")
 
         search_index.sync.assert_called_once_with("test_queue")
-
-
-pytestmark = pytest.mark.usefixtures("search_index")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/h/views/admin/search_test.py
+++ b/tests/h/views/admin/search_test.py
@@ -4,6 +4,8 @@ import pytest
 
 from h.views.admin.search import SearchAdminViews
 
+pytestmark = pytest.mark.usefixtures("search_index")
+
 
 class TestSearchAdminViews:
     def test_get(self, views):
@@ -33,6 +35,3 @@ class TestSearchAdminViews:
     @pytest.fixture(autouse=True)
     def routes(self, pyramid_config):
         pyramid_config.add_route("admin.search", "/admin/search")
-
-
-pytestmark = pytest.mark.usefixtures("search_index")


### PR DESCRIPTION
Add a `job` table to the DB for holding annotation sync jobs and a `"job_queue"` service that, when called, consumes a fixed number of jobs from the queue and syncs the annotations from Postgres to Elasticsearch. The number of annotations that the service syncs each time it's called is controlled by the `ES_SYNC_JOB_LIMIT` envvar.

Also add a Celery task that calls the new service. This Celery task is meant to be called by h-periodic on a fixed periodic schedule so that the service will consume jobs from the queue at a fixed rate.

Finally, change the search admin page's "reindex annotations in date range" feature to work by finding the annotation IDs and adding them to the job queue. This means that no matter how many annotations are reindexed, no matter how long the queue grows, they'll only be indexed at a fixed rate by the periodic task.

See also:

* The h-periodic PR that schedules the new Celery task to run periodically: https://github.com/hypothesis/h-periodic/pull/17
* The DB migration to add the `job` table that this PR uses: https://github.com/hypothesis/h/pull/6296

The plan is to use the "reindex annotations in date range" admin page to test this in production and then:

1. Change the other admin pages that do reindexing to also use this job queue
2. Change the annotation create and update APIs to also append jobs to this queue with a delayed `scheduled_at` time
3. Send a separate PR to add queue length monitoring in New Relic

## Testing

1. Reset your DB to get the new table: `make services args='down' && make services db devdata`

2. Create 10,000 annotations that are in your DB but not in Elasticsearch: `tox -qe dev -- sh bin/hypothesis --dev create-annotations --number 10000`

3. Go to http://localhost:5000/search and observe that the annotations aren't visible

4. Log in as `devdata_admin`, go to http://localhost:5000/admin/search, and schedule a reindexing of a time frame

5. Observe that jobs have been added to the job queue: `tox -qqe dockercompose -- exec postgres psql -U postgres -c "select * from job;"`

6. Checkout the [corresponding h-periodic PR](https://github.com/hypothesis/h-periodic/pull/17), run `make dev` in h-periodic, and wait for a minute for the sync-annotations task to be run

7. The first time the task runs you should see output like this in h's terminal:

   ```
   Received task: h.tasks.job_queue.sync_annotations[c0821314-bfe9-465e-ace4-d9286737636f]  
   GET http://localhost:9200/_search [status:200 request:0.040s]
   Syncing 1000 annotations that are missing from Elasticsearch
   POST http://localhost:9200/_bulk [status:200 request:0.132s]
   POST http://localhost:9200/_bulk [status:200 request:0.059s]
   ...
   POST http://localhost:9200/_bulk [status:200 request:0.036s]
   Task h.tasks.job_queue.sync_annotations[c0821314-bfe9-465e-ace4-d9286737636f] succeeded in 3.453727593005169s: None
   ```

8. Go to http://localhost:5000/search and observe that 1000 annotations are now visible

9. Observe the no jobs have been removed from the job queue yet

10. The second time the job runs you should see output like this:

    ```
    Received task: h.tasks.job_queue.sync_annotations[d7fe0e2b-1c9c-4e2c-9e0f-29ad11c3fd07]  
    GET http://localhost:9200/_search [status:200 request:0.077s]
    Deleting 1000 successfully synced annotations from job queue
    Task h.tasks.job_queue.sync_annotations[d7fe0e2b-1c9c-4e2c-9e0f-29ad11c3fd07] succeeded in 0.2429510239744559s: None
    ```

11. Observe that 1000 jobs have now been removed from the job queue

12. If you leave it running for another 18 minutes it will eat through the rest of the job queue at a rate of 1000 jobs every 2 minutes
