### PR TITLE
Increase NGINX file limits to match the current hard limit

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -2,7 +2,11 @@ daemon off;
 worker_processes auto;
 pid /var/lib/hypothesis/nginx.pid;
 error_log /dev/stderr;
-worker_rlimit_nofile 65536;
+
+# This file handle limit should ideally by the number of worker 
+# connections * 2. But it can't exceed the "hard" limit applied 
+# by the OS. Which for the moment is 4096 in our deploys.
+worker_rlimit_nofile 4096;
 
 events {
   worker_connections 4096;


### PR DESCRIPTION
The `worker_rlimit_nofile` setting appears to cause NGINX to request it's file limit be increased from the soft limit. This cannot be increased to a value beyond the hard limit. 

This matches the hard limit we currently have deployed.