### PR TITLE
Move the organization resources to their own file

### DIFF
--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -2,8 +2,12 @@ from h.traversal.contexts import (
     AnnotationContext,
     GroupContext,
     GroupUpsertContext,
-    OrganizationContext,
     UserContext,
+)
+from h.traversal.organization import (
+    OrganizationContext,
+    OrganizationLogoRoot,
+    OrganizationRoot,
 )
 from h.traversal.roots import (
     AnnotationRoot,
@@ -11,8 +15,6 @@ from h.traversal.roots import (
     BulkAPIRoot,
     GroupRoot,
     GroupUpsertRoot,
-    OrganizationLogoRoot,
-    OrganizationRoot,
     ProfileRoot,
     Root,
     UserRoot,

--- a/h/traversal/contexts.py
+++ b/h/traversal/contexts.py
@@ -21,6 +21,7 @@ the view callable as the ``context`` argument.
 from pyramid.security import DENY_ALL, Allow, principals_allowed_by_permission
 
 from h.auth import role
+from h.traversal.organization import OrganizationContext
 
 
 class AnnotationContext:
@@ -89,32 +90,6 @@ class AnnotationContext:
             return []
         principals = principals_allowed_by_permission(group, principal)
         return principals
-
-
-class OrganizationContext:
-    """Context for organization-based views."""
-
-    def __init__(self, organization, request):
-        # TODO Links service
-        self.organization = organization
-        self.request = request
-
-    @property
-    def id(self):
-        return self.organization.pubid  # Web-facing unique ID for this resource
-
-    @property
-    def links(self):
-        # TODO
-        return {}
-
-    @property
-    def logo(self):
-        if self.organization.logo:
-            return self.request.route_url(
-                "organization_logo", pubid=self.organization.pubid
-            )
-        return None
 
 
 class GroupContext:

--- a/h/traversal/organization.py
+++ b/h/traversal/organization.py
@@ -1,0 +1,74 @@
+import sqlalchemy.orm
+
+from h.models import Organization
+from h.traversal.roots import Root, RootFactory
+
+
+class OrganizationRoot(RootFactory):
+    """
+    Root factory for routes whose context is an :py:class:`h.traversal.OrganizationContext`.
+
+    FIXME: This class should return OrganizationContext objects, not Organization
+    objects.
+
+    """
+
+    def __getitem__(self, pubid):
+        try:
+            org = self.request.db.query(Organization).filter_by(pubid=pubid).one()
+
+            # Inherit global ACL. See comments in :py:class`h.traversal.AuthClientRoot`.
+            org.__parent__ = Root(self.request)
+
+            return org
+        except sqlalchemy.orm.exc.NoResultFound:
+            raise KeyError()
+
+
+class OrganizationLogoRoot(RootFactory):
+    """
+    Root factory for routes whose context is an :py:class:`h.traversal.OrganizationLogoContext`.
+
+    FIXME: This class should return OrganizationLogoContext objects, not
+    organization logos.
+
+    """
+
+    def __init__(self, request):
+        super().__init__(request)
+        self.organization_factory = OrganizationRoot(self.request)
+
+    def __getitem__(self, pubid):
+        # This will raise KeyError if the organization doesn't exist.
+        organization = self.organization_factory[pubid]
+
+        if not organization.logo:
+            raise KeyError()
+
+        return organization.logo
+
+
+class OrganizationContext:
+    """Context for organization-based views."""
+
+    def __init__(self, organization, request):
+        # TODO Links service
+        self.organization = organization
+        self.request = request
+
+    @property
+    def id(self):
+        return self.organization.pubid  # Web-facing unique ID for this resource
+
+    @property
+    def links(self):
+        # TODO
+        return {}
+
+    @property
+    def logo(self):
+        if self.organization.logo:
+            return self.request.route_url(
+                "organization_logo", pubid=self.organization.pubid
+            )
+        return None

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -70,7 +70,7 @@ from h.auth import role
 from h.auth.util import client_authority
 from h.exceptions import InvalidUserId
 from h.interfaces import IGroupService
-from h.models import AuthClient, Organization
+from h.models import AuthClient
 from h.traversal import contexts
 
 
@@ -147,50 +147,6 @@ class BulkAPIRoot(RootFactory):
 
     # Currently only LMS uses this end-point
     __acl__ = [(Allow, "client_authority:lms.hypothes.is", "bulk_action")]
-
-
-class OrganizationRoot(RootFactory):
-    """
-    Root factory for routes whose context is an :py:class:`h.traversal.OrganizationContext`.
-
-    FIXME: This class should return OrganizationContext objects, not Organization
-    objects.
-
-    """
-
-    def __getitem__(self, pubid):
-        try:
-            org = self.request.db.query(Organization).filter_by(pubid=pubid).one()
-
-            # Inherit global ACL. See comments in :py:class`h.traversal.AuthClientRoot`.
-            org.__parent__ = Root(self.request)
-
-            return org
-        except sqlalchemy.orm.exc.NoResultFound:
-            raise KeyError()
-
-
-class OrganizationLogoRoot(RootFactory):
-    """
-    Root factory for routes whose context is an :py:class:`h.traversal.OrganizationLogoContext`.
-
-    FIXME: This class should return OrganizationLogoContext objects, not
-    organization logos.
-
-    """
-
-    def __init__(self, request):
-        super().__init__(request)
-        self.organization_factory = OrganizationRoot(self.request)
-
-    def __getitem__(self, pubid):
-        # This will raise KeyError if the organization doesn't exist.
-        organization = self.organization_factory[pubid]
-
-        if not organization.logo:
-            raise KeyError()
-
-        return organization.logo
 
 
 class GroupRoot(RootFactory):

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -10,7 +10,6 @@ from h.traversal.contexts import (
     AnnotationContext,
     GroupContext,
     GroupUpsertContext,
-    OrganizationContext,
     UserContext,
 )
 
@@ -292,58 +291,6 @@ class TestGroupContext:
         assert group_context.organization is None
 
 
-@pytest.mark.usefixtures("organization_routes")
-class TestOrganizationContext:
-    def test_it_returns_organization_model_as_property(
-        self, factories, pyramid_request
-    ):
-        organization = factories.Organization()
-
-        organization_context = OrganizationContext(organization, pyramid_request)
-
-        assert organization_context.organization == organization
-
-    def test_it_returns_pubid_as_id(self, factories, pyramid_request):
-        organization = factories.Organization()
-
-        organization_context = OrganizationContext(organization, pyramid_request)
-
-        assert organization_context.id != organization.id
-        assert organization_context.id == organization.pubid
-
-    def test_it_returns_links_property(self, factories, pyramid_request):
-        organization = factories.Organization()
-
-        organization_context = OrganizationContext(organization, pyramid_request)
-
-        assert organization_context.links == {}
-
-    def test_it_returns_logo_property_as_route_url(self, factories, pyramid_request):
-        fake_logo = "<svg>H</svg>"
-        pyramid_request.route_url = mock.Mock()
-
-        organization = factories.Organization(logo=fake_logo)
-
-        organization_context = OrganizationContext(organization, pyramid_request)
-        logo = organization_context.logo
-
-        pyramid_request.route_url.assert_called_with(
-            "organization_logo", pubid=organization.pubid
-        )
-        assert logo is not None
-
-    def test_it_returns_none_for_logo_if_no_logo(self, factories, pyramid_request):
-        pyramid_request.route_url = mock.Mock()
-
-        organization = factories.Organization(logo=None)
-
-        organization_context = OrganizationContext(organization, pyramid_request)
-        logo = organization_context.logo
-
-        pyramid_request.route_url.assert_not_called
-        assert logo is None
-
-
 @pytest.mark.usefixtures("links_svc")
 class TestGroupUpsertContext:
     def test_acl_applies_root_upsert_to_user_role_when_no_group(
@@ -454,8 +401,3 @@ def links_svc(pyramid_config):
     svc = mock.create_autospec(GroupLinksService, spec_set=True, instance=True)
     pyramid_config.register_service(svc, name="group_links")
     return svc
-
-
-@pytest.fixture
-def organization_routes(pyramid_config):
-    pyramid_config.add_route("organization_logo", "/organization/{pubid}/logo")

--- a/tests/h/traversal/organization_test.py
+++ b/tests/h/traversal/organization_test.py
@@ -1,0 +1,113 @@
+from unittest import mock
+
+import pytest
+
+from h.traversal.organization import (
+    OrganizationContext,
+    OrganizationLogoRoot,
+    OrganizationRoot,
+)
+
+
+@pytest.mark.usefixtures("organizations")
+class TestOrganizationRoot:
+    def test_it_returns_the_requested_organization(
+        self, organizations, organization_factory
+    ):
+        organization = organizations[1]
+
+        assert organization_factory[organization.pubid] == organization
+
+    def test_it_404s_if_the_organization_doesnt_exist(self, organization_factory):
+        with pytest.raises(KeyError):
+            organization_factory["does_not_exist"]
+
+    @pytest.fixture
+    def organization_factory(self, pyramid_request):
+        return OrganizationRoot(pyramid_request)
+
+
+@pytest.mark.usefixtures("organizations")
+class TestOrganizationLogoRoot:
+    def test_it_returns_the_requested_organizations_logo(
+        self, organizations, organization_logo_factory
+    ):
+        organization = organizations[1]
+        organization.logo = "<svg>blah</svg>"
+
+        assert organization_logo_factory[organization.pubid] == "<svg>blah</svg>"
+
+    def test_it_404s_if_the_organization_doesnt_exist(self, organization_logo_factory):
+        with pytest.raises(KeyError):
+            organization_logo_factory["does_not_exist"]
+
+    def test_it_404s_if_the_organization_has_no_logo(
+        self, organizations, organization_logo_factory
+    ):
+        with pytest.raises(KeyError):
+            assert organization_logo_factory[organizations[0].pubid]
+
+    @pytest.fixture
+    def organization_logo_factory(self, pyramid_request):
+        return OrganizationLogoRoot(pyramid_request)
+
+
+class TestOrganizationContext:
+    def test_it_returns_organization_model_as_property(
+        self, factories, pyramid_request
+    ):
+        organization = factories.Organization()
+
+        organization_context = OrganizationContext(organization, pyramid_request)
+
+        assert organization_context.organization == organization
+
+    def test_it_returns_pubid_as_id(self, factories, pyramid_request):
+        organization = factories.Organization()
+
+        organization_context = OrganizationContext(organization, pyramid_request)
+
+        assert organization_context.id != organization.id
+        assert organization_context.id == organization.pubid
+
+    def test_it_returns_links_property(self, factories, pyramid_request):
+        organization = factories.Organization()
+
+        organization_context = OrganizationContext(organization, pyramid_request)
+
+        assert organization_context.links == {}
+
+    def test_it_returns_logo_property_as_route_url(self, factories, pyramid_request):
+        fake_logo = "<svg>H</svg>"
+        pyramid_request.route_url = mock.Mock()
+
+        organization = factories.Organization(logo=fake_logo)
+
+        organization_context = OrganizationContext(organization, pyramid_request)
+        logo = organization_context.logo
+
+        pyramid_request.route_url.assert_called_with(
+            "organization_logo", pubid=organization.pubid
+        )
+        assert logo is not None
+
+    def test_it_returns_none_for_logo_if_no_logo(self, factories, pyramid_request):
+        pyramid_request.route_url = mock.Mock()
+
+        organization = factories.Organization(logo=None)
+
+        organization_context = OrganizationContext(organization, pyramid_request)
+        logo = organization_context.logo
+
+        pyramid_request.route_url.assert_not_called
+        assert logo is None
+
+    @pytest.fixture(autouse=True)
+    def organization_routes(self, pyramid_config):
+        pyramid_config.add_route("organization_logo", "/organization/{pubid}/logo")
+
+
+@pytest.fixture
+def organizations(factories):
+    # Add a handful of organizations to the DB to make the test realistic.
+    return [factories.Organization() for _ in range(3)]

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -17,8 +17,6 @@ from h.traversal.roots import (
     BulkAPIRoot,
     GroupRoot,
     GroupUpsertRoot,
-    OrganizationLogoRoot,
-    OrganizationRoot,
     ProfileRoot,
     Root,
     UserRoot,
@@ -261,49 +259,6 @@ class TestBulkAPIRoot:
         )
 
 
-@pytest.mark.usefixtures("organizations")
-class TestOrganizationRoot:
-    def test_it_returns_the_requested_organization(
-        self, organizations, organization_factory
-    ):
-        organization = organizations[1]
-
-        assert organization_factory[organization.pubid] == organization
-
-    def test_it_404s_if_the_organization_doesnt_exist(self, organization_factory):
-        with pytest.raises(KeyError):
-            organization_factory["does_not_exist"]
-
-    @pytest.fixture
-    def organization_factory(self, pyramid_request):
-        return OrganizationRoot(pyramid_request)
-
-
-@pytest.mark.usefixtures("organizations")
-class TestOrganizationLogoRoot:
-    def test_it_returns_the_requested_organizations_logo(
-        self, organizations, organization_logo_factory
-    ):
-        organization = organizations[1]
-        organization.logo = "<svg>blah</svg>"
-
-        assert organization_logo_factory[organization.pubid] == "<svg>blah</svg>"
-
-    def test_it_404s_if_the_organization_doesnt_exist(self, organization_logo_factory):
-        with pytest.raises(KeyError):
-            organization_logo_factory["does_not_exist"]
-
-    def test_it_404s_if_the_organization_has_no_logo(
-        self, organizations, organization_logo_factory
-    ):
-        with pytest.raises(KeyError):
-            assert organization_logo_factory[organizations[0].pubid]
-
-    @pytest.fixture
-    def organization_logo_factory(self, pyramid_request):
-        return OrganizationLogoRoot(pyramid_request)
-
-
 class TestProfileRoot:
     def test_it_assigns_update_permission_with_user_role(
         self, set_permissions, pyramid_request
@@ -521,12 +476,6 @@ def client_authority(patch):
     client_authority = patch("h.traversal.roots.client_authority")
     client_authority.return_value = None
     return client_authority
-
-
-@pytest.fixture
-def organizations(factories):
-    # Add a handful of organizations to the DB to make the test realistic.
-    return [factories.Organization() for _ in range(3)]
 
 
 @pytest.fixture


### PR DESCRIPTION
Move the organization resources to their own file to make it easier to consider them at once. The division between "roots" and "contexts" is somewhat artificial.