### PR TITLE
Add job queue length metric

### DIFF
--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -199,8 +199,8 @@ class Queue:
 
         return counts
 
-    def count(self, tags=None, expired=False):
-        return self._job_query(tags=tags, expired=expired).count()
+    def count(self, tags=None):
+        return self._job_query(tags=tags).count()
 
     def _get_jobs_from_queue(self, limit):
         return (
@@ -211,22 +211,15 @@ class Queue:
             .all()
         )
 
-    def _job_query(self, tags=None, expired=False):
+    def _job_query(self, tags=None):
         now = datetime.utcnow()
 
         query = self._db.query(Job).filter(
-            Job.name == "sync_annotation", Job.scheduled_at < now
+            Job.name == "sync_annotation", Job.scheduled_at < now, Job.expires_at >= now
         )
 
         if tags:
             query = query.filter(Job.tag.in_(tags))
-
-        if expired:
-            # Only find expired jobs.
-            query = query.filter(Job.expires_at < now)
-        else:
-            # Only find jobs that aren't expired.
-            query = query.filter(Job.expires_at >= now)
 
         return query
 

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -384,17 +384,13 @@ class TestSync:
 
 class TestCount:
     @pytest.mark.parametrize(
-        "tags,expired,expected_result",
+        "tags,expected_result",
         [
-            (None, False, 3),
-            (None, True, 1),
-            (["storage.create_annotation", "storage.update_annotation"], False, 2),
-            (["storage.create_annotation", "storage.update_annotation"], True, 1),
+            (None, 3),
+            (["storage.create_annotation", "storage.update_annotation"], 2),
         ],
     )
-    def test_it(
-        self, db_session, factories, now, queue, tags, expired, expected_result
-    ):
+    def test_it(self, db_session, factories, now, queue, tags, expected_result):
         one_minute = datetime_.timedelta(minutes=1)
 
         class JobFactory(factories.Job):
@@ -414,7 +410,7 @@ class TestCount:
         # A job that isn't scheduled yet.
         JobFactory.create(scheduled_at=now + one_minute)
 
-        count = queue.count(tags=tags, expired=expired)
+        count = queue.count(tags=tags)
 
         assert count == expected_result
 


### PR DESCRIPTION
Add a New Relic metric for the total length of the job queue, a count of all job table rows regardless of name, tag, scheduled, expired or anything else.

I don't think we strictly need this and I'm not planning to set any alarms based on it, but it just seems like an obvious thing to have, and it could reveal useful information when looking at the dashboard. For example if an admin page adds a large batch of jobs that'll show up in this