### PR TITLE
Remove a non-essential group table query from ES query construction

### DIFF
--- a/h/search/query.py
+++ b/h/search/query.py
@@ -357,13 +357,9 @@ class HiddenFilter:
         ]
 
         if self.user is not None:
-            # Always show the logged-in user's annotations even if they have nipsa.
+            # Always show the logged-in user's annotations even if they have
+            # been hidden or the user has been NIPSA'd
             should_clauses.append(Q("term", user=self.user.userid.lower()))
-
-            # Also include nipsa'd annotations for groups that the user created.
-            created_groups = self.group_service.groupids_created_by(self.user)
-            if created_groups:
-                should_clauses.append(Q("terms", group=created_groups))
 
         return search.filter(Q("bool", should=should_clauses))
 

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -706,17 +706,6 @@ class TestHiddenFilter:
 
         assert result.annotation_ids == [annotation.id]
 
-    @pytest.mark.usefixtures("as_user")
-    def test_shows_banned_users_annotations_in_groups_they_created(
-        self, pyramid_request, search, banned_user, group_service, make_annotation
-    ):
-        group_service.groupids_created_by.return_value = ["created_by_banneduser"]
-        annotation = make_annotation(banned_user, groupid="created_by_banneduser")
-
-        result = search.run({})
-
-        assert result.annotation_ids == [annotation.id]
-
     @pytest.fixture(params=[True, False], ids=["nipsa", "not nipsa"])
     def is_nipsaed(self, request):
         return request.param


### PR DESCRIPTION
The filter which removes shadowbanned ("NIPSA'd") users' annotations from search results (`HiddenFilter`) had logic to enable shadowbanned users to see _all_ annotations in groups they created. This required a scan of the groups table to get a list of groups the user created, whether the user was NIPSA'd or not. The generated query looks like this:

```
SELECT pubid FROM "group" WHERE creator_id = :creator_id
```

This query has shown up in a number of [transaction traces](https://one.newrelic.com/launcher/nr1-core.explorer?platform[accountId]=1385283&platform[timeRange][duration]=1800000&pane=eyJ0cmFuc2FjdGlvbklkIjoiNWIyMjU3NjU2MjU0NzI2MTZlNzM2MTYzNzQ2OTZmNmUyZjQ2NzU2ZTYzNzQ2OTZmNmUyZjY4MmU3NjY5NjU3NzczMmU2MTcwNjkyZTYxNmU2ZTZmNzQ2MTc0Njk2ZjZlNzMzYTczNjU2MTcyNjM2ODIyMmMyMjIyNWQiLCJuZXJkbGV0SWQiOiJhcG0tbmVyZGxldHMudHJhbnNhY3Rpb25zIiwiZW50aXR5SWQiOiJNVE00TlRJNE0zeEJVRTE4UVZCUVRFbERRVlJKVDA1OE1qSTJPRGcyTXpFIn0&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5SWQiOiJNVE00TlRJNE0zeEJVRTE4UVZCUVRFbERRVlJKVDA1OE1qSTJPRGcyTXpFIiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImFwbS1uZXJkbGV0cy50cmFuc2FjdGlvbnMifX0) as being relatively expensive and I believe explains why "Postgres group select" operations account for an unexpectedly large part of the cost of handling `/api/search` calls.

Running `EXPLAIN <Query>` in metabase shows that it isn't benefitting from any indexes.

Although we could add indexes to the database to optimize this query, it really doesn't seem important enough to justify spending cycles on. This commit just removes the logic. The result is that a user (whether shadowbanned or not) will no longer see annotations from _other_ shadowbanned users in groups that they created.

