### PR TITLE
Prevent the websocket causing more exceptions during exception view handling

### DIFF
--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -54,8 +54,7 @@ def error_badhandshake(exc, request):
 @view_config(context=Exception, renderer="json")
 def error(context, request):
     request.response.status_code = 500
-    if request.debug:
-        raise
+
     return {
         "ok": False,
         "error": "server_error",

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -67,7 +67,7 @@ class WebSocketWSGIHandler(PyWSGIHandler):
             # response, confusing this method into sending "Transfer-Encoding:
             # chunked" and, in turn, this confuses some strict WebSocket
             # clients.
-            if not hasattr(self.result, "__len__"):
+            if not hasattr(self.result, "__len__") and self.result is not None:
                 self.result = list(self.result)
 
             # ws4py 0.3.4 will try to pop the websocket from the environ


### PR DESCRIPTION
During exception handling:

 * `request` doesn't have a debug property, and appears to report fine in dev anyway
 * The `result` is None and can't be converted to a list

The effect of this is that when executing the error handler we cause a massive cascade of other exceptions to be emitted, obscuring the real problem.