### PR TITLE
Enable listening to localhost IP

### DIFF
--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -24,7 +24,7 @@ sqlalchemy.url: postgresql://postgres@localhost/postgres
 
 [server:main]
 use: egg:gunicorn#main
-host: localhost
+host: 0.0.0.0
 port: 5000
 proc_name: web
 graceful_timeout: 0


### PR DESCRIPTION
Currently, h only listens and responds to localhost
(`http://localhost:5000`).

Is there any security risk by enabling h to listen and respond to
localhost's IP? `http://<IP localhost>:5000`

Changing the host to `0.0.0.0` is necessary to debug the client on
certain situation (see step 3 of the `Preparation` section
[here](https://stackoverflow.com/c/hypothesis/questions/388/389#389)).

If changing this setting is not a risk (it seems the setting only works on
development settings), then it would facilitate debugging the client and
developers of the client would appreciate it.