### PR TITLE
Add feature flag for notebook prototype

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -13,6 +13,7 @@ FEATURES = {
     ),
     "client_display_names": "Render display names instead of user names in the client",
     "client_search_input": "Show redesigned search/filter input in client",
+    "notebook_launch": "Allow access to notebook feature",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.


### PR DESCRIPTION
This adds a feature flag to use while developing the "Project Notebook" prototype. Part of https://github.com/hypothesis/product-backlog/issues/1153

Note: While adding this, I noted an out-of-date client-related flag still tracked. I've added a TODO to my list to remove this.