### PR TITLE
Various small tidies to the queue services and surrounding things

### DIFF
--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -79,7 +79,6 @@ class Queue:
         :param start_time: The time to queue annotations from (inclusive)
         :param end_time: The time to queue annotations until (inclusive)
         """
-
         where = [Annotation.updated >= start_time, Annotation.updated <= end_time]
         self.add_where(where, tag, Queue.Priority.BETWEEN_TIMES, force)
 
@@ -104,7 +103,6 @@ class Queue:
         :param userid: The ID of the user in "acct:USERNAME@AUTHORITY" format
         :type userid: unicode
         """
-
         where = [Annotation.userid == userid]
         self.add_where(where, tag, Queue.Priority.SINGLE_USER, force, schedule_in)
 
@@ -167,7 +165,7 @@ class Queue:
             elif not annotation_from_es:
                 annotation_ids_to_sync.add(annotation_id)
                 counts[Queue.Result.MISSING] += 1
-            elif not self.equal(annotation_from_es, annotation_from_db):
+            elif not self._equal(annotation_from_es, annotation_from_db):
                 annotation_ids_to_sync.add(annotation_id)
                 counts[Queue.Result.DIFFERENT] += 1
             else:
@@ -223,8 +221,8 @@ class Queue:
         return {hit["_id"]: hit["_source"] for hit in hits}
 
     @staticmethod
-    def equal(annotation_from_es, annotation_from_db):
-        """Return True if the annotation from Elasticsearch is equal to the one from Postgres."""
+    def _equal(annotation_from_es, annotation_from_db):
+        """Test if the annotations are equal."""
         return (
             annotation_from_es["updated"] == annotation_from_db.updated
             and annotation_from_es["user"] == annotation_from_db.userid

--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -70,19 +70,7 @@ class Queue:
         self._db.execute(query)
         mark_changed(self._db)
 
-    def add(self, annotation_id, tag, schedule_in=None, force=False):
-        """
-        Queue an annotation to be synced to Elasticsearch.
-
-        See Queue.add_where() for documentation of the params.
-
-        :param annotation_id: The ID of the annotation to be queued, in the
-            application-level URL-safe format
-        """
-        where = [Annotation.id == annotation_id]
-        self.add_where(where, tag, self.Priority.SINGLE_ITEM, force, schedule_in)
-
-    def add_annotations_between_times(self, start_time, end_time, tag, force=False):
+    def add_between_times(self, start_time, end_time, tag, force=False):
         """
         Queue all annotations between two times to be synced to Elasticsearch.
 
@@ -95,7 +83,19 @@ class Queue:
         where = [Annotation.updated >= start_time, Annotation.updated <= end_time]
         self.add_where(where, tag, Queue.Priority.BETWEEN_TIMES, force)
 
-    def add_users_annotations(self, userid, tag, force=False, schedule_in=None):
+    def add_by_id(self, annotation_id, tag, force=False, schedule_in=None):
+        """
+        Queue an annotation to be synced to Elasticsearch.
+
+        See Queue.add_where() for documentation of the params.
+
+        :param annotation_id: The ID of the annotation to be queued, in the
+            application-level URL-safe format
+        """
+        where = [Annotation.id == annotation_id]
+        self.add_where(where, tag, Queue.Priority.SINGLE_ITEM, force, schedule_in)
+
+    def add_by_user(self, userid, tag, force=False, schedule_in=None):
         """
         Queue all a user's annotations to be synced to Elasticsearch.
 

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -23,16 +23,14 @@ def add_annotation(id_):
 
 @celery.task
 def add_annotations_between_times(start_time, end_time, tag):
-    celery.request.find_service(name="search_index")._queue.add_between_times(
-        start_time, end_time, tag
-    )
+    search_index = celery.request.find_service(name="search_index")
+    search_index._queue.add_between_times(start_time, end_time, tag)
 
 
 @celery.task
 def add_users_annotations(userid, tag, force, schedule_in):
-    celery.request.find_service(name="search_index")._queue.add_by_user(
-        userid, tag, force=force, schedule_in=schedule_in
-    )
+    search_index = celery.request.find_service(name="search_index")
+    search_index._queue.add_by_user(userid, tag, force=force, schedule_in=schedule_in)
 
 
 @celery.task(base=_BaseTaskWithRetry)
@@ -43,4 +41,5 @@ def delete_annotation(id_):
 
 @celery.task(acks_late=False)
 def sync_annotations(limit):
-    celery.request.find_service(name="search_index").sync(limit)
+    search_index = celery.request.find_service(name="search_index")
+    search_index.sync(limit)

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -23,14 +23,14 @@ def add_annotation(id_):
 
 @celery.task
 def add_annotations_between_times(start_time, end_time, tag):
-    celery.request.find_service(
-        name="search_index"
-    )._queue.add_annotations_between_times(start_time, end_time, tag)
+    celery.request.find_service(name="search_index")._queue.add_between_times(
+        start_time, end_time, tag
+    )
 
 
 @celery.task
 def add_users_annotations(userid, tag, force, schedule_in):
-    celery.request.find_service(name="search_index")._queue.add_users_annotations(
+    celery.request.find_service(name="search_index")._queue.add_by_user(
         userid, tag, force=force, schedule_in=schedule_in
     )
 

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -66,22 +66,9 @@ class TestQueue:
     ):
         annotation = factories.Annotation.create()
 
-        queue.add_where(
-            tag="test_tag",
-            priority=1,
-            where=[Annotation.id == annotation.id],
-            force=force,
-        )
+        queue.add_where([Annotation.id == annotation.id], "test_tag", 1, force=force)
 
-        assert db_session.query(Job).one() == Any.instance_of(Job).with_attrs(
-            {
-                "kwargs": Any.dict.containing(
-                    {
-                        "force": expected_force,
-                    }
-                )
-            }
-        )
+        assert db_session.query(Job).one().kwargs["force"] == expected_force
 
     def test_add_by_id(self, queue, add_where):
         queue.add_by_id(

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -83,8 +83,8 @@ class TestQueue:
             }
         )
 
-    def test_add(self, queue, add_where):
-        queue.add(
+    def test_add_by_id(self, queue, add_where):
+        queue.add_by_id(
             sentinel.annotation_id,
             sentinel.tag,
             schedule_in=sentinel.schedule_in,
@@ -103,7 +103,7 @@ class TestQueue:
         assert where[0].compare(Annotation.id == sentinel.annotation_id)
 
     def test_add_annotations_between_times(self, queue, add_where):
-        queue.add_annotations_between_times(
+        queue.add_between_times(
             sentinel.start_time, sentinel.end_time, sentinel.tag, force=sentinel.force
         )
 
@@ -119,7 +119,7 @@ class TestQueue:
         assert where[1].compare(Annotation.updated <= sentinel.end_time)
 
     def test_add_users_annotations(self, queue, add_where):
-        queue.add_users_annotations(
+        queue.add_by_user(
             sentinel.userid,
             sentinel.tag,
             force=sentinel.force,
@@ -279,7 +279,6 @@ class TestSync:
         self, annotations, batch_indexer, add_all, db_session, index, queue, LOG
     ):
         add_all(ids=[annotations[0].id for _ in range(LIMIT)])
-
         index([annotations[0]])
 
         queue.sync(LIMIT)
@@ -341,7 +340,9 @@ class TestSync:
     def add_all(self, queue, annotation_ids):
         def add_all(ids=annotation_ids, schedule_in=MINUS_5_MIN_IN_SECS, force=False):
             for id_ in ids:
-                queue.add(id_, tag="test_tag", schedule_in=schedule_in, force=force)
+                queue.add_by_id(
+                    id_, tag="test_tag", schedule_in=schedule_in, force=force
+                )
 
         return add_all
 

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -32,7 +32,7 @@ class TestAddAnnotationsBetweenTimes:
             sentinel.start_time, sentinel.end_time, sentinel.tag
         )
 
-        search_index._queue.add_annotations_between_times.assert_called_once_with(
+        search_index._queue.add_between_times.assert_called_once_with(
             sentinel.start_time, sentinel.end_time, sentinel.tag
         )
 
@@ -46,7 +46,7 @@ class TestAddUsersAnnotations:
             schedule_in=sentinel.schedule_in,
         )
 
-        search_index._queue.add_users_annotations.assert_called_once_with(
+        search_index._queue.add_by_user.assert_called_once_with(
             sentinel.userid,
             sentinel.tag,
             force=sentinel.force,


### PR DESCRIPTION
A bit of a grab bag of small changes, but the biggest bit is changing the names of the methods. There was some methods which mentioned `annotation` and some that didn't. The whole queue is annotation, so I think the context is enough, and the shorter names are nicer. Most methods mentioned the method by which something is added, but `add` didn't etc.

Previously we had: 

* `add`
* `add_where`
* ~`add_all`~ Removed in previous PR
* `add_annotation_by_user`
* `add_annotation_between_dates`

Now it's: 

 * `add_where`
 * `add_by_id`
 * `add_by_user`
 * `add_between dates`

Some methods had `force` before `schedule_in`, others vice versa. It's now `force` first for all

Some other small bits:

 * A simple test in one place
 * Made `_equals` private with a shorter description
 * Made all the celery tasks have the same layout (get service, use service)