### PR TITLE
Add monthly dependabot checks for NPM libraries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
     interval: weekly
     time: "10:00"
   open-pull-requests-limit: 10
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "10:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
The configuration file only allows: daily, weekly, or monthly checks. I
choose monthly because the code is not changed often.