### PR TITLE
Optimised websocket message sending

### DIFF
--- a/tests/h/streamer/messages_speed_test.py
+++ b/tests/h/streamer/messages_speed_test.py
@@ -1,0 +1,83 @@
+import pytest
+from _datetime import datetime
+from pyramid import security
+
+from h.streamer.messages import handle_annotation_event
+from h.streamer.websocket import WebSocket
+from h.websocket import create_app
+from tests.common.fixtures.elasticsearch import ELASTICSEARCH_INDEX, ELASTICSEARCH_URL
+
+
+@pytest.mark.skip("Only of use during development")
+class TestHandleAnnotationEventSpeed:  # pragma: no cover
+    @pytest.mark.parametrize("reps", (1, 16, 256, 4096))
+    @pytest.mark.parametrize("action", ("create", "delete"))
+    def test_speed(self, db_session, registry, socket, message, action, reps):
+        sockets = list(socket for _ in range(reps))
+        message["action"] = action
+
+        start = datetime.utcnow()
+        handle_annotation_event(message, sockets, registry, db_session)
+        diff = datetime.utcnow() - start
+
+        assert socket.send_json.count == reps
+
+        millis = diff.seconds * 1000 + diff.microseconds / 1000
+        print(
+            f"{action} x {reps}: {millis} ms, {millis/reps} ms/item, {reps/millis*1000} items/sec"
+        )
+
+    @pytest.fixture
+    def annotation(self, factories):
+        return factories.Annotation()
+
+    @pytest.fixture()
+    def message(self, annotation):
+        return {
+            "annotation_id": annotation.id,
+            "action": "create",
+            "src_client_id": "1235",
+        }
+
+    @pytest.fixture(scope="session")
+    def registry(self):
+        settings = {
+            "es.url": ELASTICSEARCH_URL,
+            "es.index": ELASTICSEARCH_INDEX,
+            "h.app_url": "http://example.com",
+            "h.authority": "example.com",
+            "secret_key": "notasecret",
+            "sqlalchemy.url": "postgresql://postgres@localhost/htest",
+        }
+
+        return create_app(None, **settings).registry
+
+    @pytest.fixture(autouse=True)
+    def SocketFilter(self, patch):
+        # We aren't interested in the speed of the socket filter, as that has
+        # it's own speed tests
+        SocketFilter = patch("h.streamer.messages.SocketFilter")
+        SocketFilter.matching.side_effect = lambda sockets, annotation: iter(sockets)
+        return SocketFilter
+
+    @pytest.fixture
+    def socket(self, registry):
+        socket = WebSocket(
+            sock=None,
+            environ={
+                "h.ws.authenticated_userid": "foo",
+                "h.ws.effective_principals": [security.Everyone, "group:__world__"],
+                "h.ws.streamer_work_queue": None,
+            },
+        )
+
+        # We need to fake out the send reply function so it doesn't try and
+        # actually do it. Using a mock here is _very_ slow in the numbers we are
+        # doing
+        def fake_send(_reply):
+            fake_send.count += 1
+
+        fake_send.count = 0
+        socket.send_json = fake_send
+
+        return socket

--- a/tests/h/streamer/messages_speed_test.py
+++ b/tests/h/streamer/messages_speed_test.py
@@ -31,7 +31,7 @@ class TestHandleAnnotationEventSpeed:  # pragma: no cover
     def annotation(self, factories):
         return factories.Annotation()
 
-    @pytest.fixture()
+    @pytest.fixture
     def message(self, annotation):
         return {
             "annotation_id": annotation.id,

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from unittest.mock import Mock, create_autospec, sentinel
 
 import pytest
@@ -325,15 +326,18 @@ class TestHandleUserEvent:
     def test_sends_session_change_when_joining_or_leaving_group(self, socket, message):
         socket.authenticated_userid = message["userid"]
 
-        messages.handle_user_event(message, [socket], None, None)
+        messages.handle_user_event(message, [socket, socket], None, None)
 
-        socket.send_json.assert_called_once_with(
-            {
-                "type": "session-change",
-                "action": "group-join",
-                "model": message["session_model"],
-            }
-        )
+        reply = {
+            "type": "session-change",
+            "action": "group-join",
+            "model": message["session_model"],
+        }
+
+        assert socket.send_json.call_args_list == [
+            mock.call(reply),
+            mock.call(reply),
+        ]
 
     def test_no_send_when_socket_is_not_event_users(self, socket, message):
         """Don't send session-change events if the event user is not the socket user."""

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -154,6 +154,12 @@ class TestWebSocket:
 
         assert not fake_socket_send.called
 
+    @pytest.fixture(autouse=True)
+    def with_no_socket_instances(self):
+        # The instances set is automatically populated when web sockets are
+        # created and can couple different tests together
+        websocket.WebSocket.instances.clear()
+
     @pytest.fixture
     def client(self, fake_environ):
         sock = mock.Mock(spec_set=["sendall"])


### PR DESCRIPTION
Currently theres a lot of repeated work in the preparing and sending of messages. This should be easy to improve.

Some numbers:
```
Master:

create x 1:    8.08 ms, 8.08 ms/item, 123.67 items/sec
create x 16:   10.96 ms, 0.68 ms/item, 1459.72 items/sec
create x 256:  88.39 ms, 0.34 ms/item, 2896.18 items/sec
create x 4096: 1245.62 ms, 0.30 ms/item, 3288.29 items/sec
delete x 1:    7.63 ms, 7.63 ms/item, 130.90 items/sec
delete x 16:   11.63 ms, 0.72 ms/item, 1374.80 items/sec
delete x 256:  89.42 ms, 0.34 ms/item, 2862.83 items/sec
delete x 4096: 1259.40 ms, 0.30 ms/item, 3252.33 items/sec

Optimised:

create x 1:    8.43 ms, 8.43 ms/item, 118.53 items/sec
create x 16:   9.29 ms, 0.58 ms/item, 1721.72 items/sec
create x 256:  8.06 ms, 0.03 ms/item, 31730.29 items/sec
create x 4096: 9.55 ms, 0.00 ms/item, 428900.52 items/sec
delete x 1:    3.92 ms, 3.92 ms/item, 254.58 items/sec
delete x 16:   4.30 ms, 0.26 ms/item, 3716.60 items/sec
delete x 256:  4.17 ms, 0.01 ms/item, 61273.33 items/sec
delete x 4096: 10.16 ms, 0.00 ms/item, 402911.66 items/sec
```

**Note:** This does not include the actual time to send the reply, only do all of the work to decide to. That sending process is likely pretty significant, but also outside of our control.

The message here is that:

 * In normal circumstances we aren't going to see much performance difference
 * ... but our scaling is _much_ better if we need to send a lot of notifications (close to constant time for any reasonable number)