### PR TITLE
Try and contain New Relic activity in the websocket

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -19,7 +19,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:websocket]
-command=newrelic-admin run-program pserve conf/websocket.ini
+command=pserve conf/websocket.ini
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true

--- a/h/streamer/__init__.py
+++ b/h/streamer/__init__.py
@@ -5,7 +5,6 @@ __all__ = ["close_db_session_tween_factory"]
 
 def includeme(config):  # pragma: no cover
     config.include("h.streamer.views")
-    config.include("h.streamer.metrics")
 
     config.add_subscriber(
         "h.streamer.streamer.start", "pyramid.events.ApplicationCreated"

--- a/h/streamer/streamer.py
+++ b/h/streamer/streamer.py
@@ -4,6 +4,7 @@ import sys
 import gevent
 
 from h.streamer import db, messages, websocket
+from h.streamer.metrics import metrics_process
 
 log = logging.getLogger(__name__)
 
@@ -41,6 +42,7 @@ def start(event):
     settings = registry.settings
 
     greenlets = [
+        gevent.spawn(metrics_process, registry, WORK_QUEUE),
         # Start greenlets to process messages from RabbitMQ
         gevent.spawn(messages.process_messages, settings, ANNOTATION_TOPIC, WORK_QUEUE),
         gevent.spawn(messages.process_messages, settings, USER_TOPIC, WORK_QUEUE),


### PR DESCRIPTION
 * We now run the metrics as push rather than pull (from New Relic)
 * All stats are gathered inside a read only transaction
 * The hope is this is less likely to be able to do terrible things

Test notes of how to setup New Relic for testing locally here: https://github.com/hypothesis/h/pull/6246

## Why

Something is causing this error:

`sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) execute cannot be used while an asynchronous query is underway`

Once that happens the socket server seems totally dead. This is in hopeful expectation that New Relic might be executing db queries in a way that is causing this.

There isn't much direct evidence to suspect so. We don't do anything in this function that should call on the DB.