### PR TITLE
Replace Stale app with GitHub Action

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,4 +1,0 @@
-# Label to use when marking as stale
-staleLabel: stale
-# Limit to only `issues` or `pulls`
-only: pulls

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,14 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 10 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-stale: 30
+          days-before-close: 5


### PR DESCRIPTION
Replace the "Stale" GitHub App that we use to label and automatically
close inactive pull requests with a GitHub Action.

We encountered an issue where the app was not closing stale issues
despite being inactive for 30+ days. The bot's configuration doesn't
specify how long to wait but according to its README [1] this should
happen after 7 days by default. Looking at the state of the issue
tracker it doesn't appear to be actively maintained. Therefore we're
going to try the Stale action from the official GitHub Actions org
instead [2].

[1] https://github.com/probot/stale
[2] https://github.com/actions/stale