### PR TITLE
Pull all org values to the org and eliminate duplications

### DIFF
--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -134,7 +134,9 @@ def _maybe_create_default_organization(engine, authority):
 
     if default_org is None:
         default_org = models.Organization(
-            name="Hypothesis", authority=authority, pubid="__default__"
+            name="Hypothesis",
+            authority=authority,
+            pubid=models.Organization.DEFAULT_PUBID,
         )
 
         default_org.logo = (

--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -3,12 +3,13 @@ import sqlalchemy as sa
 from h import pubid
 from h.db import Base, mixins
 
-ORGANIZATION_DEFAULT_PUBID = "__default__"
-ORGANIZATION_NAME_MIN_CHARS = 1
-ORGANIZATION_NAME_MAX_CHARS = 25
-
 
 class Organization(Base, mixins.Timestamps):
+    DEFAULT_PUBID = "__default__"
+    NAME_MIN_CHARS = 1
+    NAME_MAX_CHARS = 25
+    LOGO_MAX_CHARS = 100000
+
     __tablename__ = "organization"
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
@@ -26,11 +27,11 @@ class Organization(Base, mixins.Timestamps):
     @sa.orm.validates("name")
     def validate_name(self, key, name):
         if not (
-            ORGANIZATION_NAME_MIN_CHARS <= len(name) <= ORGANIZATION_NAME_MAX_CHARS
+            Organization.NAME_MIN_CHARS <= len(name) <= Organization.NAME_MAX_CHARS
         ):
             raise ValueError(
                 "name must be between {min} and {max} characters long".format(
-                    min=ORGANIZATION_NAME_MIN_CHARS, max=ORGANIZATION_NAME_MAX_CHARS
+                    min=Organization.NAME_MIN_CHARS, max=Organization.NAME_MAX_CHARS
                 )
             )
         return name
@@ -40,4 +41,4 @@ class Organization(Base, mixins.Timestamps):
 
     @classmethod
     def default(cls, session):
-        return session.query(cls).filter_by(pubid=ORGANIZATION_DEFAULT_PUBID).one()
+        return session.query(cls).filter_by(pubid=Organization.DEFAULT_PUBID).one()

--- a/h/schemas/forms/admin/organization.py
+++ b/h/schemas/forms/admin/organization.py
@@ -4,17 +4,11 @@ import colander
 from deform.widget import TextAreaWidget, TextInputWidget
 
 import h.i18n
-from h.models.organization import (
-    ORGANIZATION_NAME_MAX_CHARS,
-    ORGANIZATION_NAME_MIN_CHARS,
-)
+from h.models.organization import Organization
 from h.schemas import validators
 from h.schemas.base import CSRFSchema
 
 _ = h.i18n.TranslationString
-
-
-ORGANIZATION_LOGO_MAX_CHARS = 100000
 
 
 def _strip_xmlns(tag):
@@ -24,12 +18,12 @@ def _strip_xmlns(tag):
 
 
 def validate_logo(node, value):
-    if len(value) > ORGANIZATION_LOGO_MAX_CHARS:
+    if len(value) > Organization.LOGO_MAX_CHARS:
         raise colander.Invalid(
             node,
             _(
                 "Logo is larger than {:,d} characters".format(
-                    ORGANIZATION_LOGO_MAX_CHARS
+                    Organization.LOGO_MAX_CHARS
                 )
             ),
         )
@@ -50,9 +44,9 @@ class OrganizationSchema(CSRFSchema):
         colander.String(),
         title=_("Name"),
         validator=validators.Length(
-            ORGANIZATION_NAME_MIN_CHARS, ORGANIZATION_NAME_MAX_CHARS
+            Organization.NAME_MIN_CHARS, Organization.NAME_MAX_CHARS
         ),
-        widget=TextInputWidget(max_length=ORGANIZATION_NAME_MAX_CHARS),
+        widget=TextInputWidget(max_length=Organization.NAME_MAX_CHARS),
     )
 
     logo = colander.SchemaNode(

--- a/h/traversal/contexts.py
+++ b/h/traversal/contexts.py
@@ -21,7 +21,7 @@ the view callable as the ``context`` argument.
 from pyramid.security import DENY_ALL, Allow, principals_allowed_by_permission
 
 from h.auth import role
-from h.models.organization import ORGANIZATION_DEFAULT_PUBID
+from h.models.organization import Organization
 
 
 class AnnotationContext:
@@ -106,7 +106,7 @@ class OrganizationContext:
 
     @property
     def default(self):
-        return self.id == ORGANIZATION_DEFAULT_PUBID
+        return self.id == Organization.DEFAULT_PUBID
 
     @property
     def links(self):

--- a/h/views/admin/organizations.py
+++ b/h/views/admin/organizations.py
@@ -148,7 +148,7 @@ class OrganizationEditController:
 
     def _template_context(self):
         delete_url = None
-        if self.org.pubid != "__default__":
+        if self.org.pubid != Organization.DEFAULT_PUBID:
             delete_url = self.request.route_url(
                 "admin.organizations_delete", pubid=self.org.pubid
             )

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -18,7 +18,6 @@ from webob.multidict import MultiDict
 
 from h import db
 from h.models import Organization
-from h.models.organization import ORGANIZATION_DEFAULT_PUBID
 from h.settings import database_url
 from tests.common.fixtures import es_client  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
@@ -119,7 +118,7 @@ def default_organization(db_session):
     # This looks a bit odd, but as part of our DB initialization we always add
     # a default org. So tests can't add their own without causing a conflict.
     return (
-        db_session.query(Organization).filter_by(pubid=ORGANIZATION_DEFAULT_PUBID).one()
+        db_session.query(Organization).filter_by(pubid=Organization.DEFAULT_PUBID).one()
     )
 
 

--- a/tests/h/models/organization_test.py
+++ b/tests/h/models/organization_test.py
@@ -47,4 +47,7 @@ def test_repr(db_session, factories):
 
 
 def test_default_returns_the_default_organization(db_session):
-    assert models.Organization.default(db_session).pubid == "__default__"
+    assert (
+        models.Organization.default(db_session).pubid
+        == models.Organization.DEFAULT_PUBID
+    )

--- a/tests/h/schemas/forms/admin/organization_test.py
+++ b/tests/h/schemas/forms/admin/organization_test.py
@@ -1,10 +1,8 @@
 import colander
 import pytest
 
-from h.schemas.forms.admin.organization import (
-    ORGANIZATION_LOGO_MAX_CHARS,
-    OrganizationSchema,
-)
+from h.models import Organization
+from h.schemas.forms.admin.organization import OrganizationSchema
 
 pytestmark = pytest.mark.usefixtures("pyramid_config")
 
@@ -15,12 +13,12 @@ class TestOrganizationSchema:
 
     def test_it_raises_if_logo_is_too_long(self, org_data, bound_schema):
         org_data["logo"] = '<svg xmlns="http://svg.com">{}</svg>'.format(
-            "a" * ORGANIZATION_LOGO_MAX_CHARS + "b"
+            "a" * Organization.LOGO_MAX_CHARS + "b"
         )
 
         with pytest.raises(
             colander.Invalid,
-            match="larger than {:,d} characters".format(ORGANIZATION_LOGO_MAX_CHARS),
+            match="larger than {:,d} characters".format(Organization.LOGO_MAX_CHARS),
         ):
             bound_schema.deserialize(org_data)
 

--- a/tests/h/views/admin/organizations_test.py
+++ b/tests/h/views/admin/organizations_test.py
@@ -123,7 +123,7 @@ class TestOrganizationEditController:
     def test_read_does_not_show_delete_button_for_default_org(
         self, pyramid_request, org
     ):
-        org.pubid = "__default__"
+        org.pubid = Organization.DEFAULT_PUBID
         ctrl = OrganizationEditController(org, pyramid_request)
 
         ctx = ctrl.read()


### PR DESCRIPTION
This means we centrally define the default pubid and can easily find all references to it.