### PR TITLE
Fail realtime annotation update messages quickly if Rabbit is down

### DIFF
--- a/h/exceptions.py
+++ b/h/exceptions.py
@@ -3,3 +3,10 @@ class InvalidUserId(Exception):
 
     def __init__(self, user_id):
         super().__init__(f"User id '{user_id}' is not valid")
+
+
+class RealtimeMessageQueueError(Exception):
+    """A message could not be sent to the realtime Rabbit queue."""
+
+    def __init__(self):
+        super().__init__("Could not queue message")

--- a/h/realtime.py
+++ b/h/realtime.py
@@ -1,7 +1,6 @@
 import base64
 import random
 import struct
-from logging import getLogger
 
 import kombu
 from kombu.exceptions import LimitExceeded, OperationalError
@@ -9,8 +8,6 @@ from kombu.mixins import ConsumerMixin
 from kombu.pools import producers as producer_pool
 
 from h.exceptions import RealtimeMessageQueueError
-
-LOG = getLogger(__name__)
 
 
 class Consumer(ConsumerMixin):
@@ -106,8 +103,6 @@ class Publisher:
         except (OperationalError, LimitExceeded) as err:
             # If we fail to connect (OperationalError), or we don't get a
             # producer from the pool in time (LimitExceeded) raise
-            LOG.error("Failed to queue realtime message with error %s", err)
-            LOG.debug("Failed message payload was: %s", payload)
             raise RealtimeMessageQueueError() from err
 
 

--- a/h/realtime.py
+++ b/h/realtime.py
@@ -135,11 +135,11 @@ def get_connection(settings, fail_fast=False):
             # connection error will be re-raised
             "max_retries": 2,
             # The number of seconds we start sleeping for (when retrying)
-            "interval_start": 0.1,
+            "interval_start": 0.2,
             #  How many seconds added to the interval for each retry
-            "interval_step": 0.1,
+            "interval_step": 0.2,
             # Maximum number of seconds to sleep between each retry
-            "interval_max": 1.0,
+            "interval_max": 0.6,
         }
 
     return kombu.Connection(conn, **kwargs)

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -1,5 +1,4 @@
-from logging import getLogger
-
+from h_pyramid_sentry import report_exception
 from pyramid.events import BeforeRender, subscriber
 
 from h import __version__, emails, storage
@@ -8,8 +7,6 @@ from h.exceptions import RealtimeMessageQueueError
 from h.notification import reply
 from h.tasks import mailer
 from h.tasks.indexer import add_annotation, delete_annotation
-
-LOG = getLogger(__name__)
 
 
 @subscriber(BeforeRender)
@@ -94,9 +91,5 @@ def publish_annotation_event(event):
     try:
         event.request.realtime.publish_annotation(data)
 
-    except RealtimeMessageQueueError:
-        LOG.warning(
-            "Failed to publish annotation %s event for annotation '%s'",
-            event.action,
-            event.annotation_id,
-        )
+    except RealtimeMessageQueueError as err:
+        report_exception(err)

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from h import subscribers
 from h.events import AnnotationEvent
+from h.exceptions import RealtimeMessageQueueError
 
 
 class FakeMailer:
@@ -83,6 +84,19 @@ class TestPublishAnnotationEvent:
                 "src_client_id": "client_id",
             }
         )
+
+    def test_it_exits_cleanly_when_RealtimeMessageQueueError_is_raised(self, event):
+        event.request.realtime.publish_annotation.side_effect = (
+            RealtimeMessageQueueError
+        )
+
+        subscribers.publish_annotation_event(event)
+
+    def test_it_raises_for_other_errors(self, event):
+        event.request.realtime.publish_annotation.side_effect = EnvironmentError
+
+        with pytest.raises(EnvironmentError):
+            subscribers.publish_annotation_event(event)
 
     @pytest.fixture
     def event(self, pyramid_request):


### PR DESCRIPTION
With https://github.com/hypothesis/h/pull/6267 we have cut Rabbit out of the mechanism for synchronising annotations to Elasticsearch, but we still need it to queue messages for the websocket. 

Previously we would wait _forever_ attempting to get a connection to Rabbit when sending these messages meaning:

 * The client would never get a successful response
 * We would block the worker indefinitely (presumably until the Gunicorn timeout)
 * We would have additional service degradation as fewer workers would be available to respond to new requests

This puts a pretty short leash on how long we will wait around trying to get a connection. If we fail, we log and move on.

### Testing

**Old path:**

- Start h, client, and via3
- Goto: http://localhost:9083/html/v/http://example.com/?via.rewrite=on&via.client.openSidebar=1
- Add an annotation
- Refresh the page, it should be there still
- Delete it
- Refresh the page, it should be gone
- Run `docker stop h_rabbit_1`
- Repeat the tests above
- The thread should hang indefintely

**New path:**

- Repeat the above
- Everything should work fine
- There should be logging output complaining about failures

### Open questions

 * Are these numbers right? Are the timings correct?
 * Should we be only enabling this with `syncrhonous_indexing` enabled, or all the time? (It's presently all the time)
 * This only applies to the `producer` which adds messages, what about the `consumer` that is used in the websocket?