### PR TITLE
Add jobs to the queue asynchronously

### DIFF
--- a/h/services/search_index/service.py
+++ b/h/services/search_index/service.py
@@ -76,7 +76,7 @@ class SearchIndexService:
         :type start_time: datetime.datetime
         :type end_time: datetime.datetime
         """
-        self._queue.add_annotations_between_times(start_time, end_time, tag)
+        indexer.add_annotations_between_times.delay(start_time, end_time, tag)
 
     def delete_annotation_by_id(self, annotation_id, refresh=False):
         """

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -23,6 +23,13 @@ def add_annotation(id_):
     search_index.add_annotation_by_id(id_)
 
 
+@celery.task
+def add_annotations_between_times(start_time, end_time, tag):
+    celery.request.find_service(
+        name="search_index"
+    )._queue.add_annotations_between_times(start_time, end_time, tag)
+
+
 @celery.task(base=_BaseTaskWithRetry)
 def delete_annotation(id_):
     search_index = celery.request.find_service(name="search_index")

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -7,6 +7,7 @@ from h.services.groupfinder import GroupfinderService
 from h.services.links import LinksService
 from h.services.nipsa import NipsaService
 from h.services.search_index import SearchIndexService
+from h.services.search_index._queue import Queue
 
 __all__ = (
     "mock_service",
@@ -23,8 +24,10 @@ from h.services.user import UserService
 
 @pytest.fixture
 def mock_service(pyramid_config):
-    def mock_service(service_class, name):
-        service = create_autospec(service_class, instance=True, spec_set=True)
+    def mock_service(service_class, name, spec_set=True, **kwargs):
+        service = create_autospec(
+            service_class, instance=True, spec_set=spec_set, **kwargs
+        )
         pyramid_config.register_service(service, name=name)
 
         return service
@@ -34,7 +37,12 @@ def mock_service(pyramid_config):
 
 @pytest.fixture
 def search_index(mock_service):
-    return mock_service(SearchIndexService, "search_index")
+    return mock_service(
+        SearchIndexService,
+        "search_index",
+        spec_set=False,
+        _queue=create_autospec(Queue, spec_set=True, instance=True),
+    )
 
 
 @pytest.fixture

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -136,7 +136,7 @@ class TestAddAnnotation:
 
 
 class TestAddAnnotationsBetweenTimes:
-    def test_it(self, queue, search_index):
+    def test_it(self, indexer, search_index):
         start_time = datetime.datetime(2020, 9, 9)
         end_time = datetime.datetime(2020, 9, 11)
 
@@ -146,7 +146,7 @@ class TestAddAnnotationsBetweenTimes:
             "test_tag",
         )
 
-        queue.add_annotations_between_times.assert_called_once_with(
+        indexer.add_annotations_between_times.delay.assert_called_once_with(
             start_time, end_time, "test_tag"
         )
 

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -26,6 +26,17 @@ class TestSearchIndexServicesWrapperTasks:
         )
 
 
+class TestAddAnnotationsBetweenTimes:
+    def test_it(self, search_index):
+        indexer.add_annotations_between_times(
+            sentinel.start_time, sentinel.end_time, sentinel.tag
+        )
+
+        search_index._queue.add_annotations_between_times.assert_called_once_with(
+            sentinel.start_time, sentinel.end_time, sentinel.tag
+        )
+
+
 class TestReindexUserAnnotations:
     def test_it_creates_batch_indexer(self, BatchIndexer, annotation_ids, celery):
         userid = list(annotation_ids.keys())[0]


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h/pull/6340

Have the /admin/search page schedule a Celery task to enqueue sync_annotation jobs for all annotations within a date range, instead of enqueueing them itself.

The admin page is still timing out when try to enqueue jobs for multi-month timeframes. We've made the DB query as fast as we can but it's still too slow to do during an HTTP request. So move the DB query into a Celery task.

* * *

For what it's worth I don't think I'm a fan of the code design here:

1. `SearchAdminViews` calls `SearchIndexService.add_annotations_between_times()`
2. `SearchIndexService.add_annotations_between_times()` calls `tasks.indexer.add_annotations_between_times.delay()` (a Celery task)
3. `tasks.indexer.add_annotations_between_times()` calls `SearchIndexService._queue.add_annotations_between_times()`

I'd like to go with this design right now so that I can make progress but I dislike it because:

1. I think you can at least make a good argument that the view, not the service, should be deciding whether to do something synchronously or asynchronously. The reason it needs to be done asynchronously is that the view needs to return an HTTP response quickly, so that's the view's requirement not the service layer's. For example if a Celery task or command line script etc were calling the services layer it wouldn't need and probably wouldn't want the task to be done asynchronously (and therefore to depend on Celery and Rabbit and to hand off to a worker process which makes debugging difficult), it would probably want the service layer to just do the work. At least I think we don't _have_ to decide that the service layer should hide synchronous vs asynchronous from the view. And if we _do_ decide that, we create a bunch of problems:

2. The Celery task now needs to call `SearchIndexService._queue`, accessing a private member. Generally speaking if a view is gonna call a service which is gonna call a task which is gonna call a service, then for every service method `foo()` we're gonna need a corresponding `foo_synchronously()` method for the task to call, or a `foo(..., synchronously=True)` argument, or `svc._queue.foo()` as in this case. So you get a proliferation of service-layer public methods/arguments instead of just one `svc.foo()` method

3. It's circuitous for a view to call a service that schedules a task that re-calls the same service. This is the kind of thing that makes developers tear their hair out and scream about indirectness and lack of simplicity. The view could just schedule a task to call the service.

4. It'd be nice to keep Celery out of our service layer. Keep all the Celery stuff in `h/tasks/` and have Celery tasks be called by views and Celery tasks call services. Keep the services pure. It'd be nice if our service layer could be used without RabbitMQ.

I'd prefer:

1. `SearchAdminViews` calls `tasks.indexer.add_annotations_between_times.delay()`, the view is making the decision to do a potentially long-running task asynchronously because the view needs to return a response quickly

2. `tasks.indexer.add_annotations_between_times()` calls `SearchIndexService.add_annotations_between_times()`

Less circuitous, avoids the private member access, keeps Celery and Rabbit out of the services, also puts the aysnchronous vs synchronous decision in the view which I think is probably the right place for it.

The current state of things is that there are some other existing cases where services call Celery tasks: the nipsa service does it (probably easy to change) and the `user_signup` service does it to send an email (I think this one may be an example of where it makes good sense for the service layer to call Celery), and `search_index` service does it in `handle_annotation_event()`