### PR TITLE
Add jobs to the DB faster

### DIFF
--- a/h/db/types.py
+++ b/h/db/types.py
@@ -50,11 +50,31 @@ class URLSafeUUID(types.TypeDecorator):
     impl = postgresql.UUID
 
     def process_bind_param(self, value, dialect):
+        return self.url_safe_to_hex(value)
+
+    def process_result_value(self, value, dialect):
+        return self.hex_to_url_safe(value)
+
+    @staticmethod
+    def url_safe_to_hex(value):
+        """
+        Return the hex version of the given URL-safe UUID.
+
+        Converts UUID's from the application-level URL-safe format to the hex
+        format that's used internally in the DB.
+        """
         if value is None:
             return None
         return _get_hex_from_urlsafe(value)
 
-    def process_result_value(self, value, dialect):
+    @staticmethod
+    def hex_to_url_safe(value):
+        """
+        Return the URL-safe version of the given hex-format UUID.
+
+        Converts UUID's from the database-internal hex format to the URL-safe
+        format that's in the application.
+        """
         if value is None:
             return None
         hexstring = uuid.UUID(value).hex

--- a/h/db/types.py
+++ b/h/db/types.py
@@ -73,7 +73,7 @@ class URLSafeUUID(types.TypeDecorator):
         Return the URL-safe version of the given hex-format UUID.
 
         Converts UUID's from the database-internal hex format to the URL-safe
-        format that's in the application.
+        format that's used in the application.
         """
         if value is None:
             return None

--- a/h/services/search_index/service.py
+++ b/h/services/search_index/service.py
@@ -1,7 +1,6 @@
 from h_pyramid_sentry import report_exception
 
 from h import storage
-from h.models import Annotation
 from h.presenters import AnnotationSearchIndexPresenter
 from h.tasks.indexer import add_annotation, delete_annotation
 
@@ -77,15 +76,7 @@ class SearchIndexService:
         :type start_time: datetime.datetime
         :type end_time: datetime.datetime
         """
-        self._queue.add_all(
-            [
-                row[0]
-                for row in self._db.query(Annotation.id)
-                .filter(Annotation.updated >= start_time)
-                .filter(Annotation.updated <= end_time)
-            ],
-            tag=tag,
-        )
+        self._queue.add_annotations_between_times(start_time, end_time, tag)
 
     def delete_annotation_by_id(self, annotation_id, refresh=False):
         """

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -144,37 +144,19 @@ class TestAddAnnotation:
 
 
 class TestAddAnnotationsBetweenTimes:
-    def test_it(self, annotation_ids, search_index, queue):
+    def test_it(self, queue, search_index):
+        start_time = datetime.datetime(2020, 9, 9)
+        end_time = datetime.datetime(2020, 9, 11)
+
         search_index.add_annotations_between_times(
-            datetime.datetime(2020, 9, 9),
-            datetime.datetime(2020, 9, 11),
+            start_time,
+            end_time,
             "test_tag",
         )
 
-        queue.add_all.assert_called_once_with(
-            Any.list.containing(annotation_ids).only(), tag="test_tag"
+        queue.add_annotations_between_times.assert_called_once_with(
+            start_time, end_time, "test_tag"
         )
-
-    @pytest.fixture
-    def annotations(self, factories):
-        return factories.Annotation.create_batch(
-            size=10, updated=datetime.datetime(year=2020, month=9, day=10)
-        )
-
-    @pytest.fixture(autouse=True)
-    def non_matching_annotations(self, factories):
-        """Annotations from outside the date range that we're reindexing."""
-        before_annotations = factories.Annotation.create_batch(
-            size=3, updated=datetime.datetime(year=2020, month=9, day=8)
-        )
-        after_annotations = factories.Annotation.create_batch(
-            size=3, updated=datetime.datetime(year=2020, month=9, day=12)
-        )
-        return before_annotations + after_annotations
-
-    @pytest.fixture
-    def annotation_ids(self, annotations):
-        return [annotation.id for annotation in annotations]
 
 
 class TestDeleteAnnotationById:


### PR DESCRIPTION
Add jobs to the DB faster

When adding `"sync_annotation"` jobs for all annotations between two dates to the DB, instead of using SQLAlchemy's ORM use its SQL expression language to generate a single `insert into job ... select ... from annotation where ...` SQL expression. This is much faster than using the ORM so it should enable larger numbers of jobs to be added to the DB without the admin page form submission request timing out.

This means that the annotation ID's stored in the `Job.kwargs` column are now in the DB's internal hex format instead of the application-level URL-safe format, so conversion to URL-safe format had to be added when reading these IDs from the `kwargs` column.

`add_annotations_between_times()` uses a hard-coded priority of `1000` because it's not possible to efficiently count the number of annotations being added for use as the priority. Now that we're using a single `insert into job ... select ... from annotation where ...` to both select the matching annotations and insert the jobs in a single statement, we no longer materialize a list of all the matching annotations at any time so we can't count them. To get a count we'd have to do a separate SQL statement. Just use a hard-coded priority instead, it's much simpler and faster.