### PR TITLE
Add DB migration to add job table

### DIFF
--- a/h/migrations/versions/be612e693243_add_the_job_table.py
+++ b/h/migrations/versions/be612e693243_add_the_job_table.py
@@ -1,0 +1,38 @@
+"""Add the job table."""
+from alembic import op
+from sqlalchemy import Column, DateTime, Integer, Sequence, UnicodeText, func, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.schema import CreateSequence, DropSequence
+
+revision = "be612e693243"
+down_revision = "64039842150a"
+
+
+def upgrade():
+    op.execute(CreateSequence(Sequence("job_id_seq", cycle=True)))
+    op.create_table(
+        "job",
+        Column("id", Integer, Sequence("job_id_seq", cycle=True), primary_key=True),
+        Column("name", UnicodeText, nullable=False),
+        Column("enqueued_at", DateTime, nullable=False, server_default=func.now()),
+        Column("scheduled_at", DateTime, nullable=False, server_default=func.now()),
+        Column(
+            "expires_at",
+            DateTime,
+            nullable=False,
+            server_default=text("now() + interval '30 days'"),
+        ),
+        Column("priority", Integer, nullable=False),
+        Column("tag", UnicodeText, nullable=False),
+        Column(
+            "kwargs",
+            JSONB,
+            server_default=text("'{}'::jsonb"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("job")
+    op.execute(DropSequence(Sequence("job_id_seq")))


### PR DESCRIPTION
See: https://github.com/hypothesis/h/pull/6265

Testing:

```terminal
$ git checkout master
$ make services args='down'; and make services db devdata
...
$ tox -qqe dockercompose -- exec postgres psql -U postgres -c "\d job"
Did not find any relation named "job".
$ git fetch && git checkout --track origin/add-job-table
$ make db args='upgrade +1'
...
$ tox -qqe dockercompose -- exec postgres psql -U postgres -c "\d job"
                                    Table "public.job"
    Column    |            Type             | Collation | Nullable |       Default        
--------------+-----------------------------+-----------+----------+----------------------
 id           | uuid                        |           | not null | uuid_generate_v1mc()
 enqueued_at  | timestamp without time zone |           | not null | now()
 scheduled_at | timestamp without time zone |           | not null | now()
 tag          | text                        |           | not null | 
 kwargs       | jsonb                       |           | not null | '{}'::jsonb
Indexes:
    "pk__job" PRIMARY KEY, btree (id)

$ make db args='downgrade -1'
...
$ tox -qqe dockercompose -- exec postgres psql -U postgres -c "\d job"
Did not find any relation named "job".
$  
```