### PR TITLE
Prepare to remove unused client-search feature flag

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -12,7 +12,6 @@ FEATURES = {
         "using a cached version?"
     ),
     "client_display_names": "Render display names instead of user names in the client",
-    "client_search_input": "Show redesigned search/filter input in client",
     "notebook_launch": "Allow access to notebook feature",
 }
 
@@ -34,7 +33,9 @@ FEATURES = {
 #
 # 4. Finally, remove the feature from FEATURES_PENDING_REMOVAL.
 #
-FEATURES_PENDING_REMOVAL = {}
+FEATURES_PENDING_REMOVAL = {
+    "client_search_input": "Show redesigned search/filter input in client",
+}
 
 
 class Feature(Base):


### PR DESCRIPTION
We started to do some search-input UI redesign a few months ago that we are not continuing on at this time. Remove the associated feature flag (easy to add back!). Part 1 of 2.