### PR TITLE
Add Celery task name and ID to log messages

### DIFF
--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -1,7 +1,7 @@
+import logging
 from collections import Counter
 from datetime import datetime
 
-from celery.utils.log import get_task_logger
 from dateutil.parser import isoparse
 from sqlalchemy import func, select, text
 from zope.sqlalchemy import mark_changed
@@ -9,7 +9,7 @@ from zope.sqlalchemy import mark_changed
 from h.db.types import URLSafeUUID
 from h.models import Annotation, Job
 
-logger = get_task_logger(__name__)
+logger = logging.getLogger(__name__)
 
 # Strings used in log messages.
 DELETED_FROM_DB = "Jobs deleted because annotations were deleted from the DB"


### PR DESCRIPTION
Add the Celery task name and ID to all log messages logged by any part
of our code or third-party code called during a Celery task.

This is so we can see which log messages come from Celery tasks in the
logs, and easily filter to all log messages from a given task.

`{task.name}[{task.id}]` (with square brackets around the ID) is used as
the format for the task name and ID in the log messages because this is
how Celery formats it when representing a task in its own log messages.
Example:
`h.tasks.indexer.sync_annotations[12dd9a0d-a6d3-4917-b6f9-40b47ed9f268]`

`Queue` no longer needs to use Celery's `get_task_logger()` so remove
that.

Examples of how the log messages now look:

Celery logging when it receives a task. This is logged by the main
Celery process not by the task, so this log message is unchanged by this
commit:

    worker (stderr)      | [2020-10-21 14:50:45,257: INFO/MainProcess] Received task: h.tasks.indexer.sync_annotations[12dd9a0d-a6d3-4917-b6f9-40b47ed9f268]   expires:[2020-10-21 13:51:15.251935+00:00]

The `elasticsearch` lib logging `GET`'s and `POST`'s, now with the task
name and ID:

    worker (stderr)      | [2020-10-21 14:50:45,978: INFO/ForkPoolWorker-7] h.tasks.indexer.sync_annotations[12dd9a0d-a6d3-4917-b6f9-40b47ed9f268] GET http://localhost:9200/hypothesis/_search [status:200 request:0.029s]
    worker (stderr)      | [2020-10-21 14:50:48,959: INFO/ForkPoolWorker-7] h.tasks.indexer.sync_annotations[12dd9a0d-a6d3-4917-b6f9-40b47ed9f268] POST http://localhost:9200/_bulk [status:200 request:0.023s]

The batch indexer logging its indexing rate, now with the task name and
ID:

    worker (stderr)      | [2020-10-21 14:50:53,705: INFO/ForkPoolWorker-7] h.tasks.indexer.sync_annotations[12dd9a0d-a6d3-4917-b6f9-40b47ed9f268] indexed 2k annotations, rate=261/s

The job queue logging its results, now with the task name and ID:

    worker (stderr)      | [2020-10-21 14:51:14,850: INFO/ForkPoolWorker-7] h.tasks.indexer.sync_annotations[12dd9a0d-a6d3-4917-b6f9-40b47ed9f268] {'Annotations synced because they were not in Elasticsearch': 10000}

Celery logging the task result. This unfortunately now includes the task
name and ID twice because Celery also puts them in the `%(message)s`
part of the message. I don't think there's anything to be done about
this:

    worker (stderr)      | [2020-10-21 14:51:14,888: INFO/ForkPoolWorker-7] h.tasks.indexer.sync_annotations[12dd9a0d-a6d3-4917-b6f9-40b47ed9f268] Task h.tasks.indexer.sync_annotations[12dd9a0d-a6d3-4917-b6f9-40b47ed9f268] succeeded in 29.621645140927285s: None