### PR TITLE
Don't use the organization model `default()` function in the tests

### DIFF
--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -16,7 +16,9 @@ from pyramid.request import apply_request_extensions
 from sqlalchemy.orm import sessionmaker
 from webob.multidict import MultiDict
 
-from h import db, models
+from h import db
+from h.models import Organization
+from h.models.organization import ORGANIZATION_DEFAULT_PUBID
 from h.settings import database_url
 from tests.common.fixtures import es_client  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
@@ -114,7 +116,11 @@ def db_engine():
 
 @pytest.fixture
 def default_organization(db_session):
-    return models.Organization.default(db_session)
+    # This looks a bit odd, but as part of our DB initialization we always add
+    # a default org. So tests can't add their own without causing a conflict.
+    return (
+        db_session.query(Organization).filter_by(pubid=ORGANIZATION_DEFAULT_PUBID).one()
+    )
 
 
 @pytest.fixture

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -54,7 +54,7 @@ def test_enforce_scope_can_be_set_False(db_session, factories):
     assert group.enforce_scope is False
 
 
-def test_slug(db_session, factories, default_organization):
+def test_slug(db_session, factories, organization):
     name = "My Hypothesis Group"
     user = factories.User()
 
@@ -62,7 +62,7 @@ def test_slug(db_session, factories, default_organization):
         name=name,
         authority="foobar.com",
         creator=user,
-        organization=default_organization,
+        organization=organization,
     )
     db_session.add(group)
     db_session.flush()
@@ -170,7 +170,7 @@ def test_you_cannot_set_type(factories):
         group.type = "open"
 
 
-def test_repr(db_session, factories, default_organization):
+def test_repr(db_session, factories, organization):
     name = "My Hypothesis Group"
     user = factories.User()
 
@@ -178,7 +178,7 @@ def test_repr(db_session, factories, default_organization):
         name=name,
         authority="foobar.com",
         creator=user,
-        organization=default_organization,
+        organization=organization,
     )
     db_session.add(group)
     db_session.flush()
@@ -201,7 +201,7 @@ def test_group_organization(db_session):
     assert group.organization_id == org.id
 
 
-def test_created_by(db_session, factories, default_organization):
+def test_created_by(db_session, factories, organization):
     name_1 = "My first group"
     name_2 = "My second group"
     user = factories.User()
@@ -210,13 +210,13 @@ def test_created_by(db_session, factories, default_organization):
         name=name_1,
         authority="foobar.com",
         creator=user,
-        organization=default_organization,
+        organization=organization,
     )
     group_2 = models.Group(
         name=name_2,
         authority="foobar.com",
         creator=user,
-        organization=default_organization,
+        organization=organization,
     )
 
     db_session.add_all([group_1, group_2])
@@ -447,3 +447,8 @@ class TestGroupACL:
         )
         group.pubid = "test-group"
         return group
+
+
+@pytest.fixture()
+def organization(factories):
+    return factories.Organization()

--- a/tests/h/presenters/organization_json_test.py
+++ b/tests/h/presenters/organization_json_test.py
@@ -1,6 +1,5 @@
 import pytest
 
-from h.models.organization import Organization
 from h.presenters.organization_json import OrganizationJSONPresenter
 from h.traversal import OrganizationContext
 
@@ -34,9 +33,12 @@ class TestOrganizationJSONPresenter:
             ),
         }
 
-    def test_default_organization(self, db_session, routes, pyramid_request):
-        organization = Organization.default(db_session)
-        organization_context = OrganizationContext(organization, pyramid_request)
+    def test_default_organization(
+        self, db_session, routes, pyramid_request, default_organization
+    ):
+        organization_context = OrganizationContext(
+            default_organization, pyramid_request
+        )
 
         presenter = OrganizationJSONPresenter(organization_context)
         presented = presenter.asdict()

--- a/tests/h/schemas/forms/admin/group_test.py
+++ b/tests/h/schemas/forms/admin/group_test.py
@@ -204,8 +204,8 @@ def user_service(user_service, factories):
 
 
 @pytest.fixture
-def org(db_session):
-    return Organization.default(db_session)
+def org(factories):
+    return factories.Organization()
 
 
 @pytest.fixture

--- a/tests/h/services/group_create_test.py
+++ b/tests/h/services/group_create_test.py
@@ -68,9 +68,7 @@ class TestCreatePrivateGroup:
 
         assert getattr(group, flag) == expected_value
 
-    def test_it_creates_group_with_no_organization_by_default(
-        self, default_organization, creator, svc
-    ):
+    def test_it_creates_group_with_no_organization_by_default(self, creator, svc):
         group = svc.create_private_group("Anteater fans", creator.userid)
 
         assert group.organization is None
@@ -171,7 +169,7 @@ class TestCreateOpenGroup:
         assert getattr(group, flag) == expected_value
 
     def test_it_creates_group_with_no_organization_by_default(
-        self, default_organization, creator, svc, origins
+        self, creator, svc, origins
     ):
         group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
@@ -312,7 +310,7 @@ class TestCreateRestrictedGroup:
         assert getattr(group, flag) == expected_value
 
     def test_it_creates_group_with_no_organization_by_default(
-        self, default_organization, creator, svc, origins
+        self, creator, svc, origins
     ):
         group = svc.create_restricted_group(
             "Anteater fans", creator.userid, scopes=origins

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -352,10 +352,12 @@ class TestOrganizationContext:
 
         assert organization_context.default is False
 
-    def test_default_property_if_default_organization(self, factories, pyramid_request):
-        organization = Organization.default(pyramid_request.db)
-
-        organization_context = OrganizationContext(organization, pyramid_request)
+    def test_default_property_if_default_organization(
+        self, factories, pyramid_request, default_organization
+    ):
+        organization_context = OrganizationContext(
+            default_organization, pyramid_request
+        )
 
         assert organization_context.default is True
 

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -5,7 +5,6 @@ from pyramid import security
 from pyramid.authorization import ACLAuthorizationPolicy
 
 from h.auth import role
-from h.models import Organization
 from h.services.group_links import GroupLinksService
 from h.traversal.contexts import (
     AnnotationContext,

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -7,7 +7,6 @@ from pyramid import httpexceptions
 from webob.multidict import MultiDict
 
 from h.activity.query import ActivityResults
-from h.models import Organization
 from h.services.annotation_stats import AnnotationStatsService
 from h.views import activity
 
@@ -256,7 +255,6 @@ class TestGroupSearchController:
         factories,
         test_group,
         test_user,
-        default_org,
         OrganizationContext,
         pyramid_request,
     ):
@@ -281,7 +279,6 @@ class TestGroupSearchController:
         factories,
         test_group,
         test_user,
-        default_org,
         OrganizationContext,
         pyramid_request,
     ):
@@ -1367,11 +1364,6 @@ def search(patch):
         "zero_message": "No annotations matched your search.",
     }
     return search
-
-
-@pytest.fixture
-def default_org(db_session):
-    return Organization.default(db_session)
 
 
 @pytest.fixture


### PR DESCRIPTION
This prevents the tests from using the `Organization.default()` in the tests. This means we can refactor or remove it without half the tests failing.

This comes in three flavours in different commits:

 * Test that don't even use it (but included a fixture anyway for some reason)
 * Tests that need _an_ organization, but don't need the default one
 * Tests that actually do need the default org

I took the time to tidy up some weirdness in `tests/h/services/list_organizations_test.py` which was using the real organization service to setup fixtures instead of a factory.