### PR TITLE
Use a central function for queuing tasks

### DIFF
--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -53,16 +53,16 @@ class Queue:
         schedule_at = datetime.utcnow() + timedelta(seconds=schedule_in or 0)
 
         query = Job.__table__.insert().from_select(
-            [Job.name, Job.tag, Job.priority, Job.kwargs, Job.scheduled_at],
+            [Job.name, Job.scheduled_at, Job.priority, Job.tag, Job.kwargs],
             select(
                 [
                     text("'sync_annotation'"),
-                    text(repr(tag)),
+                    text(f"'{schedule_at}'"),
                     text(str(priority)),
+                    text(repr(tag)),
                     func.jsonb_build_object(
                         "annotation_id", Annotation.id, "force", bool(force)
                     ),
-                    text(f"'{schedule_at}'"),
                 ]
             ).where(where_clause),
         )

--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from logging import getLogger
 
 from dateutil.parser import isoparse
-from sqlalchemy import func, select, text, and_
+from sqlalchemy import and_, func, select, text
 from zope.sqlalchemy import mark_changed
 
 from h.db.types import URLSafeUUID
@@ -14,6 +14,11 @@ LOG = getLogger(__name__)
 
 class Queue:
     """A job queue for synchronizing annotations from Postgres to Elastic."""
+
+    class Priority:
+        SINGLE_ITEM = 1
+        SINGLE_USER = 100
+        BETWEEN_TIMES = 1000
 
     class Result:
         # Values for reporting which should stringify nicely
@@ -29,17 +34,28 @@ class Queue:
         self._batch_indexer = batch_indexer
 
     def add_where(self, tag, priority, where, force=False, schedule_in=None):
+        """
+        :param where
+
+        :param tag: The tag to add to the job on the queue. For documentation
+            purposes only
+        :param schedule_in: A number of seconds from now to wait before making
+            the job available for processing. The annotation won't be synced
+            until at least `schedule_in` seconds from now
+        :param force: Whether to force reindexing of the annotation even if
+            it's already indexed
+        """
         where_clause = and_(*where) if len(where) > 1 else where[0]
 
         query = Job.__table__.insert().from_select(
-            [Job.name, Job.priority, Job.tag, Job.kwargs, Job.scheduled_at],
+            [Job.name, Job.tag, Job.priority, Job.kwargs, Job.scheduled_at],
             select(
                 [
                     text("'sync_annotation'"),
-                    text(str(priority)),
                     text(repr(tag)),
+                    text(str(priority)),
                     func.jsonb_build_object(
-                        "annotation_id", Annotation.id, "force", force
+                        "annotation_id", Annotation.id, "force", bool(force)
                     ),
                     text(f"'{self._datetime_at(schedule_in)}'"),
                 ]
@@ -53,65 +69,26 @@ class Queue:
         """
         Queue an annotation to be synced to Elasticsearch.
 
+        See Queue.add_where() for documentation of the params.
+
         :param annotation_id: The ID of the annotation to be queued, in the
             application-level URL-safe format
-        :type annotation_id: unicode
-
-        :param tag: The tag to add to the job on the queue. For documentation
-            purposes only
-        :type tag: unicode
-
-        :param schedule_in: A number of seconds from now to wait before making
-            the job available for processing. The annotation won't be synced
-            until at least `schedule_in` seconds from now
-        :type schedule_in: int
-
-        :param force: Whether to force reindexing of the annotation even if
-            it's already indexed
-        :type force: bool
         """
-        return self.add_where(tag, priority=1, where=[
-            Annotation.id == annotation_id
-        ], schedule_in=schedule_in, force=force)
-
-    def add_all(self, annotation_ids, tag, schedule_in=None, force=False):
-        """
-        Queue a list of annotations to be synced to Elasticsearch.
-
-        See Queue.add() for documentation of the params.
-        """
-
-        # Jobs with a lower number for their priority get processed before jobs
-        # with a higher number. Make large batches of jobs added all at once
-        # get processed *after* small batches added a few at a time, so that
-        # large batches don't hold up small ones for a long time.
-
-        return self.add_where(tag, priority=len(annotation_ids), where=[
-            Annotation.id.in_(annotation_ids)
-        ], schedule_in=schedule_in, force=force)
+        where = [Annotation.id == annotation_id]
+        self.add_where(tag, self.Priority.SINGLE_ITEM, where, force, schedule_in)
 
     def add_annotations_between_times(self, start_time, end_time, tag, force=False):
         """
         Queue all annotations between two times to be synced to Elasticsearch.
 
-        All annotations whose updated time is >= start_time and <= end_time
-        will be queued for syncing to Elasticsearch.
+        See Queue.add_where() for documentation of the params.
 
-        See Queue.add() for documentation of the params.
-
-        :param start_time: The time to queue annotations from
-        :type start_time: datetime.datetime
-
-        :param end_time: The time to queue annotations until
-        :type end_time: datetime.datetime
+        :param start_time: The time to queue annotations from (inclusive)
+        :param end_time: The time to queue annotations until (inclusive)
         """
 
-        self.add_where(
-            tag,
-            priority=1000,
-            where=[Annotation.updated >= start_time, Annotation.updated <= end_time],
-            force=force,
-        )
+        where = [Annotation.updated >= start_time, Annotation.updated <= end_time]
+        self.add_where(tag, Queue.Priority.BETWEEN_TIMES, where, force)
 
     def add_users_annotations(self, userid, tag, force=False, schedule_in=None):
         """
@@ -123,13 +100,8 @@ class Queue:
         :type userid: unicode
         """
 
-        self.add_where(
-            tag,
-            priority=100,
-            where=[Annotation.userid == userid],
-            force=force,
-            schedule_in=schedule_in,
-        )
+        where = [Annotation.userid == userid]
+        self.add_where(tag, Queue.Priority.SINGLE_USER, where, force, schedule_in)
 
     def sync(self, limit):
         """

--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -35,15 +35,19 @@ class Queue:
 
     def add_where(self, tag, priority, where, force=False, schedule_in=None):
         """
-        :param where
+        Queue annotations matching a filter to be synced to ElasticSearch.
 
         :param tag: The tag to add to the job on the queue. For documentation
             purposes only
+        :param priority: Integer priority value (higher number is lower
+            priority)
+        :param where: A list of SQLAlchemy BinaryExpression objects to limit
+            the annotations to be added
+        :param force: Whether to force reindexing of the annotation even if
+            it's already indexed
         :param schedule_in: A number of seconds from now to wait before making
             the job available for processing. The annotation won't be synced
             until at least `schedule_in` seconds from now
-        :param force: Whether to force reindexing of the annotation even if
-            it's already indexed
         """
         where_clause = and_(*where) if len(where) > 1 else where[0]
         schedule_at = datetime.utcnow() + timedelta(seconds=schedule_in or 0)

--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -33,16 +33,16 @@ class Queue:
         self._es = es
         self._batch_indexer = batch_indexer
 
-    def add_where(self, tag, priority, where, force=False, schedule_in=None):
+    def add_where(self, where, tag, priority, force=False, schedule_in=None):
         """
         Queue annotations matching a filter to be synced to ElasticSearch.
 
+        :param where: A list of SQLAlchemy BinaryExpression objects to limit
+            the annotations to be added
         :param tag: The tag to add to the job on the queue. For documentation
             purposes only
         :param priority: Integer priority value (higher number is lower
             priority)
-        :param where: A list of SQLAlchemy BinaryExpression objects to limit
-            the annotations to be added
         :param force: Whether to force reindexing of the annotation even if
             it's already indexed
         :param schedule_in: A number of seconds from now to wait before making
@@ -80,7 +80,7 @@ class Queue:
             application-level URL-safe format
         """
         where = [Annotation.id == annotation_id]
-        self.add_where(tag, self.Priority.SINGLE_ITEM, where, force, schedule_in)
+        self.add_where(where, tag, self.Priority.SINGLE_ITEM, force, schedule_in)
 
     def add_annotations_between_times(self, start_time, end_time, tag, force=False):
         """
@@ -93,7 +93,7 @@ class Queue:
         """
 
         where = [Annotation.updated >= start_time, Annotation.updated <= end_time]
-        self.add_where(tag, Queue.Priority.BETWEEN_TIMES, where, force)
+        self.add_where(where, tag, Queue.Priority.BETWEEN_TIMES, force)
 
     def add_users_annotations(self, userid, tag, force=False, schedule_in=None):
         """
@@ -106,7 +106,7 @@ class Queue:
         """
 
         where = [Annotation.userid == userid]
-        self.add_where(tag, Queue.Priority.SINGLE_USER, where, force, schedule_in)
+        self.add_where(where, tag, Queue.Priority.SINGLE_USER, force, schedule_in)
 
     def sync(self, limit):
         """

--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -46,6 +46,7 @@ class Queue:
             it's already indexed
         """
         where_clause = and_(*where) if len(where) > 1 else where[0]
+        schedule_at = datetime.utcnow() + timedelta(seconds=schedule_in or 0)
 
         query = Job.__table__.insert().from_select(
             [Job.name, Job.tag, Job.priority, Job.kwargs, Job.scheduled_at],
@@ -57,7 +58,7 @@ class Queue:
                     func.jsonb_build_object(
                         "annotation_id", Annotation.id, "force", bool(force)
                     ),
-                    text(f"'{self._datetime_at(schedule_in)}'"),
+                    text(f"'{schedule_at}'"),
                 ]
             ).where(where_clause),
         )
@@ -224,8 +225,3 @@ class Queue:
             annotation_from_es["updated"] == annotation_from_db.updated
             and annotation_from_es["user"] == annotation_from_db.userid
         )
-
-    @staticmethod
-    def _datetime_at(delta_seconds):
-        """Return the datetime at delta_seconds seconds from now."""
-        return datetime.utcnow() + timedelta(seconds=delta_seconds or 0)

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -30,9 +30,9 @@ class TestAddMethods:
         factories.Annotation.create(shared=False)
 
         queue.add_where(
+            where=[Annotation.shared.is_(True)],
             tag="test_tag",
             priority=1234,
-            where=[Annotation.shared.is_(True)],
             schedule_in=ONE_WEEK_IN_SECONDS,
         )
 
@@ -92,14 +92,14 @@ class TestAddMethods:
         )
 
         add_where.assert_called_once_with(
+            [Any.instance_of(BinaryExpression)],
             sentinel.tag,
             Queue.Priority.SINGLE_ITEM,
-            [Any.instance_of(BinaryExpression)],
             sentinel.force,
             sentinel.schedule_in,
         )
 
-        where = add_where.call_args[0][2]
+        where = add_where.call_args[0][0]
         assert where[0].compare(Annotation.id == sentinel.annotation_id)
 
     def test_add_annotations_between_times(self, queue, add_where):
@@ -108,13 +108,13 @@ class TestAddMethods:
         )
 
         add_where.assert_called_once_with(
+            [Any.instance_of(BinaryExpression)] * 2,
             sentinel.tag,
             Queue.Priority.BETWEEN_TIMES,
-            [Any.instance_of(BinaryExpression)] * 2,
             sentinel.force,
         )
 
-        where = add_where.call_args[0][2]
+        where = add_where.call_args[0][0]
         assert where[0].compare(Annotation.updated >= sentinel.start_time)
         assert where[1].compare(Annotation.updated <= sentinel.end_time)
 
@@ -127,14 +127,14 @@ class TestAddMethods:
         )
 
         add_where.assert_called_once_with(
+            [Any.instance_of(BinaryExpression)],
             sentinel.tag,
             Queue.Priority.SINGLE_USER,
-            [Any.instance_of(BinaryExpression)],
             sentinel.force,
             sentinel.schedule_in,
         )
 
-        where = add_where.call_args[0][2]
+        where = add_where.call_args[0][0]
         assert where[0].compare(Annotation.userid == sentinel.userid)
 
     def database_id(self, annotation):

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -32,9 +32,7 @@ class TestAddMethods:
         queue.add_where(
             tag="test_tag",
             priority=1234,
-            # Tell lint to ignore comparisons to True, which are required to
-            # form the SQLAlchemy BinaryExpression
-            where=[Annotation.shared == True],  # noqa: E712
+            where=[Annotation.shared.is_(True)],
             schedule_in=ONE_WEEK_IN_SECONDS,
         )
 
@@ -46,7 +44,7 @@ class TestAddMethods:
                     tag="test_tag",
                     priority=1234,
                     kwargs={
-                        "annotation_id": self.mapped_id(annotation),
+                        "annotation_id": self.database_id(annotation),
                         "force": False,
                     },
                 )
@@ -139,7 +137,8 @@ class TestAddMethods:
         where = add_where.call_args[0][2]
         assert where[0].compare(Annotation.userid == sentinel.userid)
 
-    def mapped_id(self, annotation):
+    def database_id(self, annotation):
+        """Return `annotation.id` in the internal format used within the database."""
         return str(uuid.UUID(URLSafeUUID.url_safe_to_hex(annotation.id)))
 
     @pytest.fixture()

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -20,7 +20,7 @@ MINUS_5_MIN = datetime_.timedelta(minutes=-5)
 MINUS_5_MIN_IN_SECS = int(MINUS_5_MIN.total_seconds())
 
 
-class TestAddMethods:
+class TestQueue:
     def test_add_where(self, queue, factories, db_session, now):
         matching = [
             factories.Annotation.create(shared=True),
@@ -147,7 +147,7 @@ class TestAddMethods:
             yield add_where
 
 
-class TestSyncAnnotations:
+class TestSync:
     def test_it_does_nothing_if_the_queue_is_empty(self, batch_indexer, queue):
         queue.sync(LIMIT)
 


### PR DESCRIPTION
Change summary:

 * There is now a function called `add_where`
 * This function is the only one that calls SQLAlchemy for adding, all others proxy to it
 * Added a priority enum like object
 * Removed `add_all()` as it was only used by the tests (and the behavior changed as a result of this)
 * Rewrote the tests to grill `add_where` as before, but have mocked tests for the rest
 * Added some `use_fixture` decorators to make the tests a bit shorter and more focused
 
## Review notes

 * There's some jumble in the `_queue.py` file as the add methods have been re-ordered to put where at the top, as it's the one that actually does the work
 * All of the `add_*` methods are now tested together in `TestAddMethods`
 * The changes to `TestSyncAnnotations` were:
   * Using a fixture for `add_all` instead of the function
   * Using some fixtures to cut down on arguments and repetition in some places
   * Hopefully this leaves what we are setting up and asserting a bit clearer
