### PR TITLE
Remove gulp-newer stream when processing vendor CSS

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,6 @@ const commander = require('commander');
 const gulp = require('gulp');
 const gulpIf = require('gulp-if');
 const log = require('fancy-log');
-const newer = require('gulp-newer');
 const postcss = require('gulp-postcss');
 const postcssURL = require('postcss-url');
 const svgmin = require('gulp-svgmin');
@@ -139,7 +138,6 @@ gulp.task('build-vendor-css', function () {
 
   return gulp
     .src(vendorCSSFiles)
-    .pipe(newer(STYLE_DIR))
     .pipe(postcss([cssURLRewriter]))
     .pipe(gulp.dest(STYLE_DIR));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,20 +40,20 @@ function parseCommandLine() {
   };
 }
 
-var taskArgs = parseCommandLine();
+const taskArgs = parseCommandLine();
 
-var vendorBundles = {
+const vendorBundles = {
   jquery: ['jquery'],
   bootstrap: ['bootstrap'],
   raven: ['raven-js'],
 };
-var vendorModules = ['jquery', 'bootstrap', 'raven-js'];
-var vendorNoParseModules = ['jquery'];
+const vendorModules = ['jquery', 'bootstrap', 'raven-js'];
+const vendorNoParseModules = ['jquery'];
 
 // Builds the bundles containing vendor JS code
-gulp.task('build-vendor-js', function () {
-  var finished = [];
-  Object.keys(vendorBundles).forEach(function (name) {
+gulp.task('build-vendor-js', () => {
+  const finished = [];
+  Object.keys(vendorBundles).forEach(name => {
     finished.push(
       createBundle({
         name: name,
@@ -67,14 +67,14 @@ gulp.task('build-vendor-js', function () {
   return Promise.all(finished);
 });
 
-var bundleBaseConfig = {
+const bundleBaseConfig = {
   path: SCRIPT_DIR,
   external: vendorModules,
   minify: IS_PRODUCTION_BUILD,
   noParse: vendorNoParseModules,
 };
 
-var bundles = [
+const bundles = [
   {
     // Public-facing website
     name: 'site',
@@ -97,15 +97,15 @@ var bundles = [
   },
 ];
 
-var bundleConfigs = bundles.map(function (config) {
+const bundleConfigs = bundles.map(config => {
   return Object.assign({}, bundleBaseConfig, config);
 });
 
 gulp.task(
   'build-js',
-  gulp.series(['build-vendor-js'], function () {
+  gulp.series(['build-vendor-js'], () => {
     return Promise.all(
-      bundleConfigs.map(function (config) {
+      bundleConfigs.map(config => {
         return createBundle(config);
       })
     );
@@ -114,7 +114,7 @@ gulp.task(
 
 gulp.task(
   'watch-js',
-  gulp.series(['build-vendor-js'], function () {
+  gulp.series(['build-vendor-js'], () => {
     return bundleConfigs.map(config => createBundle(config, { watch: true }));
   })
 );
@@ -125,14 +125,14 @@ function rewriteCSSURL(asset) {
   return asset.url.replace(/^fonts\//, '../fonts/');
 }
 
-gulp.task('build-vendor-css', function () {
-  var vendorCSSFiles = [
+gulp.task('build-vendor-css', () => {
+  const vendorCSSFiles = [
     // Icon font
     './h/static/styles/vendor/icomoon.css',
     './node_modules/bootstrap/dist/css/bootstrap.css',
   ];
 
-  var cssURLRewriter = postcssURL({
+  const cssURLRewriter = postcssURL({
     url: rewriteCSSURL,
   });
 
@@ -142,7 +142,7 @@ gulp.task('build-vendor-css', function () {
     .pipe(gulp.dest(STYLE_DIR));
 });
 
-var styleBundleEntryFiles = [
+const styleBundleEntryFiles = [
   './h/static/styles/admin.scss',
   './h/static/styles/help-page.scss',
   './h/static/styles/site.scss',
@@ -159,12 +159,12 @@ function buildStyleBundle(entryFile) {
 
 gulp.task(
   'build-css',
-  gulp.series(['build-vendor-css'], function () {
+  gulp.series(['build-vendor-css'], () => {
     return Promise.all(styleBundleEntryFiles.map(buildStyleBundle));
   })
 );
 
-gulp.task('watch-css', function () {
+gulp.task('watch-css', () => {
   gulp.watch(
     'h/static/styles/**/*.scss',
     { ignoreInitial: false },
@@ -172,27 +172,27 @@ gulp.task('watch-css', function () {
   );
 });
 
-var fontFiles = 'h/static/styles/vendor/fonts/*.woff';
+const fontFiles = 'h/static/styles/vendor/fonts/*.woff';
 
-gulp.task('build-fonts', function () {
+gulp.task('build-fonts', () => {
   return gulp
     .src(fontFiles)
     .pipe(changed(FONTS_DIR))
     .pipe(gulp.dest(FONTS_DIR));
 });
 
-gulp.task('watch-fonts', function () {
+gulp.task('watch-fonts', () => {
   gulp.watch(fontFiles, gulp.series('build-fonts'));
 });
 
-var imageFiles = 'h/static/images/**/*';
-gulp.task('build-images', function () {
-  var shouldMinifySVG = function (file) {
+const imageFiles = 'h/static/images/**/*';
+gulp.task('build-images', () => {
+  const shouldMinifySVG = function (file) {
     return IS_PRODUCTION_BUILD && file.path.match(/\.svg$/);
   };
 
   // See https://github.com/ben-eb/gulp-svgmin#plugins
-  var svgminConfig = {
+  const svgminConfig = {
     plugins: [
       {
         // svgo removes `viewBox` by default, which breaks scaled rendering of
@@ -211,11 +211,11 @@ gulp.task('build-images', function () {
     .pipe(gulp.dest(IMAGES_DIR));
 });
 
-gulp.task('watch-images', function () {
+gulp.task('watch-images', () => {
   gulp.watch(imageFiles, gulp.series('build-images'));
 });
 
-var MANIFEST_SOURCE_FILES = 'build/@(fonts|images|scripts|styles)/**/*.*';
+const MANIFEST_SOURCE_FILES = 'build/@(fonts|images|scripts|styles)/**/*.*';
 
 /**
  * Generate a JSON manifest mapping file paths to
@@ -235,7 +235,7 @@ function generateManifest() {
     .pipe(gulp.dest('build/'));
 }
 
-gulp.task('watch-manifest', function () {
+gulp.task('watch-manifest', () => {
   gulp.watch(MANIFEST_SOURCE_FILES, generateManifest);
 });
 
@@ -259,7 +259,7 @@ gulp.task(
 
 function runKarma(baseConfig, opts, done) {
   // See https://github.com/karma-runner/karma-mocha#configuration
-  var cliOpts = {
+  const cliOpts = {
     client: {
       mocha: {
         grep: taskArgs.grep,
@@ -268,17 +268,17 @@ function runKarma(baseConfig, opts, done) {
     ...opts,
   };
 
-  var karma = require('karma');
+  const karma = require('karma');
   new karma.Server(
     karma.config.parseConfig(path.resolve(__dirname, baseConfig), cliOpts),
     done
   ).start();
 }
 
-gulp.task('test', function (callback) {
+gulp.task('test', callback => {
   runKarma('./h/static/scripts/karma.config.js', { singleRun: true }, callback);
 });
 
-gulp.task('test-watch', function (callback) {
+gulp.task('test-watch', callback => {
   runKarma('./h/static/scripts/karma.config.js', {}, callback);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "gulp": "^4.0.0",
         "gulp-changed": "^4.0.2",
         "gulp-if": "^3.0.0",
-        "gulp-newer": "^1.2.0",
         "gulp-postcss": "^9.0.0",
         "gulp-svgmin": "^3.0.0",
         "jquery": "^3.6.0",
@@ -1691,32 +1690,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ansi-cyan": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
-      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
-      "dependencies": {
-        "ansi-wrap": "0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ansi-gray": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
       "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-      "dependencies": {
-        "ansi-wrap": "0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ansi-red": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
       "dependencies": {
         "ansi-wrap": "0.1.0"
       },
@@ -6494,16 +6471,6 @@
         "minimatch": "^3.0.3"
       }
     },
-    "node_modules/gulp-newer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gulp-newer/-/gulp-newer-1.4.0.tgz",
-      "integrity": "sha512-h79fGO55S/P9eAADbLAP9aTtVYpLSR1ONj08VPaSdVVNVYhTS8p1CO1TW7kEMu+hC+sytmCqcUr5LesvZEtDoQ==",
-      "dependencies": {
-        "glob": "^7.0.3",
-        "kew": "^0.7.0",
-        "plugin-error": "^0.1.2"
-      }
-    },
     "node_modules/gulp-postcss": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-9.0.0.tgz",
@@ -7926,11 +7893,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/kew": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
     },
     "node_modules/kind-of": {
       "version": "3.1.0",
@@ -9721,68 +9683,6 @@
       "dependencies": {
         "pinkie": "^2.0.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/plugin-error": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
-      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
-      "dependencies": {
-        "ansi-cyan": "^0.1.1",
-        "ansi-red": "^0.1.1",
-        "arr-diff": "^1.0.1",
-        "arr-union": "^2.0.1",
-        "extend-shallow": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/plugin-error/node_modules/arr-diff": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-      "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
-      "dependencies": {
-        "arr-flatten": "^1.0.1",
-        "array-slice": "^0.2.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/plugin-error/node_modules/arr-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
-      "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/plugin-error/node_modules/array-slice": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/plugin-error/node_modules/extend-shallow": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-      "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
-      "dependencies": {
-        "kind-of": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/plugin-error/node_modules/kind-of": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-      "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14833,26 +14733,10 @@
         "ansi-wrap": "^0.1.0"
       }
     },
-    "ansi-cyan": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
-      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
     "ansi-gray": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
       "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-red": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
       "requires": {
         "ansi-wrap": "0.1.0"
       }
@@ -18633,16 +18517,6 @@
         "minimatch": "^3.0.3"
       }
     },
-    "gulp-newer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gulp-newer/-/gulp-newer-1.4.0.tgz",
-      "integrity": "sha512-h79fGO55S/P9eAADbLAP9aTtVYpLSR1ONj08VPaSdVVNVYhTS8p1CO1TW7kEMu+hC+sytmCqcUr5LesvZEtDoQ==",
-      "requires": {
-        "glob": "^7.0.3",
-        "kew": "^0.7.0",
-        "plugin-error": "^0.1.2"
-      }
-    },
     "gulp-postcss": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-9.0.0.tgz",
@@ -19684,11 +19558,6 @@
       "resolved": "https://registry.npmjs.org/karma-sinon/-/karma-sinon-1.0.5.tgz",
       "integrity": "sha1-TjRD8oMP3s/2JNN0cWPxIX2qKpo=",
       "dev": true
-    },
-    "kew": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
     },
     "kind-of": {
       "version": "3.1.0",
@@ -21082,52 +20951,6 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
         "pinkie": "^2.0.0"
-      }
-    },
-    "plugin-error": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
-      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
-      "requires": {
-        "ansi-cyan": "^0.1.1",
-        "ansi-red": "^0.1.1",
-        "arr-diff": "^1.0.1",
-        "arr-union": "^2.0.1",
-        "extend-shallow": "^1.1.2"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
-          "requires": {
-            "arr-flatten": "^1.0.1",
-            "array-slice": "^0.2.3"
-          }
-        },
-        "arr-union": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
-          "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
-        },
-        "array-slice": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-          "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
-        },
-        "extend-shallow": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
-          "requires": {
-            "kind-of": "^1.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
-        }
       }
     },
     "posix-character-classes": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "gulp": "^4.0.0",
     "gulp-changed": "^4.0.2",
     "gulp-if": "^3.0.0",
-    "gulp-newer": "^1.2.0",
     "gulp-postcss": "^9.0.0",
     "gulp-svgmin": "^3.0.0",
     "jquery": "^3.6.0",


### PR DESCRIPTION
We tried to upgrade the version of `bootstrap.css`, however the newer
version of this file was not copy over `build/styles`. This is because
(at least on mac) different version of `bootstrap.css` shows the same
date (26 Oct 1985).

```
% ls -lh ./node_modules/bootstrap/dist/css/bootstrap.css
-rw-r--r--  1 esanzgar  staff   191K 26 Oct  1985 ./node_modules/bootstrap/dist/css/bootstrap.css <- this is version 5.0

% ls -lh build/styles/bootstrap.css
-rw-r--r--  1 esanzgar  staff   193K 26 Oct  1985 build/styles/bootstrap.css <- this is version 4.6
```

I have just confirmed that `npm` publishes packages with all the
(contained) file timestamps locked to 26 Oct 1985:

https://github.com/npm/npm/issues/20439

Given the above information it is better to not rely on the timestamp.

The second commit the file was reformatted in this way: `./node_modules/.bin/eslint --fix gulpfile.js`
