### PR TITLE
Fix service_test.py patches

### DIFF
--- a/h/services/search_index/service.py
+++ b/h/services/search_index/service.py
@@ -2,7 +2,7 @@ from h_pyramid_sentry import report_exception
 
 from h import storage
 from h.presenters import AnnotationSearchIndexPresenter
-from h.tasks.indexer import add_annotation, delete_annotation
+from h.tasks import indexer
 
 
 class SearchIndexService:
@@ -105,9 +105,12 @@ class SearchIndexService:
         :param event: AnnotationEvent object
         """
         if event.action in ["create", "update"]:
-            sync_handler, async_task = self.add_annotation_by_id, add_annotation
+            sync_handler, async_task = self.add_annotation_by_id, indexer.add_annotation
         elif event.action == "delete":
-            sync_handler, async_task = self.delete_annotation_by_id, delete_annotation
+            sync_handler, async_task = (
+                self.delete_annotation_by_id,
+                indexer.delete_annotation,
+            )
         else:
             return False
 

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -134,10 +134,6 @@ class TestAddAnnotation:
     def annotation(self, factories):
         return factories.Annotation.build()
 
-    @pytest.fixture(autouse=True)
-    def AnnotationSearchIndexPresenter(self, patch):
-        return patch("h.services.search_index.service.AnnotationSearchIndexPresenter")
-
 
 class TestAddAnnotationsBetweenTimes:
     def test_it(self, queue, search_index):
@@ -260,6 +256,11 @@ class TestSync:
         search_index.sync(10)
 
         queue.sync.assert_called_once_with(10)
+
+
+@pytest.fixture(autouse=True)
+def AnnotationSearchIndexPresenter(patch):
+    return patch("h.services.search_index.service.AnnotationSearchIndexPresenter")
 
 
 @pytest.fixture

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -223,12 +223,7 @@ class TestHandleAnnotationEvent:
         assert result == async_handler.return_value
 
     @pytest.fixture(autouse=True)
-    def handler_for(self, patch, add_annotation_by_id, delete_annotation_by_id):
-        add_annotation_task = patch("h.services.search_index.service.add_annotation")
-        delete_annotation_task = patch(
-            "h.services.search_index.service.delete_annotation"
-        )
-
+    def handler_for(self, add_annotation_by_id, delete_annotation_by_id, indexer):
         handler_map = {
             True: {
                 "create": add_annotation_by_id,
@@ -236,9 +231,9 @@ class TestHandleAnnotationEvent:
                 "delete": delete_annotation_by_id,
             },
             False: {
-                "create": add_annotation_task.delay,
-                "update": add_annotation_task.delay,
-                "delete": delete_annotation_task.delay,
+                "create": indexer.add_annotation.delay,
+                "update": indexer.add_annotation.delay,
+                "delete": indexer.delete_annotation.delay,
             },
         }
 
@@ -306,3 +301,8 @@ def search_index(es_client, pyramid_request, settings_service, queue):
 @pytest.fixture(autouse=True)
 def es_client():
     return create_autospec(Client, instance=True)
+
+
+@pytest.fixture(autouse=True)
+def indexer(patch):
+    return patch("h.services.search_index.service.indexer")

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -55,10 +55,6 @@ class TestAddAnnotationById:
 
         add_annotation.assert_has_calls([call(reply_annotation), call(root_annotation)])
 
-    @pytest.fixture(autouse=True)
-    def storage(self, patch):
-        return patch("h.services.search_index.service.storage")
-
     @pytest.fixture
     def root_annotation(self, factories):
         return factories.Annotation.build(references=[])
@@ -311,3 +307,8 @@ def indexer(patch):
 @pytest.fixture(autouse=True)
 def report_exception(patch):
     return patch("h.services.search_index.service.report_exception")
+
+
+@pytest.fixture(autouse=True)
+def storage(patch):
+    return patch("h.services.search_index.service.storage")

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -306,3 +306,8 @@ def es_client():
 @pytest.fixture(autouse=True)
 def indexer(patch):
     return patch("h.services.search_index.service.indexer")
+
+
+@pytest.fixture(autouse=True)
+def report_exception(patch):
+    return patch("h.services.search_index.service.report_exception")


### PR DESCRIPTION
Some fixups to the patch fixtures in `service_test.py`. I needed an `indexer` patch fixture in our usual style for the test change in https://github.com/hypothesis/h/pull/6339. I therefore needed to fix the `add_annotation_task` and `delete_annotation_task` patches, which were making the `indexer` patch impossible (once the `indexer` patch had been added the `add_annotation_task` and `delete_annotation_task` patches would be trying to re-patch already-patched names).

Also did some trivial fixups to the `storage` and `AnnotationSearchIndexPresenter` patches to follow our style, and added a missing `report_exception` patch.