### PR TITLE
Fix test failures under future Python versions

### DIFF
--- a/h/assets.py
+++ b/h/assets.py
@@ -42,8 +42,9 @@ class _CachedFile:
 
         current_mtime = os.path.getmtime(self.path)
         if not self._mtime or self._mtime < current_mtime:
-            self._cached = self.loader(open(self.path))
-            self._mtime = current_mtime
+            with open(self.path) as fp:
+                self._cached = self.loader(fp)
+                self._mtime = current_mtime
         return self._cached
 
 

--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -71,7 +71,8 @@ class SvgIcon(Extension):
         super(SvgIcon, self).__init__(environment)
 
         def read_icon(name):
-            return open("build/images/icons/{}.svg".format(name)).read()
+            with open("build/images/icons/{}.svg".format(name)) as fp:
+                return fp.read()
 
         environment.globals["svg_icon"] = partial(svg_icon, read_icon)
 

--- a/h/search/client.py
+++ b/h/search/client.py
@@ -25,6 +25,14 @@ class Client:
         # See https://www.elastic.co/guide/en/elasticsearch/reference/6.x/removal-of-types.html
         self._mapping_type = "annotation"
 
+    def close(self):
+        """Close the connection to the Elasticsearch server."""
+
+        # In the latest version of the `elasticsearch` package we could just
+        # do `self._conn.close()` but this method is missing in v6 so we have
+        # to close the underlying transport directly.
+        self._conn.transport.close()
+
     @property
     def index(self):
         return self._index

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -1,6 +1,6 @@
-import collections
 import logging
 from codecs import open
+from collections.abc import Sequence
 
 from pkg_resources import resource_filename
 from pyramid import httpexceptions
@@ -35,8 +35,7 @@ def conditional_http_tween_factory(handler, registry):
         # status code of 200. The subtleties of doing it correctly in other
         # cases don't bear thinking about (at the moment).
         have_buffered_response = (
-            isinstance(response.app_iter, collections.Sequence)
-            and len(response.app_iter) == 1
+            isinstance(response.app_iter, Sequence) and len(response.app_iter) == 1
         )
         cacheable = request.method in {"GET", "HEAD"} and response.status_code == 200
         if have_buffered_response and cacheable:

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -51,7 +51,12 @@ def parse_origin(url):
 
     if url is None:
         return None
+
     parsed = urlsplit(url)
+
+    if not parsed.scheme or not parsed.netloc:
+        return None
+
     # netloc contains both host and port
     origin = SplitResult(parsed.scheme, parsed.netloc, "", "", "")
     return origin.geturl() or None

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -26,6 +26,9 @@ def es_client():
         refresh=True,
     )
 
+    # Close connection to ES server to avoid ResourceWarning about a leaked TCP socket.
+    client.close()
+
 
 @pytest.fixture(scope="session", autouse=True)
 def init_elasticsearch(request):

--- a/tests/h/jinja_extension_test.py
+++ b/tests/h/jinja_extension_test.py
@@ -55,7 +55,12 @@ def test_svg_icon_loads_icon():
 
     result = ext.svg_icon(read_icon, "settings")
 
-    assert result == Markup('<svg class="svg-icon" id="settings" />')
+    # nb. The order of attributes can differ depending on the Python version.
+    # In Python 3.9+ the `id` attribute is first.
+    assert result in [
+        Markup('<svg class="svg-icon" id="settings" />'),
+        Markup('<svg id="settings" class="svg-icon" />'),
+    ]
 
 
 def test_svg_icon_removes_title():

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -71,6 +71,10 @@ class TestParseOrigin:
             ("http://foo.com/baz", "http://foo.com"),
             ("http://foo.com:3553/bar", "http://foo.com:3553"),
             ("http://www.foo.bar.com", "http://www.foo.bar.com"),
+            # URLs with missing scheme or host.
+            ("file:///apath", None),
+            ("foo:123", None),
+            ("bar:", None),
             ("foo.com", None),
         ],
     )

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ filterwarnings =
     ignore:^The behavior of AcceptValidHeader\.best_match is currently being maintained for backward compatibility, but it will be deprecated in the future, as it does not conform to the RFC\.$:DeprecationWarning:webob.acceptparse
     ignore:^The behavior of AcceptValidHeader\.__contains__ is currently being maintained for backward compatibility, but it will change in the future to better conform to the RFC\.$:DeprecationWarning:webob.acceptparse
     ignore:^The behavior of AcceptLanguageValidHeader\.__iter__ is currently maintained for backward compatibility, but will change in the future.$:DeprecationWarning:webob.acceptparse
+    ignore:`formatargspec` is deprecated since Python 3.5:DeprecationWarning:newrelic.console
 
 [testenv]
 skip_install = true


### PR DESCRIPTION
This PR fixes several resource leaks and use of deprecated APIs that caused tests to fail under post-3.6 Python versions, as well as accommodating two minor behaviour changes. With the changes in this PR, all of the unit and functional tests pass locally under both Python 3.6.9 and Python 3.9.1. Core workflows involving the client, activity pages and WebSocket also seem good in Python 3.9, but I haven't tested those extensively.

See individual commits for details. In summary:

- Close connection to Elasticsearch server after each test that uses it
- Close asset files (eg. SVG icons) after reading them
- Import ABCs from `collections.abc` instead of `collections`
- Make `parse_origin` utility more strict to accommodate variations in how `urlsplit` handles certain invalid URLs
- Ignore an unimportant difference in XML serialization in tests for `svg_icon` Jinja utility
- Ignore a `DeprecationWarning` about `formatargspec` produced by `newrelic.console`

One issue I encountered that is not addressed in this PR is that `make format` fails in Py 3.9 due to the `dataclasses` package, which Python 3.6-only. A workaround is just to remove that entry from `requirements/format.txt` before running `make format` locally.