### PR TITLE
Fix groups icon rendering in production builds

### DIFF
--- a/h/static/images/icons/groups.svg
+++ b/h/static/images/icons/groups.svg
@@ -57,7 +57,7 @@
      id="Page-1"
      sketch:type="MSPage"
      transform="translate(0.50847458,7.627119)"
-     style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1">
+     style="fill-rule:evenodd;stroke:none;stroke-width:1">
     <g
        id="Artboard-1"
        sketch:type="MSArtboardGroup"


### PR DESCRIPTION
The `groups.svg` icon has a structure like this:

```
...
<g style="fill:none;...">
  <g fill="currentColor" ...>
    ...
  </g>
</g>
```

The newest version of svgo, introduced in https://github.com/hypothesis/h/pull/6739, combines the two `<g>` elements:

```
<g fill="currentColor" style="fill:none;...">
```

The result is that the icon ends up being transparent instead of inheriting the current CSS `color` value. Example in an annotation card on the `/search` page

<img width="522" alt="Missing groups icon" src="https://user-images.githubusercontent.com/2458/124749286-f1df8200-df1b-11eb-9d37-c757d3abb6a2.png">

This commit fixes the issue by just removing the conflicting `style`
property. No other icons are affected AFAICS.

