### PR TITLE
Use the organization context, not just the plain organization

### DIFF
--- a/h/traversal/organization.py
+++ b/h/traversal/organization.py
@@ -2,12 +2,7 @@ from h.traversal.root import Root, RootFactory
 
 
 class OrganizationRoot(RootFactory):
-    """
-    Root factory for routes whose context is an :py:class:`h.traversal.OrganizationContext`.
-
-    FIXME: This class should return OrganizationContext objects, not Organization
-    objects.
-    """
+    """Root factory for routes whose context is an `OrganizationContext`."""
 
     def __getitem__(self, pubid):
         organization = self.request.find_service(name="organization").get_by_public_id(
@@ -16,17 +11,16 @@ class OrganizationRoot(RootFactory):
         if organization is None:
             raise KeyError()
 
-        # Inherit global ACL. See comments in :py:class`h.traversal.AuthClientRoot`.
-        organization.__parent__ = Root(self.request)
-
-        return organization
+        return OrganizationContext(organization, self.request)
 
 
 class OrganizationContext:
     """Context for organization-based views."""
 
     def __init__(self, organization, request):
-        # TODO Links service
+        # Inherit global ACL. See comments in :py:class`h.traversal.AuthClientRoot`.
+        self.__parent__ = Root(request)
+
         self.organization = organization
         self.request = request
 

--- a/h/views/organizations.py
+++ b/h/views/organizations.py
@@ -5,8 +5,8 @@ from pyramid.view import view_config
 @view_config(
     route_name="organization_logo", request_method="GET", renderer="svg", http_cache=600
 )
-def organization_logo(organization, request):
-    if not organization.logo:
-        raise NotFound()
+def organization_logo(context, _request):
+    if logo := context.organization.logo:
+        return logo
 
-    return organization.logo
+    raise NotFound()

--- a/tests/h/traversal/organization_test.py
+++ b/tests/h/traversal/organization_test.py
@@ -7,12 +7,13 @@ from h.traversal.organization import OrganizationContext, OrganizationRoot
 
 @pytest.mark.usefixtures("organization_service")
 class TestOrganizationRoot:
-    def test_it_returns_the_requested_organization(
+    def test_it_returns_the_organization_context(
         self, pyramid_request, organization_service
     ):
         result = OrganizationRoot(pyramid_request)[sentinel.pubid]
 
-        assert result == organization_service.get_by_public_id.return_value
+        assert isinstance(result, OrganizationContext)
+        assert result.organization == organization_service.get_by_public_id.return_value
         organization_service.get_by_public_id.assert_called_once_with(sentinel.pubid)
 
     def test_it_404s_if_the_organization_doesnt_exist(

--- a/tests/h/views/organizations_test.py
+++ b/tests/h/views/organizations_test.py
@@ -3,22 +3,23 @@ from unittest import mock
 import pytest
 from pyramid.exceptions import NotFound
 
+from h.traversal import OrganizationContext
 from h.views.organizations import organization_logo
 
 
 class TestOrganizationLogo:
-    def test_it_returns_the_logo(self, organization):
-        organization.logo = "some logo content"
-        result = organization_logo(organization, mock.sentinel.request)
+    def test_it_returns_the_logo(self, organization_context):
+        organization_context.organization.logo = "some logo content"
+        result = organization_logo(organization_context, mock.sentinel.request)
 
-        assert result == organization.logo
+        assert result == organization_context.organization.logo
 
-    def test_it_raises_a_NotFound_error_for_no_logo(self, organization):
-        organization.logo = None
+    def test_it_raises_a_NotFound_error_for_no_logo(self, organization_context):
+        organization_context.organization.logo = None
 
         with pytest.raises(NotFound):
-            organization_logo(organization, mock.sentinel.request)
+            organization_logo(organization_context, mock.sentinel.request)
 
     @pytest.fixture
-    def organization(self, factories):
-        return factories.Organization()
+    def organization_context(self, factories, pyramid_request):
+        return OrganizationContext(factories.Organization(), pyramid_request)


### PR DESCRIPTION
This finally swaps in the organization context instead of the context.

Fun story. I did this whole chain of PRs to get an idea of how much work it would be to do the same for Groups, which have `__acl__`'s on them. Fair amount I recon. However some of it has been done already.