### PR TITLE
Add sync-annotations API job queue length metric

### DIFF
--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -11,6 +11,7 @@ from .feature import Feature
 from .flag import Flag
 from .group import Group, OpenGroup, RestrictedGroup
 from .group_scope import GroupScope
+from .job import Job
 from .organization import Organization
 from .setting import Setting
 from .token import DeveloperToken, OAuth2Token
@@ -33,6 +34,7 @@ __all__ = (
     "Flag",
     "Group",
     "GroupScope",
+    "Job",
     "OAuth2Token",
     "OpenGroup",
     "Organization",

--- a/tests/common/factories/job.py
+++ b/tests/common/factories/job.py
@@ -1,0 +1,14 @@
+from factory import Faker
+
+from h import models
+
+from .base import ModelFactory
+
+
+class Job(ModelFactory):
+    class Meta:
+        model = models.Job
+
+    name = "test_job"
+    priority = Faker("random_element", elements=[1, 100, 1000, 10000])
+    tag = "test_tag"


### PR DESCRIPTION
Add a Celery task, intended to be called periodically by h-periodic, that reports the number of API-created sync_annotations jobs on the queue.

The aim is to be able to create a New Relic alarm that:

* Will go off if the sync_annotation jobs being added by the create_annotation and update_annotation APIs aren't being consumed fast enough
* Will not be triggered by batches of jobs added by admin pages. These aren't a problem (the `priority` ensures that), it's totally fine for admin pages to make the queue really long
* Will not be triggered by expired jobs. These aren't a problem because they get ignored: https://github.com/hypothesis/h/pull/6371 I intend to add a separate metric and alarm for expired jobs because jobs shouldn't be living long enough to expire, so any expired jobs indicates a problem
* Will not be triggered by non-sync_annotation jobs (if we ever have any other types of job in future)