### PR TITLE
Set `repo-token` input for Stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           days-before-stale: 30
           days-before-close: 5


### PR DESCRIPTION
This is needed to enable the action to use the GitHub API.

See https://docs.github.com/en/actions/reference/authentication-in-a-workflow.

I have tested this change by running the workflow manually here: https://github.com/hypothesis/h/actions/runs/493492536