### PR TITLE
Use a config file to try and disable as much of New Relic as possible

### DIFF
--- a/h/streamer/conf/newrelic.ini
+++ b/h/streamer/conf/newrelic.ini
@@ -1,0 +1,332 @@
+# ---------------------------------------------------------------------------
+
+#
+# This file configures the New Relic Python Agent.
+#
+# The path to the configuration file should be supplied to the function
+# newrelic.agent.initialize() when the agent is being initialized.
+#
+# The configuration file follows a structure similar to what you would
+# find for Microsoft Windows INI files. For further information on the
+# configuration file format see the Python ConfigParser documentation at:
+#
+#    http://docs.python.org/library/configparser.html
+#
+# For further discussion on the behaviour of the Python agent that can
+# be configured via this configuration file see:
+#
+#    http://newrelic.com/docs/python/python-agent-configuration
+#
+
+# ---------------------------------------------------------------------------
+
+# Here are the settings that are common to all environments.
+
+[newrelic]
+
+# You must specify the license key associated with your New
+# Relic account. This key binds the Python Agent's data to your
+# account in the New Relic service.
+#license_key = ... <set by ENV var>
+
+# The application name. Set this to be the name of your
+# application as you would like it to show up in New Relic UI.
+# The UI will then auto-map instances of your application into a
+# entry on your home dashboard page.
+#app_name = ... <set by ENV var>
+
+# When "true", the agent collects performance data about your
+# application and reports this data to the New Relic UI at
+# newrelic.com. This global switch is normally overridden for
+# each environment below.
+monitor_mode = true
+
+# Sets the name of a file to log agent messages to. Useful for
+# debugging any issues with the agent. This is not set by
+# default as it is not known in advance what user your web
+# application processes will run as and where they have
+# permission to write to. Whatever you set this to you must
+# ensure that the permissions for the containing directory and
+# the file itself are correct, and that the user that your web
+# application runs as can write to the file. If not able to
+# write out a log file, it is also possible to say "stderr" and
+# output to standard error output. This would normally result in
+# output appearing in your web server log.
+#log_file = /tmp/newrelic-python-agent.log
+
+# Sets the level of detail of messages sent to the log file, if
+# a log file location has been provided. Possible values, in
+# increasing order of detail, are: "critical", "error", "warning",
+# "info" and "debug". When reporting any agent issues to New
+# Relic technical support, the most useful setting for the
+# support engineers is "debug". However, this can generate a lot
+# of information very quickly, so it is best not to keep the
+# agent at this level for longer than it takes to reproduce the
+# problem you are experiencing.
+log_level = info
+
+# High Security Mode enforces certain security settings, and prevents
+# them from being overridden, so that no sensitive data is sent to New
+# Relic. Enabling High Security Mode means that request parameters are
+# not collected and SQL can not be sent to New Relic in its raw form.
+# To activate High Security Mode, it must be set to 'true' in this
+# local .ini configuration file AND be set to 'true' in the
+# server-side configuration in the New Relic user interface. For
+# details, see
+# https://docs.newrelic.com/docs/subscriptions/high-security
+high_security = false
+
+# The Python Agent will attempt to connect directly to the New
+# Relic service. If there is an intermediate firewall between
+# your host and the New Relic service that requires you to use a
+# HTTP proxy, then you should set both the "proxy_host" and
+# "proxy_port" settings to the required values for the HTTP
+# proxy. The "proxy_user" and "proxy_pass" settings should
+# additionally be set if proxy authentication is implemented by
+# the HTTP proxy. The "proxy_scheme" setting dictates what
+# protocol scheme is used in talking to the HTTP proxy. This
+# would normally always be set as "http" which will result in the
+# agent then using a SSL tunnel through the HTTP proxy for end to
+# end encryption.
+# proxy_scheme = http
+# proxy_host = hostname
+# proxy_port = 8080
+# proxy_user =
+# proxy_pass =
+
+# Capturing request parameters is off by default. To enable the
+# capturing of request parameters, first ensure that the setting
+# "attributes.enabled" is set to "true" (the default value), and
+# then add "request.parameters.*" to the "attributes.include"
+# setting. For details about attributes configuration, please
+# consult the documentation.
+# attributes.include = request.parameters.*
+
+# The transaction tracer captures deep information about slow
+# transactions and sends this to the UI on a periodic basis. The
+# transaction tracer is enabled by default. Set this to "false"
+# to turn it off.
+transaction_tracer.enabled = false
+
+# Threshold in seconds for when to collect a transaction trace.
+# When the response time of a controller action exceeds this
+# threshold, a transaction trace will be recorded and sent to
+# the UI. Valid values are any positive float value, or (default)
+# "apdex_f", which will use the threshold for a dissatisfying
+# Apdex controller action - four times the Apdex T value.
+transaction_tracer.transaction_threshold = apdex_f
+
+# When the transaction tracer is on, SQL statements can
+# optionally be recorded. The recorder has three modes, "off"
+# which sends no SQL, "raw" which sends the SQL statement in its
+# original form, and "obfuscated", which strips out numeric and
+# string literals.
+transaction_tracer.record_sql = obfuscated
+
+# Threshold in seconds for when to collect stack trace for a SQL
+# call. In other words, when SQL statements exceed this
+# threshold, then capture and send to the UI the current stack
+# trace. This is helpful for pinpointing where long SQL calls
+# originate from in an application.
+transaction_tracer.stack_trace_threshold = 0.5
+
+# Determines whether the agent will capture query plans for slow
+# SQL queries. Only supported in MySQL and PostgreSQL. Set this
+# to "false" to turn it off.
+transaction_tracer.explain_enabled = false
+
+# Threshold for query execution time below which query plans
+# will not not be captured. Relevant only when "explain_enabled"
+# is true.
+transaction_tracer.explain_threshold = 0.5
+
+# Space separated list of function or method names in form
+# 'module:function' or 'module:class.function' for which
+# additional function timing instrumentation will be added.
+transaction_tracer.function_trace =
+
+# The error collector captures information about uncaught
+# exceptions or logged exceptions and sends them to UI for
+# viewing. The error collector is enabled by default. Set this
+# to "false" to turn it off.
+error_collector.enabled = false
+
+# To stop specific errors from reporting to the UI, set this to
+# a space separated list of the Python exception type names to
+# ignore. The exception name should be of the form 'module:class'.
+error_collector.ignore_errors =
+
+# Browser monitoring is the Real User Monitoring feature of the UI.
+# For those Python web frameworks that are supported, this
+# setting enables the auto-insertion of the browser monitoring
+# JavaScript fragments.
+browser_monitoring.auto_instrument = false
+
+# A thread profiling session can be scheduled via the UI when
+# this option is enabled. The thread profiler will periodically
+# capture a snapshot of the call stack for each active thread in
+# the application to construct a statistically representative
+# call tree.
+thread_profiler.enabled = false
+
+# Your application deployments can be recorded through the
+# New Relic REST API. To use this feature provide your API key
+# below then use the `newrelic-admin record-deploy` command.
+# api_key =
+
+# Distributed tracing lets you see the path that a request takes
+# through your distributed system. Enabling distributed tracing
+# changes the behavior of some New Relic features, so carefully
+# consult the transition guide before you enable this feature:
+# https://docs.newrelic.com/docs/transition-guide-distributed-tracing
+distributed_tracing.enabled = false
+
+# Turn off everythign we can find. For details see:
+# https://docs.newrelic.com/docs/agents/python-agent/configuration/python-agent-configuration
+
+disable_all_plugins = true
+
+transaction_events.enabled = false
+transaction_segments.attributes.enabled = false
+browser_monitoring.enabled = false
+datastore_tracer.instance_reporting.enabled = false
+custom_insights_events.enabled = false
+span_events.enabled = false
+event_loop_visibility.enabled = false
+cross_application_tracer.enabled = false
+slow_sql.enabled = false
+
+# Disabling various detection settings
+utilization.detect_aws = false
+utilization.detect_azure = false
+utilization.detect_gcp = false
+utilization.detect_pcf = false
+utilization.detect_docker = false
+
+# Disable various instrumentations of modules
+# These can be discovered by setting the "log_level" to "debug" and
+# observing "instrument module" messages on start up
+
+[import-hook:asyncio]
+enabled = false
+
+[import-hook:asyncio.base_events]
+enabled = false
+
+[import-hook:asyncio.events]
+enabled = false
+
+[import-hook:billiard.pool]
+enabled = false
+
+[import-hook:celery.app.task]
+enabled = false
+
+[import-hook:celery.app.trace]
+enabled = false
+
+[import-hook:elasticsearch.client]
+enabled = false
+
+[import-hook:elasticsearch.client.cat]
+enabled = false
+
+[import-hook:elasticsearch.client.cluster]
+enabled = false
+
+[import-hook:elasticsearch.client.indices]
+enabled = false
+
+[import-hook:elasticsearch.client.ingest]
+enabled = false
+
+[import-hook:elasticsearch.client.nodes]
+enabled = false
+
+[import-hook:elasticsearch.client.snapshot]
+enabled = false
+
+[import-hook:elasticsearch.client.tasks]
+enabled = false
+
+[import-hook:elasticsearch.connection.base]
+enabled = false
+
+[import-hook:elasticsearch.transport]
+enabled = false
+
+[import-hook:gevent.monkey]
+enabled = false
+
+[import-hook:gevent.pywsgi]
+enabled = false
+
+[import-hook:greenlet]
+enabled = false
+
+[import-hook:gunicorn.app.base]
+enabled = false
+
+[import-hook:http.client]
+enabled = false
+
+[import-hook:jinja2.environment]
+enabled = false
+
+[import-hook:psycopg2]
+enabled = false
+
+[import-hook:psycopg2._json]
+enabled = false
+
+[import-hook:psycopg2._range]
+enabled = false
+
+[import-hook:psycopg2.extensions]
+enabled = false
+
+[import-hook:pyramid.config]
+enabled = false
+
+[import-hook:pyramid.config.tweens]
+enabled = false
+
+[import-hook:pyramid.config.views]
+enabled = false
+
+[import-hook:pyramid.router]
+enabled = false
+
+[import-hook:urllib.request]
+enabled = false
+
+[import-hook:urllib3.connection]
+enabled = false
+
+[import-hook:urllib3.connectionpool]
+enabled = false
+
+# ---------------------------------------------------------------------------
+
+#
+# The application environments. These are specific settings which
+# override the common environment settings. The settings related to a
+# specific environment will be used when the environment argument to the
+# newrelic.agent.initialize() function has been defined to be either
+# "development", "test", "staging" or "production".
+#
+
+;[newrelic:development]
+;monitor_mode = false
+;
+;[newrelic:test]
+;monitor_mode = false
+;
+;[newrelic:staging]
+;app_name = Python Application (Staging)
+;monitor_mode = false
+;
+;[newrelic:production]
+;monitor_mode = false
+
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
The hope is that this might let us see if New Relic always causes problems or if it's just a specific issue with one of the things we turned off.

If we've turned all of this off and it's still a problem either it's nothing to do with New Relic, or we just can't use it.

This also includes a kill switch for the metrics specifically, allowing them to be turned off without deploying from scratch.

# Review notes

This looks like a big commit, but it's mostly a config file which is generated by New Relic command line tools. There have been a lot of additions to it to attempt to turn off everything I could find in the docs.