### PR TITLE
Move the traversal `default()` to model `is_default()`

### DIFF
--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -39,6 +39,10 @@ class Organization(Base, mixins.Timestamps):
     def __repr__(self):
         return "<Organization: %s>" % self.pubid
 
+    @property
+    def is_default(self):
+        return self.pubid == self.DEFAULT_PUBID
+
     @classmethod
     def default(cls, session):
         return session.query(cls).filter_by(pubid=Organization.DEFAULT_PUBID).one()

--- a/h/presenters/organization_json.py
+++ b/h/presenters/organization_json.py
@@ -11,7 +11,7 @@ class OrganizationJSONPresenter:
     def _model(self):
         model = {
             "id": self.context.id,
-            "default": self.context.default,
+            "default": self.organization.is_default,
             "logo": self.context.logo,
             "name": self.organization.name,
         }

--- a/h/traversal/contexts.py
+++ b/h/traversal/contexts.py
@@ -21,7 +21,6 @@ the view callable as the ``context`` argument.
 from pyramid.security import DENY_ALL, Allow, principals_allowed_by_permission
 
 from h.auth import role
-from h.models.organization import Organization
 
 
 class AnnotationContext:
@@ -103,10 +102,6 @@ class OrganizationContext:
     @property
     def id(self):
         return self.organization.pubid  # Web-facing unique ID for this resource
-
-    @property
-    def default(self):
-        return self.id == Organization.DEFAULT_PUBID
 
     @property
     def links(self):

--- a/h/views/admin/organizations.py
+++ b/h/views/admin/organizations.py
@@ -148,7 +148,7 @@ class OrganizationEditController:
 
     def _template_context(self):
         delete_url = None
-        if self.org.pubid != Organization.DEFAULT_PUBID:
+        if not self.org.is_default:
             delete_url = self.request.route_url(
                 "admin.organizations_delete", pubid=self.org.pubid
             )

--- a/tests/h/models/organization_test.py
+++ b/tests/h/models/organization_test.py
@@ -46,6 +46,16 @@ def test_repr(db_session, factories):
     assert repr(organization) == "<Organization: test_pubid>"
 
 
+@pytest.mark.parametrize(
+    "pubid,is_default",
+    ((models.Organization.DEFAULT_PUBID, True), ("anything_else", False)),
+)
+def test_is_default(pubid, is_default):
+    organization = models.Organization(pubid=pubid)
+
+    assert organization.is_default == is_default
+
+
 def test_default_returns_the_default_organization(db_session):
     assert (
         models.Organization.default(db_session).pubid

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -343,24 +343,6 @@ class TestOrganizationContext:
         pyramid_request.route_url.assert_not_called
         assert logo is None
 
-    def test_default_property_if_not_default_organization(
-        self, factories, pyramid_request
-    ):
-        organization = factories.Organization()
-
-        organization_context = OrganizationContext(organization, pyramid_request)
-
-        assert organization_context.default is False
-
-    def test_default_property_if_default_organization(
-        self, factories, pyramid_request, default_organization
-    ):
-        organization_context = OrganizationContext(
-            default_organization, pyramid_request
-        )
-
-        assert organization_context.default is True
-
 
 @pytest.mark.usefixtures("links_svc")
 class TestGroupUpsertContext:


### PR DESCRIPTION
Remove the organization traversal `default` method and move it to a model property.