### PR TITLE
Inline the `GroupContext` into the `GroupJSONPresenter`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,5 +12,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 97.13
+fail_under = 97.12
 skip_covered = True

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -8,11 +8,6 @@ class _GroupContext:
     def __init__(self, group, request):
         self.request = request
         self.group = group
-        self.links_service = self.request.find_service(name="group_links")
-
-    @property
-    def links(self):
-        return self.links_service.get_all(self.group)
 
     @property
     def organization(self):
@@ -27,13 +22,14 @@ class GroupJSONPresenter:
     def __init__(self, group, request):
         self.context = _GroupContext(group, request)
 
+        self.links_service = request.find_service(name="group_links")
         self.group = group
         self.organization_context = self.context.organization
 
     def asdict(self, expand=None):
         model = {
             "id": self.group.pubid,
-            "links": self.context.links or {},
+            "links": self.links_service.get_all(self.group) or {},
             "groupid": self.group.groupid,
             "name": self.group.name,
             "organization": (

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -1,12 +1,31 @@
 from h.presenters.organization_json import OrganizationJSONPresenter
-from h.traversal import GroupContext
+from h.traversal import OrganizationContext
+
+
+class _GroupContext:
+    """Context for group-based views."""
+
+    def __init__(self, group, request):
+        self.request = request
+        self.group = group
+        self.links_service = self.request.find_service(name="group_links")
+
+    @property
+    def links(self):
+        return self.links_service.get_all(self.group)
+
+    @property
+    def organization(self):
+        if self.group.organization is not None:
+            return OrganizationContext(self.group.organization, self.request)
+        return None
 
 
 class GroupJSONPresenter:
     """Present a group in the JSON format returned by API requests."""
 
     def __init__(self, group, request):
-        self.context = GroupContext(group, request)
+        self.context = _GroupContext(group, request)
 
         self.group = group
         self.organization_context = self.context.organization

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -2,29 +2,17 @@ from h.presenters.organization_json import OrganizationJSONPresenter
 from h.traversal import OrganizationContext
 
 
-class _GroupContext:
-    """Context for group-based views."""
-
-    def __init__(self, group, request):
-        self.request = request
-        self.group = group
-
-    @property
-    def organization(self):
-        if self.group.organization is not None:
-            return OrganizationContext(self.group.organization, self.request)
-        return None
-
-
 class GroupJSONPresenter:
     """Present a group in the JSON format returned by API requests."""
 
     def __init__(self, group, request):
-        self.context = _GroupContext(group, request)
-
         self.links_service = request.find_service(name="group_links")
         self.group = group
-        self.organization_context = self.context.organization
+
+        if group.organization is None:
+            self.organization_context = None
+        else:
+            self.organization_context = OrganizationContext(group.organization, request)
 
     def asdict(self, expand=None):
         model = {

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -1,13 +1,15 @@
 from h.presenters.organization_json import OrganizationJSONPresenter
+from h.traversal import GroupContext
 
 
 class GroupJSONPresenter:
     """Present a group in the JSON format returned by API requests."""
 
-    def __init__(self, group_context):
-        self.context = group_context
+    def __init__(self, group, request):
+        self.context = GroupContext(group, request)
+
+        self.group = group
         self.organization_context = self.context.organization
-        self.group = group_context.group
 
     def asdict(self, expand=None):
         model = {
@@ -53,11 +55,12 @@ class GroupJSONPresenter:
 class GroupsJSONPresenter:
     """Present a list of groups as JSON"""
 
-    def __init__(self, group_contexts):
-        self.contexts = group_contexts
+    def __init__(self, groups, request):
+        self.groups = groups
+        self.request = request
 
     def asdicts(self, expand=None):
         return [
-            GroupJSONPresenter(group_context).asdict(expand=expand)
-            for group_context in self.contexts
+            GroupJSONPresenter(group, self.request).asdict(expand=expand)
+            for group in self.groups
         ]

--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -63,12 +63,7 @@ shouldn't return model objects directly).
 from h.traversal.annotation import AnnotationContext, AnnotationRoot
 from h.traversal.auth_client import AuthClientRoot
 from h.traversal.bulk_api import BulkAPIRoot
-from h.traversal.group import (
-    GroupContext,
-    GroupRoot,
-    GroupUpsertContext,
-    GroupUpsertRoot,
-)
+from h.traversal.group import GroupRoot, GroupUpsertContext, GroupUpsertRoot
 from h.traversal.organization import OrganizationContext, OrganizationRoot
 from h.traversal.profile import ProfileRoot
 from h.traversal.root import Root
@@ -80,7 +75,6 @@ __all__ = (
     "AnnotationRoot",
     "AuthClientRoot",
     "BulkAPIRoot",
-    "GroupContext",
     "GroupRoot",
     "GroupUpsertContext",
     "GroupUpsertRoot",

--- a/h/traversal/group.py
+++ b/h/traversal/group.py
@@ -1,7 +1,6 @@
 from pyramid.security import Allow
 
 from h.auth import role
-from h.traversal.organization import OrganizationContext
 from h.traversal.root import RootFactory
 
 
@@ -24,25 +23,6 @@ class GroupRoot(RootFactory):
         if group is None:
             raise KeyError()
         return group
-
-
-class GroupContext:
-    """Context for group-based views."""
-
-    def __init__(self, group, request):
-        self.request = request
-        self.group = group
-        self.links_service = self.request.find_service(name="group_links")
-
-    @property
-    def links(self):
-        return self.links_service.get_all(self.group)
-
-    @property
-    def organization(self):
-        if self.group.organization is not None:
-            return OrganizationContext(self.group.organization, self.request)
-        return None
 
 
 class GroupUpsertRoot(RootFactory):

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -10,7 +10,6 @@ from h.auth.util import client_authority
 from h.i18n import TranslationString as _  # noqa: N813
 from h.presenters import GroupJSONPresenter, GroupsJSONPresenter, UserJSONPresenter
 from h.schemas.api.group import CreateGroupAPISchema, UpdateGroupAPISchema
-from h.traversal import GroupContext
 from h.views.api.config import api_config
 from h.views.api.exceptions import PayloadError
 
@@ -33,8 +32,8 @@ def groups(request):
         authority=request.params.get("authority"),
         document_uri=request.params.get("document_uri"),
     )
-    all_groups = [GroupContext(group, request) for group in all_groups]
-    all_groups = GroupsJSONPresenter(all_groups).asdicts(expand=expand)
+
+    all_groups = GroupsJSONPresenter(all_groups, request).asdicts(expand=expand)
     return all_groups
 
 
@@ -71,9 +70,7 @@ def create(request):
         description=appstruct.get("description", None),
         groupid=groupid,
     )
-    return GroupJSONPresenter(GroupContext(group, request)).asdict(
-        expand=["organization", "scopes"]
-    )
+    return GroupJSONPresenter(group, request).asdict(expand=["organization", "scopes"])
 
 
 @api_config(
@@ -89,7 +86,7 @@ def read(group, request):
 
     expand = request.GET.getall("expand") or []
 
-    return GroupJSONPresenter(GroupContext(group, request)).asdict(expand=expand)
+    return GroupJSONPresenter(group, request).asdict(expand=expand)
 
 
 @api_config(
@@ -121,9 +118,7 @@ def update(group, request):
 
     group = group_update_service.update(group, **appstruct)
 
-    return GroupJSONPresenter(GroupContext(group, request)).asdict(
-        expand=["organization", "scopes"]
-    )
+    return GroupJSONPresenter(group, request).asdict(expand=["organization", "scopes"])
 
 
 @api_config(
@@ -184,9 +179,7 @@ def upsert(context, request):
     group = group_update_service.update(group, **update_properties)
 
     # Note that this view takes a ``GroupUpsertContext`` but uses a ``GroupContext`` here
-    return GroupJSONPresenter(GroupContext(group, request)).asdict(
-        expand=["organization", "scopes"]
-    )
+    return GroupJSONPresenter(group, request).asdict(expand=["organization", "scopes"])
 
 
 @api_config(

--- a/h/views/api/profile.py
+++ b/h/views/api/profile.py
@@ -2,7 +2,6 @@ from pyramid.httpexceptions import HTTPBadRequest
 
 from h import session as h_session
 from h.presenters import GroupsJSONPresenter
-from h.traversal import GroupContext
 from h.views.api.config import api_config
 
 
@@ -37,8 +36,7 @@ def profile_groups(request):
     list_svc = request.find_service(name="group_list")
 
     groups = list_svc.user_groups(user=request.user)
-    group_contexts = [GroupContext(group, request) for group in groups]
-    groups_formatted = GroupsJSONPresenter(group_contexts).asdicts(expand=expand)
+    groups_formatted = GroupsJSONPresenter(groups, request).asdicts(expand=expand)
     return groups_formatted
 
 

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -161,7 +161,7 @@ class TestGroupsJSONPresenter:
         return patch("h.presenters.group_json.GroupJSONPresenter")
 
 
-@pytest.mark.usefixtures("group_links_service")
+
 class TestGroupContext:
     def test_it_returns_group_model_as_property(self, factories, pyramid_request):
         group = factories.Group()
@@ -169,15 +169,6 @@ class TestGroupContext:
         group_context = _GroupContext(group, pyramid_request)
 
         assert group_context.group == group
-
-    def test_it_proxies_links_to_svc(
-        self, factories, group_links_service, pyramid_request
-    ):
-        group = factories.Group()
-
-        group_context = _GroupContext(group, pyramid_request)
-
-        assert group_context.links == group_links_service.get_all.return_value
 
     def test_organization_is_None_if_the_group_has_no_organization(
         self, factories, pyramid_request

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -3,11 +3,7 @@ from unittest.mock import sentinel
 import pytest
 from h_matchers import Any
 
-from h.presenters.group_json import (
-    GroupJSONPresenter,
-    GroupsJSONPresenter,
-    _GroupContext,
-)
+from h.presenters.group_json import GroupJSONPresenter, GroupsJSONPresenter
 
 
 @pytest.mark.usefixtures("group_links_service")
@@ -159,42 +155,3 @@ class TestGroupsJSONPresenter:
     @pytest.fixture(autouse=True)
     def GroupJSONPresenter(self, patch):
         return patch("h.presenters.group_json.GroupJSONPresenter")
-
-
-
-class TestGroupContext:
-    def test_it_returns_group_model_as_property(self, factories, pyramid_request):
-        group = factories.Group()
-
-        group_context = _GroupContext(group, pyramid_request)
-
-        assert group_context.group == group
-
-    def test_organization_is_None_if_the_group_has_no_organization(
-        self, factories, pyramid_request
-    ):
-        group = factories.Group()
-
-        group_context = _GroupContext(group, pyramid_request)
-
-        assert group_context.organization is None
-
-    def test_it_expands_organization_if_the_group_has_one(
-        self, factories, pyramid_request
-    ):
-        organization = factories.Organization()
-        group = factories.Group(organization=organization)
-
-        group_context = _GroupContext(group, pyramid_request)
-
-        assert group_context.organization.organization == organization
-
-    def test_it_returns_None_for_missing_organization_relation(
-        self, factories, pyramid_request
-    ):
-        group = factories.Group()
-        group.organization = None
-
-        group_context = _GroupContext(group, pyramid_request)
-
-        assert group_context.organization is None

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -3,7 +3,11 @@ from unittest.mock import sentinel
 import pytest
 from h_matchers import Any
 
-from h.presenters.group_json import GroupJSONPresenter, GroupsJSONPresenter
+from h.presenters.group_json import (
+    GroupJSONPresenter,
+    GroupsJSONPresenter,
+    _GroupContext,
+)
 
 
 @pytest.mark.usefixtures("group_links_service")
@@ -155,3 +159,51 @@ class TestGroupsJSONPresenter:
     @pytest.fixture(autouse=True)
     def GroupJSONPresenter(self, patch):
         return patch("h.presenters.group_json.GroupJSONPresenter")
+
+
+@pytest.mark.usefixtures("group_links_service")
+class TestGroupContext:
+    def test_it_returns_group_model_as_property(self, factories, pyramid_request):
+        group = factories.Group()
+
+        group_context = _GroupContext(group, pyramid_request)
+
+        assert group_context.group == group
+
+    def test_it_proxies_links_to_svc(
+        self, factories, group_links_service, pyramid_request
+    ):
+        group = factories.Group()
+
+        group_context = _GroupContext(group, pyramid_request)
+
+        assert group_context.links == group_links_service.get_all.return_value
+
+    def test_organization_is_None_if_the_group_has_no_organization(
+        self, factories, pyramid_request
+    ):
+        group = factories.Group()
+
+        group_context = _GroupContext(group, pyramid_request)
+
+        assert group_context.organization is None
+
+    def test_it_expands_organization_if_the_group_has_one(
+        self, factories, pyramid_request
+    ):
+        organization = factories.Organization()
+        group = factories.Group(organization=organization)
+
+        group_context = _GroupContext(group, pyramid_request)
+
+        assert group_context.organization.organization == organization
+
+    def test_it_returns_None_for_missing_organization_relation(
+        self, factories, pyramid_request
+    ):
+        group = factories.Group()
+        group.organization = None
+
+        group_context = _GroupContext(group, pyramid_request)
+
+        assert group_context.organization is None

--- a/tests/h/traversal/group_test.py
+++ b/tests/h/traversal/group_test.py
@@ -6,60 +6,7 @@ from pyramid.authorization import ACLAuthorizationPolicy
 
 from h.auth import role
 from h.services.group import GroupService
-from h.traversal.group import (
-    GroupContext,
-    GroupRoot,
-    GroupUpsertContext,
-    GroupUpsertRoot,
-)
-
-
-@pytest.mark.usefixtures("group_links_service")
-class TestGroupContext:
-    def test_it_returns_group_model_as_property(self, factories, pyramid_request):
-        group = factories.Group()
-
-        group_context = GroupContext(group, pyramid_request)
-
-        assert group_context.group == group
-
-    def test_it_proxies_links_to_svc(
-        self, factories, group_links_service, pyramid_request
-    ):
-        group = factories.Group()
-
-        group_context = GroupContext(group, pyramid_request)
-
-        assert group_context.links == group_links_service.get_all.return_value
-
-    def test_organization_is_None_if_the_group_has_no_organization(
-        self, factories, pyramid_request
-    ):
-        group = factories.Group()
-
-        group_context = GroupContext(group, pyramid_request)
-
-        assert group_context.organization is None
-
-    def test_it_expands_organization_if_the_group_has_one(
-        self, factories, pyramid_request
-    ):
-        organization = factories.Organization()
-        group = factories.Group(organization=organization)
-
-        group_context = GroupContext(group, pyramid_request)
-
-        assert group_context.organization.organization == organization
-
-    def test_it_returns_None_for_missing_organization_relation(
-        self, factories, pyramid_request
-    ):
-        group = factories.Group()
-        group.organization = None
-
-        group_context = GroupContext(group, pyramid_request)
-
-        assert group_context.organization is None
+from h.traversal.group import GroupRoot, GroupUpsertContext, GroupUpsertRoot
 
 
 @pytest.mark.usefixtures("group_links_service")


### PR DESCRIPTION
### Background

* It turns out that the `GroupContext` is used _exclusively_ in conjuntion with the group JSON presenters and vice versa
* It also turns out the JSON presenter tests are effectively integration tests and re-tested everything that happened in the `GroupContext` object anyway
* There were also lots of  _incredibly_ anti-refactoring tests which make each assertion about how the presenter was initialised, what it was called with and what it returned in separate tests... 

### In this PR

 * The `GroupContext` object is absorbed into the `GroupJSONPresenter`
 * The `GroupJSONPresenter` and `GroupsJSONPresenter` are now called directly with groups and the request object

This has been broken into a number of steps in the commits, but I don't think it makes sense to deploy these independently. These refactoring steps are to:

* Move the creation of the `GroupContext` object into the `GroupJSONPresenter`
* Make the `GroupContext` private to the `GroupJSONPresenter`
* Remove links look-ups from the `GroupContext` 
* Remove `OrganizationContext` from the `GroupContext` (which kills it)