### PR TITLE
Remove un-used permissions

### DIFF
--- a/h/security/permissions.py
+++ b/h/security/permissions.py
@@ -1,8 +1,6 @@
 class Permission:
     class Annotation:
-        ADMIN = "annotation:admin"  # Is this used anywhere?
         READ = "annotation:read"
-        WRITE = "annotation:write"  # Is this granted anywhere?
         UPDATE = "annotation:update"
         CREATE = "annotation:create"
         DELETE = "annotation:delete"

--- a/h/traversal/annotation.py
+++ b/h/traversal/annotation.py
@@ -79,7 +79,6 @@ class AnnotationContext:
 
         # The user who created the annotation always has the following permissions
         for action in [
-            Permission.Annotation.ADMIN,
             Permission.Annotation.UPDATE,
             Permission.Annotation.DELETE,
         ]:

--- a/tests/h/traversal/annotation_test.py
+++ b/tests/h/traversal/annotation_test.py
@@ -139,7 +139,6 @@ class TestAnnotationContext:
         expect = [
             (security.Allow, "saoirse", Permission.Annotation.READ),
             (security.Allow, "saoirse", Permission.Annotation.FLAG),
-            (security.Allow, "saoirse", Permission.Annotation.ADMIN),
             (security.Allow, "saoirse", Permission.Annotation.UPDATE),
             (security.Allow, "saoirse", Permission.Annotation.DELETE),
             security.DENY_ALL,
@@ -159,7 +158,6 @@ class TestAnnotationContext:
         res = AnnotationContext(ann, groupfinder_service, links_service)
 
         for perm in [
-            Permission.Annotation.ADMIN,
             Permission.Annotation.UPDATE,
             Permission.Annotation.DELETE,
         ]:
@@ -178,7 +176,6 @@ class TestAnnotationContext:
 
         for perm in [
             Permission.Annotation.READ,
-            Permission.Annotation.ADMIN,
             Permission.Annotation.UPDATE,
             Permission.Annotation.DELETE,
             Permission.Annotation.MODERATE,

--- a/tests/h/views/api/auth_test.py
+++ b/tests/h/views/api/auth_test.py
@@ -9,7 +9,6 @@ from oauthlib.oauth2 import InvalidRequestFatalError
 from pyramid import httpexceptions
 
 from h.models.auth_client import ResponseType
-from h.security.permissions import Permission
 from h.services.auth_token import auth_token_service_factory
 from h.services.oauth_provider import OAuthProviderService
 from h.services.oauth_validator import DEFAULT_SCOPES
@@ -217,7 +216,7 @@ class TestOAuthAuthorizeController:
     def oauth_provider(self, pyramid_config, auth_client, oauth_request):
         svc = mock.create_autospec(OAuthProviderService, instance=True)
 
-        scopes = [Permission.Annotation.READ, Permission.Annotation.WRITE]
+        scopes = ["annotation:read", "annotation:write"]
         credentials = {
             "client_id": auth_client.id,
             "state": "foobar",


### PR DESCRIPTION
After moving to unique Enum like values for permissions, it's become easier to review which permissions are used where. Some of these appear not to do anything.

Neither the `Annotation.ADMIN` nor the `Annotation.WRITE` appear to ever be read of consulted anywhere, only set.

_edit_:  Pretty sure `Annotation.WRITE` was my mistake as this was a scope not a permission