### PR TITLE
Update Celery to 5.1

### DIFF
--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -70,3 +70,7 @@ def main():
     for cmd in SUBCOMMANDS:
         cli.add_command(resolver.resolve(cmd))
     cli(prog_name="hypothesis", obj={})
+
+
+if __name__ == "__main__":
+    main()

--- a/h/cli/commands/celery.py
+++ b/h/cli/commands/celery.py
@@ -15,5 +15,4 @@ def celery(ctx):
     This command delegates to the celery-worker command, giving access to the
     full Celery CLI.
     """
-    argv = [ctx.command_path] + list(ctx.args)
-    start(argv=argv, bootstrap=ctx.obj["bootstrap"])
+    start(argv=list(ctx.args), bootstrap=ctx.obj["bootstrap"])

--- a/requirements/analyze.txt
+++ b/requirements/analyze.txt
@@ -6,7 +6,7 @@
 #
 alembic==1.6.5
     # via -r requirements/requirements.txt
-amqp==2.6.1
+amqp==5.0.6
     # via
     #   -r requirements/requirements.txt
     #   kombu
@@ -22,13 +22,13 @@ bcrypt==3.2.0
     # via -r requirements/requirements.txt
 beautifulsoup4==4.9.3
     # via webtest
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via
     #   -r requirements/requirements.txt
     #   celery
 bleach==3.3.0
     # via -r requirements/requirements.txt
-celery==4.4.7
+celery==5.1.0
     # via -r requirements/requirements.txt
 certifi==2020.12.5
     # via
@@ -42,8 +42,25 @@ chameleon==3.8.1
     # via
     #   -r requirements/requirements.txt
     #   deform
-click==8.0.1
-    # via -r requirements/requirements.txt
+click-didyoumean==0.0.3
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+click-repl==0.2.0
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+click==7.1.2
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
 colander==1.8.2
     # via
     #   -r requirements/requirements.txt
@@ -104,7 +121,7 @@ jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
     #   h-api
-kombu==4.6.11
+kombu==5.1.0
     # via
     #   -r requirements/requirements.txt
     #   celery
@@ -154,6 +171,10 @@ plaster==1.0
     #   pyramid
 pluggy==0.13.1
     # via pytest
+prompt-toolkit==3.0.18
+    # via
+    #   -r requirements/requirements.txt
+    #   click-repl
 psycogreen==1.0.2
     # via -r requirements/requirements.txt
 psycopg2==2.8.6
@@ -225,7 +246,7 @@ python-editor==1.0.4
     #   alembic
 python-slugify==5.0.2
     # via -r requirements/requirements.txt
-pytz==2020.1
+pytz==2021.1
     # via
     #   -r requirements/requirements.txt
     #   celery
@@ -242,6 +263,7 @@ six==1.15.0
     #   -r requirements/requirements.txt
     #   bcrypt
     #   bleach
+    #   click-repl
     #   elasticsearch-dsl
     #   jsonschema
     #   packaging
@@ -289,18 +311,23 @@ venusian==3.0.0
     # via
     #   -r requirements/requirements.txt
     #   pyramid
-vine==1.3.0
+vine==5.0.0
     # via
     #   -r requirements/requirements.txt
     #   amqp
     #   celery
+    #   kombu
 waitress==2.0.0
     # via webtest
+wcwidth==0.2.5
+    # via
+    #   -r requirements/requirements.txt
+    #   prompt-toolkit
 webencodings==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   bleach
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/requirements.txt
     #   pyramid

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 alembic==1.6.5
     # via -r requirements/requirements.txt
-amqp==2.6.1
+amqp==5.0.6
     # via
     #   -r requirements/requirements.txt
     #   kombu
@@ -18,13 +18,13 @@ backcall==0.2.0
     # via ipython
 bcrypt==3.2.0
     # via -r requirements/requirements.txt
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via
     #   -r requirements/requirements.txt
     #   celery
 bleach==3.3.0
     # via -r requirements/requirements.txt
-celery==4.4.7
+celery==5.1.0
     # via -r requirements/requirements.txt
 certifi==2020.12.5
     # via
@@ -38,8 +38,25 @@ chameleon==3.8.1
     # via
     #   -r requirements/requirements.txt
     #   deform
-click==8.0.1
-    # via -r requirements/requirements.txt
+click-didyoumean==0.0.3
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+click-repl==0.2.0
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+click==7.1.2
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
 colander==1.8.2
     # via
     #   -r requirements/requirements.txt
@@ -108,7 +125,7 @@ jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
     #   h-api
-kombu==4.6.11
+kombu==5.1.0
     # via
     #   -r requirements/requirements.txt
     #   celery
@@ -160,7 +177,10 @@ plaster==1.0
     #   plaster-pastedeploy
     #   pyramid
 prompt-toolkit==3.0.18
-    # via ipython
+    # via
+    #   -r requirements/requirements.txt
+    #   click-repl
+    #   ipython
 psycogreen==1.0.2
     # via -r requirements/requirements.txt
 psycopg2==2.8.6
@@ -230,7 +250,7 @@ python-editor==1.0.4
     #   alembic
 python-slugify==5.0.2
     # via -r requirements/requirements.txt
-pytz==2020.1
+pytz==2021.1
     # via
     #   -r requirements/requirements.txt
     #   celery
@@ -247,6 +267,7 @@ six==1.15.0
     #   -r requirements/requirements.txt
     #   bcrypt
     #   bleach
+    #   click-repl
     #   elasticsearch-dsl
     #   jsonschema
     #   packaging
@@ -291,18 +312,21 @@ venusian==3.0.0
     # via
     #   -r requirements/requirements.txt
     #   pyramid
-vine==1.3.0
+vine==5.0.0
     # via
     #   -r requirements/requirements.txt
     #   amqp
     #   celery
+    #   kombu
 wcwidth==0.2.5
-    # via prompt-toolkit
+    # via
+    #   -r requirements/requirements.txt
+    #   prompt-toolkit
 webencodings==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   bleach
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/requirements.txt
     #   pyramid

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -6,7 +6,7 @@
 #
 alembic==1.6.5
     # via -r requirements/requirements.txt
-amqp==2.6.1
+amqp==5.0.6
     # via
     #   -r requirements/requirements.txt
     #   kombu
@@ -19,13 +19,13 @@ bcrypt==3.2.0
     # via -r requirements/requirements.txt
 beautifulsoup4==4.9.3
     # via webtest
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via
     #   -r requirements/requirements.txt
     #   celery
 bleach==3.3.0
     # via -r requirements/requirements.txt
-celery==4.4.7
+celery==5.1.0
     # via -r requirements/requirements.txt
 certifi==2020.12.5
     # via
@@ -39,8 +39,25 @@ chameleon==3.8.1
     # via
     #   -r requirements/requirements.txt
     #   deform
-click==8.0.1
-    # via -r requirements/requirements.txt
+click-didyoumean==0.0.3
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+click-repl==0.2.0
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+click==7.1.2
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
 colander==1.8.2
     # via
     #   -r requirements/requirements.txt
@@ -97,7 +114,7 @@ jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
     #   h-api
-kombu==4.6.11
+kombu==5.1.0
     # via
     #   -r requirements/requirements.txt
     #   celery
@@ -143,6 +160,10 @@ plaster==1.0
     #   pyramid
 pluggy==0.13.1
     # via pytest
+prompt-toolkit==3.0.18
+    # via
+    #   -r requirements/requirements.txt
+    #   click-repl
 psycogreen==1.0.2
     # via -r requirements/requirements.txt
 psycopg2==2.8.6
@@ -212,7 +233,7 @@ python-editor==1.0.4
     #   alembic
 python-slugify==5.0.2
     # via -r requirements/requirements.txt
-pytz==2020.1
+pytz==2021.1
     # via
     #   -r requirements/requirements.txt
     #   celery
@@ -229,6 +250,7 @@ six==1.15.0
     #   -r requirements/requirements.txt
     #   bcrypt
     #   bleach
+    #   click-repl
     #   elasticsearch-dsl
     #   jsonschema
     #   packaging
@@ -272,18 +294,23 @@ venusian==3.0.0
     # via
     #   -r requirements/requirements.txt
     #   pyramid
-vine==1.3.0
+vine==5.0.0
     # via
     #   -r requirements/requirements.txt
     #   amqp
     #   celery
+    #   kombu
 waitress==2.0.0
     # via webtest
+wcwidth==0.2.5
+    # via
+    #   -r requirements/requirements.txt
+    #   prompt-toolkit
 webencodings==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   bleach
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/requirements.txt
     #   pyramid

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -10,7 +10,7 @@ SQLAlchemy >= 1.1.4
 alembic
 bcrypt
 bleach
-celery >= 4.3
+celery
 certifi  # Required to connect to Elasticsearch over SSL.
 cffi
 click
@@ -22,7 +22,7 @@ gunicorn >= 19.9.0
 importlib_resources
 itsdangerous
 jsonschema
-kombu >= 4.2.1
+kombu
 mistune
 newrelic
 oauthlib

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,17 +6,17 @@
 #
 alembic==1.6.5
     # via -r requirements/requirements.in
-amqp==2.6.1
+amqp==5.0.6
     # via kombu
 attrs==20.2.0
     # via jsonschema
 bcrypt==3.2.0
     # via -r requirements/requirements.in
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via celery
 bleach==3.3.0
     # via -r requirements/requirements.in
-celery==4.4.7
+celery==5.1.0
     # via -r requirements/requirements.in
 certifi==2020.12.5
     # via
@@ -28,8 +28,19 @@ cffi==1.14.5
     #   bcrypt
 chameleon==3.8.1
     # via deform
-click==8.0.1
-    # via -r requirements/requirements.in
+click-didyoumean==0.0.3
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.2.0
+    # via celery
+click==7.1.2
+    # via
+    #   -r requirements/requirements.in
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
 colander==1.8.2
     # via deform
 deform==2.0.15
@@ -72,7 +83,7 @@ jsonschema==3.2.0
     # via
     #   -r requirements/requirements.in
     #   h-api
-kombu==4.6.11
+kombu==5.1.0
     # via
     #   -r requirements/requirements.in
     #   celery
@@ -103,6 +114,8 @@ plaster==1.0
     # via
     #   plaster-pastedeploy
     #   pyramid
+prompt-toolkit==3.0.18
+    # via click-repl
 psycogreen==1.0.2
     # via -r requirements/requirements.in
 psycopg2==2.8.6
@@ -161,7 +174,7 @@ python-editor==1.0.4
     # via alembic
 python-slugify==5.0.2
     # via -r requirements/requirements.in
-pytz==2020.1
+pytz==2021.1
     # via celery
 repoze.sendmail==4.3
     # via pyramid-mailer
@@ -171,6 +184,7 @@ six==1.15.0
     # via
     #   bcrypt
     #   bleach
+    #   click-repl
     #   elasticsearch-dsl
     #   jsonschema
     #   packaging
@@ -204,13 +218,16 @@ venusian==3.0.0
     # via
     #   -r requirements/requirements.in
     #   pyramid
-vine==1.3.0
+vine==5.0.0
     # via
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.5
+    # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
-webob==1.8.6
+webob==1.8.7
     # via pyramid
 wired==0.2.2
     # via pyramid-services

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,7 +6,7 @@
 #
 alembic==1.6.5
     # via -r requirements/requirements.txt
-amqp==2.6.1
+amqp==5.0.6
     # via
     #   -r requirements/requirements.txt
     #   kombu
@@ -18,13 +18,13 @@ attrs==20.2.0
     #   pytest
 bcrypt==3.2.0
     # via -r requirements/requirements.txt
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via
     #   -r requirements/requirements.txt
     #   celery
 bleach==3.3.0
     # via -r requirements/requirements.txt
-celery==4.4.7
+celery==5.1.0
     # via -r requirements/requirements.txt
 certifi==2020.12.5
     # via
@@ -38,8 +38,25 @@ chameleon==3.8.1
     # via
     #   -r requirements/requirements.txt
     #   deform
-click==8.0.1
-    # via -r requirements/requirements.txt
+click-didyoumean==0.0.3
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+click-repl==0.2.0
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+click==7.1.2
+    # via
+    #   -r requirements/requirements.txt
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
 colander==1.8.2
     # via
     #   -r requirements/requirements.txt
@@ -100,7 +117,7 @@ jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
     #   h-api
-kombu==4.6.11
+kombu==5.1.0
     # via
     #   -r requirements/requirements.txt
     #   celery
@@ -146,6 +163,10 @@ plaster==1.0
     #   pyramid
 pluggy==0.13.1
     # via pytest
+prompt-toolkit==3.0.18
+    # via
+    #   -r requirements/requirements.txt
+    #   click-repl
 psycogreen==1.0.2
     # via -r requirements/requirements.txt
 psycopg2==2.8.6
@@ -215,7 +236,7 @@ python-editor==1.0.4
     #   alembic
 python-slugify==5.0.2
     # via -r requirements/requirements.txt
-pytz==2020.1
+pytz==2021.1
     # via
     #   -r requirements/requirements.txt
     #   celery
@@ -232,6 +253,7 @@ six==1.15.0
     #   -r requirements/requirements.txt
     #   bcrypt
     #   bleach
+    #   click-repl
     #   elasticsearch-dsl
     #   jsonschema
     #   packaging
@@ -274,16 +296,21 @@ venusian==3.0.0
     # via
     #   -r requirements/requirements.txt
     #   pyramid
-vine==1.3.0
+vine==5.0.0
     # via
     #   -r requirements/requirements.txt
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.5
+    # via
+    #   -r requirements/requirements.txt
+    #   prompt-toolkit
 webencodings==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   bleach
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/requirements.txt
     #   pyramid


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/6596.

I'm not going to pretend I really understand how this was working before (it looks to me like it shouldn't have), but I think the breaking change here was in how `celery` parses it's command line arguments. We have a fairly convoluted path (especially in dev) where we call:

 * `bin/hypothesis` - This doesn't happen in live
 * Which calls `python -m h.cli ...` and passes some arguments
 * This ends up being in some `click` code in `h.cli.commands.celery`
 * Which calls `h.celery.start`
 * Which creates a `celery.Celery` app object and calls `start()` on it, passing everything through

The mistake is in `h.cli.commands.celery` which was passing through `["hypothesis", "celery", "worker"]` through, whereas the correct thing to pass is apparently just "worker". So this works now, but I don't know why it accepted it before. It's possible this is a change in `click` behavior? Which got upgraded with `celery` too.

Interesting side effect of this I noticed that the `bin/hypothesis` / `h.cli.__init__.py` script takes 1.3s just to load all the modules etc. Some obvious wins here if we can cut that down.

Ideally the `celery` stuff should be ripped out of all this as it's a part of how we run the actual system rather than just a once every so often action. The only thing it really needs is some `Pyramid` bootstrapping code from `.h.cli.__init__.py` to load the paster config and get a fake request object.