### PR TITLE
Add a dead mans handle style metric to see if websocket metrics are working

### DIFF
--- a/h/streamer/metrics.py
+++ b/h/streamer/metrics.py
@@ -19,6 +19,9 @@ def websocket_metrics():
         1 for ws in WebSocket.instances if not ws.authenticated_userid
     )
 
+    # Allow us to tell the difference between reporting 0 and not reporting
+    yield f"{PREFIX}/Alive", 1
+
     yield f"{PREFIX}/Connections/Active", connections_active
     yield f"{PREFIX}/Connections/Authenticated", connections_active - connections_anonymous
     yield f"{PREFIX}/Connections/Anonymous", connections_anonymous

--- a/tests/h/streamer/metrics_test.py
+++ b/tests/h/streamer/metrics_test.py
@@ -33,6 +33,11 @@ class TestWebsocketMetrics:
             [("Custom/WebSocket/WorkQueueSize", size)]
         )
 
+    def test_it_records_alive_metric(self, generate_metrics):
+        metrics = generate_metrics()
+
+        assert list(metrics) == Any.list.containing([("Custom/WebSocket/Alive", 1)])
+
     @pytest.fixture
     def generate_metrics(self):
         # Work with the decorator from new relic to get the actual metrics


### PR DESCRIPTION
We are seeing long stretches where all metrics are at 0 in New Relic. It's not clear if this is because we are reporting 0 for everything, or if we aren't reporting at all.

Having a metric which is always 1 should help tell the difference