### PR TITLE
Add `/user` filter to the websocket stream

### DIFF
--- a/h/streamer/filter.py
+++ b/h/streamer/filter.py
@@ -26,7 +26,7 @@ FILTER_SCHEMA = {
 
 
 class SocketFilter:
-    KNOWN_FIELDS = {"/id", "/group", "/uri", "/references"}
+    KNOWN_FIELDS = {"/id", "/group", "/user", "/uri", "/references"}
 
     @classmethod
     def matching(cls, sockets, annotation, session):
@@ -45,6 +45,7 @@ class SocketFilter:
         values = {
             "/id": [annotation.id],
             "/group": [annotation.groupid],
+            "/user": [annotation.userid],
             # Expand the URI to ensure we match any variants of it. This should
             # match the normalization when searching (see `h.search.query`)
             "/uri": set(

--- a/tests/h/streamer/filter_test.py
+++ b/tests/h/streamer/filter_test.py
@@ -13,6 +13,54 @@ class FakeSocket:
 
 
 class TestFilterHandler:
+    def test_it_matches_id(self, factories, filter_matches, annotation):
+        other_annotation = factories.Annotation()
+
+        filter_ = {
+            "match_policy": "include_any",
+            "actions": {},
+            "clauses": [{"field": "/id", "operator": "equals", "value": annotation.id}],
+        }
+
+        assert filter_matches(filter_, annotation)
+        assert not filter_matches(filter_, other_annotation)
+
+    def test_it_matches_group_id(self, factories, filter_matches, annotation):
+        other_annotation = factories.Annotation(groupid="other")
+
+        filter_ = {
+            "match_policy": "include_any",
+            "actions": {},
+            "clauses": [
+                {
+                    "field": "/group",
+                    "operator": "equals",
+                    "value": [annotation.groupid],
+                }
+            ],
+        }
+
+        assert filter_matches(filter_, annotation)
+        assert not filter_matches(filter_, other_annotation)
+
+    def test_it_matches_user(self, factories, filter_matches, annotation):
+        other_annotation = factories.Annotation()
+
+        filter_ = {
+            "match_policy": "include_any",
+            "actions": {},
+            "clauses": [
+                {
+                    "field": "/user",
+                    "operator": "equals",
+                    "value": [annotation.userid],
+                }
+            ],
+        }
+
+        assert filter_matches(filter_, annotation)
+        assert not filter_matches(filter_, other_annotation)
+
     @pytest.mark.parametrize(
         "filter_uris,ann_uri,should_match",
         [
@@ -83,91 +131,7 @@ class TestFilterHandler:
             db_session, annotation.target_uri, normalized=True
         )
 
-    def test_it_matches_id(self, factories, filter_matches, annotation):
-        other_annotation = factories.Annotation()
-
-        filter_ = {
-            "match_policy": "include_any",
-            "actions": {},
-            "clauses": [{"field": "/id", "operator": "equals", "value": annotation.id}],
-        }
-
-        assert filter_matches(filter_, annotation)
-        assert not filter_matches(filter_, other_annotation)
-
-    def test_it_matches_group_id(self, factories, filter_matches, annotation):
-        other_annotation = factories.Annotation(groupid="other")
-
-        filter_ = {
-            "match_policy": "include_any",
-            "actions": {},
-            "clauses": [
-                {
-                    "field": "/group",
-                    "operator": "equals",
-                    "value": [annotation.groupid],
-                }
-            ],
-        }
-
-        assert filter_matches(filter_, annotation)
-        assert not filter_matches(filter_, other_annotation)
-
-    def test_it_does_not_crash_without_filter_rows(self, annotation, db_session):
-        socket_no_rows = FakeSocket()
-
-        result = tuple(SocketFilter.matching([socket_no_rows], annotation, db_session))
-        assert not result
-
-    def test_it_does_not_crash_with_unexpected_fields(self, annotation, db_session):
-        socket = FakeSocket()
-        socket.filter_rows = (("/not_a_thing", "value"),)
-
-        result = tuple(SocketFilter.matching([socket], annotation, db_session))
-        assert not result
-
-    @pytest.mark.parametrize(
-        "field,value,expected",
-        (
-            # Single value
-            ("/id", "v1", [("/id", "v1")]),
-            ("/references", "v1", [("/references", "v1")]),
-            ("/uri", "v1", [("/uri", "v1")]),
-            ("/group", "v1", [("/group", "v1")]),
-            # Multiple values
-            ("/id", ["v1", "v2"], [("/id", "v1"), ("/id", "v2")]),
-            ("/id", ["same", "same"], [("/id", "same")]),
-            (
-                "/references",
-                ["v1", "v2"],
-                [("/references", "v1"), ("/references", "v2")],
-            ),
-            ("/references", ["same", "same"], [("/references", "same")]),
-            ("/uri", ["v1", "v2"], [("/uri", "v1"), ("/uri", "v2")]),
-            ("/uri", ["same", "same"], [("/uri", "same")]),
-            ("/group", ["v1", "v2"], [("/group", "v1"), ("/group", "v2")]),
-            ("/group", ["same", "same"], [("/group", "same")]),
-            # Mapping
-            ("/uri", "http://example.com", [("/uri", "httpx://example.com")]),
-            # Ignored
-            ("/filter", "v1", []),
-            ("/random", "v1", []),
-        ),
-    )
-    def test_set_filter(self, field, value, expected):
-        socket = FakeSocket()
-
-        filter_ = {
-            "match_policy": "include_any",
-            "actions": {},
-            "clauses": [{"field": field, "operator": "one_of", "value": value}],
-        }
-
-        SocketFilter.set_filter(socket, filter_)
-
-        assert socket.filter_rows == Any.iterable.containing(expected).only()
-
-    def test_it_matches_parent_id(self, factories, filter_matches):
+    def test_it_matches_reference(self, factories, filter_matches):
         parent_ann = factories.Annotation()
         other_ann = factories.Annotation()
 
@@ -189,6 +153,108 @@ class TestFilterHandler:
         )
         assert not filter_matches(filter_, ann)
 
+    @pytest.mark.parametrize(
+        "field,value,expected",
+        (
+            # Single value
+            ("/id", "v1", [("/id", "v1")]),
+            ("/group", "3456", [("/group", "3456")]),
+            ("/user", "@me", [("/user", "@me")]),
+            ("/uri", "v1", [("/uri", "v1")]),
+            ("/references", "v1", [("/references", "v1")]),
+            # Multiple values
+            ("/id", ["v1", "v2"], [("/id", "v1"), ("/id", "v2")]),
+            ("/id", ["same", "same"], [("/id", "same")]),
+            (
+                "/references",
+                ["v1", "v2"],
+                [("/references", "v1"), ("/references", "v2")],
+            ),
+            ("/group", ["3456", "3456"], [("/group", "3456")]),
+            ("/group", ["1234", "3456"], [("/group", "1234"), ("/group", "3456")]),
+            ("/user", ["@me", "@me"], [("/user", "@me")]),
+            ("/user", ["@you", "@me"], [("/user", "@you"), ("/user", "@me")]),
+            ("/uri", ["v1", "v2"], [("/uri", "v1"), ("/uri", "v2")]),
+            ("/uri", ["same", "same"], [("/uri", "same")]),
+            ("/references", ["same", "same"], [("/references", "same")]),
+            # Mapping
+            ("/uri", "http://example.com", [("/uri", "httpx://example.com")]),
+            # Ignored
+            ("/filter", "v1", []),
+            ("/random", "v1", []),
+        ),
+    )
+    def test_set_filter(self, field, value, expected):
+        socket = FakeSocket()
+
+        filter_ = {
+            "match_policy": "include_any",
+            "actions": {},
+            "clauses": [{"field": field, "operator": "one_of", "value": value}],
+        }
+
+        SocketFilter.set_filter(socket, filter_)
+
+        assert socket.filter_rows == Any.iterable.containing(expected).only()
+
+    def get_randomized_filter(self):  # pragma: no cover
+        return {
+            "match_policy": "include_any",
+            "actions": {},
+            "clauses": [
+                {
+                    "field": "/id",
+                    "operator": "equals",
+                    "value": "3jgSANNlEeebpLMf36MACw" + str(random()),
+                },
+                {
+                    "field": "/group",
+                    "operator": "equals",
+                    "value": [
+                        "333QnPxg" + str(random()),
+                        "333QnPxg" + str(random()),
+                    ],
+                },
+                {
+                    "field": "/user",
+                    "operator": "equals",
+                    "value": [
+                        "acct:@" + str(random()),
+                        "acct:@" + str(random()),
+                    ],
+                },
+                {
+                    "field": "/uri",
+                    "operator": "one_of",
+                    "value": [
+                        "https://example.com",
+                        "https://example.org" + str(random()),
+                    ],
+                },
+                {
+                    "field": "/references",
+                    "operator": "one_of",
+                    "value": [
+                        "3jgSANNlEeebpLMf36MACw" + str(random()),
+                        "3jgSANNlEeebpLMf36MACw" + str(random()),
+                    ],
+                },
+            ],
+        }
+
+    def test_it_does_not_crash_without_filter_rows(self, annotation, db_session):
+        socket_no_rows = FakeSocket()
+
+        result = tuple(SocketFilter.matching([socket_no_rows], annotation, db_session))
+        assert not result
+
+    def test_it_does_not_crash_with_unexpected_fields(self, annotation, db_session):
+        socket = FakeSocket()
+        socket.filter_rows = (("/not_a_thing", "value"),)
+
+        result = tuple(SocketFilter.matching([socket], annotation, db_session))
+        assert not result
+
     @pytest.mark.skip(reason="For dev purposes only")
     def test_speed(self, factories, db_session):  # pragma: no cover
         # I think the max number connected at once is 4096
@@ -206,43 +272,6 @@ class TestFilterHandler:
         diff = datetime.utcnow() - start
         ms = diff.seconds * 1000 + diff.microseconds / 1000
         print(ms, "ms")
-
-    def get_randomized_filter(self):  # pragma: no cover
-        return {
-            "match_policy": "include_any",
-            "actions": {},
-            "clauses": [
-                {
-                    "field": "/id",
-                    "operator": "equals",
-                    "value": "3jgSANNlEeebpLMf36MACw" + str(random()),
-                },
-                {
-                    "field": "/references",
-                    "operator": "one_of",
-                    "value": [
-                        "3jgSANNlEeebpLMf36MACw" + str(random()),
-                        "3jgSANNlEeebpLMf36MACw" + str(random()),
-                    ],
-                },
-                {
-                    "field": "/uri",
-                    "operator": "one_of",
-                    "value": [
-                        "https://example.com",
-                        "https://example.org" + str(random()),
-                    ],
-                },
-                {
-                    "field": "/group",
-                    "operator": "equals",
-                    "value": [
-                        "3jgSANNlEeebpLMf36MACw" + str(random()),
-                        "3jgSANNlEeebpLMf36MACw" + str(random()),
-                    ],
-                },
-            ],
-        }
 
     @pytest.fixture
     def storage(self, patch):


### PR DESCRIPTION
This PR adds a new filter capability to the websocket stream. It allows to filter by annotations from specific users.
    
I reorder the test to match the filters as they appear in the code: id -> group -> user -> uri -> references