### PR TITLE
Remove `OrganizationLogoRoot` by putting an `if` statement in the view

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -200,7 +200,7 @@ def includeme(config):
     config.add_route(
         "organization_logo",
         "/organizations/{pubid}/logo",
-        factory="h.traversal.OrganizationLogoRoot",
+        factory="h.traversal.OrganizationRoot",
         traverse="/{pubid}",
     )
 

--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -69,11 +69,7 @@ from h.traversal.group import (
     GroupUpsertContext,
     GroupUpsertRoot,
 )
-from h.traversal.organization import (
-    OrganizationContext,
-    OrganizationLogoRoot,
-    OrganizationRoot,
-)
+from h.traversal.organization import OrganizationContext, OrganizationRoot
 from h.traversal.profile import ProfileRoot
 from h.traversal.root import Root
 from h.traversal.user import UserContext, UserRoot, UserUserIDRoot
@@ -89,7 +85,6 @@ __all__ = (
     "GroupUpsertContext",
     "GroupUpsertRoot",
     "OrganizationRoot",
-    "OrganizationLogoRoot",
     "ProfileRoot",
     "OrganizationContext",
     "UserContext",

--- a/h/traversal/organization.py
+++ b/h/traversal/organization.py
@@ -25,29 +25,6 @@ class OrganizationRoot(RootFactory):
             raise KeyError()
 
 
-class OrganizationLogoRoot(RootFactory):
-    """
-    Root factory for routes whose context is an :py:class:`h.traversal.OrganizationLogoContext`.
-
-    FIXME: This class should return OrganizationLogoContext objects, not
-    organization logos.
-
-    """
-
-    def __init__(self, request):
-        super().__init__(request)
-        self.organization_factory = OrganizationRoot(self.request)
-
-    def __getitem__(self, pubid):
-        # This will raise KeyError if the organization doesn't exist.
-        organization = self.organization_factory[pubid]
-
-        if not organization.logo:
-            raise KeyError()
-
-        return organization.logo
-
-
 class OrganizationContext:
     """Context for organization-based views."""
 

--- a/h/views/organizations.py
+++ b/h/views/organizations.py
@@ -1,8 +1,12 @@
+from pyramid.exceptions import NotFound
 from pyramid.view import view_config
 
 
 @view_config(
     route_name="organization_logo", request_method="GET", renderer="svg", http_cache=600
 )
-def organization_logo(logo, request):
-    return logo
+def organization_logo(organization, request):
+    if not organization.logo:
+        raise NotFound()
+
+    return organization.logo

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -189,7 +189,7 @@ def test_includeme():
         call(
             "organization_logo",
             "/organizations/{pubid}/logo",
-            factory="h.traversal.OrganizationLogoRoot",
+            factory="h.traversal.OrganizationRoot",
             traverse="/{pubid}",
         ),
         call("group_create", "/groups/new"),

--- a/tests/h/traversal/organization_test.py
+++ b/tests/h/traversal/organization_test.py
@@ -2,11 +2,7 @@ from unittest import mock
 
 import pytest
 
-from h.traversal.organization import (
-    OrganizationContext,
-    OrganizationLogoRoot,
-    OrganizationRoot,
-)
+from h.traversal.organization import OrganizationContext, OrganizationRoot
 
 
 @pytest.mark.usefixtures("organizations")
@@ -26,30 +22,10 @@ class TestOrganizationRoot:
     def organization_factory(self, pyramid_request):
         return OrganizationRoot(pyramid_request)
 
-
-@pytest.mark.usefixtures("organizations")
-class TestOrganizationLogoRoot:
-    def test_it_returns_the_requested_organizations_logo(
-        self, organizations, organization_logo_factory
-    ):
-        organization = organizations[1]
-        organization.logo = "<svg>blah</svg>"
-
-        assert organization_logo_factory[organization.pubid] == "<svg>blah</svg>"
-
-    def test_it_404s_if_the_organization_doesnt_exist(self, organization_logo_factory):
-        with pytest.raises(KeyError):
-            organization_logo_factory["does_not_exist"]
-
-    def test_it_404s_if_the_organization_has_no_logo(
-        self, organizations, organization_logo_factory
-    ):
-        with pytest.raises(KeyError):
-            assert organization_logo_factory[organizations[0].pubid]
-
     @pytest.fixture
-    def organization_logo_factory(self, pyramid_request):
-        return OrganizationLogoRoot(pyramid_request)
+    def organizations(self, factories):
+        # Add a handful of organizations to the DB to make the test realistic.
+        return [factories.Organization() for _ in range(3)]
 
 
 class TestOrganizationContext:
@@ -97,9 +73,3 @@ class TestOrganizationContext:
     @pytest.fixture(autouse=True)
     def organization_routes(self, pyramid_config):
         pyramid_config.add_route("organization_logo", "/organization/{pubid}/logo")
-
-
-@pytest.fixture
-def organizations(factories):
-    # Add a handful of organizations to the DB to make the test realistic.
-    return [factories.Organization() for _ in range(3)]

--- a/tests/h/views/organizations_test.py
+++ b/tests/h/views/organizations_test.py
@@ -1,12 +1,24 @@
 from unittest import mock
 
-from h.views import organizations
+import pytest
+from pyramid.exceptions import NotFound
+
+from h.views.organizations import organization_logo
 
 
 class TestOrganizationLogo:
-    def test_it_returns_the_given_logo_unmodified(self):
-        logo = organizations.organization_logo(
-            mock.sentinel.logo, mock.sentinel.request
-        )
+    def test_it_returns_the_logo(self, organization):
+        organization.logo = "some logo content"
+        result = organization_logo(organization, mock.sentinel.request)
 
-        assert logo == mock.sentinel.logo
+        assert result == organization.logo
+
+    def test_it_raises_a_NotFound_error_for_no_logo(self, organization):
+        organization.logo = None
+
+        with pytest.raises(NotFound):
+            organization_logo(organization, mock.sentinel.request)
+
+    @pytest.fixture
+    def organization(self, factories):
+        return factories.Organization()


### PR DESCRIPTION
Views don't have to be _that_ thin. This removes a whole context which was basically view work in disguise and totally specific to a
single view.