### PR TITLE
Refactor the Queue tests

### DIFF
--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -11,7 +11,7 @@ from .feature import Feature
 from .flag import Flag
 from .group import Group, OpenGroup, RestrictedGroup
 from .group_scope import GroupScope
-from .job import Job
+from .job import Job, SyncAnnotationJob
 from .organization import Organization
 from .setting import Setting
 from .token import DeveloperToken, OAuth2Token
@@ -40,6 +40,7 @@ __all__ = (
     "Organization",
     "RestrictedGroup",
     "Setting",
+    "SyncAnnotationJob",
     "User",
     "UserIdentity",
     "set_session",

--- a/tests/common/factories/job.py
+++ b/tests/common/factories/job.py
@@ -1,7 +1,11 @@
-from factory import Faker
+import datetime
+
+from factory import Faker, LazyAttribute, LazyFunction, SubFactory
 
 from h import models
+from h.db.types import URLSafeUUID
 
+from .annotation import Annotation
 from .base import ModelFactory
 
 
@@ -12,3 +16,35 @@ class Job(ModelFactory):
     name = "test_job"
     priority = Faker("random_element", elements=[1, 100, 1000, 10000])
     tag = "test_tag"
+
+
+class SyncAnnotationJob(Job):
+    """
+    A factory for creating "sync_annotation" jobs.
+
+    By default this creates jobs with job.name="sync_annotation", with a
+    scheduled_at time in the past, and with a job.kwargs that contains an
+    annotation_id and force=False.
+
+    By default a new annotation will be created for the job to use.
+    The annotation will exist in the DB but will *not* be in
+    Elasticsearch -- tests must index the annotation themselves if they want it
+    to be in Elasticsearch.
+    """
+
+    class Meta:
+        exclude = ("annotation", "force")
+
+    annotation = SubFactory(Annotation)
+    force = False
+
+    name = "sync_annotation"
+    scheduled_at = LazyFunction(
+        lambda: datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    )
+    kwargs = LazyAttribute(
+        lambda o: {
+            "annotation_id": URLSafeUUID.url_safe_to_hex(o.annotation.id),
+            "force": o.force,
+        }
+    )

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -14,7 +14,6 @@ from h.search.index import BatchIndexer
 from h.services.search_index import SearchIndexService
 from h.services.search_index._queue import Queue
 
-LIMIT = 2
 ONE_WEEK = datetime_.timedelta(weeks=1)
 ONE_WEEK_IN_SECONDS = int(ONE_WEEK.total_seconds())
 MINUS_5_MIN = datetime_.timedelta(minutes=-5)
@@ -24,11 +23,11 @@ MINUS_5_MIN_IN_SECS = int(MINUS_5_MIN.total_seconds())
 class TestQueue:
     def test_add_where(self, queue, factories, db_session, now):
         matching = [
-            factories.Annotation.create(shared=True),
-            factories.Annotation.create(shared=True),
+            factories.Annotation(shared=True),
+            factories.Annotation(shared=True),
         ]
         # Add some noise
-        factories.Annotation.create(shared=False)
+        factories.Annotation(shared=False)
 
         queue.add_where(
             where=[Annotation.shared.is_(True)],
@@ -65,7 +64,7 @@ class TestQueue:
     def test_add_where_with_force(
         self, queue, db_session, factories, force, expected_force
     ):
-        annotation = factories.Annotation.create()
+        annotation = factories.Annotation()
 
         queue.add_where([Annotation.id == annotation.id], "test_tag", 1, force=force)
 
@@ -137,206 +136,192 @@ class TestQueue:
 
 class TestSync:
     def test_it_does_nothing_if_the_queue_is_empty(self, batch_indexer, queue):
-        counts = queue.sync(LIMIT)
+        counts = queue.sync(1)
 
         assert counts == {}
         batch_indexer.index.assert_not_called()
 
     def test_it_ignores_jobs_that_arent_scheduled_yet(
-        self, add_all, batch_indexer, queue
+        self, batch_indexer, now, queue, SyncAnnotationJobFactory
     ):
-        add_all(schedule_in=ONE_WEEK_IN_SECONDS)
+        SyncAnnotationJobFactory(scheduled_at=now + datetime_.timedelta(hours=1))
 
-        counts = queue.sync(LIMIT)
+        counts = queue.sync(1)
 
         assert counts == {}
         batch_indexer.index.assert_not_called()
 
-    @pytest.mark.usefixtures("with_queued_annotations")
     def test_it_ignores_jobs_beyond_limit(
-        self, all_annotation_ids, batch_indexer, queue
+        self, batch_indexer, queue, SyncAnnotationJobFactory
     ):
-        queue.sync(LIMIT)
+        limit = 1
+        SyncAnnotationJobFactory.create_batch(size=limit + 1)
 
-        for annotation_id in all_annotation_ids[LIMIT:]:
-            assert annotation_id not in batch_indexer.index.call_args[0][0]
+        queue.sync(limit)
+
+        assert len(batch_indexer.index.call_args[0][0]) == limit
 
     def test_it_ignores_jobs_that_are_expired(
-        self, batch_indexer, db_session, factories, now, queue
+        self, batch_indexer, db_session, now, queue, SyncAnnotationJobFactory
     ):
-        annotation = factories.Annotation()
-        queue.add_by_id(annotation.id, "test_tag", schedule_in=MINUS_5_MIN_IN_SECS)
-        # Change the job's expires_at date so that it's expired.
-        job = db_session.query(Job).one()
-        job.expires_at = now - datetime_.timedelta(minutes=1)
+        job = SyncAnnotationJobFactory(expires_at=now - datetime_.timedelta(hours=1))
 
-        counts = queue.sync(LIMIT)
+        counts = queue.sync(1)
 
         assert counts == {}
         batch_indexer.index.assert_not_called()
         assert db_session.query(Job).all() == [job]
 
-    @pytest.mark.usefixtures("with_indexed_annotations")
     def test_if_the_job_has_force_True_it_indexes_the_annotation_and_deletes_the_job(
-        self, annotation_ids, add_all, batch_indexer, db_session, queue
+        self, batch_indexer, db_session, queue, SyncAnnotationJobFactory
     ):
-        add_all(force=True)
+        job = SyncAnnotationJobFactory(force=True)
 
-        counts = queue.sync(LIMIT)
+        counts = queue.sync(1)
 
         assert counts == {
-            Queue.Result.SYNCED_FORCED: LIMIT,
-            Queue.Result.COMPLETED_FORCED: LIMIT,
-            Queue.Result.SYNCED_TOTAL: LIMIT,
-            Queue.Result.COMPLETED_TOTAL: LIMIT,
+            Queue.Result.SYNCED_FORCED: 1,
+            Queue.Result.COMPLETED_FORCED: 1,
+            Queue.Result.SYNCED_TOTAL: 1,
+            Queue.Result.COMPLETED_TOTAL: 1,
         }
         assert db_session.query(Job).all() == []
-        batch_indexer.index.assert_called_once_with(
-            Any.list.containing(annotation_ids).only()
-        )
+        batch_indexer.index.assert_called_once_with([self.url_safe_id(job)])
 
     def test_if_the_annotation_isnt_in_the_DB_it_deletes_the_job_from_the_queue(
-        self, annotations, add_all, db_session, queue
+        self, db_session, factories, queue, SyncAnnotationJobFactory
     ):
-        for annotation in annotations:
-            db_session.delete(annotation)
+        # We have to actually create an annotation and save it to the DB in
+        # order to get a valid annotation ID. Then we delete the annotation
+        # from the DB again because we actually don't want the annotation to be
+        # in the DB in this test.
+        annotation = factories.Annotation()
+        SyncAnnotationJobFactory(annotation=annotation)
+        db_session.delete(annotation)
 
-        add_all()
-
-        counts = queue.sync(LIMIT)
+        counts = queue.sync(1)
 
         assert counts == {
-            Queue.Result.COMPLETED_DELETED: LIMIT,
-            Queue.Result.COMPLETED_TOTAL: LIMIT,
+            Queue.Result.COMPLETED_DELETED: 1,
+            Queue.Result.COMPLETED_TOTAL: 1,
         }
         assert db_session.query(Job).all() == []
 
     def test_if_the_annotation_is_marked_as_deleted_in_the_DB_it_deletes_the_job_from_the_queue(
-        self, annotations, add_all, db_session, queue
+        self, db_session, factories, queue, SyncAnnotationJobFactory
     ):
-        for annotation in annotations:
-            annotation.deleted = True
+        annotation = factories.Annotation()
+        SyncAnnotationJobFactory(annotation=annotation)
+        annotation.deleted = True
 
-        add_all()
-
-        counts = queue.sync(LIMIT)
+        counts = queue.sync(1)
 
         assert counts == {
-            Queue.Result.COMPLETED_DELETED: LIMIT,
-            Queue.Result.COMPLETED_TOTAL: LIMIT,
+            Queue.Result.COMPLETED_DELETED: 1,
+            Queue.Result.COMPLETED_TOTAL: 1,
         }
         assert db_session.query(Job).all() == []
 
-    @pytest.mark.usefixtures("with_queued_annotations")
     def test_if_the_annotation_is_missing_from_Elastic_it_indexes_it(
-        self, annotation_ids, batch_indexer, queue
+        self, batch_indexer, queue, SyncAnnotationJobFactory
     ):
-        counts = queue.sync(LIMIT)
+        job = SyncAnnotationJobFactory()
+
+        counts = queue.sync(1)
 
         assert counts == {
-            Queue.Result.SYNCED_MISSING: LIMIT,
-            Queue.Result.SYNCED_TOTAL: LIMIT,
+            Queue.Result.SYNCED_MISSING: 1,
+            Queue.Result.SYNCED_TOTAL: 1,
         }
-        batch_indexer.index.assert_called_once_with(
-            Any.list.containing(annotation_ids).only()
-        )
+        batch_indexer.index.assert_called_once_with([self.url_safe_id(job)])
 
-    @pytest.mark.usefixtures("with_indexed_annotations", "with_queued_annotations")
     def test_if_the_annotation_is_already_in_Elastic_it_removes_the_job_from_the_queue(
-        self, batch_indexer, db_session, queue
+        self, batch_indexer, db_session, queue, SyncAnnotationJobFactory
     ):
-        counts = queue.sync(LIMIT)
+        SyncAnnotationJobFactory(index=True)
+
+        counts = queue.sync(1)
 
         assert counts == {
-            Queue.Result.COMPLETED_UP_TO_DATE: LIMIT,
-            Queue.Result.COMPLETED_TOTAL: LIMIT,
+            Queue.Result.COMPLETED_UP_TO_DATE: 1,
+            Queue.Result.COMPLETED_TOTAL: 1,
         }
         assert db_session.query(Job).all() == []
         batch_indexer.index.assert_not_called()
 
-    @pytest.mark.usefixtures("with_indexed_annotations", "with_queued_annotations")
     def test_if_the_annotation_has_a_different_updated_time_in_Elastic_it_indexes_it(
-        self, annotations, annotation_ids, batch_indexer, now, queue
+        self, batch_indexer, factories, now, queue, SyncAnnotationJobFactory
     ):
-        # Simulate the annotations having been updated in the DB after they
-        # were indexed.
-        for annotation in annotations:
-            annotation.updated = now
+        annotation = factories.Annotation()
+        SyncAnnotationJobFactory(annotation=annotation, index=True)
+        # Simulate the annotation having been updated in the DB after it was
+        # indexed.
+        annotation.updated = now
 
-        counts = queue.sync(LIMIT)
+        counts = queue.sync(1)
 
         assert counts == {
-            Queue.Result.SYNCED_DIFFERENT: LIMIT,
-            Queue.Result.SYNCED_TOTAL: LIMIT,
+            Queue.Result.SYNCED_DIFFERENT: 1,
+            Queue.Result.SYNCED_TOTAL: 1,
         }
-        batch_indexer.index.assert_called_once_with(
-            Any.list.containing(annotation_ids).only()
-        )
+        batch_indexer.index.assert_called_once_with([annotation.id])
 
-    @pytest.mark.usefixtures("with_indexed_annotations", "with_queued_annotations")
     def test_if_the_annotation_has_a_different_userid_in_Elastic_it_indexes_it(
-        self, annotations, annotation_ids, batch_indexer, queue
+        self, batch_indexer, factories, queue, SyncAnnotationJobFactory
     ):
+        annotation = factories.Annotation()
+        SyncAnnotationJobFactory(annotation=annotation, index=True)
         # Simulate the user having been renamed in the DB.
-        for annotation in annotations:
-            annotation.userid = "new_userid"
+        annotation.userid = "new_userid"
 
-        counts = queue.sync(LIMIT)
+        counts = queue.sync(1)
 
         assert counts == {
-            Queue.Result.SYNCED_DIFFERENT: LIMIT,
-            Queue.Result.SYNCED_TOTAL: LIMIT,
+            Queue.Result.SYNCED_DIFFERENT: 1,
+            Queue.Result.SYNCED_TOTAL: 1,
         }
-        batch_indexer.index.assert_called_once_with(
-            Any.list.containing(annotation_ids).only()
-        )
+        batch_indexer.index.assert_called_once_with([annotation.id])
 
     def test_if_there_are_multiple_jobs_with_the_same_annotation_id(
-        self, annotation_ids, batch_indexer, add_all, queue
+        self, batch_indexer, factories, queue, SyncAnnotationJobFactory
     ):
-        add_all(ids=[annotation_ids[0] for _ in range(LIMIT)])
+        annotation = factories.Annotation()
+        jobs = SyncAnnotationJobFactory.create_batch(size=2, annotation=annotation)
 
-        counts = queue.sync(LIMIT)
+        counts = queue.sync(len(jobs))
 
-        # It only syncs the annotation to Elasticsearch once.
+        # Unfortunately the method gets the metrics wrong here: it reports that
+        # it synced two annotations because it processed two different jobs.
+        # But actually the two jobs were for the same annotation and it only
+        # synced one.
         assert counts == {
-            Queue.Result.SYNCED_MISSING: LIMIT,
-            Queue.Result.SYNCED_TOTAL: LIMIT,
+            Queue.Result.SYNCED_MISSING: 2,
+            Queue.Result.SYNCED_TOTAL: 2,
         }
-        batch_indexer.index.assert_called_once_with(
-            Any.list.containing([annotation_ids[0]]).only()
-        )
+        # It only syncs the annotation to Elasticsearch once, even though it
+        # processed two separate jobs (for the same annotation).
+        batch_indexer.index.assert_called_once_with([annotation.id])
 
     def test_deleting_multiple_jobs_with_the_same_annotation_id(
-        self, annotations, batch_indexer, add_all, db_session, index, queue
+        self, batch_indexer, db_session, factories, queue, SyncAnnotationJobFactory
     ):
-        add_all(ids=[annotations[0].id for _ in range(LIMIT)])
-        index([annotations[0]])
+        annotation = factories.Annotation()
+        jobs = SyncAnnotationJobFactory.create_batch(
+            size=2, annotation=annotation, index=True
+        )
 
-        counts = queue.sync(LIMIT)
+        counts = queue.sync(len(jobs))
 
         assert counts == {
-            Queue.Result.COMPLETED_UP_TO_DATE: LIMIT,
-            Queue.Result.COMPLETED_TOTAL: LIMIT,
+            Queue.Result.COMPLETED_UP_TO_DATE: 2,
+            Queue.Result.COMPLETED_TOTAL: 2,
         }
         assert db_session.query(Job).all() == []
         batch_indexer.index.assert_not_called()
 
-    @pytest.fixture
-    def annotations(self, factories, now):
-        return factories.Annotation.create_batch(
-            size=LIMIT + 1,  # Make sure there's always over the limit
-            created=now - datetime_.timedelta(minutes=1),
-            updated=now - datetime_.timedelta(minutes=1),
-        )
-
-    @pytest.fixture
-    def all_annotation_ids(self, annotations):
-        return [annotation.id for annotation in annotations]
-
-    @pytest.fixture
-    def annotation_ids(self, all_annotation_ids):
-        return all_annotation_ids[:LIMIT]
+    def url_safe_id(self, job):
+        """Return the URL-safe version of the given job's annotation ID."""
+        return URLSafeUUID.hex_to_url_safe(job.kwargs["annotation_id"])
 
     @pytest.fixture
     def search_index(
@@ -351,35 +336,96 @@ class TestSync:
         )
 
     @pytest.fixture
-    def with_indexed_annotations(self, index, annotations):
-        index(annotations)
+    def index(self, es_client, search_index):
+        """A method that indexes the given annotation into Elasticsearch."""
 
-    @pytest.fixture
-    def with_queued_annotations(self, add_all):
-        add_all()
-
-    @pytest.fixture
-    def index(self, es_client, search_index, nipsa_service):
-        """A function for adding annotations to Elasticsearch."""
-
-        def index(annotations):
-            """Add `annotations` to the Elasticsearch index."""
-            for annotation in annotations:
-                search_index.add_annotation(annotation)
-
+        def index(annotation):
+            search_index.add_annotation(annotation)
             es_client.conn.indices.refresh(index=es_client.index)
 
         return index
 
     @pytest.fixture
-    def add_all(self, queue, annotation_ids):
-        def add_all(ids=annotation_ids, schedule_in=MINUS_5_MIN_IN_SECS, force=False):
-            for id_ in ids:
-                queue.add_by_id(
-                    id_, tag="test_tag", schedule_in=schedule_in, force=force
-                )
+    def SyncAnnotationJobFactory(self, factories, index, now):
+        """
+        A factory for creating sync_annotation jobs.
 
-        return add_all
+        By default this creates jobs with job.name="sync_annotation", with a
+        scheduled_at time in the past, and with a job.kwargs that contains an
+        annotation_id and force=False.
+
+        By default a new annotation will be created for the job to use.
+
+        By default the annotation will exist in the DB but will *not* be in
+        Elasticsearch.
+
+        Usage:
+
+            SyncAnnotationJobFactory()
+
+            # Create multiple jobs, each with its own annotation.
+            SyncAnnotationJobFactory.create_batch(size=3)
+
+            # Create a job that isn't scheduled yet.
+            one_hour_from_now = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+            SyncAnnotationJobFactory(scheduled_at=one_hour_from_now)
+
+            # Create an expired job.
+            one_hour_ago = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+            SyncAnnotationJobFactory(expires_at=one_hour_ago)
+
+            # Create multiple jobs with force=True in their kwargs.
+            SyncAnnotationJobFactory.create_batch(size=3, force=True)
+
+            # Create a job for a given annotation, instead of
+            # SyncAnnotationJobFactory creating a new annotation automatically.
+            annotation = factories.Annotation()
+            SyncAnnotationJobFactory(annotation=annotation)
+
+            # Create a job for an annotation that *is* already in Elasticsearch.
+            SyncAnnotationJobFactory(index=True)
+        """
+
+        class SyncAnnotationJobFactory(factories.Job):
+            class Meta:
+                exclude = "force"
+
+            annotation = factory.SubFactory(factories.Annotation)
+            force = False
+
+            scheduled_at = factory.LazyFunction(
+                lambda: now - datetime_.timedelta(hours=1)
+            )
+            name = "sync_annotation"
+
+            kwargs = factory.LazyAttribute(
+                lambda o: {
+                    "annotation_id": URLSafeUUID.url_safe_to_hex(o.annotation.id),
+                    "force": o.force,
+                }
+            )
+
+            @classmethod
+            def _create(cls, model_class, *args, **kwargs):
+                annotation = kwargs.pop("annotation")
+                index_ = kwargs.pop("index", False)
+
+                job = super()._create(model_class, *args, **kwargs)
+
+                if index_:
+                    index(annotation)
+
+                return job
+
+        return SyncAnnotationJobFactory
+
+    @pytest.fixture(autouse=True)
+    def noise_annotations(self, factories, index):
+        # Create some noise annotations in the DB. Some of them also in
+        # Elasticsearch, some not. None of these should ever be touched by the
+        # sync() method in these tests.
+        annotations = factories.Annotation.create_batch(size=2)
+        index(annotations[0])
 
 
 class TestCount:
@@ -407,12 +453,12 @@ class TestCount:
             scheduled_at = now - one_minute
 
         JobFactory.create_batch(size=2)
-        JobFactory.create(tag="another_tag")
-        JobFactory.create(name="another_name")
+        JobFactory(tag="another_tag")
+        JobFactory(name="another_name")
         # A job that's expired.
-        JobFactory.create(expires_at=now - one_minute)
+        JobFactory(expires_at=now - one_minute)
         # A job that isn't scheduled yet.
-        JobFactory.create(scheduled_at=now + one_minute)
+        JobFactory(scheduled_at=now + one_minute)
 
         count = queue.count(tags=tags, expired=expired)
 


### PR DESCRIPTION
When making some changes to `Queue` (coming up in a future commit) I found that these tests were hard to work with. There's a lot of clever and unique interdependent fixtures that're shared between all the tests, which makes the tests hard to maintain. Adding a new test is particularly difficult as the new test ought to make use of the fixture-complex like the existing tests do, but writing such a new test requires understanding the fixture-complex and possibly adapting it to the needs of the new test, without breaking any of the existing tests.

I've changed the tests in a way that should make maintaining them, and adding new tests, much easier. This makes the new test that I'm adding in a future commit much easier to write, and also makes the existing tests much easier to understand.

I think these tests have fallen into a typical difficult tests pitfall:

Pitfall 1: Lots of complex inter-related fixtures
-------------------------------------------------

These tests have a bunch of complex and inter-related fixtures and constants: 


* `LIMIT` is `2` as a constant. All the tests pass it as the `limit` argument to `Queue.sync()` and various of the fixtures below also use it

* The `annotations()` fixture adds `LIMIT + 1` annotations to the DB and returns them

* The `all_annotation_ids` fixture depends on the `annotations()` fixture and returns a list of all their IDs

* The `annotation_ids` fixture depends on the `annotations()` fixture and returns a list of all the IDs of the first `LIMIT` annotations

* The `index(annotations)` fixture returns a function that indexes the given annotations into Elasticsearch.

* The `with_indexed_annotations()` fixture depends on the `annotations` and `index` fixtures and indexes all the annotations into Elasticsearch

* The `add_all()` fixture returns a function that, given no arguments(!), takes the annotation IDs from the `annotation_ids` fixture and adds `sync_annotation` jobs for them all to the queue.

* The `with_queued_annotations()` fixture depends on the `add_all()` and fixture and calls it, so it adds `sync_annotation` jobs for all the annotations from the `annotations` fixture to the job queue.

That's a **lot** of stuff to understand, and you need to understand it all before you can understand any of the tests.

Pitfall 2: Tests tightly coupled to each other via fixtures
-----------------------------------------------------------

All the tests use all the fixtures above, so you can't make any changes to any of the fixtures without potentially breaking some of the existing tests. And in some cases you might have broken the test such that it always passes even if the code is wrong, and it'd be hard to know that you had done this.

Pitfall 3: Unusual fixtures
---------------------------

Wherever possible it's best to use common test patterns. For example we often write patch fixtures, or use test factories. Services tests often have a fixture called `svc` that returns the service under test. We use the `pyramid_request` fixture all over the place. Etc etc.

Common patterns like this are easier to understand because they're familiar. You learn them once and then you recognise them everywhere.

The fixtures in these tests are very unique to these tests, so you have to read through and understand them all just to understand these particular tests.

Pitfall 4: Hiding too much stuff in fixtures
--------------------------------------------

The tests are just hard to understand because so much is done in fixtures:

```python
def test_it_ignores_jobs_that_arent_scheduled_yet(self, add_all, batch_indexer, queue):
    add_all(schedule_in=ONE_WEEK_IN_SECONDS)

    counts = queue.sync(LIMIT)

    assert counts == {}
    batch_indexer.index.assert_not_called()
```

The call to `add_all()` causes 3 annotations to be added to the DB but does not add those annotations to Elasticsearch and it adds `sync_annotation` jobs to the queue for each of them. But this is all totally invisible in the test. To understand it you'd need to know about the `LIMIT` constant, the `annotations` and `annotation_ids` fixtures, and the `queue` fixture, as well as the `add_all()` fixture itself.

Solution
--------

I've gotten rid of `LIMIT` and the `annotations()`, `all_annotation_ids()`, `annotation_ids()`, `with_indexed_annotations()`, `with_queued_annotations()`, and `add_all()` fixtures, and replaced them with one fixture that follows a common pattern: `factories.SyncAnnotationJob()`.

This is a test factory that's based on the generic `factories.Job()` but that specifically creates `"sync_annotation"` jobs. It will automatically create an annotation for each job, and supports creating unscheduled jobs, expired jobs, multiple jobs, and `force=True` jobs. Its usage is familiar from how you'd use any test factory.

All the tests are changed to use this factory, and are much clearer as a result. The simple case where we just need a `"sync_annotation"` job is just:

```python
def test_foo(self, factories):
    job = factories.SyncAnnotationJob(...)

    ...
```

The most complex case, where the test needs an annotation that is already indexed into Elasticsearch and a job for that annotation, is:

```python
def test_bar(self, factories, index):
    annotation = factories.Annotation(...)
    index(annotation)
    job = factories.SyncAnnotationJob(annotation=annotation, ...)

    ...
```

This does tend to lead to more repetitive test code as each test has to create the annotation(s) and job(s) that it needs and also has to index the annotation(s) if it needs to. Up to three lines in the worst case. Rather than relying on hidden fixtures to do all this magically. But the repetition is worth it because you can now see the test set up at the top of the test method itself in plain code (straightforward `factory_boy` usage), instead of having to infer it from a bunch of interdependent shared fixtures below. And the tests are much less coupled to each other. It's much easier to understand and maintain the tests, and to add new tests.

Given familiarity with test factories it's pretty obvious what `factories.SyncAnnotationJob()` does without looking but if you want to you can go to this one fixture and read its docstring.