### PR TITLE
Use the delayed task when the synchronous task fails

### DIFF
--- a/h/services/search_index/service.py
+++ b/h/services/search_index/service.py
@@ -38,7 +38,7 @@ class SearchIndexService:
         :param annotation_id: Id of the annotation to add.
         """
         annotation = storage.fetch_annotation(self._db, annotation_id)
-        if not annotation:
+        if not annotation or annotation.deleted:
             return
 
         self.add_annotation(annotation)
@@ -56,6 +56,9 @@ class SearchIndexService:
 
         :param annotation: Annotation object to index
         """
+        if annotation.deleted:
+            return
+
         body = AnnotationSearchIndexPresenter(annotation, self._request).asdict()
 
         self._index_annotation_body(annotation.id, body, refresh=False)

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -28,6 +28,15 @@ class TestAddAnnotationById:
 
         add_annotation.assert_not_called()
 
+    def test_it_does_nothing_if_the_annotation_is_deleted(
+        self, search_index, root_annotation, es_client
+    ):
+        root_annotation.deleted = True
+
+        search_index.add_annotation_by_id(root_annotation.id)
+
+        es_client.conn.index.assert_not_called()
+
     def test_it_also_adds_the_thread_root(
         self, search_index, reply_annotation, root_annotation, storage, add_annotation
     ):
@@ -113,6 +122,15 @@ class TestAddAnnotation:
             id=annotation.id,
             refresh=False,
         )
+
+    def test_it_does_nothing_if_the_annotation_is_deleted(
+        self, search_index, annotation, es_client
+    ):
+        annotation.deleted = True
+
+        search_index.add_annotation(annotation)
+
+        es_client.conn.index.assert_not_called()
 
     @pytest.fixture
     def annotation(self, factories):

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -174,71 +174,22 @@ class TestSendReplyNotifications:
 
 
 class TestSyncAnnotation:
-    @pytest.mark.usefixtures("without_synchronous_flag")
-    @pytest.mark.parametrize("action", ["create", "update"])
-    def test_it_enqueues_add_annotation_celery_task(
-        self,
-        pyramid_request,
-        action,
-        add_annotation,
-        delete_annotation,
-        transaction_manager,
-    ):
-        event = AnnotationEvent(pyramid_request, {"id": "any"}, action)
-
-        subscribers.sync_annotation(event)
-
-        transaction_manager.__enter__.assert_called_once()
-        add_annotation.delay.assert_called_once_with(event.annotation_id)
-        transaction_manager.__exit__.assert_called_once()
-        assert not delete_annotation.delay.called
-
-    @pytest.mark.usefixtures("without_synchronous_flag")
-    def test_it_enqueues_delete_annotation_celery_task_for_delete(
-        self, add_annotation, delete_annotation, pyramid_request
-    ):
-        event = AnnotationEvent(pyramid_request, {"id": "test_annotation_id"}, "delete")
-
-        subscribers.sync_annotation(event)
-
-        delete_annotation.delay.assert_called_once_with(event.annotation_id)
-        assert not add_annotation.delay.called
-
-    @pytest.mark.usefixtures("search_index")
     @pytest.mark.parametrize("synchronous", (True, False))
-    def test_nothing_happens_with_an_unrecognised_action(
-        self, add_annotation, delete_annotation, pyramid_request, synchronous
+    def test_it_calls_sync_service(
+        self, pyramid_request, search_index, transaction_manager, synchronous
     ):
         pyramid_request.feature.flags = {"synchronous_indexing": synchronous}
-        event = AnnotationEvent(
-            pyramid_request, {"id": "test_annotation_id"}, "something_strange"
-        )
-        subscribers.sync_annotation(event)
-
-        assert not delete_annotation.delay.called
-        assert not add_annotation.delay.called
-
-    @pytest.mark.parametrize(
-        "action,method",
-        (
-            ("create", "add_annotation_by_id"),
-            ("update", "add_annotation_by_id"),
-            ("delete", "delete_annotation_by_id"),
-        ),
-    )
-    @pytest.mark.usefixtures("with_synchronous_flag")
-    def test_it_calls_sync_service(
-        self, action, pyramid_request, search_index, method, transaction_manager
-    ):
-        event = AnnotationEvent(pyramid_request, {"id": "any"}, action)
+        event = AnnotationEvent(pyramid_request, {"id": "any"}, "action")
 
         subscribers.sync_annotation(event)
 
         transaction_manager.__enter__.assert_called_once()
-        getattr(search_index, method).assert_called_once_with(event.annotation_id)
+        search_index.handle_annotation_event.assert_called_once_with(
+            event, synchronous=synchronous
+        )
         transaction_manager.__exit__.assert_called_once()
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture
     def transaction_manager(self, pyramid_request):
         from transaction import TransactionManager
 
@@ -246,19 +197,3 @@ class TestSyncAnnotation:
             TransactionManager, instance=True, spec_set=True
         )
         return pyramid_request.tm
-
-    @pytest.fixture
-    def with_synchronous_flag(self, pyramid_request):
-        pyramid_request.feature.flags = {"synchronous_indexing": True}
-
-    @pytest.fixture
-    def without_synchronous_flag(self, pyramid_request):
-        pyramid_request.feature.flags = {"synchronous_indexing": False}
-
-    @pytest.fixture(autouse=True)
-    def add_annotation(self, patch):
-        return patch("h.subscribers.add_annotation")
-
-    @pytest.fixture(autouse=True)
-    def delete_annotation(self, patch):
-        return patch("h.subscribers.delete_annotation")


### PR DESCRIPTION
This gives us more robustness to temporary failures with ElasticSearch

### Testing notes

 * Start H and friends and find a page to annotate
 * Go to: http://localhost:5000/admin/features and enable `synchronous_indexing`
 * Annotate and delete and observe this persists over page reloads
 * Run `docker stop h_elasticsearch_1`
 * Then _quickly_ annotate and run `docker start h_elasticsearch_1`
 * You should see a big explosion in the logs, and a task being queued
 * Keep refreshing the page, eventually the annotation should appear or disappear as expected