### PR TITLE
Remove the synchronous indexing feature flag

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -13,10 +13,6 @@ FEATURES = {
     ),
     "client_display_names": "Render display names instead of user names in the client",
     "client_search_input": "Show redesigned search/filter input in client",
-    "synchronous_indexing": (
-        "Index annotations to Elasticsearch synchronously without involving "
-        "RabbitMQ or Celery"
-    ),
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -46,9 +46,7 @@ def annotation_sync(event):
     # transaction to ensure we don't leave an un-closed transaction
     with event.request.tm:
         search_index = event.request.find_service(name="search_index")
-        search_index.handle_annotation_event(
-            event, synchronous=event.request.feature("synchronous_indexing")
-        )
+        search_index.handle_annotation_event(event)
 
 
 @subscriber(AnnotationEvent)

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -173,22 +173,20 @@ class TestDeleteAnnotationById:
 
 class TestHandleAnnotationEvent:
     def test_we_dispatch_correctly(
-        self, search_index, pyramid_request, action, synchronous, handler_for
+        self, search_index, pyramid_request, action, handler_for
     ):
         event = AnnotationEvent(pyramid_request, {"id": "any"}, action)
 
-        result = search_index.handle_annotation_event(event, synchronous=synchronous)
+        result = search_index.handle_annotation_event(event)
 
-        handler = handler_for(action, synchronous)
+        handler = handler_for(action, synchronous=True)
         handler.assert_called_once_with(event.annotation_id)
         assert result == handler.return_value
 
-    def test_we_do_nothing_for_unexpected_actions(
-        self, search_index, pyramid_request, synchronous
-    ):
+    def test_we_do_nothing_for_unexpected_actions(self, search_index, pyramid_request):
         event = AnnotationEvent(pyramid_request, {"id": "any"}, "strange_action")
 
-        result = search_index.handle_annotation_event(event, synchronous=synchronous)
+        result = search_index.handle_annotation_event(event)
 
         assert result is False
 
@@ -199,7 +197,7 @@ class TestHandleAnnotationEvent:
         sync_handler = handler_for(action, synchronous=True)
         sync_handler.side_effect = ValueError
 
-        result = search_index.handle_annotation_event(event, synchronous=True)
+        result = search_index.handle_annotation_event(event)
 
         sync_handler.assert_called_once_with(event.annotation_id)
         async_handler = handler_for(action, synchronous=False)
@@ -233,10 +231,6 @@ class TestHandleAnnotationEvent:
 
     @pytest.fixture(params=("create", "update", "delete"))
     def action(self, request):
-        return request.param
-
-    @pytest.fixture(params=(True, False))
-    def synchronous(self, request):
         return request.param
 
     @pytest.fixture(autouse=True)

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -170,19 +170,16 @@ class TestSendReplyNotifications:
 
 
 class TestSyncAnnotation:
-    @pytest.mark.parametrize("synchronous", (True, False))
     def test_it_calls_sync_service(
-        self, pyramid_request, search_index, transaction_manager, synchronous
+        self, pyramid_request, search_index, transaction_manager
     ):
-        pyramid_request.feature.flags = {"synchronous_indexing": synchronous}
+
         event = AnnotationEvent(pyramid_request, {"id": "any"}, "action")
 
         subscribers.annotation_sync(event)
 
         transaction_manager.__enter__.assert_called_once()
-        search_index.handle_annotation_event.assert_called_once_with(
-            event, synchronous=synchronous
-        )
+        search_index.handle_annotation_event.assert_called_once_with(event)
         transaction_manager.__exit__.assert_called_once()
 
     @pytest.fixture


### PR DESCRIPTION
This has been in place for a while now and we've not seen any issues so far