### PR TITLE
Acknowledge periodic Celery tasks early

### DIFF
--- a/h/tasks/cleanup.py
+++ b/h/tasks/cleanup.py
@@ -6,7 +6,7 @@ from h.celery import celery, get_task_logger
 log = get_task_logger(__name__)
 
 
-@celery.task
+@celery.task(acks_late=False)
 def purge_deleted_annotations():
     """
     Remove annotations marked as deleted from the database.
@@ -22,21 +22,21 @@ def purge_deleted_annotations():
     ).delete()
 
 
-@celery.task
+@celery.task(acks_late=False)
 def purge_expired_auth_tickets():
     celery.request.db.query(models.AuthTicket).filter(
         models.AuthTicket.expires < datetime.utcnow()
     ).delete()
 
 
-@celery.task
+@celery.task(acks_late=False)
 def purge_expired_authz_codes():
     celery.request.db.query(models.AuthzCode).filter(
         models.AuthzCode.expires < datetime.utcnow()
     ).delete()
 
 
-@celery.task
+@celery.task(acks_late=False)
 def purge_expired_tokens():
     now = datetime.utcnow()
     celery.request.db.query(models.Token).filter(
@@ -44,7 +44,7 @@ def purge_expired_tokens():
     ).delete()
 
 
-@celery.task
+@celery.task(acks_late=False)
 def purge_removed_features():
     """Remove old feature flags from the database."""
     models.Feature.remove_old_flags(celery.request.db)

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -49,6 +49,6 @@ def reindex_user_annotations(userid):
         log.warning("Failed to re-index annotations into ES6 %s", errored)
 
 
-@celery.task
+@celery.task(acks_late=False)
 def sync_annotations(limit):
     celery.request.find_service(name="search_index").sync(limit)


### PR DESCRIPTION
By default our Celery tasks use `acks_late=True`:

https://github.com/hypothesis/h/blob/ade4a83ddf6d4587bc7aa16fde53403275f10d73/h/celery.py#L34

This means that the worker doesn't acknowledge the task (causing it to
be removed from the queue) until it has completed the task successfully.

That's actually what we want for most tasks but not for the periodic
tasks. If a worker takes a periodic task and for some reason doesn't
complete it we don't want Celery to re-deliver that periodic task to
another worker. The task will get tried again the next time its
scheduled.

Change the periodic tasks to ack early: the worker acknowledges the task
as soon as it receives it (before actually beginning to execute the
task) and Celery removes the task from the queue as soon as it has been
received by a worker, whether the worker completes the task or not.