### PR TITLE
Websocket metrics consolidation and refactoring

### DIFF
--- a/h/streamer/__init__.py
+++ b/h/streamer/__init__.py
@@ -5,6 +5,7 @@ __all__ = ["close_db_session_tween_factory"]
 
 def includeme(config):  # pragma: no cover
     config.include("h.streamer.views")
+    config.include("h.streamer.metrics")
 
     config.add_subscriber(
         "h.streamer.streamer.start", "pyramid.events.ApplicationCreated"

--- a/h/streamer/metrics.py
+++ b/h/streamer/metrics.py
@@ -1,4 +1,4 @@
-from newrelic.agent import data_source_generator
+from newrelic.agent import data_source_generator, register_data_source
 
 from h.streamer.streamer import WORK_QUEUE
 from h.streamer.websocket import WebSocket
@@ -24,3 +24,7 @@ def websocket_metrics():
     yield f"{PREFIX}/Connections/Anonymous", connections_anonymous
 
     yield f"{PREFIX}/WorkQueueSize", WORK_QUEUE.qsize()
+
+
+def includeme(_config):  # pragma: no cover
+    register_data_source(websocket_metrics)

--- a/h/streamer/metrics.py
+++ b/h/streamer/metrics.py
@@ -1,30 +1,26 @@
-from newrelic.agent import data_source_factory
+from newrelic.agent import data_source_generator
 
 from h.streamer.streamer import WORK_QUEUE
 from h.streamer.websocket import WebSocket
 
+PREFIX = "Custom/WebSocket"
 
-@data_source_factory(name="WebSocket Metrics")
-def websocket_metrics(_settings, _environ):
+
+@data_source_generator(name="WebSocket Metrics")
+def websocket_metrics():
     """
-    A New Relic metric data source which provides metrics about WebSocket
-    connections.
+    Report metrics about the websocket service to New Relic.
 
     See https://docs.newrelic.com/docs/agents/python-agent/supported-features/python-custom-metrics.
     """
 
-    prefix = "Custom/WebSocket"
+    connections_active = len(WebSocket.instances)
+    connections_anonymous = sum(
+        1 for ws in WebSocket.instances if not ws.authenticated_userid
+    )
 
-    def generate_metrics():
-        connections_active = len(WebSocket.instances)
-        connections_anonymous = sum(
-            1 for ws in WebSocket.instances if not ws.authenticated_userid
-        )
+    yield f"{PREFIX}/Connections/Active", connections_active
+    yield f"{PREFIX}/Connections/Authenticated", connections_active - connections_anonymous
+    yield f"{PREFIX}/Connections/Anonymous", connections_anonymous
 
-        yield f"{prefix}/Connections/Active", connections_active
-        yield f"{prefix}/Connections/Authenticated", connections_active - connections_anonymous
-        yield f"{prefix}/Connections/Anonymous", connections_anonymous
-
-        yield f"{prefix}/WorkQueueSize", WORK_QUEUE.qsize()
-
-    return generate_metrics
+    yield f"{PREFIX}/WorkQueueSize", WORK_QUEUE.qsize()

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -37,7 +37,6 @@ license distributed with the ws4py project. Such code remains copyright (c)
 import logging
 import os
 
-import newrelic.agent
 import pyramid
 from gevent.pool import Pool
 from gunicorn.workers.ggevent import GeventPyWSGIWorker, PyWSGIHandler, PyWSGIServer
@@ -45,7 +44,6 @@ from ws4py import format_addresses
 
 from h.config import configure
 from h.sentry_filters import SENTRY_FILTERS
-from h.streamer.metrics import websocket_metrics
 
 log = logging.getLogger(__name__)
 
@@ -206,8 +204,5 @@ def create_app(_global_config, **settings):
     # Add support for logging exceptions whenever they arise
     config.include("pyramid_exclog")
     config.add_settings({"exclog.extra_info": True})
-
-    # Set up metrics collection
-    newrelic.agent.register_data_source(websocket_metrics)
 
     return config.make_wsgi_app()


### PR DESCRIPTION
* Use the simpler form of the generator for metrics, rather than the factory returning a generator
* Move the configuration of the websocket into the metrics, rather than spreading it between the metrics and the `h.websocket` app file