### PR TITLE
Add expired jobs metric

### DIFF
--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -2,7 +2,6 @@ from unittest import mock
 from unittest.mock import sentinel
 
 import pytest
-from h_matchers import Any
 
 from h.tasks import indexer
 
@@ -62,16 +61,9 @@ class TestSyncAnnotations:
         search_index.sync.assert_called_once_with("test_queue")
 
 
-class TestReportSyncAnnotationsQueueLength:
-    def test_it(self, newrelic, search_index):
-        indexer.report_sync_annotations_queue_length()
-
-        search_index._queue.count.assert_called_once_with(
-            ["storage.create_annotation", "storage.update_annotation"]
-        )
-        newrelic.agent.record_custom_metric.assert_called_once_with(
-            Any.string(), search_index._queue.count.return_value
-        )
+class TestReportJobQueueMetrics:
+    def test_it(self):
+        indexer.report_job_queue_metrics()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Rather than creating a periodic Celery task to delete them, I want to create a New Relic alarm for when there are any expired jobs on the queue because jobs should never live long enough to expire (all jobs [expire after 30 days](https://github.com/hypothesis/h/blob/6c38a98efa3d447a682bc1a94fddd70b21c45825/h/models/job.py#L45-L47))