### PR TITLE
Move organization lookup from the traversal to service

### DIFF
--- a/h/services/organization.py
+++ b/h/services/organization.py
@@ -31,6 +31,15 @@ class OrganizationService:
         self.session.add(organization)
         return organization
 
+    def get_by_public_id(self, pubid):
+        """
+        Get an organization by public id.
+
+        :param pubid: The public id to search for
+        :return: An organization model or None if no match is found
+        """
+        return self.session.query(Organization).filter_by(pubid=pubid).one_or_none()
+
     def get_default(self, authority=None):
         """Get the default org with an option to create it if missing.
 

--- a/h/traversal/organization.py
+++ b/h/traversal/organization.py
@@ -1,6 +1,3 @@
-import sqlalchemy.orm
-
-from h.models import Organization
 from h.traversal.root import Root, RootFactory
 
 
@@ -10,19 +7,19 @@ class OrganizationRoot(RootFactory):
 
     FIXME: This class should return OrganizationContext objects, not Organization
     objects.
-
     """
 
     def __getitem__(self, pubid):
-        try:
-            org = self.request.db.query(Organization).filter_by(pubid=pubid).one()
-
-            # Inherit global ACL. See comments in :py:class`h.traversal.AuthClientRoot`.
-            org.__parent__ = Root(self.request)
-
-            return org
-        except sqlalchemy.orm.exc.NoResultFound:
+        organization = self.request.find_service(name="organization").get_by_public_id(
+            pubid
+        )
+        if organization is None:
             raise KeyError()
+
+        # Inherit global ACL. See comments in :py:class`h.traversal.AuthClientRoot`.
+        organization.__parent__ = Root(self.request)
+
+        return organization
 
 
 class OrganizationContext:

--- a/tests/h/services/organization_test.py
+++ b/tests/h/services/organization_test.py
@@ -19,6 +19,18 @@ class TestOrganizationService:
         assert isinstance(organization, Organization)
         assert organization.logo is None
 
+    def test_get_by_public_id(self, service, factories):
+        organization = factories.Organization()
+
+        result = service.get_by_public_id(organization.pubid)
+
+        assert result == organization
+
+    def test_get_by_public_with_no_match(self, service):
+        result = service.get_by_public_id("no_matching_org")
+
+        assert result is None
+
     def test_get_default(self, service, default_organization):
         assert service.get_default() == default_organization
 


### PR DESCRIPTION
Seeing as we have an organization service, it seems a simple place to put the org lookup