### PR TITLE
Use the `UserContext` instead of the model object in all places

### DIFF
--- a/h/models/user.py
+++ b/h/models/user.py
@@ -335,16 +335,16 @@ class User(Base):
         )
 
     def __acl__(self):
-        terms = []
+        client_authority = "client_authority:{}".format(self.authority)
 
-        # auth_clients that have the same authority as the user
-        # may update the user
-        user_update_principal = "client_authority:{}".format(self.authority)
-        terms.append((security.Allow, user_update_principal, "update"))
-
-        terms.append(security.DENY_ALL)
-
-        return terms
+        return [
+            # auth_clients that have the same authority as the user may update
+            # the user
+            (security.Allow, client_authority, "update"),
+            (security.Allow, client_authority, "read"),
+            # This is for inheriting security policies... do we inherit?
+            security.DENY_ALL,
+        ]
 
     def __repr__(self):
         return "<User: %s>" % self.username

--- a/h/traversal/user.py
+++ b/h/traversal/user.py
@@ -30,7 +30,7 @@ class UserRoot(RootFactory):
 
         self.user_service = self.request.find_service(name="user")
 
-    def get_user(self, userid_or_username, authority):
+    def get_user_context(self, userid_or_username, authority):
         """Get a user while handling errors appropriately for a traversal."""
 
         try:
@@ -42,15 +42,14 @@ class UserRoot(RootFactory):
         if not user:
             raise KeyError()
 
-        return user
+        return UserContext(user)
 
 
 class UserByNameRoot(UserRoot):
     """Root factory for routes which look up users by username."""
 
     def __getitem__(self, username):
-        # TODO: This should be a UserContext
-        return self.get_user(
+        return self.get_user_context(
             username,
             authority=client_authority(self.request) or self.request.default_authority,
         )
@@ -60,4 +59,4 @@ class UserByIDRoot(UserRoot):
     """Root factory for routes which look up users by id."""
 
     def __getitem__(self, userid):
-        return UserContext(self.get_user(userid, authority=None))
+        return self.get_user_context(userid, authority=None)

--- a/h/traversal/user.py
+++ b/h/traversal/user.py
@@ -17,12 +17,9 @@ class UserContext:
     user: User
 
     def __acl__(self):
-        """
-        Set the "read" permission for AuthClients that have a matching authority
-        to the user. This supercedes the ACL in `h.models.User`.
-        """
+        """Return user access control lists."""
 
-        return [(Allow, f"client_authority:{self.user.authority}", "read")]
+        return self.user.__acl__()
 
 
 class UserRoot(RootFactory):

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -342,9 +342,9 @@ class GroupSearchController(SearchController):
 class UserSearchController(SearchController):
     """View callables unique to the "activity.user_search" route."""
 
-    def __init__(self, user, request):
+    def __init__(self, context, request):
         super().__init__(request)
-        self.user = user
+        self.user = context.user
 
     @view_config(request_method="GET")
     def search(self):

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -86,7 +86,7 @@ def create(request):
     description="Update a user",
     permission="update",
 )
-def update(user, request):
+def update(context, request):
     """
     Update a user.
 
@@ -97,7 +97,7 @@ def update(user, request):
     appstruct = schema.validate(_json_payload(request))
 
     user_update_service = request.find_service(name="user_update")
-    user = user_update_service.update(user, **appstruct)
+    user = user_update_service.update(context.user, **appstruct)
 
     presenter = TrustedUserJSONPresenter(user)
     return presenter.asdict()

--- a/tests/h/traversal/user_test.py
+++ b/tests/h/traversal/user_test.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch, sentinel
 
 import pytest
-from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.httpexceptions import HTTPBadRequest
 
 from h.auth import role
@@ -10,16 +9,12 @@ from h.traversal.user import UserByIDRoot, UserByNameRoot, UserContext, UserRoot
 
 
 class TestUserContext:
-    def test_acl_matching_authority_allows_read(self, factories):
+    def test_acl_matching_user(self, factories):
         user = factories.User()
 
-        context = UserContext(user)
+        acl = UserContext(user).__acl__()
 
-        policy = ACLAuthorizationPolicy()
-        assert policy.permits(context, [f"client_authority:{user.authority}"], "read")
-        assert not policy.permits(
-            context, ["client_authority:DIFFERENT_AUTHORITY"], "read"
-        )
+        assert acl == user.__acl__()
 
 
 @pytest.mark.usefixtures("user_service")

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -8,6 +8,7 @@ from webob.multidict import MultiDict
 
 from h.activity.query import ActivityResults
 from h.services.annotation_stats import AnnotationStatsService
+from h.traversal import UserContext
 from h.traversal.group import GroupContext
 from h.views import activity
 
@@ -931,9 +932,6 @@ class TestGroupSearchController:
 
 @pytest.mark.usefixtures("annotation_stats_service", "user_service", "routes", "search")
 class TestUserSearchController:
-
-    """Tests unique to UserSearchController."""
-
     def test_search_calls_search_with_request(
         self, controller, pyramid_request, search
     ):
@@ -1095,7 +1093,7 @@ class TestUserSearchController:
 
     @pytest.fixture
     def controller(self, user, pyramid_request, query):
-        return activity.UserSearchController(user, pyramid_request)
+        return activity.UserSearchController(UserContext(user), pyramid_request)
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request, user):
@@ -1252,7 +1250,7 @@ class TestGroupAndUserSearchController:
 
     @pytest.fixture
     def user_search_controller(self, user, pyramid_request):
-        return activity.UserSearchController(user, pyramid_request)
+        return activity.UserSearchController(UserContext(user), pyramid_request)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR uses the `UserContext` everywhere instead of the context sometimes and the `User` model other times.

This involves:

* Consolidating the user ACLs onto the model
* This is sort of backwards step for the moment (we'll be moving ACLs out of the models soon)
* Uniting the different user traversal objects to always return contexts