### PR TITLE
Only search the "hypothesis" index not all indexes

### DIFF
--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -146,7 +146,8 @@ class Queue:
                 "_source": ["updated"],
                 "query": {"ids": {"values": list(annotation_ids)}},
                 "size": len(annotation_ids),
-            }
+            },
+            index=self._es.index,
         )
 
         logger.info(f"Elasticsearch response: {response}")


### PR DESCRIPTION
Our production Elasticsearch contains a `"hypothesis"` index alias that
points at the most recent `"hypothesis-*"` index. There are actually for
`"hypothesis-*"` indexes in production currently, three presumably left
around from previous upgrades and reindexes. Change the
`"sync_annotations"` task to query only the index currently being
pointed to by the `"hypothesis"` alias, rather than querying all
indexes.

`self._es.index` comes from the `"es.index"` setting which defaults to
`"hypothesis"`:

* https://github.com/hypothesis/h/blob/e832077de4014f2114c8ff607572528652ed12f4/h/search/client.py#L67-L74
* https://github.com/hypothesis/h/blob/e832077de4014f2114c8ff607572528652ed12f4/h/search/client.py#L4-L30

If you don't pass an `index` argument to `search()` it searches all
indexes at once, which matches with the incorrect behaviour we've been
seeing in production (we've been seeing annotations from multiple
different search indexes in the search responses):

https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.search

When other parts of h's code do searches they pass the `"es.index"`
setting as the `index`. For example:

https://github.com/hypothesis/h/blob/e832077de4014f2114c8ff607572528652ed12f4/h/search/core.py#L103-L105

There may be some code refactoring to be done here: maybe there should
be only one place in the code where Elasticsearch's `search()` method
gets called. But for now I'd like to try this quick fix, and verify
whether it fixes the issue in production.