### PR TITLE
Add autocomplete attributes to improve login and password reset forms

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -63,7 +63,9 @@ def email_node(**kwargs):
         validator=colander.All(
             validators.Length(max=EMAIL_MAX_LENGTH), validators.Email(), unique_email
         ),
-        widget=deform.widget.TextInputWidget(template="emailinput"),
+        widget=deform.widget.TextInputWidget(
+            template="emailinput", autocomplete="username"
+        ),
         **kwargs
     )
 
@@ -91,13 +93,17 @@ def privacy_acceptance_validator(node, value):
 
 def password_node(**kwargs):
     """Return a Colander schema node for an existing user password."""
-    kwargs.setdefault("widget", deform.widget.PasswordWidget())
+    kwargs.setdefault(
+        "widget", deform.widget.PasswordWidget(autocomplete="current-password")
+    )
     return colander.SchemaNode(colander.String(), **kwargs)
 
 
 def new_password_node(**kwargs):
     """Return a Colander schema node for a new user password."""
-    kwargs.setdefault("widget", deform.widget.PasswordWidget())
+    kwargs.setdefault(
+        "widget", deform.widget.PasswordWidget(autocomplete="new-password")
+    )
     return colander.SchemaNode(
         colander.String(),
         validator=validators.Length(min=PASSWORD_MIN_LENGTH),
@@ -193,13 +199,15 @@ class EmailChangeSchema(CSRFSchema):
 
 class PasswordChangeSchema(CSRFSchema):
     password = password_node(title=_("Current password"), inactive_label=_("Password"))
-    new_password = password_node(title=_("New password"), hide_until_form_active=True)
+    new_password = new_password_node(
+        title=_("New password"), hide_until_form_active=True
+    )
     # No validators: all validation is done on the new_password field and we
     # merely assert that the confirmation field is the same.
     new_password_confirm = colander.SchemaNode(
         colander.String(),
         title=_("Confirm new password"),
-        widget=deform.widget.PasswordWidget(),
+        widget=deform.widget.PasswordWidget(autocomplete="new-password"),
         hide_until_form_active=True,
     )
 

--- a/h/schemas/forms/accounts/login.py
+++ b/h/schemas/forms/accounts/login.py
@@ -11,13 +11,17 @@ _ = i18n.TranslationString
 @colander.deferred
 def _deferred_username_widget(node, kw):
     """Return a username widget that autofocuses if username isn't pre-filled."""
-    return deform.widget.TextInputWidget(autofocus=_should_autofocus_username(kw))
+    return deform.widget.TextInputWidget(
+        autofocus=_should_autofocus_username(kw), autocomplete="username"
+    )
 
 
 @colander.deferred
 def _deferred_password_widget(node, kw):
     """Return a password widget that autofocuses if username *is* pre-filled."""
-    return deform.widget.PasswordWidget(autofocus=not _should_autofocus_username(kw))
+    return deform.widget.PasswordWidget(
+        autofocus=not _should_autofocus_username(kw), autocomplete="current-password"
+    )
 
 
 class LoginSchema(CSRFSchema):

--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -29,6 +29,9 @@ autofocus
 {%- if field.widget.disable_autocomplete -%}
 autocomplete="off"
 {% endif -%}
+{%- if field.widget.autocomplete -%}
+autocomplete="{{ field.widget.autocomplete }}"
+{% endif -%}
 {%- if field.widget.max_length -%}
 data-maxlength="{{ field.widget.max_length }}"
 {% endif -%}


### PR DESCRIPTION
Following suggested practices around login forms, I added
'autocomplete="username|current-password|new-password"` to the login and
account setting forms. This little annotation makes the completion of
forms simpler and allows password managers to work better.

It also eliminates the warning that appeared on the Chrome Canary web console.

Reading:
* https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands
* https://www.chromium.org/developers/design-documents/create-amazing-password-forms

Password manager suggesting a new password:

![Screenshot 2021-05-18 at 13 19 53](https://user-images.githubusercontent.com/8555781/118644162-cc68ae80-b7dd-11eb-826b-2e21093f095a.png)