### PR TITLE
Centralise service mocks for user, groupfinder and links

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,5 +12,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 96.93
+fail_under = 96.91
 skip_covered = True

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -2,6 +2,7 @@ from unittest.mock import create_autospec
 
 import pytest
 
+from h.services.groupfinder import GroupfinderService
 from h.services.links import LinksService
 from h.services.nipsa import NipsaService
 from h.services.search_index import SearchIndexService
@@ -12,6 +13,7 @@ __all__ = (
     "nipsa_service",
     "user_service",
     "links_service",
+    "groupfinder_service",
 )
 
 from h.services.user import UserService
@@ -49,3 +51,11 @@ def user_service(mock_service):
 @pytest.fixture
 def links_service(mock_service):
     return mock_service(LinksService, name="links")
+
+
+@pytest.fixture
+def groupfinder_service(pyramid_config):
+    service = create_autospec(GroupfinderService, instance=True, spec_set=True)
+    pyramid_config.register_service(service, iface="h.interfaces.IGroupService")
+
+    return service

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -2,10 +2,17 @@ from unittest.mock import create_autospec
 
 import pytest
 
+from h.services.links import LinksService
 from h.services.nipsa import NipsaService
 from h.services.search_index import SearchIndexService
 
-__all__ = ("mock_service", "search_index", "nipsa_service", "user_service")
+__all__ = (
+    "mock_service",
+    "search_index",
+    "nipsa_service",
+    "user_service",
+    "links_service",
+)
 
 from h.services.user import UserService
 
@@ -37,3 +44,8 @@ def nipsa_service(mock_service):
 @pytest.fixture
 def user_service(mock_service):
     return mock_service(UserService, name="user")
+
+
+@pytest.fixture
+def links_service(mock_service):
+    return mock_service(LinksService, name="links")

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -5,7 +5,9 @@ import pytest
 from h.services.nipsa import NipsaService
 from h.services.search_index import SearchIndexService
 
-__all__ = ("mock_service", "search_index", "nipsa_service")
+__all__ = ("mock_service", "search_index", "nipsa_service", "user_service")
+
+from h.services.user import UserService
 
 
 @pytest.fixture
@@ -30,3 +32,8 @@ def nipsa_service(mock_service):
     nipsa_service.is_flagged.return_value = False
 
     return nipsa_service
+
+
+@pytest.fixture
+def user_service(mock_service):
+    return mock_service(UserService, name="user")

--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -43,11 +43,3 @@ class TestGetUser:
         result = accounts.get_user(pyramid_request)
 
         assert result == user
-
-
-@pytest.fixture
-def user_service(pyramid_config):
-    service = mock.Mock(spec_set=["fetch"])
-    service.fetch.return_value = None
-    pyramid_config.register_service(service, name="user")
-    return service

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -195,13 +195,6 @@ class TestCheckURL:
         return factories.Group()
 
     @pytest.fixture
-    def user_service(self, factories, pyramid_config):
-        user_service = mock.Mock(spec_set=["fetch"])
-        user_service.fetch.return_value = factories.User.build()
-        pyramid_config.register_service(user_service, name="user")
-        return user_service
-
-    @pytest.fixture
     def unparse(self):
         return mock.Mock(spec_set=[], return_value="UNPARSED_QUERY")
 

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -13,7 +13,6 @@ from h.auth.policy import (
     TokenAuthenticationPolicy,
 )
 from h.exceptions import InvalidUserId
-from h.services.user import UserService
 
 API_PATHS = ("/api", "/api/foo", "/api/annotations/abc123")
 
@@ -657,13 +656,6 @@ class TestAuthClientAuthenticationPolicy:
             matched_user, verify_auth_client.return_value
         )
         assert principals == principals_for_auth_client_user.return_value
-
-    @pytest.fixture
-    def user_service(self, pyramid_config):
-        service = mock.create_autospec(UserService, spec_set=True, instance=True)
-        service.fetch.return_value = None
-        pyramid_config.register_service(service, name="user")
-        return service
 
     @pytest.fixture
     def principals_for_auth_client(self, patch):

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -7,7 +7,6 @@ import sqlalchemy as sa
 from h.auth import role, util
 from h.models import AuthClient
 from h.models.auth_client import GrantType
-from h.services.user import UserService
 
 FakeUser = namedtuple("FakeUser", ["authority", "admin", "staff", "groups"])
 FakeGroup = namedtuple("FakeGroup", ["pubid"])
@@ -326,14 +325,6 @@ class TestVerifyAuthClient:
     @pytest.fixture
     def hmac(self, patch):
         return patch("h.auth.util.hmac")
-
-
-@pytest.fixture
-def user_service(pyramid_config):
-    service = mock.create_autospec(UserService, spec_set=True, instance=True)
-    service.fetch.return_value = None
-    pyramid_config.register_service(service, name="user")
-    return service
 
 
 @pytest.fixture

--- a/tests/h/notification/reply_test.py
+++ b/tests/h/notification/reply_test.py
@@ -1,10 +1,7 @@
-from unittest import mock
-
 import pytest
 
 from h.models import Annotation, Document, DocumentMeta, Subscriptions
 from h.notification.reply import Notification, get_notification
-from h.services.user import UserService
 
 FIXTURE_DATA = {
     "reply": {
@@ -183,14 +180,10 @@ class TestGetNotification:
         return sub
 
     @pytest.fixture
-    def user_service(self, factories, pyramid_config):
-        user_service = mock.create_autospec(UserService, spec_set=True, instance=True)
-
+    def user_service(self, user_service, factories):
         users = {
             "acct:giraffe@safari.net": factories.User(),
             "acct:elephant@safari.net": factories.User(),
         }
         user_service.fetch.side_effect = users.get
-
-        pyramid_config.register_service(user_service, name="user")
         return user_service

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -39,7 +39,7 @@ class IDDuplicatingFormatter:
 
 
 class TestAnnotationJSONPresenter:
-    def test_asdict(self, document_asdict, group_service, links_service):
+    def test_asdict(self, document_asdict, groupfinder_service, links_service):
         ann = mock.Mock(
             id="the-id",
             created=datetime.datetime(2016, 2, 24, 18, 3, 25, 768),
@@ -54,7 +54,7 @@ class TestAnnotationJSONPresenter:
             references=["referenced-id-1", "referenced-id-2"],
             extra={"extra-1": "foo", "extra-2": "bar"},
         )
-        resource = AnnotationContext(ann, group_service, links_service)
+        resource = AnnotationContext(ann, groupfinder_service, links_service)
 
         document_asdict.return_value = {"foo": "bar"}
 
@@ -91,21 +91,21 @@ class TestAnnotationJSONPresenter:
         assert result == expected
 
     def test_asdict_extra_cannot_override_other_data(
-        self, document_asdict, group_service, links_service
+        self, document_asdict, groupfinder_service, links_service
     ):
         ann = mock.Mock(id="the-real-id", extra={"id": "the-extra-id"})
-        resource = AnnotationContext(ann, group_service, links_service)
+        resource = AnnotationContext(ann, groupfinder_service, links_service)
         document_asdict.return_value = {}
 
         presented = AnnotationJSONPresenter(resource).asdict()
         assert presented["id"] == "the-real-id"
 
     def test_asdict_extra_uses_copy_of_extra(
-        self, document_asdict, group_service, links_service
+        self, document_asdict, groupfinder_service, links_service
     ):
         extra = {"foo": "bar"}
         ann = mock.Mock(id="my-id", extra=extra)
-        resource = AnnotationContext(ann, group_service, links_service)
+        resource = AnnotationContext(ann, groupfinder_service, links_service)
         document_asdict.return_value = {}
 
         AnnotationJSONPresenter(resource).asdict()
@@ -113,9 +113,9 @@ class TestAnnotationJSONPresenter:
         # Presenting the annotation shouldn't change the "extra" dict.
         assert extra == {"foo": "bar"}
 
-    def test_asdict_merges_formatters(self, group_service, links_service):
+    def test_asdict_merges_formatters(self, groupfinder_service, links_service):
         ann = mock.Mock(id="the-real-id", extra={})
-        resource = AnnotationContext(ann, group_service, links_service)
+        resource = AnnotationContext(ann, groupfinder_service, links_service)
 
         formatters = [
             FakeFormatter({"flagged": "nope"}),
@@ -127,7 +127,7 @@ class TestAnnotationJSONPresenter:
         assert presented["flagged"] == "nope"
         assert presented["nipsa"] == "maybe"
 
-    def test_immutable_formatters(self, group_service, links_service):
+    def test_immutable_formatters(self, groupfinder_service, links_service):
         """Double-check we can't mutate the formatters list after the fact.
 
         This is an extra check just to make sure we can't accidentally change
@@ -136,7 +136,7 @@ class TestAnnotationJSONPresenter:
 
         """
         ann = mock.Mock(id="the-real-id", extra={})
-        resource = AnnotationContext(ann, group_service, links_service)
+        resource = AnnotationContext(ann, groupfinder_service, links_service)
 
         formatters = [FakeFormatter({"flagged": "nope"})]
         presenter = AnnotationJSONPresenter(resource, formatters)
@@ -145,9 +145,11 @@ class TestAnnotationJSONPresenter:
 
         assert "enterprise" not in presented
 
-    def test_formatter_uses_annotation_resource(self, group_service, links_service):
+    def test_formatter_uses_annotation_resource(
+        self, groupfinder_service, links_service
+    ):
         annotation = mock.Mock(id="the-id", extra={})
-        resource = AnnotationContext(annotation, group_service, links_service)
+        resource = AnnotationContext(annotation, groupfinder_service, links_service)
 
         formatters = [IDDuplicatingFormatter()]
         presenter = AnnotationJSONPresenter(resource, formatters)
@@ -201,7 +203,7 @@ class TestAnnotationJSONPresenter:
         group_readable,
         action,
         expected,
-        group_service,
+        groupfinder_service,
         links_service,
     ):
         annotation.deleted = False
@@ -213,9 +215,9 @@ class TestAnnotationJSONPresenter:
         }
         group = mock.Mock(spec_set=["__acl__"])
         group.__acl__.return_value = [group_principals[group_readable]]
-        group_service.find.return_value = group
+        groupfinder_service.find.return_value = group
 
-        resource = AnnotationContext(annotation, group_service, links_service)
+        resource = AnnotationContext(annotation, groupfinder_service, links_service)
         presenter = AnnotationJSONPresenter(resource)
         assert expected == presenter.permissions[action]
 

--- a/tests/h/presenters/annotation_jsonld_test.py
+++ b/tests/h/presenters/annotation_jsonld_test.py
@@ -8,7 +8,7 @@ from h.traversal import AnnotationContext
 
 
 class TestAnnotationJSONLDPresenter:
-    def test_asdict(self, group_service, links_service):
+    def test_asdict(self, groupfinder_service, links_service):
         annotation = mock.Mock(
             id="foobar",
             created=datetime.datetime(2016, 2, 24, 18, 3, 25, 768),
@@ -42,14 +42,14 @@ class TestAnnotationJSONLDPresenter:
             ],
         }
 
-        resource = AnnotationContext(annotation, group_service, links_service)
+        resource = AnnotationContext(annotation, groupfinder_service, links_service)
         result = AnnotationJSONLDPresenter(resource).asdict()
 
         assert result == expected
 
-    def test_id_returns_jsonld_id_link(self, group_service, links_service):
+    def test_id_returns_jsonld_id_link(self, groupfinder_service, links_service):
         annotation = mock.Mock(id="foobar")
-        resource = AnnotationContext(annotation, group_service, links_service)
+        resource = AnnotationContext(annotation, groupfinder_service, links_service)
         presenter = AnnotationJSONLDPresenter(resource)
 
         result = presenter.id
@@ -57,9 +57,9 @@ class TestAnnotationJSONLDPresenter:
         assert result == links_service.get.return_value
         links_service.get.assert_called_once_with(annotation, Any())
 
-    def test_bodies_returns_textual_body(self, group_service, links_service):
+    def test_bodies_returns_textual_body(self, groupfinder_service, links_service):
         annotation = mock.Mock(text="Flib flob flab", tags=None)
-        resource = AnnotationContext(annotation, group_service, links_service)
+        resource = AnnotationContext(annotation, groupfinder_service, links_service)
 
         bodies = AnnotationJSONLDPresenter(resource).bodies
 
@@ -71,9 +71,9 @@ class TestAnnotationJSONLDPresenter:
             }
         ]
 
-    def test_bodies_appends_tag_bodies(self, group_service, links_service):
+    def test_bodies_appends_tag_bodies(self, groupfinder_service, links_service):
         annotation = mock.Mock(text="Flib flob flab", tags=["giraffe", "lion"])
-        resource = AnnotationContext(annotation, group_service, links_service)
+        resource = AnnotationContext(annotation, groupfinder_service, links_service)
 
         bodies = AnnotationJSONLDPresenter(resource).bodies
 
@@ -84,19 +84,21 @@ class TestAnnotationJSONLDPresenter:
         } in bodies
         assert {"type": "TextualBody", "value": "lion", "purpose": "tagging"} in bodies
 
-    def test_ignores_selectors_lacking_types(self, group_service, links_service):
+    def test_ignores_selectors_lacking_types(self, groupfinder_service, links_service):
         annotation = mock.Mock(target_uri="http://example.com")
         annotation.target_selectors = [
             {"type": "TestSelector", "test": "foobar"},
             {"something": "else"},
         ]
-        resource = AnnotationContext(annotation, group_service, links_service)
+        resource = AnnotationContext(annotation, groupfinder_service, links_service)
 
         selectors = AnnotationJSONLDPresenter(resource).target[0]["selector"]
 
         assert selectors == [{"type": "TestSelector", "test": "foobar"}]
 
-    def test_rewrites_rangeselectors_same_element(self, group_service, links_service):
+    def test_rewrites_rangeselectors_same_element(
+        self, groupfinder_service, links_service
+    ):
         """
         A RangeSelector that starts and ends in the same element should be
         rewritten to an XPathSelector refinedBy a TextPositionSelector, for
@@ -112,7 +114,7 @@ class TestAnnotationJSONLDPresenter:
                 "endOffset": 43,
             }
         ]
-        resource = AnnotationContext(annotation, group_service, links_service)
+        resource = AnnotationContext(annotation, groupfinder_service, links_service)
 
         selectors = AnnotationJSONLDPresenter(resource).target[0]["selector"]
 
@@ -125,7 +127,7 @@ class TestAnnotationJSONLDPresenter:
         ]
 
     def test_rewrites_rangeselectors_different_element(
-        self, group_service, links_service
+        self, groupfinder_service, links_service
     ):
         """
         A RangeSelector that starts and ends in the different elements should
@@ -142,7 +144,7 @@ class TestAnnotationJSONLDPresenter:
                 "endOffset": 72,
             }
         ]
-        resource = AnnotationContext(annotation, group_service, links_service)
+        resource = AnnotationContext(annotation, groupfinder_service, links_service)
 
         selectors = AnnotationJSONLDPresenter(resource).target[0]["selector"]
 
@@ -166,7 +168,7 @@ class TestAnnotationJSONLDPresenter:
             }
         ]
 
-    def test_ignores_malformed_rangeselectors(self, group_service, links_service):
+    def test_ignores_malformed_rangeselectors(self, groupfinder_service, links_service):
         annotation = mock.Mock(target_uri="http://example.com")
         annotation.target_selectors = [
             {
@@ -176,7 +178,7 @@ class TestAnnotationJSONLDPresenter:
                 "endContainer": "/div[1]/main[1]/article[1]/div[2]/p[339]",
             }
         ]
-        resource = AnnotationContext(annotation, group_service, links_service)
+        resource = AnnotationContext(annotation, groupfinder_service, links_service)
 
         target = AnnotationJSONLDPresenter(resource).target[0]
 

--- a/tests/h/presenters/conftest.py
+++ b/tests/h/presenters/conftest.py
@@ -3,24 +3,6 @@ from unittest import mock
 import pytest
 
 
-class FakeLinksService:
-    def __init__(self):
-        self.last_annotation = None
-
-    def get(self, annotation, name):
-        self.last_annotation = annotation
-        return "http://fake-link/" + name
-
-    def get_all(self, annotation):
-        self.last_annotation = annotation
-        return {"giraffe": "http://giraffe.com", "toad": "http://toad.net"}
-
-
-@pytest.fixture
-def fake_links_service():
-    return FakeLinksService()
-
-
 @pytest.fixture
 def group_service():
     return mock.Mock(spec_set=["find"])

--- a/tests/h/presenters/conftest.py
+++ b/tests/h/presenters/conftest.py
@@ -1,8 +1,0 @@
-from unittest import mock
-
-import pytest
-
-
-@pytest.fixture
-def group_service():
-    return mock.Mock(spec_set=["find"])

--- a/tests/h/schemas/forms/accounts/login_test.py
+++ b/tests/h/schemas/forms/accounts/login_test.py
@@ -5,7 +5,7 @@ import pytest
 from pyramid.exceptions import BadCSRFToken
 
 from h.schemas.forms.accounts import LoginSchema
-from h.services.user import UserNotActivated, UserService
+from h.services.user import UserNotActivated
 from h.services.user_password import UserPasswordService
 
 
@@ -107,16 +107,6 @@ class TestLoginSchema:
         pyramid_request.params = params
 
         assert LoginSchema.default_values(pyramid_request)["username"] == value
-
-
-@pytest.fixture
-def user_service(db_session, pyramid_config):
-    service = Mock(
-        spec_set=UserService(default_authority="example.com", session=db_session)
-    )
-    service.fetch_for_login.return_value = None
-    pyramid_config.register_service(service, name="user")
-    return service
 
 
 @pytest.fixture

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -235,10 +235,10 @@ class TestAnnotationJSONPresentationServiceFactory:
 
 
 @pytest.fixture
-def services(pyramid_config):
-    service_mocks = {}
+def services(pyramid_config, user_service):
+    service_mocks = {"user": user_service}
 
-    for name in ["links", "flag", "flag_count", "annotation_moderation", "user"]:
+    for name in ["links", "flag", "flag_count", "annotation_moderation"]:
         svc = mock.Mock()
         service_mocks[name] = svc
         pyramid_config.register_service(svc, name=name)

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -235,10 +235,10 @@ class TestAnnotationJSONPresentationServiceFactory:
 
 
 @pytest.fixture
-def services(pyramid_config, user_service):
-    service_mocks = {"user": user_service}
+def services(pyramid_config, user_service, links_service):
+    service_mocks = {"user": user_service, "links": links_service}
 
-    for name in ["links", "flag", "flag_count", "annotation_moderation"]:
+    for name in ["flag", "flag_count", "annotation_moderation"]:
         svc = mock.Mock()
         service_mocks[name] = svc
         pyramid_config.register_service(svc, name=name)

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -3,7 +3,6 @@ from unittest import mock
 import pytest
 from h_matchers import Any
 
-from h.interfaces import IGroupService
 from h.services.annotation_json_presentation import (
     AnnotationJSONPresentationService,
     annotation_json_presentation_service_factory,
@@ -235,16 +234,16 @@ class TestAnnotationJSONPresentationServiceFactory:
 
 
 @pytest.fixture
-def services(pyramid_config, user_service, links_service):
-    service_mocks = {"user": user_service, "links": links_service}
+def services(pyramid_config, user_service, links_service, groupfinder_service):
+    service_mocks = {
+        "user": user_service,
+        "links": links_service,
+        "group": groupfinder_service,
+    }
 
     for name in ["flag", "flag_count", "annotation_moderation"]:
         svc = mock.Mock()
         service_mocks[name] = svc
         pyramid_config.register_service(svc, name=name)
-
-    group_svc = mock.Mock()
-    service_mocks["group"] = group_svc
-    pyramid_config.register_service(group_svc, iface=IGroupService)
 
     return service_mocks

--- a/tests/h/services/auth_ticket_test.py
+++ b/tests/h/services/auth_ticket_test.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from unittest import mock
 
 import pytest
 
@@ -11,7 +10,6 @@ from h.services.auth_ticket import (
     AuthTicketService,
     auth_ticket_service_factory,
 )
-from h.services.user import UserService
 
 
 class TestAuthTicketService:
@@ -210,15 +208,6 @@ class TestAuthTicketServiceFactory:
     def test_it_provides_user_service(self, pyramid_request, user_service):
         svc = auth_ticket_service_factory(None, pyramid_request)
         assert svc.usersvc == user_service
-
-
-@pytest.fixture
-def user_service(db_session, pyramid_config):
-    service = mock.Mock(
-        spec=UserService(default_authority="example.com", session=db_session)
-    )
-    pyramid_config.register_service(service, name="user")
-    return service
 
 
 @pytest.fixture

--- a/tests/h/services/group_create_test.py
+++ b/tests/h/services/group_create_test.py
@@ -6,7 +6,6 @@ from h_matchers import Any
 from h.models import Group, GroupScope, User
 from h.models.group import JoinableBy, ReadableBy, WriteableBy
 from h.services.group_create import GroupCreateService, group_create_factory
-from h.services.user import UserService
 from tests.common.matchers import Matcher
 
 
@@ -474,13 +473,6 @@ def svc(db_session, usr_svc, publish):
 @pytest.fixture
 def creator(factories):
     return factories.User(username="group_creator")
-
-
-@pytest.fixture
-def user_service(pyramid_config):
-    service = mock.create_autospec(UserService, spec_set=True, instance=True)
-    pyramid_config.register_service(service, name="user")
-    return service
 
 
 class GroupScopeWithOrigin(Matcher):

--- a/tests/h/services/group_members_test.py
+++ b/tests/h/services/group_members_test.py
@@ -4,7 +4,6 @@ import pytest
 
 from h.models import GroupScope, User
 from h.services.group_members import GroupMembersService, group_members_factory
-from h.services.user import UserService
 from tests.common.matchers import Matcher
 
 
@@ -226,13 +225,6 @@ def group_members_service(db_session, usr_group_members_service, publish):
 @pytest.fixture
 def creator(factories):
     return factories.User(username="group_creator")
-
-
-@pytest.fixture
-def user_service(pyramid_config):
-    service = mock.create_autospec(UserService, spec_set=True, instance=True)
-    pyramid_config.register_service(service, name="user")
-    return service
 
 
 class GroupScopeWithOrigin(Matcher):

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -6,7 +6,6 @@ import pytest
 from h.models import Group, GroupScope, User
 from h.models.group import ReadableBy
 from h.services.group import GroupService, groups_factory
-from h.services.user import UserService
 from tests.common.matchers import Matcher
 
 
@@ -196,13 +195,6 @@ def usr_svc(pyramid_request, db_session):
 @pytest.fixture
 def svc(db_session, usr_svc):
     return GroupService(db_session, usr_svc)
-
-
-@pytest.fixture
-def user_service(pyramid_config):
-    service = mock.create_autospec(UserService, spec_set=True, instance=True)
-    pyramid_config.register_service(service, name="user")
-    return service
 
 
 class GroupWithName(Matcher):

--- a/tests/h/services/oauth_provider_test.py
+++ b/tests/h/services/oauth_provider_test.py
@@ -115,10 +115,3 @@ def validator_service(pyramid_config):
     svc = mock.Mock()
     pyramid_config.register_service(svc, name="oauth_validator")
     return svc
-
-
-@pytest.fixture
-def user_service(pyramid_config):
-    svc = mock.Mock()
-    pyramid_config.register_service(svc, name="user")
-    return svc

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -643,14 +643,14 @@ class TestValidateRefreshToken:
         assert result is True
 
     def test_sets_user_when_token_valid(
-        self, svc, client, oauth_request, token, user_svc
+        self, svc, client, oauth_request, token, user_service
     ):
         def fake_fetch(userid, authority=None):
             if userid == token.userid:
                 return mock.Mock(userid=userid)
             return None
 
-        user_svc.fetch.side_effect = fake_fetch
+        user_service.fetch.side_effect = fake_fetch
 
         assert oauth_request.user is None
         svc.validate_refresh_token(token.refresh_token, client, oauth_request)
@@ -707,20 +707,20 @@ class TestValidateScopes:
         assert svc.validate_scopes("something", scopes, None) is False
 
 
-@pytest.mark.usefixtures("user_svc")
+@pytest.mark.usefixtures("user_service")
 class TestOAuthValidatorServiceFactory:
     def test_it_returns_oauth_service(self, pyramid_request):
         svc = oauth_validator_service_factory(None, pyramid_request)
         assert isinstance(svc, OAuthValidatorService)
 
-    def test_provides_user_service(self, pyramid_request, user_svc):
+    def test_provides_user_service(self, pyramid_request, user_service):
         svc = oauth_validator_service_factory(None, pyramid_request)
-        assert svc.user_svc == user_svc
+        assert svc.user_svc == user_service
 
 
 @pytest.fixture
-def svc(db_session, user_svc):
-    return OAuthValidatorService(db_session, user_svc)
+def svc(db_session, user_service):
+    return OAuthValidatorService(db_session, user_service)
 
 
 @pytest.fixture
@@ -731,13 +731,6 @@ def oauth_request():
 @pytest.fixture
 def client(factories):
     return factories.AuthClient()
-
-
-@pytest.fixture
-def user_svc(pyramid_config):
-    svc = mock.Mock(spec_set=["fetch"])
-    pyramid_config.register_service(svc, name="user")
-    return svc
 
 
 @pytest.fixture

--- a/tests/h/services/user_unique_test.py
+++ b/tests/h/services/user_unique_test.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 
-from h.services.user import UserService
 from h.services.user_unique import (
     DuplicateUserError,
     UserUniqueService,
@@ -181,10 +180,3 @@ def user_model(patch):
 @pytest.fixture
 def svc(db_session, user_service):
     return UserUniqueService(session=db_session, user_service=user_service)
-
-
-@pytest.fixture
-def user_service(pyramid_config):
-    service = mock.create_autospec(UserService, spec_set=True, instance=True)
-    pyramid_config.register_service(service, name="user")
-    return service

--- a/tests/h/streamer/contexts_test.py
+++ b/tests/h/streamer/contexts_test.py
@@ -2,7 +2,6 @@ import pytest
 from h_matchers import Any
 from pyramid.security import DENY_ALL
 
-from h.services.groupfinder import GroupfinderService
 from h.streamer.contexts import AnnotationNotificationContext
 
 
@@ -29,12 +28,10 @@ class TestAnnotationNotificationContext:
         assert acl[-1] == DENY_ALL
 
     @pytest.fixture
-    def get_context_acl(self, db_session):
+    def get_context_acl(self, db_session, groupfinder_service):
         def get_context(annotation):
-            group_service = GroupfinderService(db_session, annotation.authority)
-
             context = AnnotationNotificationContext(
-                annotation, group_service=group_service, links_service=None
+                annotation, group_service=groupfinder_service, links_service=None
             )
 
             return context.__acl__()

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -240,12 +240,6 @@ class TestAnnotationContext:
         )
         return group_service
 
-    @pytest.fixture
-    def links_service(self, pyramid_config):
-        service = mock.Mock(spec_set=["get", "get_all"])
-        pyramid_config.register_service(service, name="links")
-        return service
-
 
 @pytest.mark.usefixtures("links_svc")
 class TestGroupContext:

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -157,12 +157,6 @@ class TestAnnotationRoot:
         )
         return group_service
 
-    @pytest.fixture
-    def links_service(self, pyramid_config):
-        service = mock.Mock()
-        pyramid_config.register_service(service, name="links")
-        return service
-
 
 class TestAuthClientRoot:
     def test_getitem_returns_the_right_AuthClient(self, db_session, pyramid_request):

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -10,7 +10,6 @@ from h.auth import role
 from h.exceptions import InvalidUserId
 from h.models import AuthClient
 from h.services.group import GroupService
-from h.services.user import UserService
 from h.traversal.contexts import AnnotationContext, UserContext
 from h.traversal.roots import (
     AnnotationRoot,
@@ -537,13 +536,6 @@ def client_authority(patch):
     client_authority = patch("h.traversal.roots.client_authority")
     client_authority.return_value = None
     return client_authority
-
-
-@pytest.fixture
-def user_service(pyramid_config):
-    user_service = mock.create_autospec(UserService, spec_set=True, instance=True)
-    pyramid_config.register_service(user_service, name="user")
-    return user_service
 
 
 @pytest.fixture

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -1120,12 +1120,6 @@ class TestUserSearchController:
             orcid="0000-0000-0000-0000",
         )
 
-    @pytest.fixture
-    def user_service(self, patch, pyramid_config):
-        user_service = patch("h.services.user.UserService")
-        pyramid_config.register_service(user_service, name="user")
-        return user_service
-
 
 @pytest.mark.usefixtures("routes", "search")
 class TestGroupAndUserSearchController:

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -7,7 +7,6 @@ from pyramid import httpexceptions
 from h.models import Annotation
 from h.services.annotation_stats import AnnotationStatsService
 from h.services.delete_user import DeleteUserService
-from h.services.user import UserService
 from h.views.admin.users import (
     UserNotFoundError,
     format_date,
@@ -231,16 +230,6 @@ def models(patch):
     module = patch("h.views.admin.users.models")
     module.Annotation = Annotation
     return module
-
-
-@pytest.fixture
-def user_service(pyramid_config, db_session):
-    service = mock.create_autospec(UserService, instance=True, spec_set=True)
-    service.return_value.default_authority = "example.com"
-    service.return_value.session = db_session
-
-    pyramid_config.register_service(service, name="user")
-    return service
 
 
 @pytest.fixture

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -398,13 +398,6 @@ def annotation_resource(patch):
 
 
 @pytest.fixture
-def links_service(pyramid_config):
-    service = mock.Mock(spec_set=["get", "get_all"])
-    pyramid_config.register_service(service, name="links")
-    return service
-
-
-@pytest.fixture
 def presentation_service(pyramid_config):
     svc = mock.Mock(spec_set=["present", "present_all"])
     pyramid_config.register_service(svc, name="annotation_json_presentation")

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -77,7 +77,7 @@ class TestSearch:
     "AnnotationEvent",
     "create_schema",
     "links_service",
-    "group_service",
+    "groupfinder_service",
     "presentation_service",
     "storage",
 )
@@ -115,14 +115,14 @@ class TestCreate:
         assert str(exc.value) == "asplode"
 
     def test_it_creates_the_annotation_in_storage(
-        self, pyramid_request, storage, create_schema, group_service
+        self, pyramid_request, storage, create_schema, groupfinder_service
     ):
         schema = create_schema.return_value
 
         views.create(pyramid_request)
 
         storage.create_annotation.assert_called_once_with(
-            pyramid_request, schema.validate.return_value, group_service
+            pyramid_request, schema.validate.return_value, groupfinder_service
         )
 
     def test_it_raises_if_create_annotation_raises(self, pyramid_request, storage):
@@ -153,7 +153,7 @@ class TestCreate:
         storage,
         annotation_resource,
         pyramid_request,
-        group_service,
+        groupfinder_service,
         links_service,
     ):
 
@@ -162,7 +162,7 @@ class TestCreate:
         views.create(pyramid_request)
 
         annotation_resource.assert_called_once_with(
-            annotation, group_service, links_service
+            annotation, groupfinder_service, links_service
         )
 
     def test_it_presents_annotation(
@@ -244,7 +244,7 @@ class TestReadJSONLD:
 @pytest.mark.usefixtures(
     "AnnotationEvent",
     "links_service",
-    "group_service",
+    "groupfinder_service",
     "presentation_service",
     "update_schema",
     "storage",
@@ -285,7 +285,7 @@ class TestUpdate:
             views.update(mock.Mock(), pyramid_request)
 
     def test_it_updates_the_annotation_in_storage(
-        self, pyramid_request, storage, update_schema, group_service
+        self, pyramid_request, storage, update_schema, groupfinder_service
     ):
         context = mock.Mock()
         schema = update_schema.return_value
@@ -297,7 +297,7 @@ class TestUpdate:
             pyramid_request,
             context.annotation.id,
             mock.sentinel.validated_data,
-            group_service,
+            groupfinder_service,
         )
 
     def test_it_raises_if_storage_raises(self, pyramid_request, storage):
@@ -329,7 +329,7 @@ class TestUpdate:
         storage,
         annotation_resource,
         pyramid_request,
-        group_service,
+        groupfinder_service,
         links_service,
     ):
 
@@ -338,7 +338,7 @@ class TestUpdate:
         views.update(mock.Mock(), pyramid_request)
 
         annotation_resource.assert_called_once_with(
-            annotation, group_service, links_service
+            annotation, groupfinder_service, links_service
         )
 
     def test_it_presents_annotation(
@@ -402,13 +402,6 @@ def presentation_service(pyramid_config):
     svc = mock.Mock(spec_set=["present", "present_all"])
     pyramid_config.register_service(svc, name="annotation_json_presentation")
     return svc
-
-
-@pytest.fixture
-def group_service(pyramid_config):
-    group_service = mock.Mock(spec_set=["find"])
-    pyramid_config.register_service(group_service, iface="h.interfaces.IGroupService")
-    return group_service
 
 
 @pytest.fixture

--- a/tests/h/views/api/flags_test.py
+++ b/tests/h/views/api/flags_test.py
@@ -4,7 +4,6 @@ import pytest
 from pyramid.httpexceptions import HTTPNoContent
 
 from h.services.flag import FlagService
-from h.services.groupfinder import GroupfinderService
 from h.traversal import AnnotationContext
 from h.views.api import flags as views
 
@@ -125,16 +124,6 @@ class TestCreate:
         flag_service = mock.create_autospec(FlagService, instance=True, spec_set=True)
         pyramid_config.register_service(flag_service, name="flag")
         return flag_service
-
-    @pytest.fixture
-    def groupfinder_service(self, pyramid_config):
-        groupfinder_service = mock.create_autospec(
-            GroupfinderService, instance=True, spec_set=True
-        )
-        pyramid_config.register_service(
-            groupfinder_service, iface="h.interfaces.IGroupService"
-        )
-        return groupfinder_service
 
     @pytest.fixture
     def flag_notification_email(self, patch):

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -15,7 +15,6 @@ from h.services.group_links import GroupLinksService
 from h.services.group_list import GroupListService
 from h.services.group_members import GroupMembersService
 from h.services.group_update import GroupUpdateService
-from h.services.user import UserService
 from h.views.api import groups as views
 
 pytestmark = pytest.mark.usefixtures("GroupsJSONPresenter")
@@ -566,11 +565,10 @@ class TestAddMember:
         return pyramid_request
 
     @pytest.fixture
-    def user_service(self, pyramid_config, user):
-        service = mock.create_autospec(UserService, spec_set=True, instance=True)
-        service.fetch.return_value = user
-        pyramid_config.register_service(service, name="user")
-        return service
+    def user_service(self, user_service, user):
+        user_service.fetch.return_value = user
+
+        return user_service
 
 
 @pytest.mark.usefixtures("authenticated_userid", "group_members_service")

--- a/tests/h/views/api/profile_test.py
+++ b/tests/h/views/api/profile_test.py
@@ -53,12 +53,6 @@ class TestUpdatePreferences:
 
         assert result == session_profile.return_value
 
-    @pytest.fixture
-    def user_service(self, pyramid_config):
-        svc = mock.Mock()
-        pyramid_config.register_service(svc, name="user")
-        return svc
-
 
 @pytest.mark.usefixtures("group_list_service", "GroupContext", "GroupsJSONPresenter")
 class TestProfileGroups:

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -147,7 +147,7 @@ class TestCreate:
 
 @pytest.mark.usefixtures(
     "auth_client",
-    "user_svc",
+    "user_service",
     "user",
     "user_update_svc",
     "UpdateUserAPISchema",
@@ -222,17 +222,14 @@ class TestUpdate:
         return {"email": "jeremy@weylandtech.com", "display_name": "Jeremy Weyland"}
 
     @pytest.fixture
-    def user_svc(self, pyramid_config, user):
-        svc = mock.Mock(spec_set=["fetch"])
-
+    def user_service(self, user_service, user):
         def fake_fetch(username, authority):
             if username == user.username and authority == user.authority:
                 return user
 
-        svc.fetch.side_effect = fake_fetch
+        user_service.fetch.side_effect = fake_fetch
 
-        pyramid_config.register_service(svc, name="user")
-        return svc
+        return user_service
 
 
 @pytest.fixture

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -157,10 +157,3 @@ def group_service(pyramid_config):
     group_service = mock.Mock(spec_set=["find"])
     pyramid_config.register_service(group_service, iface="h.interfaces.IGroupService")
     return group_service
-
-
-@pytest.fixture
-def links_service(pyramid_config):
-    service = mock.Mock(spec_set=["get", "get_all"])
-    pyramid_config.register_service(service, name="links")
-    return service

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 from h_matchers import All, Any
 from pyramid import httpexceptions
@@ -15,10 +13,10 @@ def _fake_sidebar_app(request, extra):
 
 @pytest.mark.usefixtures("routes")
 def test_og_document(
-    factories, pyramid_request, group_service, links_service, sidebar_app
+    factories, pyramid_request, groupfinder_service, links_service, sidebar_app
 ):
     annotation = factories.Annotation(userid="acct:foo@example.com")
-    context = AnnotationContext(annotation, group_service, links_service)
+    context = AnnotationContext(annotation, groupfinder_service, links_service)
     sidebar_app.side_effect = _fake_sidebar_app
 
     ctx = main.annotation_page(context, pyramid_request)
@@ -38,9 +36,11 @@ def test_og_document(
 
 
 @pytest.mark.usefixtures("routes")
-def test_og_no_document(pyramid_request, group_service, links_service, sidebar_app):
+def test_og_no_document(
+    pyramid_request, groupfinder_service, links_service, sidebar_app
+):
     annotation = Annotation(id="123", userid="foo", target_uri="http://example.com")
-    context = AnnotationContext(annotation, group_service, links_service)
+    context = AnnotationContext(annotation, groupfinder_service, links_service)
     sidebar_app.side_effect = _fake_sidebar_app
 
     ctx = main.annotation_page(context, pyramid_request)
@@ -150,10 +150,3 @@ def routes(pyramid_config):
     pyramid_config.add_route("api.annotation", "/api/ann/{id}")
     pyramid_config.add_route("api.index", "/api/index")
     pyramid_config.add_route("index", "/index")
-
-
-@pytest.fixture
-def group_service(pyramid_config):
-    group_service = mock.Mock(spec_set=["find"])
-    pyramid_config.register_service(group_service, iface="h.interfaces.IGroupService")
-    return group_service


### PR DESCRIPTION
Some services which we need in the websocket stuff, which it would be good if we used everywhere.

This has a few benefits:

 * We use properly auto-specced versions of the services, instead of bare mocks in many places, meaning more realistic tests
 * We don't repeat ourselves over and over
 * Previously there was some confusion about the `group_service` vs the `groupfinder_service`. This is now clear

The last one unfortunately mean't we didn't get the line savings you might expect from the de-duplication as many single lines were forced onto multiple by the name change.

## Review notes

 * Each commit introduces a different mock separately bar the last
 * Due to the fact we deleted so much test code our coverage appeared to go down (but didn't really)