### PR TITLE
Replace `hkdf` with `pycryptodomex`

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -75,8 +75,6 @@ h-matchers==1.2.10
     # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.txt
-hkdf==0.0.3
-    # via -r requirements/requirements.txt
 hupper==1.10.2
     # via
     #   -r requirements/requirements.txt
@@ -173,6 +171,8 @@ pycparser==2.20
     # via
     #   -r requirements/requirements.txt
     #   cffi
+pycryptodomex==3.10.1
+    # via -r requirements/requirements.txt
 pygments==2.7.4
     # via ipython
 pyjwt==2.0.1

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -72,8 +72,6 @@ h-matchers==1.2.10
     # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.txt
-hkdf==0.0.3
-    # via -r requirements/requirements.txt
 hupper==1.10.2
     # via
     #   -r requirements/requirements.txt
@@ -159,6 +157,8 @@ pycparser==2.20
     # via
     #   -r requirements/requirements.txt
     #   cffi
+pycryptodomex==3.10.1
+    # via -r requirements/requirements.txt
 pyjwt==2.0.1
     # via -r requirements/requirements.txt
 pyparsing==2.4.7

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -19,7 +19,6 @@ elasticsearch==6.8.2
 elasticsearch-dsl==6.3.1
 gevent >= 1.4.0
 gunicorn >= 19.9.0
-hkdf
 itsdangerous
 jsonschema
 kombu >= 4.2.1
@@ -29,6 +28,7 @@ oauthlib
 passlib
 psycogreen
 psycopg2
+pycryptodomex
 pyparsing >= 2.1.5
 pyramid
 pyramid_authsanity >= 1.0.0  # 1.0.0 fixes an IE bug: https://git.io/vH3mi

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -54,8 +54,6 @@ h-matchers==1.2.10
     # via -r requirements/requirements.in
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.in
-hkdf==0.0.3
-    # via -r requirements/requirements.in
 hupper==1.10.2
     # via pyramid
 importlib-metadata==1.7.0
@@ -112,6 +110,8 @@ psycopg2==2.8.6
     # via -r requirements/requirements.in
 pycparser==2.20
     # via cffi
+pycryptodomex==3.10.1
+    # via -r requirements/requirements.in
 pyjwt==2.0.1
     # via -r requirements/requirements.in
 pyparsing==2.4.7

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -73,8 +73,6 @@ h-matchers==1.2.10
     # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.txt
-hkdf==0.0.3
-    # via -r requirements/requirements.txt
 hupper==1.10.2
     # via
     #   -r requirements/requirements.txt
@@ -162,6 +160,8 @@ pycparser==2.20
     # via
     #   -r requirements/requirements.txt
     #   cffi
+pycryptodomex==3.10.1
+    # via -r requirements/requirements.txt
 pyjwt==2.0.1
     # via -r requirements/requirements.txt
 pyparsing==2.4.7


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/6570

This replaces `hkdf` with `pycryptodomex` which is active and supports Python 3.9. This causes no trouble with our build process (unlike `cryptography` for the moment).

We are removing `hkdf` as it only advertises support for Python 3.4.

An example implementation using `cryptography` has been added as a comment in case we need / want to switch one day.