### PR TITLE
Use fewer retries when indexing annotations

### DIFF
--- a/h/storage.py
+++ b/h/storage.py
@@ -148,7 +148,7 @@ def create_annotation(request, data, group_service):
     request.db.flush()
 
     request.find_service(name="search_index")._queue.add_by_id(
-        annotation.id, tag="storage.create_annotation", schedule_in=180
+        annotation.id, tag="storage.create_annotation", schedule_in=60
     )
 
     return annotation
@@ -211,7 +211,7 @@ def update_annotation(request, id_, data, group_service):
         annotation.document = document
 
     request.find_service(name="search_index")._queue.add_by_id(
-        id_, tag="storage.update_annotation", schedule_in=180
+        id_, tag="storage.update_annotation", schedule_in=60
     )
 
     return annotation

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -9,11 +9,7 @@ log = get_task_logger(__name__)
 # See: https://docs.celeryproject.org/en/stable/userguide/tasks.html#automatic-retry-for-known-exceptions
 class _BaseTaskWithRetry(Task):
     autoretry_for = (Exception,)
-    retry_kwargs = {"max_retries": 5}
-    # Add exponential back-off
-    retry_backoff = True
-    # Shuffle the times a bit to prevent the thundering herd problem
-    retry_jitter = True
+    retry_kwargs = {"countdown": 5, "max_retries": 1}
 
 
 @celery.task(base=_BaseTaskWithRetry)

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -360,7 +360,7 @@ class TestCreateAnnotation:
         )
 
         search_index._queue.add_by_id.assert_called_once_with(
-            annotation.id, tag="storage.create_annotation", schedule_in=180
+            annotation.id, tag="storage.create_annotation", schedule_in=60
         )
 
     def test_it_returns_the_annotation(
@@ -623,7 +623,7 @@ class TestUpdateAnnotation:
         )
 
         search_index._queue.add_by_id.assert_called_once_with(
-            "test_annotation_id", tag="storage.update_annotation", schedule_in=180
+            "test_annotation_id", tag="storage.update_annotation", schedule_in=60
         )
 
     def test_it_returns_the_annotation(


### PR DESCRIPTION
When an API request's initial attempt to index an annotation into Elasticsearch during the request fails it hands the annotation over to Celery to re-try the indexing a number of times over a period of time.

Change the number of re-tries that Celery performs from 5, which means the first Celery attempt plus five re-tries, making 7 attempts in total (counting the original non-Celery attempt by the web request) to 1 (3 attempts total).

This is to avoid potentially shooting ourselves in the foot by greatly increasing our RabbitMQ usage and Elasticsearch index requests (by up to 7x for Elasticsearch and orders of magnitude for RabbitMQ) if Elasticsearch starts struggling and requests to it start failing. Given that we have the periodic sync task to ensure that annotations get into Elasticsearch eventually, making 7 attempts before leaving it to the periodic task seems like overkill and may cause an unnecessary burden on Elasticsearch or RabbitMQ during an incident.

Also remove the `retry_backoff` and `retry_jitter` options as these are no longer necessary when we're only using one retry.

Also schedule newly created or updated annotations for syncing by the periodic sync task sooner. These were being scheduled for syncing no less than three minutes after the annotation create/update in the DB to allow the Celery task with 5 retries (in the worst case) to complete all its attempts before the periodic task began trying to sync the annotation. Now that the Celery task is only making 1 retry it's no longer necessary to delay the periodic sync by as long.

From testing in dev if Elasticsearch is down it seems to take about 40 secs for all the Celery task retries to be finished. So I've set `schedule_in` to 60s.

See this Slack thread for discussion:

https://hypothes-is.slack.com/archives/C4K6M7P5E/p1604314197454200

These same retry settings also affect the Celery task that's used for deleting annotations from Elasticsearch.