### PR TITLE
Remove polyfills not required by supported browsers

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,10 +48,9 @@ var vendorBundles = {
   jquery: ['jquery'],
   bootstrap: ['bootstrap'],
   raven: ['raven-js'],
-  unorm: ['unorm'],
 };
-var vendorModules = ['jquery', 'bootstrap', 'raven-js', 'unorm'];
-var vendorNoParseModules = ['jquery', 'unorm'];
+var vendorModules = ['jquery', 'bootstrap', 'raven-js'];
+var vendorNoParseModules = ['jquery'];
 
 // Builds the bundles containing vendor JS code
 gulp.task('build-vendor-js', function() {

--- a/h/assets.ini
+++ b/h/assets.ini
@@ -17,7 +17,6 @@ admin_js =
 # The H website
 site_js =
   scripts/raven.bundle.js
-  scripts/unorm.bundle.js
   scripts/site.bundle.js
 
 header_js =

--- a/h/static/scripts/base/raven.js
+++ b/h/static/scripts/base/raven.js
@@ -8,8 +8,6 @@
  * version to be provided via the app's settings object.
  */
 
-require('core-js/fn/object/assign');
-
 const Raven = require('raven-js');
 
 function init(config) {

--- a/h/static/scripts/base/settings.js
+++ b/h/static/scripts/base/settings.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('core-js/fn/object/assign');
-
 /**
  * Return application configuration information from the host page.
  *

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -1,45 +1,5 @@
 'use strict';
 
-// ES2015 polyfills
-require('core-js/es6/promise');
-require('core-js/fn/array/find');
-require('core-js/fn/array/find-index');
-require('core-js/fn/array/from');
-require('core-js/fn/array/includes');
-require('core-js/fn/object/assign');
-require('core-js/fn/string/starts-with');
+// There are no polyfills needed at present.
+// This module is a place to add them if needed in future.
 
-// Sets Element.prototype.closest and Element.prototype.matches
-require('element-closest');
-
-// String.prototype.normalize()
-// FIXME: This is a large polyfill which should be only loaded when necessary
-require('unorm');
-
-// Element.prototype.dataset, required by IE 10
-require('element-dataset')();
-
-// Element.prototype.remove. Required by IE 10/11
-if (!Element.prototype.remove) {
-  Element.prototype.remove = function() {
-    if (this.parentNode) {
-      this.parentNode.removeChild(this);
-    }
-  };
-}
-
-// URL constructor, required by IE 10/11,
-// early versions of Microsoft Edge.
-try {
-  new window.URL('https://hypothes.is');
-} catch (err) {
-  require('js-polyfills/url');
-}
-
-// KeyboardEvent.prototype.key
-// (Native in Chrome >= 51, Firefox >= 23, IE >= 9)
-require('keyboardevent-key-polyfill').polyfill();
-
-// Fetch API
-// https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
-require('whatwg-fetch');

--- a/h/static/scripts/tests/bootstrap.js
+++ b/h/static/scripts/tests/bootstrap.js
@@ -1,4 +1,21 @@
 'use strict';
 
+// Polyfills needed only for PhantomJS, not any of our supported minimum
+// browser versions.
+require('core-js/features/array/find');
+require('core-js/features/array/from');
+require('core-js/features/array/includes');
+require('core-js/features/object/assign');
+require('core-js/features/promise');
+
+// `Element.prototype.closest`
+require('element-closest')(window);
+
+// `String.prototype.normalize`
+require('unorm');
+
+// `fetch` and associated classes
+require('whatwg-fetch');
+
 // Expose the sinon assertions.
 sinon.assert.expose(assert, { prefix: null });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,6 @@
         "browserify": "^16.2.3",
         "browserify-shim": "^3.8.12",
         "commander": "^2.9.0",
-        "core-js": "^1.2.5",
-        "element-closest": "^2.0.2",
-        "element-dataset": "^1.3.0",
         "escape-html": "^1.0.3",
         "exorcist": "^0.4.0",
         "gulp": "^4.0.0",
@@ -28,8 +25,6 @@
         "gulp-svgmin": "^2.2.0",
         "gulplog": "^1.0.0",
         "jquery": "^3.5.0",
-        "js-polyfills": "^0.1.16",
-        "keyboardevent-key-polyfill": "^1.0.2",
         "mkdirp": "^0.5.1",
         "normalize.css": "^8.0.0",
         "popper.js": "^1.14.4",
@@ -41,16 +36,16 @@
         "scroll-into-view": "^1.7.1",
         "through2": "^2.0.1",
         "uglifyify": "^4.0.5",
-        "unorm": "^1.4.1",
         "vinyl": "^1.1.1",
-        "watchify": "^3.11.1",
-        "whatwg-fetch": "^0.10.1"
+        "watchify": "^3.11.1"
       },
       "devDependencies": {
         "babel-plugin-mockable-imports": "^1.3.1",
         "chai": "^3.5.0",
         "check-dependencies": "^1.1.0",
+        "core-js": "^3.11.2",
         "diff": "^3.5.0",
+        "element-closest": "^3.0.2",
         "eslint": "^4.18.2",
         "eslint-config-hypothesis": "^1.0.0",
         "fetch-mock": "^5.1.5",
@@ -64,7 +59,9 @@
         "mocha": "^5.2.0",
         "prettier": "1.17.0",
         "sinon": "^1.17.3",
-        "syn": "^0.2.2"
+        "syn": "^0.2.2",
+        "unorm": "^1.6.0",
+        "whatwg-fetch": "^3.6.2"
       },
       "engines": {
         "node": ">=6"
@@ -2769,9 +2766,15 @@
       }
     },
     "node_modules/core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.2.tgz",
+      "integrity": "sha512-3tfrrO1JpJSYGKnd9LKTBPqgUES/UYiCzMKeqwR1+jF16q4kD1BY2NvqkfuzXwQ6+CIWm55V9cjD7PQd+hijdw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -3376,19 +3379,12 @@
       "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
     },
     "node_modules/element-closest": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-2.0.2.tgz",
-      "integrity": "sha1-cqdAoQdFM4LijfnOXbtajfD5Zuw=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-3.0.2.tgz",
+      "integrity": "sha512-JxKQiJKX0Zr5Q2/bCaTx8P+UbfyMET1OQd61qu5xQFeWr1km3fGaxelSJtnfT27XQ5Uoztn2yIyeamAc/VX13g==",
+      "dev": true,
       "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/element-dataset": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/element-dataset/-/element-dataset-1.3.0.tgz",
-      "integrity": "sha1-BFG6Gx3FoeCYH2fUEJgwiA5DcNQ=",
-      "engines": {
-        "node": ">=4.0.0"
+        "node": ">=0.12.0"
       }
     },
     "node_modules/elliptic": {
@@ -6726,11 +6722,6 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
       "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
     },
-    "node_modules/js-polyfills": {
-      "version": "0.1.42",
-      "resolved": "https://registry.npmjs.org/js-polyfills/-/js-polyfills-0.1.42.tgz",
-      "integrity": "sha1-XUhJArNh489gH9I60PMLr8yT8Ug="
-    },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -7877,11 +7868,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
-    },
-    "node_modules/keyboardevent-key-polyfill": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keyboardevent-key-polyfill/-/keyboardevent-key-polyfill-1.1.0.tgz",
-      "integrity": "sha1-ijGdjkWhMXL8pWKGNy+QwdTHAUw="
     },
     "node_modules/kind-of": {
       "version": "3.1.0",
@@ -12049,6 +12035,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
       "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -13211,9 +13198,10 @@
       }
     },
     "node_modules/whatwg-fetch": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.10.1.tgz",
-      "integrity": "sha1-NlEl1As2gj/qyKtBtxxNVuhKUx8="
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
     },
     "node_modules/which": {
       "version": "1.2.14",
@@ -15687,9 +15675,10 @@
       }
     },
     "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.2.tgz",
+      "integrity": "sha512-3tfrrO1JpJSYGKnd9LKTBPqgUES/UYiCzMKeqwR1+jF16q4kD1BY2NvqkfuzXwQ6+CIWm55V9cjD7PQd+hijdw==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -16208,14 +16197,10 @@
       "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
     },
     "element-closest": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-2.0.2.tgz",
-      "integrity": "sha1-cqdAoQdFM4LijfnOXbtajfD5Zuw="
-    },
-    "element-dataset": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/element-dataset/-/element-dataset-1.3.0.tgz",
-      "integrity": "sha1-BFG6Gx3FoeCYH2fUEJgwiA5DcNQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-3.0.2.tgz",
+      "integrity": "sha512-JxKQiJKX0Zr5Q2/bCaTx8P+UbfyMET1OQd61qu5xQFeWr1km3fGaxelSJtnfT27XQ5Uoztn2yIyeamAc/VX13g==",
+      "dev": true
     },
     "elliptic": {
       "version": "6.5.4",
@@ -18894,11 +18879,6 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
       "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
     },
-    "js-polyfills": {
-      "version": "0.1.42",
-      "resolved": "https://registry.npmjs.org/js-polyfills/-/js-polyfills-0.1.42.tgz",
-      "integrity": "sha1-XUhJArNh489gH9I60PMLr8yT8Ug="
-    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -19767,11 +19747,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
-    },
-    "keyboardevent-key-polyfill": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keyboardevent-key-polyfill/-/keyboardevent-key-polyfill-1.1.0.tgz",
-      "integrity": "sha1-ijGdjkWhMXL8pWKGNy+QwdTHAUw="
     },
     "kind-of": {
       "version": "3.1.0",
@@ -23268,7 +23243,8 @@
     "unorm": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -24143,9 +24119,10 @@
       }
     },
     "whatwg-fetch": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.10.1.tgz",
-      "integrity": "sha1-NlEl1As2gj/qyKtBtxxNVuhKUx8="
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
     },
     "which": {
       "version": "1.2.14",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "browserify": "^16.2.3",
     "browserify-shim": "^3.8.12",
     "commander": "^2.9.0",
-    "core-js": "^1.2.5",
-    "element-closest": "^2.0.2",
-    "element-dataset": "^1.3.0",
     "escape-html": "^1.0.3",
     "exorcist": "^0.4.0",
     "gulp": "^4.0.0",
@@ -30,8 +27,6 @@
     "gulp-svgmin": "^2.2.0",
     "gulplog": "^1.0.0",
     "jquery": "^3.5.0",
-    "js-polyfills": "^0.1.16",
-    "keyboardevent-key-polyfill": "^1.0.2",
     "mkdirp": "^0.5.1",
     "normalize.css": "^8.0.0",
     "popper.js": "^1.14.4",
@@ -43,16 +38,16 @@
     "scroll-into-view": "^1.7.1",
     "through2": "^2.0.1",
     "uglifyify": "^4.0.5",
-    "unorm": "^1.4.1",
     "vinyl": "^1.1.1",
-    "watchify": "^3.11.1",
-    "whatwg-fetch": "^0.10.1"
+    "watchify": "^3.11.1"
   },
   "devDependencies": {
     "babel-plugin-mockable-imports": "^1.3.1",
     "chai": "^3.5.0",
     "check-dependencies": "^1.1.0",
+    "core-js": "^3.11.2",
     "diff": "^3.5.0",
+    "element-closest": "^3.0.2",
     "eslint": "^4.18.2",
     "eslint-config-hypothesis": "^1.0.0",
     "fetch-mock": "^5.1.5",
@@ -66,7 +61,9 @@
     "mocha": "^5.2.0",
     "prettier": "1.17.0",
     "sinon": "^1.17.3",
-    "syn": "^0.2.2"
+    "syn": "^0.2.2",
+    "unorm": "^1.6.0",
+    "whatwg-fetch": "^3.6.2"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/h/pull/6616**~~

Our current browser baseline for all apps is Safari 10.1, Edge 17,
Chrome 57 and Firefox 53. See the `browserslist` key in the client's
`package.json` file. None of the polyfills loaded by the h frontend are
required in these browsers.

We do still need some of these polyfills in PhantomJS (core-js,
element-closest, whatwg-fetch, unorm) which runs the tests.

 - Remove polyfills not needed by production browsers

 - Update PhantomJS-only polyfills (core-js, element-closest,
   whatwg-fetch, unorm) to latest versions and load them from
   `bootstrap.js` which is only used in tests