### PR TITLE
Use a single prepare per request instead of one per socket

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,5 +12,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 96.89
+fail_under = 96.92
 skip_covered = True

--- a/h/streamer/__init__.py
+++ b/h/streamer/__init__.py
@@ -3,7 +3,7 @@ from h.streamer.tweens import close_db_session_tween_factory
 __all__ = ["close_db_session_tween_factory"]
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     config.include("h.streamer.views")
 
     config.add_subscriber(

--- a/h/streamer/kill_switch_views.py
+++ b/h/streamer/kill_switch_views.py
@@ -9,5 +9,5 @@ def not_found(_exc, _request):
     return Response(status="429 Offline", headerlist=[])
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     config.scan(__name__)

--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -12,7 +12,6 @@ def websocket_view(request):
         {
             "h.ws.authenticated_userid": request.authenticated_userid,
             "h.ws.effective_principals": request.effective_principals,
-            "h.ws.registry": request.registry,
             "h.ws.streamer_work_queue": streamer.WORK_QUEUE,
         }
     )

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -57,7 +57,6 @@ class WebSocket(_WebSocket):
 
         self.authenticated_userid = environ["h.ws.authenticated_userid"]
         self.effective_principals = environ["h.ws.effective_principals"]
-        self.registry = environ["h.ws.registry"]
 
         self._work_queue = environ["h.ws.streamer_work_queue"]
 

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -353,8 +353,7 @@ class TestHandleUserEvent:
 
 
 @pytest.fixture
-def socket(pyramid_request):
+def socket():
     socket = create_autospec(WebSocket, instance=True)
     socket.effective_principals = [security.Everyone, "group:__world__"]
-    socket.registry = pyramid_request.registry
     return socket

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -117,11 +117,13 @@ class TestHandleAnnotationEvent:
         assert result is None
 
     def test_it_initializes_groupfinder_service(
-        self, groupfinder_service, handle_annotation_event, settings, session
+        self, groupfinder_service, handle_annotation_event, registry, session
     ):
-        handle_annotation_event(settings=settings, session=session)
+        handle_annotation_event(registry=registry, session=session)
 
-        groupfinder_service.assert_called_once_with(session, settings["h.authority"])
+        groupfinder_service.assert_called_once_with(
+            session, registry.settings["h.authority"]
+        )
 
     def test_it_serializes_the_annotation(
         self,
@@ -237,23 +239,26 @@ class TestHandleAnnotationEvent:
         assert bool(socket.send_json.call_count) == can_see
 
     @pytest.fixture
-    def handle_annotation_event(self, message, socket, settings, session):
+    def handle_annotation_event(self, message, socket, registry, session):
         def handle_annotation_event(
-            message=message, sockets=None, settings=settings, session=session
+            message=message, sockets=None, registry=registry, session=session
         ):
             if sockets is None:
                 sockets = [socket]
 
-            return messages.handle_annotation_event(message, sockets, settings, session)
+            return messages.handle_annotation_event(message, sockets, registry, session)
 
         return handle_annotation_event
 
     @pytest.fixture
-    def settings(self):
-        return {
+    def registry(self, pyramid_request):
+        registry = pyramid_request.registry
+        registry.settings = {
             "h.app_url": "http://streamer",
             "h.authority": "example.org",
         }
+
+        return registry
 
     @pytest.fixture
     def session(self):

--- a/tests/h/streamer/views_test.py
+++ b/tests/h/streamer/views_test.py
@@ -12,15 +12,6 @@ def test_websocket_view_adds_auth_state_to_environ(pyramid_config, pyramid_reque
     assert env["h.ws.effective_principals"] == pyramid_request.effective_principals
 
 
-def test_websocket_view_adds_registry_reference_to_environ(pyramid_request):
-    pyramid_request.get_response = lambda _: None
-
-    views.websocket_view(pyramid_request)
-    env = pyramid_request.environ
-
-    assert env["h.ws.registry"] == pyramid_request.registry
-
-
 def test_websocket_view_adds_work_queue_to_environ(pyramid_request):
     pyramid_request.get_response = lambda _: None
 

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -138,9 +138,6 @@ class TestWebSocket:
             "group:__world__",
         ]
 
-    def test_socket_sets_registry_from_environ(self, client):
-        assert client.registry == mock.sentinel.registry
-
     def test_socket_send_json(self, client, fake_socket_send):
         payload = {"foo": "bar"}
 


### PR DESCRIPTION
This constitutes a few moves:

 * Using the app registry globally
 * Removing the per socket registry
 * Using the global registry for the prepare statement

In my testing this takes about 1/3rd off the time to send replies.