### PR TITLE
Try and make annotation_sync run first by alphabetical order

### DIFF
--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -177,7 +177,7 @@ class TestSyncAnnotation:
         pyramid_request.feature.flags = {"synchronous_indexing": synchronous}
         event = AnnotationEvent(pyramid_request, {"id": "any"}, "action")
 
-        subscribers.sync_annotation(event)
+        subscribers.annotation_sync(event)
 
         transaction_manager.__enter__.assert_called_once()
         search_index.handle_annotation_event.assert_called_once_with(


### PR DESCRIPTION
Also re-order the event handlers into execution order in the file.

This is a bit of a "maybe" rather than a certainty, but on my machine at least Pyramid appears to call the subscribers in alphabetical order. This uses that fact to try and put `annotation_sync` first.

This is because previously if Rabbit is down the execution would look something like:

 * Try mailing - Celery timeout (~0.6s)
 * Try realtime - Celery timeout (~0.6s)
 * Sync

If you add an annotation and refresh the page, this is a visible change and it looks weird. We want the important stuff first.