### PR TITLE
Remove /api/ and /api/links preloading from h

### DIFF
--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -13,10 +13,6 @@
               href="{{ link.href }}"/>
       {% endfor %}
     {% endif %}
-
-    <!-- Prefetch non-authenticated API routes which client will need. !-->
-    <link rel="preload" as="fetch" href="{{ request.route_url("api.index") }}" crossorigin="anonymous">
-    <link rel="preload" as="fetch" href="{{ request.route_url("api.links") }}" crossorigin="anonymous">
   </head>
   <body>
     <hypothesis-app></hypothesis-app>


### PR DESCRIPTION
The logic to preload these API responses is being moved from h to the
client so that it applies to all distributions of the client and can be
changed without needing to modify each client distribution separately.

See https://github.com/hypothesis/client/pull/2834