### PR TITLE
Add search admin tasks to reindex a user or group's annotations

### DIFF
--- a/h/celery.py
+++ b/h/celery.py
@@ -38,6 +38,7 @@ celery.conf.update(
     task_routes={
         "h.tasks.indexer.add_annotation": "indexer",
         "h.tasks.indexer.add_annotations_between_times": "indexer",
+        "h.tasks.indexer.add_group_annotations": "indexer",
         "h.tasks.indexer.add_users_annotations": "indexer",
         "h.tasks.indexer.delete_annotation": "indexer",
     },

--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -15,6 +15,7 @@ class Queue:
     class Priority:
         SINGLE_ITEM = 1
         SINGLE_USER = 100
+        SINGLE_GROUP = 100
         BETWEEN_TIMES = 1000
 
     class Result:
@@ -109,6 +110,18 @@ class Queue:
         """
         where = [Annotation.userid == userid]
         self.add_where(where, tag, Queue.Priority.SINGLE_USER, force, schedule_in)
+
+    def add_by_group(self, groupid, tag, force=False, schedule_in=None):
+        """
+        Queue all annotations in a group to be synced to Elasticsearch.
+
+        See Queue.add() for documentation of the params.
+
+        :param groupid: The pubid of the group
+        :type groupid: unicode
+        """
+        where = [Annotation.groupid == groupid]
+        self.add_where(where, tag, Queue.Priority.SINGLE_GROUP, force, schedule_in)
 
     def sync(self, limit):
         """

--- a/h/services/search_index/service.py
+++ b/h/services/search_index/service.py
@@ -84,6 +84,12 @@ class SearchIndexService:
             userid, tag, force=force, schedule_in=schedule_in
         )
 
+    def add_group_annotations(self, groupid, tag, force=False, schedule_in=None):
+        """Add all annotations in a group to the search index."""
+        indexer.add_group_annotations.delay(
+            groupid, tag, force=force, schedule_in=schedule_in
+        )
+
     def delete_annotation_by_id(self, annotation_id, refresh=False):
         """
         Mark an annotation as deleted in the search index.

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -30,6 +30,12 @@ def add_users_annotations(userid, tag, force, schedule_in):
     search_index._queue.add_by_user(userid, tag, force=force, schedule_in=schedule_in)
 
 
+@celery.task
+def add_group_annotations(groupid, tag, force, schedule_in):
+    search_index = celery.request.find_service(name="search_index")
+    search_index._queue.add_by_group(groupid, tag, force=force, schedule_in=schedule_in)
+
+
 @celery.task(base=_BaseTaskWithRetry)
 def delete_annotation(id_):
     search_index = celery.request.find_service(name="search_index")

--- a/h/templates/admin/search.html.jinja2
+++ b/h/templates/admin/search.html.jinja2
@@ -3,14 +3,20 @@
 {% set page_id = 'search' %}
 {% set page_title = 'Search index' %}
 
-{% macro panel(heading) %}
+{% macro reindex_form(heading, action) %}
   <div class="panel panel-default">
     <div class="panel-heading">
       <h3 class="panel-title">{{ heading }}</h3>
     </div>
 
     <div class="panel-body">
-      {{ caller() }}
+      <form method="POST" class="form-inline">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+        {{ caller() }}
+        <div class="form-group">
+          <input type="submit" class="btn btn-default" name="{{ action }}" value="Reindex">
+        </div>
+      </form>
     </div>
   </div>
 {% endmacro %}
@@ -18,26 +24,26 @@
 {% block content %}
   <p>This is the search index admin page.</p>
 
-  {% call panel(heading="Reindex all annotations between two dates") %}
-    <form method="POST" class="form-inline">
-      <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+  {% call reindex_form(heading="Reindex all annotations between two dates", action="reindex_date") %}
+    <div class="form-group">
+      <label for="start">Start date</label>
+      <input required type="datetime-local" class="form-control" name="start" id="start">
+    </div>
 
-      <div class="form-group">
-        <label for="start">Start date</label>
-        <input type="datetime-local" class="form-control" name="start" id="start">
-      </div>
-
-      <div class="form-group">
-        <label for="end">End date</label>
-        <input type="datetime-local" class="form-control" name="end" id="end">
-      </div>
-
-      <div class="form-group">
-        <input type="submit" class="btn btn-default" name="reindex_date" value="Reindex">
-      </div>
-    </form>
+    <div class="form-group">
+      <label for="end">End date</label>
+      <input required type="datetime-local" class="form-control" name="end" id="end">
+    </div>
   {% endcall %}
 
+  {% call reindex_form(heading="Reindex all annotations by a user", action="reindex_user") %}
+    <label for="username">Username</label>
+    <input required class="form-control" name="username" id="username">
+  {% endcall %}
 
+  {% call reindex_form(heading="Reindex all annotations in a group", action="reindex_group") %}
+    <label for="groupid">Group ID</label>
+    <input required class="form-control" name="groupid" id="groupid">
+  {% endcall %}
 {% endblock %}
 

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -123,6 +123,25 @@ class TestQueue:
         where = add_where.call_args[0][0]
         assert where[0].compare(Annotation.userid == sentinel.userid)
 
+    def test_add_group_annotations(self, queue, add_where):
+        queue.add_by_group(
+            sentinel.groupid,
+            sentinel.tag,
+            force=sentinel.force,
+            schedule_in=sentinel.schedule_in,
+        )
+
+        add_where.assert_called_once_with(
+            [Any.instance_of(BinaryExpression)],
+            sentinel.tag,
+            Queue.Priority.SINGLE_GROUP,
+            sentinel.force,
+            sentinel.schedule_in,
+        )
+
+        where = add_where.call_args[0][0]
+        assert where[0].compare(Annotation.groupid == sentinel.groupid)
+
     def database_id(self, annotation):
         """Return `annotation.id` in the internal format used within the database."""
         return str(uuid.UUID(URLSafeUUID.url_safe_to_hex(annotation.id)))

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -168,6 +168,23 @@ class TestAddUsersAnnotations:
         )
 
 
+class TestAddGroupAnnotations:
+    def test_it(self, indexer, search_index):
+        search_index.add_group_annotations(
+            sentinel.groupid,
+            sentinel.tag,
+            force=sentinel.force,
+            schedule_in=sentinel.schedule_in,
+        )
+
+        indexer.add_group_annotations.delay.assert_called_once_with(
+            sentinel.groupid,
+            sentinel.tag,
+            force=sentinel.force,
+            schedule_in=sentinel.schedule_in,
+        )
+
+
 class TestDeleteAnnotationById:
     @pytest.mark.parametrize("refresh", (True, False))
     def test_delete_annotation(self, search_index, es_client, refresh):

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -56,6 +56,23 @@ class TestAddUsersAnnotations:
         )
 
 
+class TestAddGroupAnnotations:
+    def test_it(self, search_index):
+        indexer.add_group_annotations(
+            sentinel.groupid,
+            sentinel.tag,
+            force=sentinel.force,
+            schedule_in=sentinel.schedule_in,
+        )
+
+        search_index._queue.add_by_group.assert_called_once_with(
+            sentinel.groupid,
+            sentinel.tag,
+            force=sentinel.force,
+            schedule_in=sentinel.schedule_in,
+        )
+
+
 class TestSyncAnnotations:
     def test_it(self, newrelic, log, search_index):
         indexer.sync_annotations("test_queue")

--- a/tests/h/views/admin/search_test.py
+++ b/tests/h/views/admin/search_test.py
@@ -1,8 +1,10 @@
 import datetime
+from unittest import mock
 
 import pytest
 
-from h.views.admin.search import SearchAdminViews
+from h.services.group import GroupService
+from h.views.admin.search import NotFoundError, SearchAdminViews
 
 pytestmark = pytest.mark.usefixtures("search_index")
 
@@ -28,6 +30,59 @@ class TestSearchAdminViews:
             "Began reindexing from 2020-09-09 00:00:00 to 2020-09-11 00:00:00"
         ]
 
+    def test_reindex_user_reindexes_annotations(
+        self, views, pyramid_request, search_index, factories
+    ):
+        user = factories.User(username="johnsmith")
+        pyramid_request.params = {"username": "johnsmith"}
+
+        views.reindex_user()
+
+        search_index.add_users_annotations.assert_called_once_with(
+            user.userid,
+            "reindex_user",
+        )
+
+        assert pyramid_request.session.peek_flash("success") == [
+            f"Began reindexing annotations by {user.userid}"
+        ]
+
+    def test_reindex_user_errors_if_user_not_found(
+        self, views, pyramid_request, search_index
+    ):
+        pyramid_request.params = {"username": "johnsmith"}
+
+        with pytest.raises(NotFoundError, match="User johnsmith not found"):
+            views.reindex_user()
+
+    def test_reindex_group_reindexes_annotations(
+        self, views, pyramid_request, search_index, factories, group_service
+    ):
+        group = factories.Group(pubid="abc123")
+        pyramid_request.params = {"groupid": "abc123"}
+        group_service.fetch_by_pubid.return_value = group
+
+        views.reindex_group()
+
+        group_service.fetch_by_pubid.assert_called_with(group.pubid)
+        search_index.add_group_annotations.assert_called_once_with(
+            group.pubid,
+            "reindex_group",
+        )
+
+        assert pyramid_request.session.peek_flash("success") == [
+            f"Began reindexing annotations in group {group.pubid} ({group.name})"
+        ]
+
+    def test_reindex_group_errors_if_group_not_found(
+        self, views, pyramid_request, search_index, group_service
+    ):
+        pyramid_request.params = {"groupid": "def456"}
+        group_service.fetch_by_pubid.return_value = None
+
+        with pytest.raises(NotFoundError, match="Group def456 not found"):
+            views.reindex_group()
+
     @pytest.fixture
     def views(self, pyramid_request):
         return SearchAdminViews(pyramid_request)
@@ -35,3 +90,10 @@ class TestSearchAdminViews:
     @pytest.fixture(autouse=True)
     def routes(self, pyramid_config):
         pyramid_config.add_route("admin.search", "/admin/search")
+
+
+@pytest.fixture
+def group_service(pyramid_config):
+    service = mock.create_autospec(GroupService, spec_set=True, instance=True)
+    pyramid_config.register_service(service, name="group")
+    return service


### PR DESCRIPTION
Add two new forms to the `/admin/search` page that can be used to initiate a reindex of all annotations created by a specific user or in a specific group. These tasks will help us to resolve an issue where a group was accidentally deleted in production and we need to re-add the group and re-index the annotations in that group. The form is ugly as sin. I did some refactoring to avoid HTML duplication by improving the styling is out of scope for this PR.

Updated search admin form:

<img width="748" alt="reindex-users-and-groups" src="https://user-images.githubusercontent.com/2458/106160865-34877c00-617e-11eb-98e6-4d6c5d483bc3.png">

Notification shown when a valid username is submitted:

<img width="722" alt="reindex-user-ok" src="https://user-images.githubusercontent.com/2458/106160899-3ea97a80-617e-11eb-9df6-b08161bffaad.png">

Error shown if the user does not exist:

<img width="720" alt="reindex-user-fail" src="https://user-images.githubusercontent.com/2458/106160918-449f5b80-617e-11eb-99a1-0fc2369ee232.png">

Notification shown when a valid group ID is submitted:

<img width="719" alt="reindex-group-ok" src="https://user-images.githubusercontent.com/2458/106160948-4bc66980-617e-11eb-9781-a9773dae5c94.png">

Error shown if the group does not exist:

<img width="725" alt="reindex-group-fail" src="https://user-images.githubusercontent.com/2458/106160976-53860e00-617e-11eb-9d2b-87012bb918bd.png">

