### PR TITLE
Allow delete notifications to be sent to people via the websocket

### DIFF
--- a/h/streamer/contexts.py
+++ b/h/streamer/contexts.py
@@ -1,0 +1,15 @@
+from pyramid.security import DENY_ALL
+
+from h.traversal import AnnotationContext
+
+
+class AnnotationNotificationContext(AnnotationContext):
+    """Context for getting notifications about annotations (e.g. websocket)."""
+
+    def __acl__(self):
+        acl = list(self._read_principals())
+
+        # If we haven't explicitly authorized it, it's not allowed.
+        acl.append(DENY_ALL)
+
+        return acl

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -14,8 +14,8 @@ from h.services.links import LinksService
 from h.services.nipsa import NipsaService
 from h.services.user import UserService
 from h.streamer import websocket
+from h.streamer.contexts import AnnotationNotificationContext
 from h.streamer.filter import SocketFilter
-from h.traversal import AnnotationContext
 
 log = logging.getLogger(__name__)
 
@@ -156,7 +156,9 @@ def _generate_annotation_event(
 
         base_url = socket.registry.settings.get("h.app_url", "http://localhost:5000")
         links_service = LinksService(base_url, socket.registry)
-        resource = AnnotationContext(annotation, group_service, links_service)
+        resource = AnnotationNotificationContext(
+            annotation, group_service, links_service
+        )
 
         # Check whether client is authorized to read this annotation.
         read_principals = principals_allowed_by_permission(resource, "read")

--- a/tests/h/streamer/contexts_test.py
+++ b/tests/h/streamer/contexts_test.py
@@ -1,0 +1,42 @@
+import pytest
+from h_matchers import Any
+from pyramid.security import DENY_ALL
+
+from h.services.groupfinder import GroupfinderService
+from h.streamer.contexts import AnnotationNotificationContext
+
+
+class TestAnnotationNotificationContext:
+    def test_public_annotation_permissions(self, get_context_acl, factories):
+        acl = get_context_acl(factories.Annotation(shared=True))
+
+        assert acl[0] == ("Allow", "system.Everyone", "read")
+
+    def test_private_annotation_permissions(self, get_context_acl, factories):
+        annotation = factories.Annotation(shared=False)
+        acl = get_context_acl(annotation)
+
+        assert acl[0] == ("Allow", annotation.userid, "read")
+
+    def test_deleted_still_returns_read_permissions(self, get_context_acl, factories):
+        acl = get_context_acl(factories.Annotation(deleted=True))
+
+        assert acl[0] == ("Allow", Any.string(), "read")
+
+    def test_it_always_adds_deny_last(self, get_context_acl, factories):
+        acl = get_context_acl(factories.Annotation())
+
+        assert acl[-1] == DENY_ALL
+
+    @pytest.fixture
+    def get_context_acl(self, db_session):
+        def get_context(annotation):
+            group_service = GroupfinderService(db_session, annotation.authority)
+
+            context = AnnotationNotificationContext(
+                annotation, group_service=group_service, links_service=None
+            )
+
+            return context.__acl__()
+
+        return get_context

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -129,20 +129,20 @@ class TestHandleAnnotationEvent:
         fetch_annotation,
         links_service,
         groupfinder_service,
-        AnnotationContext,
+        AnnotationNotificationContext,
         AnnotationUserInfoFormatter,
         AnnotationJSONPresenter,
     ):
         handle_annotation_event()
 
-        AnnotationContext.assert_called_once_with(
+        AnnotationNotificationContext.assert_called_once_with(
             fetch_annotation.return_value,
             groupfinder_service.return_value,
             links_service.return_value,
         )
 
         AnnotationJSONPresenter.assert_called_once_with(
-            AnnotationContext.return_value,
+            AnnotationNotificationContext.return_value,
             formatters=[AnnotationUserInfoFormatter.return_value],
         )
         assert AnnotationJSONPresenter.return_value.asdict.called
@@ -222,7 +222,7 @@ class TestHandleAnnotationEvent:
         handle_annotation_event,
         user_principals,
         can_see,
-        AnnotationContext,
+        AnnotationNotificationContext,
         principals_allowed_by_permission,
         socket,
     ):
@@ -232,7 +232,7 @@ class TestHandleAnnotationEvent:
         handle_annotation_event(sockets=[socket])
 
         principals_allowed_by_permission.assert_called_with(
-            AnnotationContext.return_value, "read"
+            AnnotationNotificationContext.return_value, "read"
         )
         assert bool(socket.send_json.call_count) == can_see
 
@@ -284,8 +284,8 @@ class TestHandleAnnotationEvent:
         return patch("h.streamer.messages.AnnotationUserInfoFormatter")
 
     @pytest.fixture
-    def AnnotationContext(self, patch):
-        return patch("h.streamer.messages.AnnotationContext")
+    def AnnotationNotificationContext(self, patch):
+        return patch("h.streamer.messages.AnnotationNotificationContext")
 
     @pytest.fixture(autouse=True)
     def AnnotationJSONPresenter(self, patch):


### PR DESCRIPTION
 * Add a new context for annotation notifications to get the correct ACL
 * This one doesn't deny all if the annotation is deleted
 * It focusses only on the `read` permission we need