### PR TITLE
Add '/group' filter to the websocket

### DIFF
--- a/h/streamer/filter.py
+++ b/h/streamer/filter.py
@@ -26,7 +26,7 @@ FILTER_SCHEMA = {
 
 
 class SocketFilter:
-    KNOWN_FIELDS = {"/id", "/uri", "/references"}
+    KNOWN_FIELDS = {"/id", "/group", "/uri", "/references"}
 
     @classmethod
     def matching(cls, sockets, annotation, session):
@@ -44,6 +44,7 @@ class SocketFilter:
 
         values = {
             "/id": [annotation.id],
+            "/group": [annotation.groupid],
             # Expand the URI to ensure we match any variants of it. This should
             # match the normalization when searching (see `h.search.query`)
             "/uri": set(
@@ -86,7 +87,7 @@ class SocketFilter:
 
             values = clause["value"]
 
-            # Normalise to an iterable of distinct values
+            # Normalize to an iterable of distinct values
             values = set(values) if isinstance(values, list) else [values]
 
             for value in values:


### PR DESCRIPTION
This PR adds a new filter, `/group`, to the websocket annotation
stream in addition to the already present filters (`/id`, `/references` and
`/uri`).

The filter works on the `groupid` of annotation, not the group name.