### PR TITLE
Use the group context instead of the group everywhere

### DIFF
--- a/h/traversal/group.py
+++ b/h/traversal/group.py
@@ -35,7 +35,7 @@ class GroupRequiredRoot(GroupRoot):
         if group_context.group is None:
             raise KeyError()
 
-        return group_context.group
+        return group_context
 
 
 @dataclass

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -89,12 +89,12 @@ class SearchController:
 class GroupSearchController(SearchController):
     """View callables unique to the "group_read" route."""
 
-    def __init__(self, group, request):
+    def __init__(self, context, request):
         super(GroupSearchController, self).__init__(request)
-        self.group = group
-        if group.organization:
+        self.group = context.group
+        if self.group.organization:
             self._organization_context = OrganizationContext(
-                group.organization, request
+                self.group.organization, request
             )
         else:
             self._organization_context = None

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -130,7 +130,7 @@ class GroupCreateViews:
 )
 class GroupEditViews:
     def __init__(self, context, request):
-        self.group = context
+        self.group = context.group
         self.request = request
 
         self.list_org_svc = request.find_service(name="list_organizations")
@@ -157,12 +157,10 @@ class GroupEditViews:
 
     @view_config(request_method="POST", route_name="admin.groups_delete")
     def delete(self):
-        group = self.group
-        svc = self.request.find_service(name="delete_group")
+        self.request.find_service(name="delete_group").delete(self.group)
 
-        svc.delete(group)
         self.request.session.flash(
-            _("Successfully deleted group %s" % (group.name), "success"),
+            _("Successfully deleted group %s" % (self.group.name), "success"),
             queue="success",
         )
 

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -69,8 +69,8 @@ class GroupCreateController:
     permission="admin",
 )
 class GroupEditController:
-    def __init__(self, group, request):
-        self.group = group
+    def __init__(self, context, request):
+        self.group = context.group
         self.request = request
         self.schema = group_schema().bind(request=self.request)
         self.form = request.create_form(
@@ -108,8 +108,8 @@ class GroupEditController:
 
 
 @view_config(route_name="group_read_noslug", request_method="GET")
-def read_noslug(group, request):
-    check_slug(group, request)
+def read_noslug(context, request):
+    check_slug(context.group, request)
 
 
 def check_slug(group, request):

--- a/tests/h/traversal/group_test.py
+++ b/tests/h/traversal/group_test.py
@@ -58,14 +58,14 @@ class TestGroupRoot:
 
 @pytest.mark.usefixtures("group_service")
 class TestGroupRequiredRoot:
-    def test_getitem_returns_fetched_group_if_not_None(
+    def test_getitem_returns_fetched_groupcontext_if_not_None(
         self, factories, pyramid_request, GroupContext_
     ):
         GroupContext_.return_value.group = factories.Group()
 
         context = GroupRequiredRoot(pyramid_request)[sentinel.group_id]
 
-        assert context == GroupContext_.return_value.group
+        assert context == GroupContext_.return_value
 
     def test_getitem_raises_KeyError_if_there_is_no_group(
         self, pyramid_request, GroupContext_

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -8,6 +8,7 @@ from webob.multidict import MultiDict
 
 from h.activity.query import ActivityResults
 from h.services.annotation_stats import AnnotationStatsService
+from h.traversal.group import GroupContext
 from h.views import activity
 
 GROUP_TYPE_OPTIONS = ("group", "open_group", "restricted_group")
@@ -894,7 +895,9 @@ class TestGroupSearchController:
         test_group = group
         if "test_group" in request.fixturenames:
             test_group = request.getfixturevalue("test_group")
-        controller = activity.GroupSearchController(test_group, pyramid_request)
+
+        context = GroupContext(test_group)
+        controller = activity.GroupSearchController(context, pyramid_request)
         return controller
 
     @pytest.fixture
@@ -1241,7 +1244,7 @@ class TestGroupAndUserSearchController:
         # correct URL.
         pyramid_request.matchdict["slug"] = group.slug
 
-        return activity.GroupSearchController(group, pyramid_request)
+        return activity.GroupSearchController(GroupContext(group), pyramid_request)
 
     @pytest.fixture
     def delete_lozenge_request(self, pyramid_request):


### PR DESCRIPTION
This replaces returning the group directly as the context with a context object. The context object already proxies the ACL's from the group object and should do the same thing.