### PR TITLE
Revert "Force reindexing of annotations in time frames"

### DIFF
--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -70,7 +70,7 @@ class Queue:
         self._db.execute(query)
         mark_changed(self._db)
 
-    def add_between_times(self, start_time, end_time, tag, force=True):
+    def add_between_times(self, start_time, end_time, tag, force=False):
         """
         Queue all annotations between two times to be synced to Elasticsearch.
 


### PR DESCRIPTION
Reverts hypothesis/h#6351. Speed-testing of the sync task is finished (see https://hypothes-is.slack.com/archives/C4K6M7P5E/p1603385554156100) for `force` is no longer needed here