### PR TITLE
Report annotation indexing and job completion rates to New Relic

### DIFF
--- a/h/services/search_index/service.py
+++ b/h/services/search_index/service.py
@@ -131,7 +131,7 @@ class SearchIndexService:
 
     def sync(self, limit):
         """Process `limit` sync_annotation jobs from the job queue."""
-        self._queue.sync(limit)
+        return self._queue.sync(limit)
 
     def _index_annotation_body(self, annotation_id, body, refresh, target_index=None):
         self._es.conn.index(

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -43,7 +43,16 @@ def delete_annotation(id_):
 @celery.task(acks_late=False)
 def sync_annotations(limit):
     search_index = celery.request.find_service(name="search_index")
-    search_index.sync(limit)
+
+    counts = search_index.sync(limit)
+
+    log.info(dict(counts))
+    newrelic.agent.record_custom_metrics(
+        [
+            (f"Custom/SyncAnnotations/Queue/{key}", value)
+            for key, value in counts.items()
+        ]
+    )
 
 
 @celery.task(acks_late=False)

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -270,9 +270,10 @@ class TestHandleAnnotationEvent:
 
 class TestSync:
     def test_it(self, search_index, queue):
-        search_index.sync(10)
+        returned = search_index.sync(10)
 
         queue.sync.assert_called_once_with(10)
+        assert returned == queue.sync.return_value
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Add recording of the `sync_annotations()` task's annotation indexing and job completion rates to New Relic.  These are needed to round out our New Relic monitoring and alerting for the job queue.

Job completion rate
-------------------

This is needed because we need to set a low-watermark alarm (probably 0) on it. Here's the plan for the different things that could go wrong with the queue, and how we're going to alert on them from New Relic.

I'm planning to use three alarms:

1. A queue length high-watermark alarm
2. A job completion rate low-watermark alarm
3. An alarm that triggers whenever there are any expired jobs (jobs expire if they've been on the queue for 30 days)

Things that can go wrong, and which alarms will trigger:

1. The consumer has stopped consuming jobs from the queue:

   * Job completion rate low-watermark alarm would trigger
   * Since the producer is still adding jobs to the queue the queue will grow, and the queue length high watermark will _eventually_ trigger, but job completion rate low-watermark will be faster

2. The producer has stopped adding jobs to the queue:

   * Job completion rate low-watermark alarm would trigger

3. The producer has stopped producing and the consumer has stopped consuming at the same time:

   * There might still be a fixed number of jobs on the queue and they would just sit there, so no queue-length alarms would trigger
   * Job completion rate low-watermark alarm would trigger
   * Expired jobs alarm would _eventually_ trigger (after 30 days)

4. The producer is outpacing the consumer:

   * Queue length high-watermark alarm would trigger

5. There are problematic jobs on the queue that never get completed no matter how many times the consumer attempts them:

   * Queue length high-watermark alarm would trigger if there are enough problem jobs to hit it
   * Expired jobs alarm will eventually trigger (after 30 days) even if it's only a single problem job

Metric and alarms that we're _not_ going to use:

* We don't need a job creation rate metric, it wouldn't cover any situation that isn't covered by the alarms above
* We don't need a queue length low-watermark, it wouldn't cover any situation that isn't covered by the alarms above
* We don't need a job completion rate high watermark, the consumer runs at a fixed maximum rate that it can't exceed

Annotation indexing rate
------------------------

This metric isn't really needed, I'm not planning to create any alarms based on it. But if we're going to have `Queue.sync()` record metrics it seems perverse not to record how many annotations it syncs. And I can imagine this being useful to look at in the dashboard. For example when recovering from a RabbitMQ incident, you can watch it to see how many annotations actually got missed during the incident and are being indexed by the task. Or you can look at it just to see if the task actually indexed anything in the last week.

Queue refactoring
-----------------

`Queue.sync()` now returns its `counts` instead of passing them to `log.info()`, as previously suggested.

This is because the counts now need to be used to send metrics to New Relic as well and:

First, I think it's nicer to keep the `newrelic` third-party dependency in the Celery task, rather than having `Queue` call `newrelic` directly from the service layer.

Second, it makes the tests a lot easier. On master `TestQueue` has a lot of tests that do assertions about logging:

    def test_if_the_job_has_force_True_it_indexes_the_annotation_and_deletes_the_job():
        ...

        LOG.info.assert_called_with({Queue.Result.FORCED: LIMIT})

We've only actually added a single call to `newrelic.agent.record_custom_metrics()` so we should be able to cover it in one or two tests. But if `newrelic` were called within `Queue` every one of these tests would now need a `newrelic` assertion as well (unless we just didn't bother testing the `newrelic` calls):

    def test_if_the_job_has_force_True_it_indexes_the_annotation_and_deletes_the_job():
        ...

        LOG.info.assert_called_with({Queue.Result.FORCED: LIMIT})
        newrelic.agent.record_custom_metrics.assert_called_once_with(
            [
                (Queue.Metric.INDEXED, LIMIT),
                (Queue.Metric.COMPLETED, 0),
            ]
        )

We end up having to add one of these `newrelic` assertions to almost every test in `Queue`.

By having `Queue` just return `counts` and `TestQueue` just assert about what `counts` are returned, we now need only one `log.info` assert and one `newrelic` assert, in the test for the Celery task that receives the returned counts and reports them to the logs and to New Relic
