### PR TITLE
Inline the NIPSA transform

### DIFF
--- a/h/events.py
+++ b/h/events.py
@@ -5,19 +5,3 @@ class AnnotationEvent:
         self.request = request
         self.annotation_id = annotation_id
         self.action = action
-
-
-class AnnotationTransformEvent:
-
-    """
-    An event fired before an annotation is indexed or otherwise needs to be
-    transformed by third-party code.
-
-    This event can be used by subscribers who wish to modify the content of an
-    annotation just before it is indexed or in other use-cases.
-    """
-
-    def __init__(self, request, annotation, annotation_dict):
-        self.request = request
-        self.annotation = annotation
-        self.annotation_dict = annotation_dict

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -4,7 +4,6 @@ from h.util.user import split_user
 
 
 class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
-
     """Present an annotation in the JSON format used in the search index."""
 
     def __init__(self, annotation, request):
@@ -38,6 +37,12 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
         if self.annotation.references:
             result["references"] = self.annotation.references
 
+        self._add_hidden(result)
+        self._add_nipsa(result, self.annotation.userid)
+
+        return result
+
+    def _add_hidden(self, result):
         # Mark an annotation as hidden if it and all of it's children have been
         # moderated and hidden.
         parents_and_replies = [self.annotation.id] + self.annotation.thread_ids
@@ -47,7 +52,13 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
             parents_and_replies
         )
 
-        return result
+    def _add_nipsa(self, result, user_id=None):
+        if user_id is None:
+            return
+
+        nipsa_service = self.request.find_service(name="nipsa")
+        if nipsa_service.is_flagged(user_id):
+            result["nipsa"] = True
 
     @property
     def links(self):

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -48,9 +48,11 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
         parents_and_replies = [self.annotation.id] + self.annotation.thread_ids
 
         ann_mod_svc = self.request.find_service(name="annotation_moderation")
-        result["hidden"] = len(ann_mod_svc.all_hidden(parents_and_replies)) == len(
+        is_hidden = len(ann_mod_svc.all_hidden(parents_and_replies)) == len(
             parents_and_replies
         )
+
+        result["hidden"] = is_hidden
 
     def _add_nipsa(self, result, user_id=None):
         if user_id is None:

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -54,10 +54,7 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
 
         result["hidden"] = is_hidden
 
-    def _add_nipsa(self, result, user_id=None):
-        if user_id is None:
-            return
-
+    def _add_nipsa(self, result, user_id):
         nipsa_service = self.request.find_service(name="nipsa")
         if nipsa_service.is_flagged(user_id):
             result["nipsa"] = True

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -8,7 +8,6 @@ from elasticsearch import helpers as es_helpers
 from sqlalchemy.orm import subqueryload
 
 from h import models, presenters
-from h.events import AnnotationTransformEvent
 from h.util.query import column_windows
 
 log = logging.getLogger(__name__)
@@ -88,14 +87,12 @@ class BatchIndexer:
                 "_id": annotation.id,
             }
         }
+
         data = presenters.AnnotationSearchIndexPresenter(
             annotation, self.request
         ).asdict()
 
-        event = AnnotationTransformEvent(self.request, annotation, data)
-        self.request.registry.notify(event)
-
-        return (action, data)
+        return action, data
 
 
 def _all_annotations(session, windowsize=2000):

--- a/h/services/search_index/service.py
+++ b/h/services/search_index/service.py
@@ -1,5 +1,4 @@
 from h import storage
-from h.events import AnnotationTransformEvent
 from h.presenters import AnnotationSearchIndexPresenter
 
 
@@ -55,10 +54,6 @@ class SearchIndexService:
         :param annotation: Annotation object to index
         """
         body = AnnotationSearchIndexPresenter(annotation, self._request).asdict()
-
-        self._request.registry.notify(
-            AnnotationTransformEvent(self._request, annotation, body)
-        )
 
         self._index_annotation_body(annotation.id, body, refresh=False)
 

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -1,7 +1,7 @@
 from pyramid.events import BeforeRender, subscriber
 
 from h import __version__, emails, storage
-from h.events import AnnotationEvent, AnnotationTransformEvent
+from h.events import AnnotationEvent
 from h.notification import reply
 from h.tasks import mailer
 from h.tasks.indexer import add_annotation, delete_annotation
@@ -57,21 +57,6 @@ def send_reply_notifications(
 
         send_params = generate_mail(request, notification)
         send(*send_params)
-
-
-@subscriber(AnnotationTransformEvent)
-def nipsa_transform_annotation(event):
-    """Mark moderated or flagged annotations before they are saved.
-
-    Adds `{"nipsa": True}` to an annotation.
-    """
-    user = event.annotation_dict.get("user")
-    if user is None:
-        return
-
-    nipsa_service = event.request.find_service(name="nipsa")
-    if nipsa_service.is_flagged(user):
-        event.annotation_dict["nipsa"] = True
 
 
 @subscriber(AnnotationEvent)

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -1,0 +1,14 @@
+from unittest import mock
+
+import pytest
+
+from h.services.nipsa import NipsaService
+
+
+@pytest.fixture
+def nipsa_service(pyramid_config):
+    service = mock.create_autospec(NipsaService, spec_set=True, instance=True)
+    service.is_flagged.return_value = False
+
+    pyramid_config.register_service(service, name="nipsa")
+    return service

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -20,6 +20,7 @@ from h import db, models
 from h.settings import database_url
 from tests.common.fixtures import es_client  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
+from tests.common.fixtures.services import nipsa_service  # noqa: F401
 
 TEST_AUTHORITY = "example.com"
 TEST_DATABASE_URL = database_url(

--- a/tests/h/events_test.py
+++ b/tests/h/events_test.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from h.events import AnnotationEvent, AnnotationTransformEvent
+from h.events import AnnotationEvent
 
 s = mock.sentinel
 
@@ -11,11 +11,3 @@ def test_annotation_event():
     assert evt.request == s.request
     assert evt.annotation_id == s.annotation_id
     assert evt.action == s.action
-
-
-def test_annotation_transform_event():
-    evt = AnnotationTransformEvent(s.request, s.annotation, s.annotation_dict)
-
-    assert evt.request == s.request
-    assert evt.annotation == s.annotation
-    assert evt.annotation_dict == s.annotation_dict

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -4,7 +4,6 @@ import pytest
 
 from h.indexer.reindexer import reindex
 from h.search import client
-from h.services.nipsa import NipsaService
 
 
 @pytest.mark.usefixtures(
@@ -169,12 +168,6 @@ class TestReindex:
     def settings_service(self, pyramid_config):
         service = mock.Mock()
         pyramid_config.register_service(service, name="settings")
-        return service
-
-    @pytest.fixture
-    def nipsa_service(self, pyramid_config):
-        service = mock.create_autospec(NipsaService, spec_set=True, instance=True)
-        pyramid_config.register_service(service, name="nipsa")
         return service
 
     @pytest.fixture

--- a/tests/h/presenters/annotation_searchindex_test.py
+++ b/tests/h/presenters/annotation_searchindex_test.py
@@ -8,7 +8,7 @@ from h.services.annotation_moderation import AnnotationModerationService
 
 
 @pytest.mark.usefixtures(
-    "DocumentSearchIndexPresenter", "moderation_service", "thread_ids"
+    "DocumentSearchIndexPresenter", "moderation_service", "thread_ids", "nipsa_service"
 )
 class TestAnnotationSearchIndexPresenter:
     def test_asdict(self, DocumentSearchIndexPresenter, pyramid_request, thread_ids):

--- a/tests/h/presenters/annotation_searchindex_test.py
+++ b/tests/h/presenters/annotation_searchindex_test.py
@@ -7,12 +7,9 @@ from h.presenters.annotation_searchindex import AnnotationSearchIndexPresenter
 from h.services.annotation_moderation import AnnotationModerationService
 
 
-@pytest.mark.usefixtures(
-    "DocumentSearchIndexPresenter", "moderation_service", "thread_ids", "nipsa_service"
-)
+@pytest.mark.usefixtures("nipsa_service")
 class TestAnnotationSearchIndexPresenter:
-    def test_asdict(self, DocumentSearchIndexPresenter, pyramid_request, thread_ids):
-
+    def test_asdict(self, DocumentSearchIndexPresenter, pyramid_request):
         annotation = mock.MagicMock(
             id="xyz123",
             created=datetime.datetime(2016, 2, 24, 18, 3, 25, 768),
@@ -26,7 +23,7 @@ class TestAnnotationSearchIndexPresenter:
             shared=True,
             target_selectors=[{"TestSelector": "foobar"}],
             references=["referenced-id-1", "referenced-id-2"],
-            thread_ids=thread_ids,
+            thread_ids=["thread-id-1", "thread-id-2"],
             extra={"extra-1": "foo", "extra-2": "bar"},
         )
         DocumentSearchIndexPresenter.return_value.asdict.return_value = {"foo": "bar"}
@@ -57,101 +54,37 @@ class TestAnnotationSearchIndexPresenter:
             ],
             "document": {"foo": "bar"},
             "references": ["referenced-id-1", "referenced-id-2"],
-            "thread_ids": thread_ids,
+            "thread_ids": ["thread-id-1", "thread-id-2"],
             "hidden": False,
         }
 
-    def test_it_copies_target_uri_normalized_to_target_scope(self, pyramid_request):
-        annotation = mock.MagicMock(
-            userid="acct:luke@hypothes.is",
-            target_uri_normalized="http://example.com/normalized",
-            extra={},
-        )
-
-        annotation_dict = AnnotationSearchIndexPresenter(
-            annotation, pyramid_request
-        ).asdict()
-
-        assert annotation_dict["target"][0]["scope"] == [
-            "http://example.com/normalized"
-        ]
-
-    def test_it_marks_annotation_hidden_when_it_and_all_children_are_moderated(
-        self, pyramid_request, moderation_service, thread_ids
+    @pytest.mark.parametrize("is_moderated", [True, False])
+    @pytest.mark.parametrize("replies_moderated", [True, False])
+    def test_it_marks_annotation_hidden_correctly(
+        self, pyramid_request, moderation_service, is_moderated, replies_moderated
     ):
+        # Annotation reply ids are referred to as thread_ids in our code base.
+        reply_ids = ["thread-id-1", "thread-id-2"]
         annotation = mock.MagicMock(
-            userid="acct:luke@hypothes.is", thread_ids=thread_ids
+            userid="acct:luke@hypothes.is", thread_ids=reply_ids
         )
 
-        moderation_service.all_hidden.return_value = [annotation.id] + thread_ids
+        # Configure moderation return value
+        moderated_ids = []
+        if is_moderated:
+            moderated_ids.append(annotation.id)
+        if replies_moderated:
+            moderated_ids.extend(reply_ids)
+        moderation_service.all_hidden.return_value = moderated_ids
 
         annotation_dict = AnnotationSearchIndexPresenter(
             annotation, pyramid_request
         ).asdict()
 
-        assert annotation_dict["hidden"] is True
+        # We are hidden if both we, and all of our replies are moderated
+        assert annotation_dict["hidden"] == bool(is_moderated and replies_moderated)
 
-    def test_it_does_not_mark_annotation_hidden_when_it_is_not_moderated(
-        self, pyramid_request, moderation_service, thread_ids
-    ):
-        annotation = mock.MagicMock(
-            userid="acct:luke@hypothes.is", thread_ids=thread_ids
-        )
-
-        moderation_service.all_hidden.return_value = thread_ids
-
-        annotation_dict = AnnotationSearchIndexPresenter(
-            annotation, pyramid_request
-        ).asdict()
-
-        assert annotation_dict["hidden"] is False
-
-    def test_it_does_not_mark_annotation_hidden_when_children_are_not_moderated(
-        self, pyramid_request, moderation_service, thread_ids
-    ):
-        annotation = mock.MagicMock(
-            userid="acct:luke@hypothes.is", thread_ids=thread_ids
-        )
-
-        moderation_service.all_hidden.return_value = [annotation.id] + thread_ids[1:]
-
-        annotation_dict = AnnotationSearchIndexPresenter(
-            annotation, pyramid_request
-        ).asdict()
-
-        assert annotation_dict["hidden"] is False
-
-    def test_it_does_not_mark_annotation_hidden_when_not_moderated_and_no_replies(
-        self, pyramid_request
-    ):
-        thread_ids = []
-        annotation = mock.MagicMock(
-            userid="acct:luke@hypothes.is", thread_ids=thread_ids
-        )
-
-        annotation_dict = AnnotationSearchIndexPresenter(
-            annotation, pyramid_request
-        ).asdict()
-
-        assert annotation_dict["hidden"] is False
-
-    def test_it_marks_annotation_hidden_when_moderated_and_no_replies(
-        self, pyramid_request, moderation_service
-    ):
-        thread_ids = []
-        annotation = mock.MagicMock(
-            userid="acct:luke@hypothes.is", thread_ids=thread_ids
-        )
-
-        moderation_service.all_hidden.return_value = [annotation.id] + thread_ids
-
-        annotation_dict = AnnotationSearchIndexPresenter(
-            annotation, pyramid_request
-        ).asdict()
-
-        assert annotation_dict["hidden"] is True
-
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def DocumentSearchIndexPresenter(self, patch):
         class_ = patch(
             "h.presenters.annotation_searchindex.DocumentSearchIndexPresenter"
@@ -159,18 +92,11 @@ class TestAnnotationSearchIndexPresenter:
         class_.return_value.asdict.return_value = {}
         return class_
 
-
-@pytest.fixture
-def moderation_service(pyramid_config):
-    svc = mock.create_autospec(
-        AnnotationModerationService, spec_set=True, instance=True
-    )
-    svc.all_hidden.return_value = []
-    pyramid_config.register_service(svc, name="annotation_moderation")
-    return svc
-
-
-@pytest.fixture
-def thread_ids():
-    # Annotation reply ids are referred to as thread_ids in our code base.
-    return ["thread-id-1", "thread-id-2"]
+    @pytest.fixture(autouse=True)
+    def moderation_service(self, pyramid_config):
+        svc = mock.create_autospec(
+            AnnotationModerationService, spec_set=True, instance=True
+        )
+        svc.all_hidden.return_value = []
+        pyramid_config.register_service(svc, name="annotation_moderation")
+        return svc

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -14,7 +14,7 @@ from webob.multidict import MultiDict
 from h import search
 
 
-@pytest.mark.usefixtures("group_service")
+@pytest.mark.usefixtures("group_service", "nipsa_service")
 class TestSearch:
     """Unit tests for search.Search when no separate_replies argument is given."""
 
@@ -161,7 +161,7 @@ class TestSearch:
         return patch("h.search.core.query.UriCombinedWildcardFilter")
 
 
-@pytest.mark.usefixtures("group_service")
+@pytest.mark.usefixtures("group_service", "nipsa_service")
 class TestSearchWithSeparateReplies:
     """Unit tests for search.Search when separate_replies=True is given."""
 

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -85,26 +85,6 @@ class TestAddAnnotation:
             refresh=Any(),
         )
 
-    def test_it_notifies_of_annotation_transformation(
-        self,
-        search_index,
-        annotation,
-        pyramid_request,
-        AnnotationTransformEvent,
-        AnnotationSearchIndexPresenter,
-    ):
-        with patch.object(pyramid_request, "registry") as registry:
-            search_index.add_annotation(annotation)
-
-            AnnotationTransformEvent.assert_called_once_with(
-                pyramid_request,
-                annotation,
-                AnnotationSearchIndexPresenter.return_value.asdict.return_value,
-            )
-            registry.notify.assert_called_once_with(
-                AnnotationTransformEvent.return_value
-            )
-
     def test_it_calls_elasticsearch_as_expected(
         self, search_index, annotation, es_client
     ):
@@ -136,10 +116,6 @@ class TestAddAnnotation:
     @pytest.fixture
     def annotation(self, factories):
         return factories.Annotation.build()
-
-    @pytest.fixture(autouse=True)
-    def AnnotationTransformEvent(self, patch):
-        return patch("h.services.search_index.service.AnnotationTransformEvent")
 
     @pytest.fixture(autouse=True)
     def AnnotationSearchIndexPresenter(self, patch):

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -1,11 +1,9 @@
 from unittest import mock
-from unittest.mock import create_autospec
 
 import pytest
 
 from h import subscribers
-from h.events import AnnotationEvent, AnnotationTransformEvent
-from h.services.nipsa import NipsaService
+from h.events import AnnotationEvent
 
 
 class FakeMailer:
@@ -159,42 +157,6 @@ class TestSendReplyNotifications:
     def pyramid_request(self, pyramid_request):
         pyramid_request.tm = mock.MagicMock()
         return pyramid_request
-
-
-class TestNipsaTransformAnnotation:
-    def test_if_user_is_missing_nothing_happens(self, event, nipsa_service):
-        event.annotation_dict.pop("user")
-
-        subscribers.nipsa_transform_annotation(event)
-
-        assert "nipsa" not in event.annotation_dict
-        nipsa_service.is_flagged.assert_not_called()
-
-    @pytest.mark.parametrize("flagged", [True, False])
-    def test_nipsa_status_is_added_based_on_flagged(
-        self, event, nipsa_service, flagged
-    ):
-        nipsa_service.is_flagged.return_value = flagged
-
-        subscribers.nipsa_transform_annotation(event)
-
-        nipsa_service.is_flagged.assert_called_once_with(event.annotation_dict["user"])
-        assert bool(event.annotation_dict.get("nipsa")) == flagged
-
-    @pytest.fixture
-    def event(self, pyramid_request, factories):
-        return AnnotationTransformEvent(
-            request=pyramid_request,
-            annotation=factories.Annotation(),
-            annotation_dict={"user": "username"},
-        )
-
-    @pytest.fixture(autouse=True)
-    def nipsa_service(self, pyramid_config):
-        nipsa_service = create_autospec(NipsaService, instance=True)
-        nipsa_service.is_flagged.return_value = False
-        pyramid_config.register_service(nipsa_service, name="nipsa")
-        return nipsa_service
 
 
 class TestSyncAnnotation:


### PR DESCRIPTION
We had a very convoluted event messaging system to do something which was done every time we transform an annotation. 

It worked, but it's a lot more machinery, confusion and testing than necessary.

This PR:

 * Moves the NIPSA functionality inside `AnnotationSearchIndexPresenter`
 * Removes the `AnnotationTransformEvent` and subscribers etc.
 * Removes the associated testing around it
 * Refactors the testing for the `TestHiddenFilter` as I actually couldn't understand it to fix it
 * Refactors the testing for the `AnnotationSearchIndexPresenter` to reduce massive duplication

The PR is split into a few commits:

 * The first commit does 100% of the code refactoring. This is all that's actually necessary to do this and should make it clear what the change is
 * Fixing the existing tests back up
 * Refactoring the `AnnotationSearchIndexPresenter` 
 * Adding the additional coverage back