### PR TITLE
Move organization default behavior from traversal and DB to service

### DIFF
--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -42,7 +42,3 @@ class Organization(Base, mixins.Timestamps):
     @property
     def is_default(self):
         return self.pubid == self.DEFAULT_PUBID
-
-    @classmethod
-    def default(cls, session):
-        return session.query(cls).filter_by(pubid=Organization.DEFAULT_PUBID).one()

--- a/h/services/organization.py
+++ b/h/services/organization.py
@@ -1,3 +1,5 @@
+import importlib_resources
+
 from h.models import Organization
 
 
@@ -28,6 +30,34 @@ class OrganizationService:
         organization = Organization(name=name, authority=authority, logo=logo)
         self.session.add(organization)
         return organization
+
+    def get_default(self, authority=None):
+        """Get the default org with an option to create it if missing.
+
+        :param authority: Create an org with this authority if none is found
+        :return: The public organization or None.
+        """
+
+        query_extra = {"authority": authority} if authority else {}
+
+        default_org = (
+            self.session.query(Organization)
+            .filter_by(pubid=Organization.DEFAULT_PUBID, **query_extra)
+            .one_or_none()
+        )
+
+        if not default_org and authority:
+            default_org = Organization(
+                name="Hypothesis", authority=authority, pubid=Organization.DEFAULT_PUBID
+            )
+
+            default_org.logo = (
+                importlib_resources.files("h") / "static/images/icons/logo.svg"
+            ).read_text()
+
+            self.session.add(default_org)
+
+        return default_org
 
 
 def organization_factory(context, request):

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -6,7 +6,6 @@ from h import form  # noqa F401
 from h import i18n, models, paginator
 from h.models.annotation import Annotation
 from h.models.group_scope import GroupScope
-from h.models.organization import Organization
 from h.schemas.forms.admin.group import AdminGroupSchema
 
 _ = i18n.TranslationString
@@ -45,7 +44,9 @@ class GroupCreateViews:
         self.group_members_svc = self.request.find_service(name="group_members")
 
         self.organizations = {o.pubid: o for o in self.list_org_svc.organizations()}
-        self.default_org_id = Organization.default(self.request.db).pubid
+        self.default_org_id = (
+            self.request.find_service(name="organization").get_default().pubid
+        )
 
         self.schema = AdminGroupSchema().bind(
             request=request, organizations=self.organizations, user_svc=self.user_svc

--- a/tests/h/models/organization_test.py
+++ b/tests/h/models/organization_test.py
@@ -54,10 +54,3 @@ def test_is_default(pubid, is_default):
     organization = models.Organization(pubid=pubid)
 
     assert organization.is_default == is_default
-
-
-def test_default_returns_the_default_organization(db_session):
-    assert (
-        models.Organization.default(db_session).pubid
-        == models.Organization.DEFAULT_PUBID
-    )

--- a/tests/h/services/organization_test.py
+++ b/tests/h/services/organization_test.py
@@ -1,4 +1,5 @@
 import pytest
+from h_matchers import Any
 
 from h.models import Organization
 from h.services.organization import OrganizationService, organization_factory
@@ -17,6 +18,30 @@ class TestOrganizationService:
 
         assert isinstance(organization, Organization)
         assert organization.logo is None
+
+    def test_get_default(self, service, default_organization):
+        assert service.get_default() == default_organization
+
+    @pytest.mark.usefixtures("with_no_default_organization")
+    def test_get_default_if_there_is_no_default(self, service):
+        assert service.get_default() is None
+
+    @pytest.mark.usefixtures("with_no_default_organization")
+    def test_get_default_will_create_with_authority_provided(self, service):
+        default_org = service.get_default(authority="my.new.authority")
+
+        assert default_org.name == "Hypothesis"
+        assert default_org.authority == "my.new.authority"
+        assert default_org.pubid == Organization.DEFAULT_PUBID
+        assert default_org.logo == Any.string.containing("<svg")
+
+    @pytest.fixture
+    def with_no_default_organization(self, default_organization, db_session):
+        # We can't delete the default organization, as it causes foreign key
+        # errors but we can alter it so it's not the default any more
+        default_organization.pubid = "not_the_default"
+        db_session.add(default_organization)
+        db_session.flush()
 
     @pytest.fixture
     def service(self, db_session):


### PR DESCRIPTION
Based on: https://github.com/hypothesis/h/pull/6729

This is a PR to try and cut down on a confusing pattern we have in the traversal where we:

 * Sometimes return a model object
 * Sometimes return a context object
 * Often refer to the context object by the name of the model in the code which gets it
 * Have methods on the context object with the same name as the model object
 
This results in code which is identical when grepping such as `organization.default` which is either:

 * The function attached to the model which searches for the default org
 * ... or ... The method on the context which tells you if this is the default org

### This PR:

 * Moves code from `db/__init__.py` to the `get_default()` method (and now tests it)