### PR TITLE
Ignore expired jobs on the job queue

### DIFF
--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -181,11 +181,14 @@ class Queue:
         LOG.info(dict(counts))
 
     def _get_jobs_from_queue(self, limit):
+        now = datetime.utcnow()
+
         return (
             self._db.query(Job)
             .filter(
                 Job.name == "sync_annotation",
-                Job.scheduled_at < datetime.utcnow(),
+                Job.scheduled_at < now,
+                Job.expires_at > now,
             )
             .order_by(Job.priority, Job.enqueued_at)
             .limit(limit)


### PR DESCRIPTION
Currently all jobs have an `expires_at` date 30 days after they were enqueued:

https://github.com/hypothesis/h/blob/d047b6026110b0f6b693bbd418b00e62d410132a/h/models/job.py#L45-L47

(nothing ever overrides that `server_default` currently).

Up until now my plan had been to add a periodic Celery task to delete expired jobs from the queue. But deleting the jobs means we'd lose them forever, so now I'm considering adding monitoring of the number of expired jobs to New Relic and an alarm based on that.

Either way, but especially if we're going for monitoring instead of deleting, the sync-annotations task should ignore expired jobs so they don't get in the way of non-expired ones and clog up the queue.