### PR TITLE
Add not-yet-scheduled jobs to the sync annotation API queue length metric

### DIFF
--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -199,8 +199,8 @@ class Queue:
 
         return counts
 
-    def count(self, tags=None):
-        return self._job_query(tags=tags).count()
+    def count(self, tags=None, hide_scheduled=True):
+        return self._job_query(tags=tags, hide_scheduled=hide_scheduled).count()
 
     def _get_jobs_from_queue(self, limit):
         return (
@@ -211,12 +211,15 @@ class Queue:
             .all()
         )
 
-    def _job_query(self, tags=None):
+    def _job_query(self, tags=None, hide_scheduled=True):
         now = datetime.utcnow()
 
         query = self._db.query(Job).filter(
-            Job.name == "sync_annotation", Job.scheduled_at < now, Job.expires_at >= now
+            Job.name == "sync_annotation", Job.expires_at >= now
         )
+
+        if hide_scheduled:
+            query = query.filter(Job.scheduled_at < now)
 
         if tags:
             query = query.filter(Job.tag.in_(tags))

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -72,7 +72,10 @@ def report_job_queue_metrics():
             ),
             (
                 "Custom/SyncAnnotations/Queue/API/Length",
-                queue.count(["storage.create_annotation", "storage.update_annotation"]),
+                queue.count(
+                    ["storage.create_annotation", "storage.update_annotation"],
+                    hide_scheduled=False,
+                ),
             ),
         ]
     )

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -384,13 +384,17 @@ class TestSync:
 
 class TestCount:
     @pytest.mark.parametrize(
-        "tags,expected_result",
+        "tags,hide_scheduled,expected_result",
         [
-            (None, 3),
-            (["storage.create_annotation", "storage.update_annotation"], 2),
+            (None, True, 3),
+            (None, False, 4),
+            (["storage.create_annotation", "storage.update_annotation"], True, 2),
+            (["storage.create_annotation", "storage.update_annotation"], False, 3),
         ],
     )
-    def test_it(self, db_session, factories, now, queue, tags, expected_result):
+    def test_it(
+        self, db_session, factories, now, queue, tags, hide_scheduled, expected_result
+    ):
         one_minute = datetime_.timedelta(minutes=1)
 
         class JobFactory(factories.Job):
@@ -410,7 +414,7 @@ class TestCount:
         # A job that isn't scheduled yet.
         JobFactory.create(scheduled_at=now + one_minute)
 
-        count = queue.count(tags=tags)
+        count = queue.count(tags=tags, hide_scheduled=hide_scheduled)
 
         assert count == expected_result
 


### PR DESCRIPTION
Filtering unscheduled jobs out of this count just means that if (somehow) there was a pile up of unscheduled jobs those wouldn't
contribute to the metric and alarm. Since we do want to know if (somehow) unscheduled jobs are piling up we do want to include them in the metric. I can't imagine any way that we could have a pile up of unscheduled jobs, but filtering them out of the metric just seems wrong.

Context:

The purpose of the `"Custom/SyncAnnotations/Queue/API/Length"` (which only counts `sync_annotation` jobs added by the API) is to allow us to create an alarm if the queue size gets too large, which could happen if the queue consumer has stopped working or it the producer is outpacing the consumer etc.

It doesn't count jobs added by admin pages because it's okay for those to add large batches of jobs that get worked through over time--that shouldn't trigger an alarm. Jobs added by admin pages _will_ show up in the general queue length metric (https://github.com/hypothesis/h/pull/6377) so we can see a graph of those in New Relic in case that's of interest. But they're not included in this separate API-specific metric.

This metric also  doesn't count potential other types of job (besides `sync_annotation`) that we might add in the future because we can't know yet whether we'll want those jobs to trigger an alarm or whether we'll want it to be the same alarm. Again, these would show up in the general queue length metric so (even if we didn't add any new metrics for a new type of job) so we can still see them in NR.

Syncing the annotations added by the API is a crucial job so we want a specific alarm for that.