### PR TITLE
Add NewRelic monitoring for websocket connections and queue size

### DIFF
--- a/h/streamer/metrics.py
+++ b/h/streamer/metrics.py
@@ -16,14 +16,14 @@ def websocket_metrics(_settings, _environ):
     prefix = "Custom/WebSocket"
 
     def generate_metrics():
-        active_connections = len(WebSocket.instances)
-        authenticated_connections = sum(
-            1 for ws in WebSocket.instances if ws.authenticated_userid
+        connections_active = len(WebSocket.instances)
+        connections_anonymous = sum(
+            1 for ws in WebSocket.instances if not ws.authenticated_userid
         )
 
-        yield f"{prefix}/ConnectionsActive", active_connections
-        yield f"{prefix}/ConnectionsAuthenticated", authenticated_connections
-        yield f"{prefix}/ConnectionsAnonymous", active_connections - authenticated_connections
+        yield f"{prefix}/ConnectionsActive", connections_active
+        yield f"{prefix}/ConnectionsAuthenticated", connections_active - connections_anonymous
+        yield f"{prefix}/ConnectionsAnonymous", connections_anonymous
 
         yield f"{prefix}/WorkQueueSize", WORK_QUEUE.qsize()
 

--- a/h/streamer/metrics.py
+++ b/h/streamer/metrics.py
@@ -1,0 +1,27 @@
+from newrelic.agent import data_source_factory
+
+from h.streamer.websocket import WebSocket
+
+
+@data_source_factory(name="WebSocket Metrics")
+def websocket_metrics(_settings, _environ):
+    """
+    A New Relic metric data source which provides metrics about WebSocket
+    connections.
+
+    See https://docs.newrelic.com/docs/agents/python-agent/supported-features/python-custom-metrics.
+    """
+
+    prefix = "Custom/WebSocket"
+
+    def generate_metrics():
+        active_connections = len(WebSocket.instances)
+        authenticated_connections = sum(
+            1 for ws in WebSocket.instances if ws.authenticated_userid
+        )
+
+        yield f"{prefix}/ConnectionsActive", active_connections
+        yield f"{prefix}/ConnectionsAuthenticated", authenticated_connections
+        yield f"{prefix}/ConnectionsAnonymous", active_connections - authenticated_connections
+
+    return generate_metrics

--- a/h/streamer/metrics.py
+++ b/h/streamer/metrics.py
@@ -21,9 +21,9 @@ def websocket_metrics(_settings, _environ):
             1 for ws in WebSocket.instances if not ws.authenticated_userid
         )
 
-        yield f"{prefix}/ConnectionsActive", connections_active
-        yield f"{prefix}/ConnectionsAuthenticated", connections_active - connections_anonymous
-        yield f"{prefix}/ConnectionsAnonymous", connections_anonymous
+        yield f"{prefix}/Connections/Active", connections_active
+        yield f"{prefix}/Connections/Authenticated", connections_active - connections_anonymous
+        yield f"{prefix}/Connections/Anonymous", connections_anonymous
 
         yield f"{prefix}/WorkQueueSize", WORK_QUEUE.qsize()
 

--- a/h/streamer/metrics.py
+++ b/h/streamer/metrics.py
@@ -1,5 +1,6 @@
 from newrelic.agent import data_source_factory
 
+from h.streamer.streamer import WORK_QUEUE
 from h.streamer.websocket import WebSocket
 
 
@@ -23,5 +24,7 @@ def websocket_metrics(_settings, _environ):
         yield f"{prefix}/ConnectionsActive", active_connections
         yield f"{prefix}/ConnectionsAuthenticated", authenticated_connections
         yield f"{prefix}/ConnectionsAnonymous", active_connections - authenticated_connections
+
+        yield f"{prefix}/WorkQueueSize", WORK_QUEUE.qsize()
 
     return generate_metrics

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -37,6 +37,7 @@ license distributed with the ws4py project. Such code remains copyright (c)
 import logging
 import os
 
+import newrelic.agent
 import pyramid
 from gevent.pool import Pool
 from gunicorn.workers.ggevent import GeventPyWSGIWorker, PyWSGIHandler, PyWSGIServer
@@ -44,6 +45,7 @@ from ws4py import format_addresses
 
 from h.config import configure
 from h.sentry_filters import SENTRY_FILTERS
+from h.streamer.metrics import websocket_metrics
 
 log = logging.getLogger(__name__)
 
@@ -204,5 +206,8 @@ def create_app(_global_config, **settings):
     # Add support for logging exceptions whenever they arise
     config.include("pyramid_exclog")
     config.add_settings({"exclog.extra_info": True})
+
+    # Set up metrics collection
+    newrelic.agent.register_data_source(websocket_metrics)
 
     return config.make_wsgi_app()

--- a/tests/h/streamer/metrics_test.py
+++ b/tests/h/streamer/metrics_test.py
@@ -1,0 +1,42 @@
+from unittest.mock import create_autospec
+
+import pytest
+from h_matchers import Any
+
+from h.streamer.metrics import websocket_metrics
+from h.streamer.websocket import WebSocket
+
+
+class TestWebsocketMetrics:
+    def test_metrics(self, generate_metrics, sockets):
+        sockets[0].authenticated_userid = "acct:jimsmith@hypothes.is"
+        sockets[1].authenticated_userid = None
+        sockets[2].authenticated_userid = None
+
+        metrics = list(generate_metrics())
+
+        expected_counts = [
+            ("Custom/WebSocket/ConnectionsActive", 3),
+            ("Custom/WebSocket/ConnectionsAuthenticated", 1),
+            ("Custom/WebSocket/ConnectionsAnonymous", 2),
+        ]
+        assert metrics == Any.list.containing(expected_counts).only()
+
+    @pytest.fixture
+    def generate_metrics(self):
+        # Work with the decorator from new relic to get the actual metrics
+        # function inside.
+        generate_metrics = websocket_metrics(settings={})["factory"]
+
+        return generate_metrics(environ={})
+
+    @pytest.fixture(autouse=True)
+    def WebSocket(self, patch, sockets):
+        WebSocket = patch("h.streamer.metrics.WebSocket")
+        WebSocket.instances = sockets
+
+        return WebSocket
+
+    @pytest.fixture
+    def sockets(self):
+        return [create_autospec(WebSocket, instance=True) for _ in range(3)]

--- a/tests/h/streamer/metrics_test.py
+++ b/tests/h/streamer/metrics_test.py
@@ -17,9 +17,9 @@ class TestWebsocketMetrics:
 
         assert list(metrics) == Any.list.containing(
             [
-                ("Custom/WebSocket/ConnectionsActive", 3),
-                ("Custom/WebSocket/ConnectionsAuthenticated", 1),
-                ("Custom/WebSocket/ConnectionsAnonymous", 2),
+                ("Custom/WebSocket/Connections/Active", 3),
+                ("Custom/WebSocket/Connections/Authenticated", 1),
+                ("Custom/WebSocket/Connections/Anonymous", 2),
             ]
         )
 


### PR DESCRIPTION
This is a less all singing all dancing version of: https://github.com/hypothesis/h/pull/6246 which:

 * Keeps the websocket connection count reporting
 * Removes the individual message counts
 * Adds queue length monitoring

This was prompted by the kind of immediate need to know how many connections we have to see if they might be gobbling up file descriptors and causing NGINX errors.

## Testing notes

Much better notes on how to test this on the parent ticket: https://github.com/hypothesis/h/pull/6246