### PR TITLE
Link to client boot script directly in /app.html

### DIFF
--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -23,7 +23,7 @@
     </script>
 
     <!-- Client boot script !-->
-    <script src="{{ embed_url }}"></script>
+    <script src="{{ client_url }}"></script>
 
   </body>
 </html>

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -79,7 +79,7 @@ def sidebar_app(request, extra=None):
 
     ctx = {
         "app_config": json.dumps(app_config),
-        "embed_url": request.route_path("embed"),
+        "embed_url": _client_url(request),
     }
 
     if extra is not None:
@@ -92,11 +92,8 @@ def sidebar_app(request, extra=None):
     # As well as offering an extra layer of protection against various security
     # risks, this also helps to reduce noise in Sentry reports due to script
     # tags added by e.g. browser extensions.
-    #
-    # The `'self'` script-src is needed because app.html references the `/embed.js`
-    # route from h.
     client_origin = origin(_client_url(request))
-    script_src = f"'self' {client_origin} https://www.google-analytics.com"
+    script_src = f"{client_origin} https://www.google-analytics.com"
 
     # nb. Inline styles are currently allowed for the client because LaTeX
     # math rendering using KaTeX relies on them.

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -79,7 +79,7 @@ def sidebar_app(request, extra=None):
 
     ctx = {
         "app_config": json.dumps(app_config),
-        "embed_url": _client_url(request),
+        "client_url": _client_url(request),
     }
 
     if extra is not None:

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -24,10 +24,10 @@ class TestSidebarApp:
 
         assert actual_config == expected_config
 
-    def test_it_sets_embed_url(self, pyramid_request):
+    def test_it_sets_client_url(self, pyramid_request):
         ctx = client.sidebar_app(pyramid_request)
 
-        assert ctx["embed_url"] == "http://example.com/client_url"
+        assert ctx["client_url"] == "http://example.com/client_url"
 
     def test_it_sets_custom_content_security_policy_header(self, pyramid_request):
         client.sidebar_app(pyramid_request)

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -27,7 +27,7 @@ class TestSidebarApp:
     def test_it_sets_embed_url(self, pyramid_request):
         ctx = client.sidebar_app(pyramid_request)
 
-        assert ctx["embed_url"] == "/embed.js"
+        assert ctx["embed_url"] == "http://example.com/client_url"
 
     def test_it_sets_custom_content_security_policy_header(self, pyramid_request):
         client.sidebar_app(pyramid_request)
@@ -35,15 +35,13 @@ class TestSidebarApp:
 
         assert (
             csp_header
-            == "script-src 'self' http://example.com https://www.google-analytics.com; style-src http://example.com 'unsafe-inline'"
+            == "script-src http://example.com https://www.google-analytics.com; style-src http://example.com 'unsafe-inline'"
         )
 
 
 @pytest.mark.usefixtures("routes", "pyramid_settings")
 class TestEmbedRedirect:
     def test_redirects_to_client_boot_script(self, pyramid_request):
-        pyramid_request.feature.flags["embed_cachebuster"] = False
-
         rsp = client.embed_redirect(pyramid_request)
 
         assert isinstance(rsp, HTTPFound)
@@ -75,6 +73,12 @@ def pyramid_settings(pyramid_settings):
     )
 
     return pyramid_settings
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.feature.flags["embed_cachebuster"] = False
+    return pyramid_request
 
 
 @pytest.fixture


### PR DESCRIPTION
Link to the client boot script (https://cdn.hypothes.is/hypothesis)
directly in the client's sidebar HTML page (/app.html) as well as the
/notebook and /a/{id} routes, instead of referencing the /embed.js route
which redirects to the client boot script.

Referencing /embed.js instead of the client boot script historically did not
incur a performance penalty in the sidebar because the redirect would
have been cached from when the client was loaded in the host page or PDF
viewer.

However there are various scenarios when this redirect is not cached,
and for these we can speed up client boot by linking directly to the
boot script. These scenarios include:

1. When the user visits the /notebook or /a/{id} h URLs in a top-level
   frame. In that case we may not have recently fetched and cached /embed.js.
2. In a recent browser that partitions the HTTP cache by site, preventing
   a cached redirect from being used. Chrome started doing this in v86 (see https://developers.google.com/web/updates/2020/10/http-cache-partitioning and in particular [this section](https://developers.google.com/web/updates/2020/10/http-cache-partitioning#how_will_cache_partitioning_affect_chromes_http_cache))
3. When browser dev tools are open and caching is disabled. In this case
   the missing /embed.js => client boot script caching adds a misleading
   delay to app startup.

----

**Testing:**

Before:

```
$ curl http://localhost:5000/app.html

...
    <!-- Client boot script !-->
    <script src="/embed.js"></script>
...
```

After:

```
$ curl http://localhost:5000/app.html

...
    <!-- Client boot script !-->
    <script src="http://localhost:3001/hypothesis"></script>
...
```