### PR TITLE
Reformat the requirements to prevent large dependabot PRs

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,4 +1,4 @@
 ipython
 ipdb
-factory_boy
+factory-boy
 -r requirements.txt

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,3 +1,3 @@
 sphinx-autobuild
 sphinx
-sphinx_rtd_theme
+sphinx-rtd-theme

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -5,80 +5,80 @@
 #    pip-compile requirements/functests.in
 #
 alembic==1.5.8
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 amqp==2.6.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   kombu
 attrs==20.2.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   jsonschema
     #   pytest
 bcrypt==3.2.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 beautifulsoup4==4.9.1
     # via webtest
 billiard==3.6.3.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   celery
 bleach==3.3.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 celery==4.4.7
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 certifi==2020.12.5
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   sentry-sdk
 cffi==1.14.5
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   bcrypt
 chameleon==3.8.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   deform
 click==7.1.2
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 colander==1.8.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   deform
 deform==2.0.15
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 elasticsearch-dsl==6.3.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 elasticsearch==6.8.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   elasticsearch-dsl
 factory-boy==3.2.0
-    # via -r functests.in
+    # via -r requirements/functests.in
 faker==4.1.3
     # via factory-boy
 gevent==21.1.2
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 greenlet==1.0.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   gevent
     #   sqlalchemy
 gunicorn==20.1.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 h-api==1.0.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 h-matchers==1.2.10
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 hupper==1.10.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid
 importlib-metadata==1.7.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   jsonschema
     #   kombu
     #   pluggy
@@ -88,106 +88,106 @@ iniconfig==1.0.1
     # via pytest
 iso8601==0.1.13
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   colander
     #   deform
 itsdangerous==1.1.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 jinja2==2.11.3
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid-jinja2
 jsonschema==3.2.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   h-api
 kombu==4.6.11
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   celery
 mako==1.1.3
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   alembic
 markupsafe==1.1.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   jinja2
     #   mako
     #   pyramid-jinja2
 mistune==0.8.4
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 newrelic==6.2.0.156
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 oauthlib==3.1.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 packaging==20.4
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   bleach
     #   pytest
 passlib==1.7.4
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pastedeploy==2.1.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   plaster-pastedeploy
 peppercorn==0.6
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   deform
 plaster-pastedeploy==0.7
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid
 plaster==1.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   plaster-pastedeploy
     #   pyramid
 pluggy==0.13.1
     # via pytest
 psycogreen==1.0.2
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 psycopg2==2.8.6
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 py==1.10.0
     # via pytest
 pycparser==2.20
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   cffi
 pycryptodomex==3.10.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyjwt==2.0.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyparsing==2.4.7
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   packaging
 pyramid-authsanity==1.1.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-exclog==1.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-jinja2==2.8
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-layout==1.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-mailer==0.15.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-retry==2.1.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-sanity==1.0.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-services==2.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid-authsanity
 pyramid-tm==2.4
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid==1.10.8
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   h-pyramid-sentry
     #   pyramid-authsanity
     #   pyramid-exclog
@@ -200,37 +200,37 @@ pyramid==1.10.8
     #   pyramid-tm
 pyrsistent==0.17.3
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   jsonschema
 pytest==6.2.3
-    # via -r functests.in
+    # via -r requirements/functests.in
 python-dateutil==2.8.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   alembic
     #   elasticsearch-dsl
     #   faker
 python-editor==1.0.4
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   alembic
 python-slugify==4.0.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pytz==2020.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   celery
 repoze.sendmail==4.3
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid-mailer
 sentry-sdk==0.17.6
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   h-pyramid-sentry
 six==1.15.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   bcrypt
     #   bleach
     #   elasticsearch-dsl
@@ -242,83 +242,83 @@ soupsieve==2.0.1
     # via beautifulsoup4
 sqlalchemy==1.4.9
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   alembic
     #   zope.sqlalchemy
 supervisor==4.2.2
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 text-unidecode==1.3
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   faker
     #   python-slugify
 toml==0.10.1
     # via pytest
 transaction==3.0.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid-mailer
     #   pyramid-tm
     #   repoze.sendmail
     #   zope.sqlalchemy
 translationstring==1.4
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   colander
     #   deform
     #   pyramid
 urllib3==1.25.10
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   elasticsearch
     #   sentry-sdk
 venusian==3.0.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid
 vine==1.3.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   amqp
     #   celery
 waitress==1.4.4
     # via webtest
 webencodings==0.5.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   bleach
 webob==1.8.6
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid
     #   webtest
 webtest==2.0.35
-    # via -r functests.in
+    # via -r requirements/functests.in
 wired==0.2.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid-services
 ws4py==0.5.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 wsaccel==0.6.3
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 zipp==3.1.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   importlib-metadata
 zope.deprecation==4.1.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   deform
     #   pyramid
     #   pyramid-jinja2
 zope.event==4.4
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   gevent
 zope.interface==5.1.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   gevent
     #   pyramid
     #   pyramid-authsanity
@@ -329,7 +329,7 @@ zope.interface==5.1.0
     #   wired
     #   zope.sqlalchemy
 zope.sqlalchemy==1.3
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,6 @@
 # Hypothesis packages
-h_pyramid_sentry
-h_matchers
+h-pyramid-sentry
+h-matchers
 h-api
 pyramid-sanity
 
@@ -31,14 +31,14 @@ psycopg2
 pycryptodomex
 pyparsing >= 2.1.5
 pyramid
-pyramid_authsanity >= 1.0.0  # 1.0.0 fixes an IE bug: https://git.io/vH3mi
-pyramid_exclog
-pyramid_layout
+pyramid-authsanity >= 1.0.0  # 1.0.0 fixes an IE bug: https://git.io/vH3mi
+pyramid-exclog
+pyramid-layout
 pyramid-jinja2
 pyramid-services
-pyramid_mailer
-pyramid_retry
-pyramid_tm
+pyramid-mailer
+pyramid-retry
+pyramid-tm
 python-dateutil
 python-slugify < 4.1.0
 supervisor >= 4.0.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,83 +5,83 @@
 #    pip-compile requirements/tests.in
 #
 alembic==1.5.8
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 amqp==2.6.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   kombu
 attrs==20.2.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   hypothesis
     #   jsonschema
     #   pytest
 bcrypt==3.2.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 billiard==3.6.3.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   celery
 bleach==3.3.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 celery==4.4.7
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 certifi==2020.12.5
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   sentry-sdk
 cffi==1.14.5
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   bcrypt
 chameleon==3.8.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   deform
 click==7.1.2
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 colander==1.8.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   deform
 coverage==5.5
-    # via -r tests.in
+    # via -r requirements/tests.in
 deform==2.0.15
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 elasticsearch-dsl==6.3.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 elasticsearch==6.8.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   elasticsearch-dsl
 factory-boy==3.2.0
-    # via -r tests.in
+    # via -r requirements/tests.in
 faker==4.1.3
     # via factory-boy
 gevent==21.1.2
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 greenlet==1.0.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   gevent
     #   sqlalchemy
 gunicorn==20.1.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 h-api==1.0.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 h-matchers==1.2.10
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 hupper==1.10.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid
 hypothesis==6.10.0
-    # via -r tests.in
+    # via -r requirements/tests.in
 importlib-metadata==1.7.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   jsonschema
     #   kombu
     #   pluggy
@@ -91,106 +91,106 @@ iniconfig==1.0.1
     # via pytest
 iso8601==0.1.13
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   colander
     #   deform
 itsdangerous==1.1.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 jinja2==2.11.3
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid-jinja2
 jsonschema==3.2.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   h-api
 kombu==4.6.11
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   celery
 mako==1.1.3
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   alembic
 markupsafe==1.1.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   jinja2
     #   mako
     #   pyramid-jinja2
 mistune==0.8.4
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 newrelic==6.2.0.156
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 oauthlib==3.1.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 packaging==20.4
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   bleach
     #   pytest
 passlib==1.7.4
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pastedeploy==2.1.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   plaster-pastedeploy
 peppercorn==0.6
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   deform
 plaster-pastedeploy==0.7
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid
 plaster==1.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   plaster-pastedeploy
     #   pyramid
 pluggy==0.13.1
     # via pytest
 psycogreen==1.0.2
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 psycopg2==2.8.6
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 py==1.10.0
     # via pytest
 pycparser==2.20
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   cffi
 pycryptodomex==3.10.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyjwt==2.0.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyparsing==2.4.7
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   packaging
 pyramid-authsanity==1.1.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-exclog==1.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-jinja2==2.8
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-layout==1.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-mailer==0.15.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-retry==2.1.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-sanity==1.0.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid-services==2.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid-authsanity
 pyramid-tm==2.4
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyramid==1.10.8
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   h-pyramid-sentry
     #   pyramid-authsanity
     #   pyramid-exclog
@@ -203,37 +203,37 @@ pyramid==1.10.8
     #   pyramid-tm
 pyrsistent==0.17.3
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   jsonschema
 pytest==6.2.3
-    # via -r tests.in
+    # via -r requirements/tests.in
 python-dateutil==2.8.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   alembic
     #   elasticsearch-dsl
     #   faker
 python-editor==1.0.4
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   alembic
 python-slugify==4.0.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pytz==2020.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   celery
 repoze.sendmail==4.3
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid-mailer
 sentry-sdk==0.17.6
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   h-pyramid-sentry
 six==1.15.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   bcrypt
     #   bleach
     #   elasticsearch-dsl
@@ -244,78 +244,78 @@ sortedcontainers==2.2.2
     # via hypothesis
 sqlalchemy==1.4.9
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   alembic
     #   zope.sqlalchemy
 supervisor==4.2.2
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 text-unidecode==1.3
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   faker
     #   python-slugify
 toml==0.10.1
     # via pytest
 transaction==3.0.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid-mailer
     #   pyramid-tm
     #   repoze.sendmail
     #   zope.sqlalchemy
 translationstring==1.4
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   colander
     #   deform
     #   pyramid
 urllib3==1.25.10
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   elasticsearch
     #   sentry-sdk
 venusian==3.0.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid
 vine==1.3.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   amqp
     #   celery
 webencodings==0.5.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   bleach
 webob==1.8.6
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid
 wired==0.2.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pyramid-services
 ws4py==0.5.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 wsaccel==0.6.3
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 zipp==3.1.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   importlib-metadata
 zope.deprecation==4.1.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   deform
     #   pyramid
     #   pyramid-jinja2
 zope.event==4.4
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   gevent
 zope.interface==5.1.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   gevent
     #   pyramid
     #   pyramid-authsanity
@@ -326,7 +326,7 @@ zope.interface==5.1.0
     #   wired
     #   zope.sqlalchemy
 zope.sqlalchemy==1.3
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
I'm trying to go through the dependabot PRs for various products, and some of them have some pretty big PRs due to some misformatting in `h`.

This PR:

 * Normalises things like `lib_name` to `lib-name`
 * Recompiles

This should hopefully help with large PRs here:

 * https://github.com/hypothesis/h/pull/6591
 * https://github.com/hypothesis/h/pull/6597
 * https://github.com/hypothesis/h/pull/6592