### PR TITLE
Add a route to serve the "notebook" app

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -189,6 +189,7 @@ def includeme(config):
 
     # Client
     config.add_route("sidebar_app", "/app.html")
+    config.add_route("notebook_app", "/notebook")
     config.add_route("embed", "/embed.js")
 
     # Feeds

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -32,7 +32,13 @@ def _client_url(request):
 @view_config(
     route_name="sidebar_app",
     renderer="h:templates/app.html.jinja2",
-    csp_insecure_optout=True,
+    csp_insecure_optout=True,  # This view adds its own custom Content Security Policy
+    http_cache=(60 * 5, {"public": True}),
+)
+@view_config(
+    route_name="notebook_app",
+    renderer="h:templates/app.html.jinja2",
+    csp_insecure_optout=True,  # This view adds its own custom Content Security Policy
     http_cache=(60 * 5, {"public": True}),
 )
 def sidebar_app(request, extra=None):

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -182,6 +182,7 @@ def test_includeme():
         call("oauth_authorize", "/oauth/authorize"),
         call("oauth_revoke", "/oauth/revoke"),
         call("sidebar_app", "/app.html"),
+        call("notebook_app", "/notebook"),
         call("embed", "/embed.js"),
         call("stream_atom", "/stream.atom"),
         call("stream_rss", "/stream.rss"),


### PR DESCRIPTION
Add a new `@view_config` and route so that `/notebook.html` can serve
up the client application. This is identical to what `/app.html` does,
but has a different URL for browser history uses, etc.

part of https://github.com/hypothesis/product-backlog/issues/1153