### PR TITLE
Changes to speed up the sync queue tests

### DIFF
--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -11,7 +11,7 @@ from h.search.index import BatchIndexer
 from h.services.search_index import SearchIndexService
 from h.services.search_index._queue import Queue
 
-LIMIT = 10
+LIMIT = 2
 ONE_WEEK = datetime_.timedelta(weeks=1)
 MINUS_FIVE_MINUTES = datetime_.timedelta(minutes=-5)
 

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -76,19 +76,18 @@ class TestAddAnnotationsBetweenTimes:
     @pytest.fixture
     def annotations(self, factories):
         return factories.Annotation.create_batch(
-            size=10, updated=datetime_.datetime(year=2020, month=9, day=10)
+            size=2, updated=datetime_.datetime(year=2020, month=9, day=10)
         )
 
     @pytest.fixture(autouse=True)
     def non_matching_annotations(self, factories):
         """Annotations from outside the date range that we're reindexing."""
-        before_annotations = factories.Annotation.create_batch(
-            size=3, updated=datetime_.datetime(year=2020, month=9, day=8)
+        factories.Annotation.create(
+            updated=datetime_.datetime(year=2020, month=9, day=8)
         )
-        after_annotations = factories.Annotation.create_batch(
-            size=3, updated=datetime_.datetime(year=2020, month=9, day=12)
+        factories.Annotation.create(
+            updated=datetime_.datetime(year=2020, month=9, day=12)
         )
-        return before_annotations + after_annotations
 
     @pytest.fixture
     def annotation_ids(self, annotations):


### PR DESCRIPTION
I noticed these tests are quite slow, and I think it's because we create more fixtures than we really need to prove the code.

Changes here:

 * Used the limit value to define what we were looking for in assertions (we had lots of floating ints, which should be LIMIT)
 * This lets us change the limit and have the tests still work, it's also nice from a "why is this 10?" point of view
 * Made the "noise" annotations only add 1 extra on top of the LIMIT value
 * Trimmed down the values on the top test a bit too

This cut down the times for me like this over three runs:

 * master: [1280, 1003, 953]
 * this PR: [419, 386, 354]

Looks like it got faster on multiple runs a bit (I suspect postgres was doing some query magic), but it's somewhere between 2x and 3x as fast which is nice if you have to do it over and over.