### PR TITLE
Harmonise language with extension UI

### DIFF
--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -54,20 +54,20 @@
           with the application:</p>
         <div class="feature-content">
           <section class="feature">
-            <h3 class="feature-heading"><i class="feature-icon h-icon-annotate"></i> Notes</h3>
+            <h3 class="feature-heading"><i class="feature-icon h-icon-annotate"></i> Annotate</h3>
             <div class="feature-content styled-text">
               <p>Create a <em>note</em> by selecting some text and clicking the <i class="help-icon h-icon-annotate"></i> button</p>
             </div>
           </section>
           <section class="feature">
-            <h3 class="feature-heading"><i class="feature-icon h-icon-highlight"></i> Highlights</h3>
+            <h3 class="feature-heading"><i class="feature-icon h-icon-highlight"></i> Highlight</h3>
             <div class="feature-content">
               <p><em>Highlights</em> can be created by clicking the <i class="help-icon h-icon-highlight"></i> button.
               Try it on this sentence.</p>
             </div>
           </section>
           <section class="feature">
-            <h3 class="feature-heading"><i class="feature-icon h-icon-reply"></i> Replies</h3>
+            <h3 class="feature-heading"><i class="feature-icon h-icon-reply"></i> Reply</h3>
             <div class="feature-content">
               <p>You can  <em>reply</em> to any annotation by using the <i class="help-icon h-icon-reply"></i> reply action
                 on every card.</p>


### PR DESCRIPTION
I think this still works with the rest of the copy, but I think it helps for first time users to have the same terminology in this welcome screen and the extension UI.

PS: The icons also look different