### PR TITLE
Fix up subscribers test.py patch fixtures

### DIFF
--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -147,22 +147,6 @@ class TestSendReplyNotifications:
     def event(self, pyramid_request):
         return AnnotationEvent(pyramid_request, {"id": "any"}, "action")
 
-    @pytest.fixture(autouse=True)
-    def mailer_task(self, patch):
-        return patch("h.subscribers.mailer.send")
-
-    @pytest.fixture(autouse=True)
-    def fetch_annotation(self, patch):
-        return patch("h.subscribers.storage.fetch_annotation")
-
-    @pytest.fixture(autouse=True)
-    def get_notification(self, patch):
-        return patch("h.subscribers.reply.get_notification")
-
-    @pytest.fixture(autouse=True)
-    def reply_notification(self, patch):
-        return patch("h.subscribers.emails.reply_notification")
-
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.tm = mock.MagicMock()
@@ -190,3 +174,23 @@ class TestSyncAnnotation:
             TransactionManager, instance=True, spec_set=True
         )
         return pyramid_request.tm
+
+
+@pytest.fixture(autouse=True)
+def fetch_annotation(patch):
+    return patch("h.subscribers.storage.fetch_annotation")
+
+
+@pytest.fixture(autouse=True)
+def get_notification(patch):
+    return patch("h.subscribers.reply.get_notification")
+
+
+@pytest.fixture(autouse=True)
+def mailer_task(patch):
+    return patch("h.subscribers.mailer.send")
+
+
+@pytest.fixture(autouse=True)
+def reply_notification(patch):
+    return patch("h.subscribers.emails.reply_notification")

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -98,7 +98,6 @@ class TestPublishAnnotationEvent:
         return event
 
 
-@pytest.mark.usefixtures("fetch_annotation")
 class TestSendReplyNotifications:
     def test_it_sends_emails(
         self,

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -134,8 +134,8 @@ class TestSendReplyNotifications:
 
         mailer.send.delay.assert_not_called()
 
-    def test_it_fails_gracefully_if_the_task_does_not_queue(self, event, mailer_task):
-        mailer_task.side_effect = OperationalError
+    def test_it_fails_gracefully_if_the_task_does_not_queue(self, event, mailer):
+        mailer.send.side_effect = OperationalError
 
         # No explosions please
         subscribers.send_reply_notifications(event)

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -191,3 +191,8 @@ def mailer(patch):
 @pytest.fixture(autouse=True)
 def emails(patch):
     return patch("h.subscribers.emails")
+
+
+@pytest.fixture(autouse=True)
+def report_exception(patch):
+    return patch("h.subscribers.report_exception")


### PR DESCRIPTION
Various fix ups to the patch fixtures in this module, change them to use our usual style for patch fixtures:

* Put patch fixtures at the bottom of the test file with `autouse=True` so that all code in the source file that's within the scope of the name being patched will get the mock version of that name when run by the tests

* Patch names within the module-under-test's namespace, not names within the modules that it imports

* Add a missing `report_exception()` patch

* Remove an unnecessary `usefixtures`

The approach of patching the top-level imported names with module-level autouse fixtures whose fixture names are exactly the same as the imported names, is designed to make patch fixture maintenance easy:

* It's easy to check that we have a patch fixture for each import that should be patched. Just look for a fixture at the bottom of the file with the same name
* You only have to update the fixtures when the imports change. If the code changes so that another method in the file now uses an imported name when it wasn't before, no change is needed to the fixtures (it's already patched). If the code changes so that it now uses a sub-name of an imported name when it wasn't before, no change is needed to the fixtures (it's already patched). Only if the diff touches the `import` lines themselves do the fixtures potentially need to change
* The extreme regularity in how these patch fixtures are arranged in tests, makes understanding and verifying them easier too
* You never have to think about what to name your patch fixtures or where to put them