### PR TITLE
Change from `logo()` to `logo_url()` for the org context

### DIFF
--- a/h/presenters/organization_json.py
+++ b/h/presenters/organization_json.py
@@ -9,6 +9,6 @@ class OrganizationJSONPresenter:
         return {
             "id": self.organization.pubid,
             "default": self.organization.is_default,
-            "logo": self.context.logo,
+            "logo": self.context.logo_url,
             "name": self.organization.name,
         }

--- a/h/traversal/organization.py
+++ b/h/traversal/organization.py
@@ -31,7 +31,7 @@ class OrganizationContext:
         self.request = request
 
     @property
-    def logo(self):
+    def logo_url(self):
         if self.organization.logo:
             return self.request.route_url(
                 "organization_logo", pubid=self.organization.pubid

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -179,7 +179,7 @@ class GroupSearchController(SearchController):
         if self.group.organization:
             result["group"]["organization"] = {
                 "name": self.group.organization.name,
-                "logo": self._organization_context.logo,
+                "logo": self._organization_context.logo_url,
             }
         else:
             result["group"]["organization"] = None


### PR DESCRIPTION
Change the name of the property on the context for the logo URL so we can distinguish it from the different property with the same name on the model.