### PR TITLE
Increase the allowed open file handles for NGINX

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -2,6 +2,7 @@ daemon off;
 worker_processes auto;
 pid /var/lib/hypothesis/nginx.pid;
 error_log /dev/stderr;
+worker_rlimit_nofile 65536;
 
 events {
   worker_connections 4096;
@@ -19,7 +20,7 @@ http {
 
   # If there is an auth token, rate limit based on that,
   # else if there is a cloudflare ip header rate limit based on that,
-  # otherwise assume it's from an internal service and do not 
+  # otherwise assume it's from an internal service and do not
   # rate limit at all.
   map $http_authorization $limit_per_user {
     "" $http_cf_connecting_ip;


### PR DESCRIPTION
This does nothing if the OS however doesn't make file handles available. From a quick check inside our containers, it looks to me like we have the required handles available (and then some):

```shell
~ $ whoami
hypothesis
~ $ ulimit -Hn
1048576
~ $ ulimit -Sn
1048576
```

It occurs to me that these limits might actually just be the limits I have on the system outside. So basically these values are just my systems Ubuntu defaults.

This is to attempt to address issues in live where are getting failures due to insufficient file handles being available.

```2021/07/08 12:43:00 [crit] 15#15: accept4() failed (24: No file descriptors available)```

Some random internet advice about fixing this:

* https://gist.github.com/joewiz/4c39c9d061cf608cb62b - Recovery from nginx "Too many open files" error on Amazon AWS Linux (post mortem)
* https://www.cyberciti.biz/faq/linux-unix-nginx-too-many-open-files/ - Nginx: 24: Too Many Open Files Error And Solution
* https://serverfault.com/questions/516802/too-many-open-files-with-nginx-cant-seem-to-raise-limit - Too many open files with nginx, can't seem to raise limit
