### PR TITLE
Add rudamentary logging of the number of workers we have free

### DIFF
--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -17,6 +17,8 @@ port: 5001
 worker_class: h.streamer.Worker
 graceful_timeout: 0
 proc_name: websocket
+# This is very low so you can see what happens when we run out
+worker_connections: 8
 
 [loggers]
 keys = root, gunicorn.error, h

--- a/h/streamer/metrics.py
+++ b/h/streamer/metrics.py
@@ -30,7 +30,7 @@ def websocket_metrics(queue):
     yield f"{PREFIX}/WorkQueueSize", queue.qsize()
 
 
-def metrics_process(registry, queue):
+def metrics_process(registry, queue):  # pragma: no cover
     session = db.get_session(registry.settings)
 
     newrelic.agent.initialize()

--- a/h/streamer/stat_dump.py
+++ b/h/streamer/stat_dump.py
@@ -1,0 +1,27 @@
+"""This should be moved to the metrics file when we have that working again."""
+
+import os
+from logging import getLogger
+
+from gevent import sleep
+
+from h.streamer.worker import WSGIServer
+
+DUMP_INTERVAL = 60
+LOG = getLogger(__name__)
+
+
+def dump_stats():  # pragma: no cover
+    while True:
+        # There really only should be one server per instance
+        for server in WSGIServer.instances:
+            pool = server.connection_pool
+
+            free = pool.free_count()
+            in_progress = pool.size - free
+
+            stats = f"has ~{in_progress} workers occupied with ~{free}/{pool.size} free"
+            is_full = " (Pool is full!)" if pool.full() else ""
+            LOG.info(f"Web socket PID:{os.getpid()} {stats}{is_full}")
+
+        sleep(DUMP_INTERVAL)

--- a/h/streamer/streamer.py
+++ b/h/streamer/streamer.py
@@ -5,6 +5,7 @@ import gevent
 from pyramid.events import ApplicationCreated, subscriber
 
 from h.streamer import db, messages, websocket
+from h.streamer.stat_dump import dump_stats
 
 # from h.streamer.metrics import metrics_process
 
@@ -45,6 +46,7 @@ def start(event):
     settings = registry.settings
 
     greenlets = [
+        gevent.spawn(dump_stats),
         # Disable metrics for now
         # gevent.spawn(metrics_process, registry, WORK_QUEUE),
         # Start greenlets to process messages from RabbitMQ


### PR DESCRIPTION
The long and short of this is that each connected websocket seems to soak up a worker connection. So this is pretty much 1:1 with active connections. None the less it's a good thing to know.

The best way to test this is just to start `h`, the client and Via 3 then open this in a bunch of windows:

 * http://localhost:9083/html/v/http://example.com/?via.rewrite=on&via.client.openSidebar=1

I'd recommend setting the interval to 1 second to make it less boring.