### PR TITLE
Disable autocomplete for the subscription checkbox

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -222,7 +222,6 @@ class PasswordChangeSchema(CSRFSchema):
 
 class NotificationsSchema(CSRFSchema):
     types = (("reply", _("Email me when someone replies to one of my annotations.")),)
-
     notifications = colander.SchemaNode(
         colander.Set(),
         widget=deform.widget.CheckboxChoiceWidget(omit_label=True, values=types),

--- a/h/templates/deform/checkbox_choice.jinja2
+++ b/h/templates/deform/checkbox_choice.jinja2
@@ -14,8 +14,10 @@
              {%- if field.error -%}
              aria-invalid="true"
              {% endif -%}
+             {# For reason about `autocomplete="off"` see https://github.com/hypothesis/h/pull/6696 #}
+             autocomplete="off"
              {% if value in cstruct %}
-             checked="True"
+             checked
              {% endif %}>
       {{ title }}
     </label>


### PR DESCRIPTION
Firefox caches the state of checkboxes in forms. If you check a checkbox
and reload the page, Firefox ignores the state of the checkbox in the
response and keeps the checkbox checked. To avoid this behaviour, I
added an autocomplete="off" for the subscription checkbox.