### PR TITLE
Allow any LMS authority of the form `lms@lms.*.hypothes.is`

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -16,7 +16,6 @@ GROUP_NAME_MAX_LENGTH = 25
 GROUP_DESCRIPTION_MAX_LENGTH = 250
 AUTHORITY_PROVIDED_ID_PATTERN = r"^[a-zA-Z0-9._\-+!~*()']+$"
 AUTHORITY_PROVIDED_ID_MAX_LENGTH = 1024
-LMS_AUTHORITY_PATTERN = re.compile(r"^lms\.(?:.*?)?hypothes\.is$")
 
 
 class JoinableBy(enum.Enum):
@@ -249,17 +248,6 @@ class Group(Base, mixins.Timestamps):
             terms.append((security.Allow, self.creator.userid, "moderate"))
             # The creator may update this group in an upsert context
             terms.append((security.Allow, self.creator.userid, "upsert"))
-
-        # Temporary hack to allow the LMS app's machine user to upsert all LMS
-        # groups, even if the machine user isn't the group's creator.
-        # We can remove this once we've either:
-        #
-        # * Run a DB migration to change the creators of all LMS groups to the
-        #   LMS app's machine user: https://github.com/hypothesis/lms/issues/1401
-        # * Or changed the LMS app to use h's new bulk API instead of using the
-        #   group upsert API: https://github.com/hypothesis/lms/issues/1506
-        if LMS_AUTHORITY_PATTERN.match(self.authority):
-            terms.append((security.Allow, f"acct:lms@{self.authority}", "upsert"))
 
         # This authority principal may be used to grant auth clients
         # permissions for groups within their authority

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -16,6 +16,7 @@ GROUP_NAME_MAX_LENGTH = 25
 GROUP_DESCRIPTION_MAX_LENGTH = 250
 AUTHORITY_PROVIDED_ID_PATTERN = r"^[a-zA-Z0-9._\-+!~*()']+$"
 AUTHORITY_PROVIDED_ID_MAX_LENGTH = 1024
+LMS_AUTHORITY_PATTERN = re.compile(r"^lms\.(?:.*?)?hypothes\.is$")
 
 
 class JoinableBy(enum.Enum):
@@ -257,8 +258,8 @@ class Group(Base, mixins.Timestamps):
         #   LMS app's machine user: https://github.com/hypothesis/lms/issues/1401
         # * Or changed the LMS app to use h's new bulk API instead of using the
         #   group upsert API: https://github.com/hypothesis/lms/issues/1506
-        if self.authority == "lms.hypothes.is":
-            terms.append((security.Allow, "acct:lms@lms.hypothes.is", "upsert"))
+        if LMS_AUTHORITY_PATTERN.match(self.authority):
+            terms.append((security.Allow, f"acct:lms@{self.authority}", "upsert"))
 
         # This authority principal may be used to grant auth clients
         # permissions for groups within their authority

--- a/h/services/bulk_executor/_actions.py
+++ b/h/services/bulk_executor/_actions.py
@@ -171,14 +171,13 @@ class GroupMembershipCreateAction(DBAction):
 
         stmt = insert(GroupMembership).values(values)
 
-        if on_duplicate == "continue":
-            # This update doesn't change the row, but it does count as it being
-            # 'updated' which means we can get the values in the "RETURNING"
-            # clause and do the select in one go
-            stmt = stmt.on_conflict_do_update(
-                index_elements=["user_id", "group_id"],
-                set_={"user_id": stmt.excluded.user_id},
-            )
+        # This update doesn't change the row, but it does count as it being
+        # 'updated' which means we can get the values in the "RETURNING"
+        # clause and do the select in one go
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["user_id", "group_id"],
+            set_={"user_id": stmt.excluded.user_id},
+        )
 
         stmt = stmt.returning(GroupMembership.id)
 

--- a/h/services/bulk_executor/_executor.py
+++ b/h/services/bulk_executor/_executor.py
@@ -16,7 +16,7 @@ from h.services.bulk_executor._actions import (
 class BulkExecutor(Executor):
     """Executor of command objects which will modify the database in bulk."""
 
-    def __init__(self, db, authority="lms.hypothes.is"):
+    def __init__(self, db, authority):
         """
         :param db: DB session object
         :param authority: Restrict all request to this authority

--- a/h/traversal/bulk_api.py
+++ b/h/traversal/bulk_api.py
@@ -1,10 +1,18 @@
 from pyramid.security import Allow
 
+from h.auth.util import client_authority
 from h.traversal.root import RootFactory
 
 
 class BulkAPIRoot(RootFactory):
     """Root factory for the Bulk API."""
 
-    # Currently only LMS uses this end-point
-    __acl__ = [(Allow, "client_authority:lms.hypothes.is", "bulk_action")]
+    def __acl__(self):
+        """Return ACL for bulk end-points."""
+
+        if authority := client_authority(self.request):
+            # Currently only LMS uses this end-point
+            if authority.startswith("lms.") and authority.endswith(".hypothes.is"):
+                return [(Allow, f"client_authority:{authority}", "bulk_action")]
+
+        return []

--- a/h/views/api/bulk.py
+++ b/h/views/api/bulk.py
@@ -4,6 +4,7 @@ from itertools import chain
 from h_api.bulk_api import BulkAPI
 from pyramid.response import Response
 
+from h.auth.util import client_authority
 from h.services.bulk_executor import BulkExecutor
 from h.views.api.config import api_config
 
@@ -32,7 +33,8 @@ def bulk(request):
     """
 
     results = BulkAPI.from_byte_stream(
-        request.body_file, executor=BulkExecutor(request.db)
+        request.body_file,
+        executor=BulkExecutor(db=request.db, authority=client_authority(request)),
     )
 
     if results is None:

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -391,14 +391,6 @@ class TestGroupACL:
     def test_creator_has_upsert_permissions(self, group, authz_policy):
         assert authz_policy.permits(group, "acct:luke@example.com", "upsert")
 
-    @pytest.mark.parametrize("authority", ("lms.hypothes.is", "lms.ca.hypothes.is"))
-    def test_lms_machine_user_has_upsert_permissions(
-        self, group, authz_policy, authority
-    ):
-        group.authority = authority
-
-        assert authz_policy.permits(group, f"acct:lms@{authority}", "upsert")
-
     def test_admin_allowed_only_for_authority_when_no_creator(
         self, group, authz_policy
     ):

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -391,10 +391,13 @@ class TestGroupACL:
     def test_creator_has_upsert_permissions(self, group, authz_policy):
         assert authz_policy.permits(group, "acct:luke@example.com", "upsert")
 
-    def test_lms_machine_user_has_upsert_permissions(self, group, authz_policy):
-        group.authority = "lms.hypothes.is"
+    @pytest.mark.parametrize("authority", ("lms.hypothes.is", "lms.ca.hypothes.is"))
+    def test_lms_machine_user_has_upsert_permissions(
+        self, group, authz_policy, authority
+    ):
+        group.authority = authority
 
-        assert authz_policy.permits(group, "acct:lms@lms.hypothes.is", "upsert")
+        assert authz_policy.permits(group, f"acct:lms@{authority}", "upsert")
 
     def test_admin_allowed_only_for_authority_when_no_creator(
         self, group, authz_policy

--- a/tests/h/services/bulk_executor/_actions_test.py
+++ b/tests/h/services/bulk_executor/_actions_test.py
@@ -323,11 +323,11 @@ class TestBulkGroupMembershipCreate:
         return [group_membership_create(user.id, group.id) for group in groups]
 
     @pytest.fixture
-    def groups(self, db_session):
+    def groups(self, db_session, user):
         groups = [
             Group(
                 name=f"group_{i}",
-                authority="lms.hypothes.is",
+                authority=user.authority,
                 authority_provided_id=f"ap_id_{i}",
             )
             for i in range(3)

--- a/tests/h/services/bulk_executor/conftest.py
+++ b/tests/h/services/bulk_executor/conftest.py
@@ -4,7 +4,7 @@ from h_api.bulk_api import CommandBuilder
 
 from h.models import User
 
-AUTHORITY = "lms.hypothes.is"
+AUTHORITY = "lms.ca.hypothes.is"
 
 
 def upsert_user_command(n=0, authority=AUTHORITY, query_authority=AUTHORITY, **extras):
@@ -51,7 +51,7 @@ def group_membership_create(user_id, group_id):
 
 @pytest.fixture
 def user(db_session):
-    user = User(_username="username", authority="lms.hypothes.is")
+    user = User(_username="username", authority=AUTHORITY)
     db_session.add(user)
     db_session.flush()
 

--- a/tests/h/traversal/bulk_api_test.py
+++ b/tests/h/traversal/bulk_api_test.py
@@ -10,6 +10,11 @@ class TestBulkAPIRoot:
             (None, None, False),
             ("acct:user@hypothes.is", "client_authority:hypothes.is", False),
             ("acct:user@lms.hypothes.is", "client_authority:lms.hypothes.is", True),
+            (
+                "acct:user@lms.ca.hypothes.is",
+                "client_authority:lms.ca.hypothes.is",
+                True,
+            ),
         ),
     )
     def test_it_sets_bulk_action_permission_as_expected(


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/6712.

This will allow things like:

 * `lms.hypothes.is`
 * `lms.*.hypothes.is`

It requires a matching user of `lms@<authority>`

## Testing notes

I'm sure there's a quicker way to do this, but this is how I've done it:

#### Create the user

 * Start `h`: `make services`, `make dev`
 * Create a new user with name "lms"
 * http://localhost:5000/login - Login as `devdata_admin`
 * http://localhost:5000/admin/
 * Goto "Users"
 * Find the "lms" user and activate it
 * Run `make sql` (in `h`)
 * `update public.user set authority='lms.ca.hypothes.is' where username='lms' and authority='localhost';`

#### Create the credentials

 * In the admin interface again go to "OAuth clients"
 * Add credentials with:
     * Authority: `lms.ca.hypothes.is`
     * Grant type: `client_credentials`
     * ... and... 
     * Authority: `lms.ca.hypothes.is`
     * Grant type: `jwt_bearer`

#### Add the credentials

 * In LMS `conf/development.ini` set:
     *  `h_authority=lms.ca.hypothes.is`
 * In LMS `.devdata.env` set:
    * `H_CLIENT_ID` - To your `client_credentials` client id
    * `H_CLIENT_SECRET` - To your `client_credentials` secret
    * `H_JWT_CLIENT_ID` - To your `jwt_bearer` client id
    * `H_JWT_CLIENT_SECRET` - To your `jwt_bearer` secret
 
### Test it!

 * Start LMS `make services dev`
 * Start Via and the client in the same way
 * Go to a localhost Canvas test assignment: https://hypothesis.instructure.com/courses/125/assignments/874
 * In `h` run `make sql`
 * `select * from public.user where authority='lms.ca.hypothes.is';`
 * You should see that users have been synced over