### PR TITLE
Case-normalize DOI URIs and URNs

### DIFF
--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -154,6 +154,12 @@ def normalize(uristr):
     # Try to extract the scheme
     uri = urlsplit(uristr)
 
+    # Case-normalize DOI because DOIs are case insensitive.
+    # https://www.doi.org/doi_handbook/2_Numbering.html#2.4
+    # This normalization allows comparing 'doi:/10.12345/AbC' == 'doi:/10.12345/aBc'
+    if uri.scheme == "doi" or (uri.scheme == "urn" and uri.path.startswith("doi:")):
+        return uristr.lower()
+
     # If this isn't a URL, we don't perform any normalization
     if uri.scheme.lower() not in URL_SCHEMES:
         return uristr

--- a/tests/h/util/uri_test.py
+++ b/tests/h/util/uri_test.py
@@ -35,8 +35,6 @@ class TestURINormalise:
     @pytest.mark.parametrize(
         "url_in,url_out",
         (
-            # Should leave URNs as they are
-            ("urn:doi:10.0001/12345", "urn:doi:10.0001/12345"),
             # Should leave http(s) URLs with no hostname as they are
             ("http:///path/to/page", "http:///path/to/page"),
             ("https:///path/to/page", "https:///path/to/page"),
@@ -62,6 +60,8 @@ class TestURINormalise:
             # Should case-normalize hostname
             ("http://EXAMPLE.COM", "httpx://example.com"),
             ("http://EXampLE.COM", "httpx://example.com"),
+            ("urn:doi:10.0001/JoM.1", "urn:doi:10.0001/jom.1"),
+            ("doi:10.0001/JoM.1", "doi:10.0001/jom.1"),
             # Should leave userinfo case alone
             ("http://Alice:p4SSword@example.com", "httpx://Alice:p4SSword@example.com"),
             ("http://BOB@example.com", "httpx://BOB@example.com"),


### PR DESCRIPTION
DOIs are case insensitive according to official the documentation:
https://www.doi.org/doi_handbook/2_Numbering.html#2.4

Hence, API searches of DOI should return the same number of annotations
no matter its casing.

Initially, I thought about modifying elasticsearch:
https://github.com/hypothesis/product-backlog/issues/1174#issuecomment-811092986

At the end, I decided to modify the `normalize` function in `uri.py`. This
has the advantage that it doesn't need re-indexing. However, I am not
100% confident if this could have other unintentional side effects. Also, I
am not 100% if the DOI URNs should be normalised.

Closes https://github.com/hypothesis/product-backlog/issues/1174