### PR TITLE
Disable New Relic metrics for the Websocket

### DIFF
--- a/h/streamer/streamer.py
+++ b/h/streamer/streamer.py
@@ -4,7 +4,8 @@ import sys
 import gevent
 
 from h.streamer import db, messages, websocket
-from h.streamer.metrics import metrics_process
+
+# from h.streamer.metrics import metrics_process
 
 log = logging.getLogger(__name__)
 
@@ -42,7 +43,8 @@ def start(event):
     settings = registry.settings
 
     greenlets = [
-        gevent.spawn(metrics_process, registry, WORK_QUEUE),
+        # Disable metrics for now
+        # gevent.spawn(metrics_process, registry, WORK_QUEUE),
         # Start greenlets to process messages from RabbitMQ
         gevent.spawn(messages.process_messages, settings, ANNOTATION_TOPIC, WORK_QUEUE),
         gevent.spawn(messages.process_messages, settings, USER_TOPIC, WORK_QUEUE),


### PR DESCRIPTION
This is a debugging attempt to work out if the new relic things we've done have caused any problems.

We suspect this may be causing websocket failures.