### PR TITLE
Add a feature flag which enables synchronous annotation indexing

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -13,6 +13,10 @@ FEATURES = {
     ),
     "client_display_names": "Render display names instead of user names in the client",
     "client_search_input": "Show redesigned search/filter input in client",
+    "synchronous_indexing": (
+        "Index annotations to Elasticsearch synchronously without involving "
+        "Rabbit MQ or Celery"
+    ),
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -15,7 +15,7 @@ FEATURES = {
     "client_search_input": "Show redesigned search/filter input in client",
     "synchronous_indexing": (
         "Index annotations to Elasticsearch synchronously without involving "
-        "Rabbit MQ or Celery"
+        "RabbitMQ or Celery"
     ),
 }
 

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -67,7 +67,7 @@ def sync_annotation(event):
 
     if not synchronous_indexing:
         # This is exactly the same outcome as below, but just run through
-        # celery instead. These tasks just call the search index service.
+        # Celery instead. These tasks just call the search index service.
         if event.action in ["create", "update"]:
             add_annotation.delay(event.annotation_id)
 

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -5,25 +5,28 @@ import pytest
 from h.services.nipsa import NipsaService
 from h.services.search_index import SearchIndexService
 
-__all__ = ("service_mocker", "search_index")
+__all__ = ("mock_service", "search_index", "nipsa_service")
 
 
 @pytest.fixture
-def service_mocker(pyramid_config):
-    def service_mocker(class_, name):
-        service = create_autospec(class_, instance=True, spec_set=True)
+def mock_service(pyramid_config):
+    def mock_service(service_class, name):
+        service = create_autospec(service_class, instance=True, spec_set=True)
         pyramid_config.register_service(service, name=name)
 
         return service
 
-    return service_mocker
+    return mock_service
 
 
 @pytest.fixture
-def search_index(service_mocker):
-    return service_mocker(SearchIndexService, "search_index")
+def search_index(mock_service):
+    return mock_service(SearchIndexService, "search_index")
 
 
 @pytest.fixture
-def nipsa_service(pyramid_config):
-    return service_mocker(NipsaService, name="nipsa")
+def nipsa_service(mock_service):
+    nipsa_service = mock_service(NipsaService, name="nipsa")
+    nipsa_service.is_flagged.return_value = False
+
+    return nipsa_service

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -5,15 +5,13 @@ import pytest
 from h.services.nipsa import NipsaService
 from h.services.search_index import SearchIndexService
 
-# Allow people to mass import everything without getting things we don't
-# mean them to like pytest.
 __all__ = ("service_mocker", "search_index")
 
 
 @pytest.fixture
 def service_mocker(pyramid_config):
     def service_mocker(class_, name):
-        service = create_autospec(class_, instance=True)
+        service = create_autospec(class_, instance=True, spec_set=True)
         pyramid_config.register_service(service, name=name)
 
         return service

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -1,14 +1,31 @@
-from unittest import mock
+from unittest.mock import create_autospec
 
 import pytest
 
 from h.services.nipsa import NipsaService
+from h.services.search_index import SearchIndexService
+
+# Allow people to mass import everything without getting things we don't
+# mean them to like pytest.
+__all__ = ("service_mocker", "search_index")
+
+
+@pytest.fixture
+def service_mocker(pyramid_config):
+    def service_mocker(class_, name):
+        service = create_autospec(class_, instance=True)
+        pyramid_config.register_service(service, name=name)
+
+        return service
+
+    return service_mocker
+
+
+@pytest.fixture
+def search_index(service_mocker):
+    return service_mocker(SearchIndexService, "search_index")
 
 
 @pytest.fixture
 def nipsa_service(pyramid_config):
-    service = mock.create_autospec(NipsaService, spec_set=True, instance=True)
-    service.is_flagged.return_value = False
-
-    pyramid_config.register_service(service, name="nipsa")
-    return service
+    return service_mocker(NipsaService, name="nipsa")

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -20,7 +20,7 @@ from h import db, models
 from h.settings import database_url
 from tests.common.fixtures import es_client  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
-from tests.common.fixtures.services import nipsa_service  # noqa: F401
+from tests.common.fixtures.services import *  # noqa: F403,F401
 
 TEST_AUTHORITY = "example.com"
 TEST_DATABASE_URL = database_url(

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -205,7 +205,11 @@ class TestSyncAnnotation:
 
     @pytest.fixture(autouse=True)
     def transaction_manager(self, pyramid_request):
-        pyramid_request.tm = mock.MagicMock(spec=["__enter__", "__exit__"])
+        from transaction import TransactionManager
+
+        pyramid_request.tm = mock.create_autospec(
+            TransactionManager, instance=True, spec_set=True
+        )
         return pyramid_request.tm
 
     @pytest.fixture

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -183,6 +183,20 @@ class TestSyncAnnotation:
         delete_annotation.delay.assert_called_once_with(event.annotation_id)
         assert not add_annotation.delay.called
 
+    @pytest.mark.usefixtures("search_index")
+    @pytest.mark.parametrize("synchronous", (True, False))
+    def test_nothing_happens_with_an_unrecognised_action(
+        self, add_annotation, delete_annotation, pyramid_request, synchronous
+    ):
+        pyramid_request.feature.flags = {"synchronous_indexing": synchronous}
+        event = AnnotationEvent(
+            pyramid_request, {"id": "test_annotation_id"}, "something_strange"
+        )
+        subscribers.sync_annotation(event)
+
+        assert not delete_annotation.delay.called
+        assert not add_annotation.delay.called
+
     @pytest.mark.parametrize(
         "action,method",
         (

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -1,11 +1,10 @@
 import datetime
 from unittest import mock
-from unittest.mock import create_autospec, sentinel
+from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
 
-from h.services.search_index.service import SearchIndexService
 from h.tasks import indexer
 
 
@@ -25,13 +24,6 @@ class TestSearchIndexServicesWrapperTasks:
         search_index.delete_annotation_by_id.assert_called_once_with(
             sentinel.annotation_id
         )
-
-    @pytest.fixture(autouse=True)
-    def search_index(self, pyramid_config):
-        search_index = create_autospec(SearchIndexService, instance=True)
-        pyramid_config.register_service(search_index, name="search_index")
-
-        return search_index
 
 
 class TestReindexUserAnnotations:


### PR DESCRIPTION
The feature is called `synchronous_indexing` and can be enabled by going to http://localhost:5000/admin/features and checking the box.

# Testing

*Old path*

* Start `h`, `client`, and `via3`
* Goto: http://localhost:9083/html/v/http://example.com/?via.rewrite=on&via.client.openSidebar=1
* Add an annotation
* Refresh the page, it should be there still
* Delete it
* Refresh the page, it should be gone

*New path*

* Goto: http://localhost:5000/admin/features
* Check `synchronous_indexing` for `everyone`
* Repeat the old path tests with the same results

*Without rabbit*

* Run `docker stop h_rabbit_1`
* Repeat the new path tests
* Observe there is no god and `h` blocks indefinitely when rabbit is down

If you want to be sure the new path got run either add logging or raise an exception with the feature flag enabled.