### PR TITLE
Refactor message tests to reduce duplication

### DIFF
--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -137,9 +137,6 @@ def _generate_annotation_event(
     """
     action = message["action"]
 
-    if action == "read":
-        return None
-
     if message["src_client_id"] == socket.client_id:
         return None
 


### PR DESCRIPTION
 * Used a caller pattern to make the thing under test more obvious
 * This has the side effect of making them easier to change when refactoring
 * As you can change the caller when the signature changes in one place
 * Removed custom test objects in place of mocks
 * Removed 'read' check, because it never happens