### PR TITLE
Make the email task fail quickly if Rabbit is down

### DIFF
--- a/h/celery.py
+++ b/h/celery.py
@@ -15,6 +15,8 @@ from kombu import Exchange, Queue
 
 __all__ = ("celery", "get_task_logger")
 
+from h.tasks import RETRY_POLICY_QUICK
+
 log = logging.getLogger(__name__)
 
 celery = Celery("h")
@@ -23,6 +25,8 @@ celery.conf.update(
         "CELERY_BROKER_URL",
         os.environ.get("BROKER_URL", "amqp://guest:guest@localhost:5672//"),
     ),
+    # What options should we have when sending messages to the queue?
+    broker_transport_options=RETRY_POLICY_QUICK,
     accept_content=["json"],
     # Enable at-least-once delivery mode. This probably isn't actually what we
     # want for all of our queues, but it makes the failure-mode behaviour of

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from kombu.exceptions import OperationalError
 
 from h import subscribers
 from h.events import AnnotationEvent
@@ -135,6 +136,12 @@ class TestSendReplyNotifications:
         subscribers.send_reply_notifications(event)
 
         mailer_task.delay.assert_not_called()
+
+    def test_it_fails_gracefully_if_the_task_does_not_queue(self, event, mailer_task):
+        mailer_task.side_effect = OperationalError
+
+        # No explosions please
+        subscribers.send_reply_notifications(event)
 
     @pytest.fixture
     def event(self, pyramid_request):


### PR DESCRIPTION
This applies a retry policy to the Celery backend as suggested here:

https://docs.celeryproject.org/en/stable/userguide/configuration.html#broker-connection-timeout

This applies to all messages that get sent by producers. I'm still very unclear on whether this is the connection timeout, or the timeout applied to sending the tasks to the queue (once a connection is established). It may be one and the same. It certainly appears to apply as per the connection task.

This will apply to **all** messages sent when queuing tasks. So this has the effect of making the individual calls to `add_annotation` and `delete_annotation` fail quickly too (which we need).