### PR TITLE
Separate the DB functionality so it can be re-used

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,5 +12,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 96.92
+fail_under = 96.93
 skip_covered = True

--- a/h/streamer/db.py
+++ b/h/streamer/db.py
@@ -1,0 +1,33 @@
+import logging
+from contextlib import contextmanager
+
+from h import db
+
+LOG = logging.getLogger(__name__)
+
+
+def get_session(settings):
+    """Get a DB session from the provided settings."""
+    return db.Session(bind=db.make_engine(settings))
+
+
+@contextmanager
+def read_only_transaction(session):
+    """Wrap a call in a read only transaction context manager."""
+    try:
+        session.execute(
+            "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE"
+        )
+
+        yield
+
+    except (KeyboardInterrupt, SystemExit):
+        session.rollback()
+        raise
+    except Exception as exc:
+        LOG.warning("Caught exception during streamer transaction:", exc_info=exc)
+        session.rollback()
+    else:
+        session.commit()
+    finally:
+        session.close()

--- a/tests/h/streamer/db_test.py
+++ b/tests/h/streamer/db_test.py
@@ -1,0 +1,59 @@
+from unittest import mock
+from unittest.mock import sentinel
+
+import pytest
+
+from h.streamer.db import get_session, read_only_transaction
+from h.streamer.streamer import UnknownMessageType
+
+
+class TestMakeSession:
+    def test_it(self, db):
+        session = get_session(sentinel.settings)
+
+        db.make_engine.assert_called_once_with(sentinel.settings)
+        db.Session.assert_called_once_with(bind=db.make_engine.return_value)
+        assert session == db.Session.return_value
+
+    @pytest.fixture
+    def db(self, patch):
+        return patch("h.streamer.db.db")
+
+
+class TestReadOnlyTransaction:
+    def test_it_starts_a_read_only_transaction(self, session):
+        with read_only_transaction(session):
+            ...
+
+        assert session.method_calls[0] == mock.call.execute(
+            "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE"
+        )
+
+    def test_it_calls_closes_correctly(self, session):
+        with read_only_transaction(session):
+            ...
+
+        assert session.method_calls[-2:] == [mock.call.commit(), mock.call.close()]
+
+    @pytest.mark.parametrize("exception", (UnknownMessageType, RuntimeError))
+    def test_it_rolls_back_on_handler_exception(self, session, exception):
+        with read_only_transaction(session):
+            raise exception()
+
+        self._assert_rollback_and_close(session)
+
+    @pytest.mark.parametrize("exception", (KeyboardInterrupt, SystemExit))
+    def test_it_reraises_certain_exceptions(self, session, exception):
+        with pytest.raises(exception):
+            with read_only_transaction(session):
+                raise exception
+
+        self._assert_rollback_and_close(session)
+
+    def _assert_rollback_and_close(self, session):
+        session.commit.assert_not_called()
+        assert session.method_calls[-2:] == [mock.call.rollback(), mock.call.close()]
+
+    @pytest.fixture
+    def session(self):
+        return mock.Mock(spec_set=["close", "commit", "execute", "rollback"])


### PR DESCRIPTION
This also separates the testing of transaction stuff from the other
functions of `process_work_queue` method.