### PR TITLE
Use an Enum like class for Bulk API permissions

### DIFF
--- a/h/security/permissions.py
+++ b/h/security/permissions.py
@@ -12,3 +12,6 @@ class Permission:
         SEARCH = "admin:search"
         STAFF = "admin:staff"
         USERS = "admin:users"
+
+    class API:
+        BULK_ACTION = "api:bulk_action"

--- a/h/traversal/bulk_api.py
+++ b/h/traversal/bulk_api.py
@@ -1,6 +1,7 @@
 from pyramid.security import Allow
 
 from h.auth.util import client_authority
+from h.security.permissions import Permission
 from h.traversal.root import RootFactory
 
 
@@ -13,6 +14,8 @@ class BulkAPIRoot(RootFactory):
         if authority := client_authority(self.request):
             # Currently only LMS uses this end-point
             if authority.startswith("lms.") and authority.endswith(".hypothes.is"):
-                return [(Allow, f"client_authority:{authority}", "bulk_action")]
+                return [
+                    (Allow, f"client_authority:{authority}", Permission.API.BULK_ACTION)
+                ]
 
         return []

--- a/h/views/api/bulk.py
+++ b/h/views/api/bulk.py
@@ -5,6 +5,7 @@ from h_api.bulk_api import BulkAPI
 from pyramid.response import Response
 
 from h.auth.util import client_authority
+from h.security.permissions import Permission
 from h.services.bulk_executor import BulkExecutor
 from h.views.api.config import api_config
 
@@ -16,7 +17,7 @@ from h.views.api.config import api_config
     link_name="bulk",
     description="Perform multiple operations in one call",
     subtype="x-ndjson",
-    permission="bulk_action",
+    permission=Permission.API.BULK_ACTION,
 )
 def bulk(request):
     """

--- a/tests/h/traversal/bulk_api_test.py
+++ b/tests/h/traversal/bulk_api_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from h.security.permissions import Permission
 from h.traversal.bulk_api import BulkAPIRoot
 
 
@@ -25,6 +26,6 @@ class TestBulkAPIRoot:
         context = BulkAPIRoot(pyramid_request)
 
         assert (
-            pyramid_request.has_permission("bulk_action", context)
+            pyramid_request.has_permission(Permission.API.BULK_ACTION, context)
             == permission_expected
         )


### PR DESCRIPTION
I think there's already good test coverage for this one, so this should be good to release and pretty easy to test (LMS still works).