### PR TITLE
Added browserlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "url": "https://github.com/hypothesis/h/issues"
   },
   "homepage": "https://github.com/hypothesis/h",
+  "browserslist": "chrome 57, edge 17, firefox 53, safari 10.1",
   "browserify": {
     "transform": [
       "babelify",


### PR DESCRIPTION
The browser support baseline for the JavaScript code in h has been updated to match the client and LMS app. This currently means: Chrome 57+, Edge 17+, Firefox 53+, Safari 10.1+.