### PR TITLE
Fix reindex_date job queue tag

### DIFF
--- a/h/views/admin/search.py
+++ b/h/views/admin/search.py
@@ -23,7 +23,7 @@ class SearchAdminViews:
         end_time = isoparse(self.request.params["end"].strip())
 
         self.request.find_service(name="search_index").add_annotations_between_times(
-            start_time, end_time, tag="reindex_date()"
+            start_time, end_time, tag="reindex_date"
         )
 
         self.request.session.flash(

--- a/tests/h/views/admin/search_test.py
+++ b/tests/h/views/admin/search_test.py
@@ -22,7 +22,7 @@ class TestSearchAdminViews:
         search_index.add_annotations_between_times.assert_called_once_with(
             datetime.datetime(year=2020, month=9, day=9),
             datetime.datetime(year=2020, month=9, day=11),
-            "reindex_date()",
+            "reindex_date",
         )
         assert pyramid_request.session.peek_flash("success") == [
             "Began reindexing from 2020-09-09 00:00:00 to 2020-09-11 00:00:00"


### PR DESCRIPTION
Let's avoid using `()`'s on these. This was the only place where `()`'s were used in a tag