### PR TITLE
docs: fix simple typo, visbility -> visibility

### DIFF
--- a/h/static/scripts/controllers/share-widget-controller.js
+++ b/h/static/scripts/controllers/share-widget-controller.js
@@ -40,7 +40,7 @@ class ShareWidget {
     this._widget = this._container.querySelector(WIDGET_SELECTOR);
     this._widgetVisible = false;
 
-    // on initialize we need to reset container visbility
+    // on initialize we need to reset container visibility
     this.hide();
 
     this._handler = event => {


### PR DESCRIPTION
There is a small typo in h/static/scripts/controllers/share-widget-controller.js.

Should read `visibility` rather than `visbility`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md