### PR TITLE
Use an enum for permissions

### DIFF
--- a/h/formatters/annotation_moderation.py
+++ b/h/formatters/annotation_moderation.py
@@ -37,7 +37,7 @@ class AnnotationModerationFormatter:
 
     def format(self, annotation_resource):
         if not self._has_permission(
-            Permission.Group.MODERATE, annotation_resource.group
+            Permission.GROUP_MODERATE, annotation_resource.group
         ):
             return {}
 

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -226,31 +226,31 @@ class Group(Base, mixins.Timestamps):
 
         join_principal = _join_principal(self)
         if join_principal is not None:
-            terms.append((security.Allow, join_principal, Permission.Group.JOIN))
+            terms.append((security.Allow, join_principal, Permission.GROUP_JOIN))
 
         read_principal = _read_principal(self)
         if read_principal is not None:
-            terms.append((security.Allow, read_principal, Permission.Group.READ))
+            terms.append((security.Allow, read_principal, Permission.GROUP_READ))
             # Any user who can read the group should also be able to see
             # who is a member of the group
-            terms.append((security.Allow, read_principal, Permission.Group.MEMBER_READ))
+            terms.append((security.Allow, read_principal, Permission.GROUP_MEMBER_READ))
 
         flag_principal = _flag_principal(self)
         if flag_principal is not None:
-            terms.append((security.Allow, flag_principal, Permission.Group.FLAG))
+            terms.append((security.Allow, flag_principal, Permission.GROUP_FLAG))
 
         write_principal = _write_principal(self)
         if write_principal is not None:
-            terms.append((security.Allow, write_principal, Permission.Group.WRITE))
+            terms.append((security.Allow, write_principal, Permission.GROUP_WRITE))
 
         if self.creator:
             # The creator of the group should be able to update it
-            terms.append((security.Allow, self.creator.userid, Permission.Group.ADMIN))
+            terms.append((security.Allow, self.creator.userid, Permission.GROUP_ADMIN))
             terms.append(
-                (security.Allow, self.creator.userid, Permission.Group.MODERATE)
+                (security.Allow, self.creator.userid, Permission.GROUP_MODERATE)
             )
             # The creator may update this group in an upsert context
-            terms.append((security.Allow, self.creator.userid, Permission.Group.UPSERT))
+            terms.append((security.Allow, self.creator.userid, Permission.GROUP_UPSERT))
 
         # This authority principal may be used to grant auth clients
         # permissions for groups within their authority
@@ -259,21 +259,21 @@ class Group(Base, mixins.Timestamps):
         # auth_clients that have the same authority as the target group
         # may read the members within it
         terms.append(
-            (security.Allow, authority_principal, Permission.Group.MEMBER_READ)
+            (security.Allow, authority_principal, Permission.GROUP_MEMBER_READ)
         )
         # auth_clients that have the same authority as the target group
         # may add members to it
-        terms.append((security.Allow, authority_principal, Permission.Group.MEMBER_ADD))
+        terms.append((security.Allow, authority_principal, Permission.GROUP_MEMBER_ADD))
         # auth_clients that have the same authority as this group
         # should be allowed to update it
-        terms.append((security.Allow, authority_principal, Permission.Group.ADMIN))
+        terms.append((security.Allow, authority_principal, Permission.GROUP_ADMIN))
         # auth_clients with matching authority should be able to read
         # the group
-        terms.append((security.Allow, authority_principal, Permission.Group.READ))
+        terms.append((security.Allow, authority_principal, Permission.GROUP_READ))
 
         # Those with the admin or staff role should be able to admin/edit any group
-        terms.append((security.Allow, role.Staff, Permission.Group.ADMIN))
-        terms.append((security.Allow, role.Admin, Permission.Group.ADMIN))
+        terms.append((security.Allow, role.Staff, Permission.GROUP_ADMIN))
+        terms.append((security.Allow, role.Admin, Permission.GROUP_ADMIN))
 
         terms.append(security.DENY_ALL)
 

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -342,7 +342,7 @@ class User(Base):
         # may update the user
         user_update_principal = "client_authority:{}".format(self.authority)
 
-        terms.append((security.Allow, user_update_principal, Permission.User.UPDATE))
+        terms.append((security.Allow, user_update_principal, Permission.USER_UPDATE))
 
         terms.append(security.DENY_ALL)
 

--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -77,7 +77,7 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
             read = "group:{}".format(self.annotation.groupid)
 
             principals = principals_allowed_by_permission(
-                self.annotation_resource, Permission.Annotation.READ
+                self.annotation_resource, Permission.ANNOTATION_READ
             )
             if security.Everyone in principals:
                 read = "group:__world__"

--- a/h/security/permissions.py
+++ b/h/security/permissions.py
@@ -1,47 +1,44 @@
-class Permission:
-    class Group:
-        ADMIN = "group:admin"  # Is this really "EDIT" or a combination?
-        JOIN = "group:join"
-        READ = "group:read"
-        WRITE = "group:write"
-        UPSERT = "group:upsert"
-        CREATE = "group:create"
-        FLAG = "group:flag"
-        MODERATE = "group:moderate"
-        MEMBER_READ = "group:member:read"
-        MEMBER_ADD = "group:member:add"
+from enum import Enum
 
-    class Annotation:
-        ADMIN = "annotation:admin"  # Is this used anywhere?
-        READ = "annotation:read"
-        WRITE = "annotation:write"  # Is this granted anywhere?
-        UPDATE = "annotation:update"
-        CREATE = "annotation:create"
-        DELETE = "annotation:delete"
-        FLAG = "annotation:flag"
-        MODERATE = "annotation:moderate"
 
-    class User:
-        READ = "user:read"
-        CREATE = "user:create"
-        UPDATE = "user:update"
+class Permission(Enum):
+    GROUP_ADMIN = "group:admin"  # Is this really "EDIT" or a combination?
+    GROUP_JOIN = "group:join"
+    GROUP_READ = "group:read"
+    GROUP_WRITE = "group:write"
+    GROUP_UPSERT = "group:upsert"
+    GROUP_CREATE = "group:create"
+    GROUP_FLAG = "group:flag"
+    GROUP_MODERATE = "group:moderate"
+    GROUP_MEMBER_READ = "group:member:read"
+    GROUP_MEMBER_ADD = "group:member:add"
 
-    class Profile:
-        UPDATE = "profile:update"
+    ANNOTATION_ADMIN = "annotation:admin"  # Is this used anywhere?
+    ANNOTATION_READ = "annotation:read"
+    ANNOTATION_WRITE = "annotation:write"  # Is this granted anywhere?
+    ANNOTATION_UPDATE = "annotation:update"
+    ANNOTATION_CREATE = "annotation:create"
+    ANNOTATION_DELETE = "annotation:delete"
+    ANNOTATION_FLAG = "annotation:flag"
+    ANNOTATION_MODERATE = "annotation:moderate"
 
-    class AdminPage:
-        ADMINS = "admin:admins"
-        BADGE = "admin:badge"
-        FEATURES = "admin:features"
-        GROUPS = "admin:groups"
-        INDEX = "admin:index"
-        MAILER = "admin:mailer"
-        OAUTH_CLIENTS = "admin:oauth_clients"
-        ORGANIZATIONS = "admin:organizations"
-        NIPSA = "admin:nipsa"
-        SEARCH = "admin:search"
-        STAFF = "admin:staff"
-        USERS = "admin:users"
+    USER_READ = "user:read"
+    USER_CREATE = "user:create"
+    USER_UPDATE = "user:update"
 
-    class API:
-        BULK_ACTION = "api:bulk_action"
+    PROFILE_UPDATE = "profile:update"
+
+    ADMINPAGE_ADMINS = "admin:admins"
+    ADMINPAGE_BADGE = "admin:badge"
+    ADMINPAGE_FEATURES = "admin:features"
+    ADMINPAGE_GROUPS = "admin:groups"
+    ADMINPAGE_INDEX = "admin:index"
+    ADMINPAGE_MAILER = "admin:mailer"
+    ADMINPAGE_OAUTH_CLIENTS = "admin:oauth_clients"
+    ADMINPAGE_ORGANIZATIONS = "admin:organizations"
+    ADMINPAGE_NIPSA = "admin:nipsa"
+    ADMINPAGE_SEARCH = "admin:search"
+    ADMINPAGE_STAFF = "admin:staff"
+    ADMINPAGE_USERS = "admin:users"
+
+    API_BULK_ACTION = "api:bulk_action"

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -23,7 +23,7 @@ class AnnotationJSONPresentationService:
         self.links_svc = links_svc
 
         def moderator_check(group):
-            return has_permission(Permission.Group.MODERATE, group)
+            return has_permission(Permission.GROUP_MODERATE, group)
 
         self.formatters = [
             formatters.AnnotationFlagFormatter(flag_svc, user),

--- a/h/services/oauth_validator.py
+++ b/h/services/oauth_validator.py
@@ -12,7 +12,7 @@ from h.util.db import lru_cache_in_transaction
 from h.util.uri import render_url_template
 
 AUTHZ_CODE_TTL = datetime.timedelta(minutes=10)
-DEFAULT_SCOPES = [Permission.Annotation.READ, Permission.Annotation.WRITE]
+DEFAULT_SCOPES = [Permission.ANNOTATION_READ.value, Permission.ANNOTATION_WRITE.value]
 
 
 class Client:

--- a/h/storage.py
+++ b/h/storage.py
@@ -126,7 +126,7 @@ def create_annotation(request, data, group_service):
     # further checks.
     group = group_service.find(data["groupid"])
     if group is None or not request.has_permission(
-        Permission.Group.WRITE, context=group
+        Permission.GROUP_WRITE, context=group
     ):
         raise schemas.ValidationError(
             "group: " + _("You may not create annotations " "in the specified group!")

--- a/h/traversal/annotation.py
+++ b/h/traversal/annotation.py
@@ -14,7 +14,7 @@ from h.traversal.root import RootFactory
 class AnnotationRoot(RootFactory):
     """Root factory for routes whose context is an `AnnotationContext`."""
 
-    __acl__ = [(Allow, Authenticated, Permission.Annotation.CREATE)]
+    __acl__ = [(Allow, Authenticated, Permission.ANNOTATION_CREATE)]
 
     def __getitem__(self, id_):
         annotation = storage.fetch_annotation(self.request.db, id_)
@@ -47,10 +47,10 @@ class AnnotationContext:
 
     def _read_principals(self):
         if self.annotation.shared:
-            for principal in self._group_principals(self.group, Permission.Group.READ):
-                yield Allow, principal, Permission.Annotation.READ
+            for principal in self._group_principals(self.group, Permission.GROUP_READ):
+                yield Allow, principal, Permission.ANNOTATION_READ
         else:
-            yield Allow, self.annotation.userid, Permission.Annotation.READ
+            yield Allow, self.annotation.userid, Permission.ANNOTATION_READ
 
     def __acl__(self):
         """Return a Pyramid ACL for this annotation."""
@@ -65,25 +65,25 @@ class AnnotationContext:
         # permissions for this annotation's containing group.
         # Otherwise they are derived from the annotation's creator
         if self.annotation.shared:
-            for principal in self._group_principals(self.group, Permission.Group.FLAG):
-                acl.append((Allow, principal, Permission.Annotation.FLAG))
+            for principal in self._group_principals(self.group, Permission.GROUP_FLAG):
+                acl.append((Allow, principal, Permission.ANNOTATION_FLAG))
 
             for principal in self._group_principals(
-                self.group, Permission.Group.MODERATE
+                self.group, Permission.GROUP_MODERATE
             ):
-                acl.append((Allow, principal, Permission.Annotation.MODERATE))
+                acl.append((Allow, principal, Permission.ANNOTATION_MODERATE))
 
         else:
             # Flagging one's own private annotations is nonsensical,
             # but from an authz perspective, allowed. It is up to services/views
             # to handle these situations appropriately
-            acl.append((Allow, self.annotation.userid, Permission.Annotation.FLAG))
+            acl.append((Allow, self.annotation.userid, Permission.ANNOTATION_FLAG))
 
         # The user who created the annotation always has the following permissions
         for action in [
-            Permission.Annotation.ADMIN,
-            Permission.Annotation.UPDATE,
-            Permission.Annotation.DELETE,
+            Permission.ANNOTATION_ADMIN,
+            Permission.ANNOTATION_UPDATE,
+            Permission.ANNOTATION_DELETE,
         ]:
             acl.append((Allow, self.annotation.userid, action))
 

--- a/h/traversal/bulk_api.py
+++ b/h/traversal/bulk_api.py
@@ -15,7 +15,7 @@ class BulkAPIRoot(RootFactory):
             # Currently only LMS uses this end-point
             if authority.startswith("lms.") and authority.endswith(".hypothes.is"):
                 return [
-                    (Allow, f"client_authority:{authority}", Permission.API.BULK_ACTION)
+                    (Allow, f"client_authority:{authority}", Permission.API_BULK_ACTION)
                 ]
 
         return []

--- a/h/traversal/group.py
+++ b/h/traversal/group.py
@@ -13,7 +13,7 @@ class GroupRoot(RootFactory):
     """Root factory for group routes."""
 
     # Any logged in user may create a group
-    __acl__ = [(Allow, role.User, Permission.Group.CREATE)]
+    __acl__ = [(Allow, role.User, Permission.GROUP_CREATE)]
 
     def __init__(self, request):
         super().__init__(request)
@@ -49,7 +49,7 @@ class GroupContext:
         if self.group is None:
             # If there's no group then give "upsert" permission to users to
             # allow them to use the UPSERT endpoint to create a new group.
-            return [(Allow, role.User, Permission.Group.UPSERT)]
+            return [(Allow, role.User, Permission.GROUP_UPSERT)]
 
         # If there is a group associated with the context, the "upsert" and
         # all other permissions are managed by the model

--- a/h/traversal/profile.py
+++ b/h/traversal/profile.py
@@ -10,4 +10,4 @@ class ProfileRoot(RootFactory):
     Simple Root for API profile endpoints
     """
 
-    __acl__ = [(Allow, role.User, Permission.Profile.UPDATE)]
+    __acl__ = [(Allow, role.User, Permission.PROFILE_UPDATE)]

--- a/h/traversal/root.py
+++ b/h/traversal/root.py
@@ -15,11 +15,11 @@ class Root(RootFactory):
     """This app's default root factory."""
 
     __acl__ = [
-        (Allow, role.Staff, Permission.AdminPage.INDEX),
-        (Allow, role.Staff, Permission.AdminPage.GROUPS),
-        (Allow, role.Staff, Permission.AdminPage.MAILER),
-        (Allow, role.Staff, Permission.AdminPage.ORGANIZATIONS),
-        (Allow, role.Staff, Permission.AdminPage.USERS),
+        (Allow, role.Staff, Permission.ADMINPAGE_INDEX),
+        (Allow, role.Staff, Permission.ADMINPAGE_GROUPS),
+        (Allow, role.Staff, Permission.ADMINPAGE_MAILER),
+        (Allow, role.Staff, Permission.ADMINPAGE_ORGANIZATIONS),
+        (Allow, role.Staff, Permission.ADMINPAGE_USERS),
         (Allow, role.Admin, ALL_PERMISSIONS),
         DENY_ALL,
     ]

--- a/h/traversal/user.py
+++ b/h/traversal/user.py
@@ -31,7 +31,7 @@ class UserContext:
         acl = []
 
         user_authority_principal = f"client_authority:{self.user.authority}"
-        acl.append((Allow, user_authority_principal, Permission.User.READ))
+        acl.append((Allow, user_authority_principal, Permission.USER_READ))
 
         return acl
 
@@ -44,7 +44,7 @@ class UserRoot(RootFactory):
 
     """
 
-    __acl__ = [(Allow, role.AuthClient, Permission.User.CREATE)]
+    __acl__ = [(Allow, role.AuthClient, Permission.USER_CREATE)]
 
     def __init__(self, request):
         super().__init__(request)
@@ -67,7 +67,7 @@ class UserUserIDRoot(RootFactory):
     .. todo:: This should be the main Root for User objects
     """
 
-    __acl__ = [(Allow, role.AuthClient, Permission.User.CREATE)]
+    __acl__ = [(Allow, role.AuthClient, Permission.USER_CREATE)]
 
     def __init__(self, request):
         super().__init__(request)

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -197,7 +197,7 @@ class GroupSearchController(SearchController):
             self.group.creator.userid if self.group.creator else None,
         ]
 
-        if self.request.has_permission(Permission.Group.ADMIN, self.group):
+        if self.request.has_permission(Permission.GROUP_ADMIN, self.group):
             result["group_edit_url"] = self.request.route_url(
                 "group_edit", pubid=self.group.pubid
             )
@@ -236,7 +236,7 @@ class GroupSearchController(SearchController):
         This adds the authenticated user to the given group and redirect the
         browser to the search page.
         """
-        if not self.request.has_permission(Permission.Group.JOIN, self.group):
+        if not self.request.has_permission(Permission.GROUP_JOIN, self.group):
             raise httpexceptions.HTTPNotFound()
 
         group_members_service = self.request.find_service(name="group_members")
@@ -330,9 +330,9 @@ class GroupSearchController(SearchController):
         return _toggle_tag_facet(self.request)
 
     def _check_access_permissions(self):
-        if not self.request.has_permission(Permission.Group.READ, self.group):
+        if not self.request.has_permission(Permission.GROUP_READ, self.group):
             show_join_page = self.request.has_permission(
-                Permission.Group.JOIN, self.group
+                Permission.GROUP_JOIN, self.group
             )
             if not self.request.user:
                 # Show a page which will prompt the user to login to join.

--- a/h/views/admin/admins.py
+++ b/h/views/admin/admins.py
@@ -10,7 +10,7 @@ from h.security.permissions import Permission
     route_name="admin.admins",
     request_method="GET",
     renderer="h:templates/admin/admins.html.jinja2",
-    permission=Permission.AdminPage.ADMINS,
+    permission=Permission.ADMINPAGE_ADMINS,
 )
 def admins_index(request):
     """A list of all the admin users as an HTML page."""
@@ -26,7 +26,7 @@ def admins_index(request):
     request_method="POST",
     request_param="add",
     renderer="h:templates/admin/admins.html.jinja2",
-    permission=Permission.AdminPage.ADMINS,
+    permission=Permission.ADMINPAGE_ADMINS,
     require_csrf=True,
 )
 def admins_add(request):
@@ -49,7 +49,7 @@ def admins_add(request):
     request_method="POST",
     request_param="remove",
     renderer="h:templates/admin/admins.html.jinja2",
-    permission=Permission.AdminPage.ADMINS,
+    permission=Permission.ADMINPAGE_ADMINS,
     require_csrf=True,
 )
 def admins_remove(request):

--- a/h/views/admin/badge.py
+++ b/h/views/admin/badge.py
@@ -11,7 +11,7 @@ from h.security.permissions import Permission
     route_name="admin.badge",
     request_method="GET",
     renderer="h:templates/admin/badge.html.jinja2",
-    permission=Permission.AdminPage.BADGE,
+    permission=Permission.ADMINPAGE_BADGE,
 )
 def badge_index(request):
     return {"uris": request.db.query(models.Blocklist).all()}
@@ -21,7 +21,7 @@ def badge_index(request):
     route_name="admin.badge",
     request_method="POST",
     request_param="add",
-    permission=Permission.AdminPage.BADGE,
+    permission=Permission.ADMINPAGE_BADGE,
     require_csrf=True,
 )
 def badge_add(request):
@@ -46,7 +46,7 @@ def badge_add(request):
     route_name="admin.badge",
     request_method="POST",
     request_param="remove",
-    permission=Permission.AdminPage.BADGE,
+    permission=Permission.ADMINPAGE_BADGE,
     require_csrf=True,
 )
 def badge_remove(request):

--- a/h/views/admin/features.py
+++ b/h/views/admin/features.py
@@ -10,7 +10,7 @@ from h.security.permissions import Permission
     route_name="admin.features",
     request_method="GET",
     renderer="h:templates/admin/features.html.jinja2",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.ADMINPAGE_FEATURES,
 )
 def features_index(request):
 
@@ -25,7 +25,7 @@ def features_index(request):
 @view_config(
     route_name="admin.features",
     request_method="POST",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.ADMINPAGE_FEATURES,
     require_csrf=True,
 )
 def features_save(request):
@@ -53,7 +53,7 @@ def features_save(request):
     route_name="admin.cohorts",
     request_method="GET",
     renderer="h:templates/admin/cohorts.html.jinja2",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.ADMINPAGE_FEATURES,
 )
 @paginator.paginate_query
 def cohorts_index(_context, request):
@@ -66,7 +66,7 @@ def cohorts_index(_context, request):
     request_method="POST",
     request_param="add",
     renderer="h:templates/admin/cohorts.html.jinja2",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.ADMINPAGE_FEATURES,
     require_csrf=True,
 )
 def cohorts_add(request):
@@ -83,7 +83,7 @@ def cohorts_add(request):
     route_name="admin.cohorts_edit",
     request_method="GET",
     renderer="h:templates/admin/cohorts_edit.html.jinja2",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.ADMINPAGE_FEATURES,
 )
 def cohorts_edit(_context, request):
     id_ = request.matchdict["id"]
@@ -100,7 +100,7 @@ def cohorts_edit(_context, request):
     request_method="POST",
     request_param="add",
     renderer="h:templates/admin/cohorts_edit.html.jinja2",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.ADMINPAGE_FEATURES,
     require_csrf=True,
 )
 def cohorts_edit_add(request):
@@ -131,7 +131,7 @@ def cohorts_edit_add(request):
     request_method="POST",
     request_param="remove",
     renderer="h:templates/admin/cohorts_edit.html.jinja2",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.ADMINPAGE_FEATURES,
     require_csrf=True,
 )
 def cohorts_edit_remove(request):

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -16,7 +16,7 @@ _ = i18n.TranslationString
     route_name="admin.groups",
     request_method="GET",
     renderer="h:templates/admin/groups.html.jinja2",
-    permission=Permission.AdminPage.GROUPS,
+    permission=Permission.ADMINPAGE_GROUPS,
 )
 @paginator.paginate_query
 def groups_index(_context, request):
@@ -31,7 +31,7 @@ def groups_index(_context, request):
 @view_defaults(
     route_name="admin.groups_create",
     renderer="h:templates/admin/groups_create.html.jinja2",
-    permission=Permission.AdminPage.GROUPS,
+    permission=Permission.ADMINPAGE_GROUPS,
 )
 class GroupCreateViews:
     """Views for admin create-group forms"""
@@ -126,7 +126,7 @@ class GroupCreateViews:
 
 @view_defaults(
     route_name="admin.groups_edit",
-    permission=Permission.Group.ADMIN,
+    permission=Permission.GROUP_ADMIN,
     renderer="h:templates/admin/groups_edit.html.jinja2",
 )
 class GroupEditViews:

--- a/h/views/admin/index.py
+++ b/h/views/admin/index.py
@@ -10,7 +10,7 @@ from h.security.permissions import Permission
     route_name="admin.index",
     request_method="GET",
     renderer="h:templates/admin/index.html.jinja2",
-    permission=Permission.AdminPage.INDEX,
+    permission=Permission.ADMINPAGE_INDEX,
 )
 def index(_):
     return {

--- a/h/views/admin/mailer.py
+++ b/h/views/admin/mailer.py
@@ -10,7 +10,7 @@ from h.tasks import mailer
     route_name="admin.mailer",
     request_method="GET",
     renderer="h:templates/admin/mailer.html.jinja2",
-    permission=Permission.AdminPage.MAILER,
+    permission=Permission.ADMINPAGE_MAILER,
 )
 def mailer_index(request):
     """Show the mailer test tools."""
@@ -20,7 +20,7 @@ def mailer_index(request):
 @view_config(
     route_name="admin.mailer_test",
     request_method="POST",
-    permission=Permission.AdminPage.MAILER,
+    permission=Permission.ADMINPAGE_MAILER,
     require_csrf=True,
 )
 def mailer_test(request):

--- a/h/views/admin/nipsa.py
+++ b/h/views/admin/nipsa.py
@@ -14,7 +14,7 @@ class UserNotFoundError(Exception):
     route_name="admin.nipsa",
     request_method="GET",
     renderer="h:templates/admin/nipsa.html.jinja2",
-    permission=Permission.AdminPage.NIPSA,
+    permission=Permission.ADMINPAGE_NIPSA,
 )
 def nipsa_index(request):
     nipsa_service = request.find_service(name="nipsa")
@@ -28,7 +28,7 @@ def nipsa_index(request):
     route_name="admin.nipsa",
     request_method="POST",
     request_param="add",
-    permission=Permission.AdminPage.NIPSA,
+    permission=Permission.ADMINPAGE_NIPSA,
     require_csrf=True,
 )
 def nipsa_add(request):
@@ -55,7 +55,7 @@ def nipsa_add(request):
     route_name="admin.nipsa",
     request_method="POST",
     request_param="remove",
-    permission=Permission.AdminPage.NIPSA,
+    permission=Permission.ADMINPAGE_NIPSA,
     require_csrf=True,
 )
 def nipsa_remove(request):

--- a/h/views/admin/oauthclients.py
+++ b/h/views/admin/oauthclients.py
@@ -21,7 +21,7 @@ def _response_type_for_grant_type(grant_type):
 @view_config(
     route_name="admin.oauthclients",
     renderer="h:templates/admin/oauthclients.html.jinja2",
-    permission=Permission.AdminPage.OAUTH_CLIENTS,
+    permission=Permission.ADMINPAGE_OAUTH_CLIENTS,
 )
 def index(request):
     clients = request.db.query(AuthClient).order_by(AuthClient.name.asc()).all()
@@ -30,7 +30,7 @@ def index(request):
 
 @view_defaults(
     route_name="admin.oauthclients_create",
-    permission=Permission.AdminPage.OAUTH_CLIENTS,
+    permission=Permission.ADMINPAGE_OAUTH_CLIENTS,
     renderer="h:templates/admin/oauthclients_create.html.jinja2",
 )
 class AuthClientCreateController:
@@ -92,7 +92,7 @@ class AuthClientCreateController:
 
 @view_defaults(
     route_name="admin.oauthclients_edit",
-    permission=Permission.AdminPage.OAUTH_CLIENTS,
+    permission=Permission.ADMINPAGE_OAUTH_CLIENTS,
     renderer="h:templates/admin/oauthclients_edit.html.jinja2",
 )
 class AuthClientEditController:

--- a/h/views/admin/organizations.py
+++ b/h/views/admin/organizations.py
@@ -15,7 +15,7 @@ _ = i18n.TranslationString
     route_name="admin.organizations",
     request_method="GET",
     renderer="h:templates/admin/organizations.html.jinja2",
-    permission=Permission.AdminPage.ORGANIZATIONS,
+    permission=Permission.ADMINPAGE_ORGANIZATIONS,
 )
 @paginator.paginate_query
 def index(_context, request):
@@ -37,7 +37,7 @@ def index(_context, request):
 @view_defaults(
     route_name="admin.organizations_create",
     renderer="h:templates/admin/organizations_create.html.jinja2",
-    permission=Permission.AdminPage.ORGANIZATIONS,
+    permission=Permission.ADMINPAGE_ORGANIZATIONS,
 )
 class OrganizationCreateController:
     def __init__(self, request):
@@ -80,7 +80,7 @@ class OrganizationCreateController:
 
 @view_defaults(
     route_name="admin.organizations_edit",
-    permission=Permission.AdminPage.ORGANIZATIONS,
+    permission=Permission.ADMINPAGE_ORGANIZATIONS,
     renderer="h:templates/admin/organizations_edit.html.jinja2",
 )
 class OrganizationEditController:

--- a/h/views/admin/search.py
+++ b/h/views/admin/search.py
@@ -16,7 +16,7 @@ def not_found(exc, request):
     return HTTPFound(location=request.route_url("admin.search"))
 
 
-@view_defaults(route_name="admin.search", permission=Permission.AdminPage.SEARCH)
+@view_defaults(route_name="admin.search", permission=Permission.ADMINPAGE_SEARCH)
 class SearchAdminViews:
     def __init__(self, request):
         self.request = request

--- a/h/views/admin/staff.py
+++ b/h/views/admin/staff.py
@@ -10,7 +10,7 @@ from h.security.permissions import Permission
     route_name="admin.staff",
     request_method="GET",
     renderer="h:templates/admin/staff.html.jinja2",
-    permission=Permission.AdminPage.STAFF,
+    permission=Permission.ADMINPAGE_STAFF,
 )
 def staff_index(request):
     """A list of all the staff members as an HTML page."""
@@ -26,7 +26,7 @@ def staff_index(request):
     request_method="POST",
     request_param="add",
     renderer="h:templates/admin/staff.html.jinja2",
-    permission=Permission.AdminPage.STAFF,
+    permission=Permission.ADMINPAGE_STAFF,
     require_csrf=True,
 )
 def staff_add(request):
@@ -49,7 +49,7 @@ def staff_add(request):
     request_method="POST",
     request_param="remove",
     renderer="h:templates/admin/staff.html.jinja2",
-    permission=Permission.AdminPage.STAFF,
+    permission=Permission.ADMINPAGE_STAFF,
     require_csrf=True,
 )
 def staff_remove(request):

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -27,7 +27,7 @@ def format_date(date):
     route_name="admin.users",
     request_method="GET",
     renderer="h:templates/admin/users.html.jinja2",
-    permission=Permission.AdminPage.USERS,
+    permission=Permission.ADMINPAGE_USERS,
 )
 def users_index(request):
     user = None
@@ -60,7 +60,7 @@ def users_index(request):
     route_name="admin.users_activate",
     request_method="POST",
     request_param="userid",
-    permission=Permission.AdminPage.USERS,
+    permission=Permission.ADMINPAGE_USERS,
     require_csrf=True,
 )
 def users_activate(request):
@@ -86,7 +86,7 @@ def users_activate(request):
 @view_config(
     route_name="admin.users_rename",
     request_method="POST",
-    permission=Permission.AdminPage.USERS,
+    permission=Permission.ADMINPAGE_USERS,
     require_csrf=True,
 )
 def users_rename(request):
@@ -125,7 +125,7 @@ def users_rename(request):
 @view_config(
     route_name="admin.users_delete",
     request_method="POST",
-    permission=Permission.AdminPage.USERS,
+    permission=Permission.ADMINPAGE_USERS,
     require_csrf=True,
 )
 def users_delete(request):

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -65,7 +65,7 @@ def search(request):
     versions=["v1", "v2"],
     route_name="api.annotations",
     request_method="POST",
-    permission=Permission.Annotation.CREATE,
+    permission=Permission.ANNOTATION_CREATE,
     link_name="annotation.create",
     description="Create an annotation",
 )
@@ -87,7 +87,7 @@ def create(request):
     versions=["v1", "v2"],
     route_name="api.annotation",
     request_method="GET",
-    permission=Permission.Annotation.READ,
+    permission=Permission.ANNOTATION_READ,
     link_name="annotation.read",
     description="Fetch an annotation",
 )
@@ -101,7 +101,7 @@ def read(context, request):
     versions=["v1", "v2"],
     route_name="api.annotation.jsonld",
     request_method="GET",
-    permission=Permission.Annotation.READ,
+    permission=Permission.ANNOTATION_READ,
 )
 def read_jsonld(context, request):
     request.response.content_type = "application/ld+json"
@@ -117,7 +117,7 @@ def read_jsonld(context, request):
     versions=["v1", "v2"],
     route_name="api.annotation",
     request_method=("PATCH", "PUT"),
-    permission=Permission.Annotation.UPDATE,
+    permission=Permission.ANNOTATION_UPDATE,
     link_name="annotation.update",
     description="Update an annotation",
 )
@@ -144,7 +144,7 @@ def update(context, request):
     versions=["v1", "v2"],
     route_name="api.annotation",
     request_method="DELETE",
-    permission=Permission.Annotation.DELETE,
+    permission=Permission.ANNOTATION_DELETE,
     link_name="annotation.delete",
     description="Delete an annotation",
 )

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -120,7 +120,8 @@ class OAuthAuthorizeController:
 
     def _authorize(self):
         try:
-            _, credentials = self.oauth.validate_authorization_request(self.request.url)
+            url = self.request.url
+            _, credentials = self.oauth.validate_authorization_request(url)
         except OAuth2Error as err:
             raise OAuthAuthorizeError(
                 err.description or "Error: {}".format(self.context.error)

--- a/h/views/api/bulk.py
+++ b/h/views/api/bulk.py
@@ -17,7 +17,7 @@ from h.views.api.config import api_config
     link_name="bulk",
     description="Perform multiple operations in one call",
     subtype="x-ndjson",
-    permission=Permission.API.BULK_ACTION,
+    permission=Permission.API_BULK_ACTION,
 )
 def bulk(request):
     """

--- a/h/views/api/flags.py
+++ b/h/views/api/flags.py
@@ -14,7 +14,7 @@ from h.views.api.config import api_config
     request_method="PUT",
     link_name="annotation.flag",
     description="Flag an annotation for review",
-    permission=Permission.Annotation.FLAG,
+    permission=Permission.ANNOTATION_FLAG,
 )
 def create(context, request):
     svc = request.find_service(name="flag")

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -42,7 +42,7 @@ def groups(request):
     versions=["v1", "v2"],
     route_name="api.groups",
     request_method="POST",
-    permission=Permission.Group.CREATE,
+    permission=Permission.GROUP_CREATE,
     link_name="group.create",
     description="Create a new group",
 )
@@ -78,7 +78,7 @@ def create(request):
     versions=["v1", "v2"],
     route_name="api.group",
     request_method="GET",
-    permission=Permission.Group.READ,
+    permission=Permission.GROUP_READ,
     link_name="group.read",
     description="Fetch a group",
 )
@@ -94,7 +94,7 @@ def read(context, request):
     versions=["v1", "v2"],
     route_name="api.group",
     request_method="PATCH",
-    permission=Permission.Group.ADMIN,
+    permission=Permission.GROUP_ADMIN,
     link_name="group.update",
     description="Update a group",
 )
@@ -126,7 +126,7 @@ def update(context, request):
     versions=["v1", "v2"],
     route_name="api.group_upsert",
     request_method="PUT",
-    permission=Permission.Group.UPSERT,
+    permission=Permission.GROUP_UPSERT,
     link_name="group.create_or_update",
     description="Create or update a group",
 )
@@ -189,7 +189,7 @@ def upsert(context, request):
     request_method="GET",
     link_name="group.members.read",
     description="Fetch all members of a group",
-    permission=Permission.Group.MEMBER_READ,
+    permission=Permission.GROUP_MEMBER_READ,
 )
 def read_members(context, _request):
     """Fetch the members of a group."""
@@ -223,7 +223,7 @@ def remove_member(context, request):
     route_name="api.group_member",
     request_method="POST",
     link_name="group.member.add",
-    permission=Permission.Group.MEMBER_ADD,
+    permission=Permission.GROUP_MEMBER_ADD,
     description="Add the user in the request params to a group.",
 )
 def add_member(context, request):

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -11,7 +11,7 @@ from h.views.api.config import api_config
     request_method="PUT",
     link_name="annotation.hide",
     description="Hide an annotation as a group moderator",
-    permission=Permission.Annotation.MODERATE,
+    permission=Permission.ANNOTATION_MODERATE,
 )
 def create(context, request):
 
@@ -30,7 +30,7 @@ def create(context, request):
     request_method="DELETE",
     link_name="annotation.unhide",
     description="Unhide an annotation as a group moderator",
-    permission=Permission.Annotation.MODERATE,
+    permission=Permission.ANNOTATION_MODERATE,
 )
 def delete(context, request):
 

--- a/h/views/api/profile.py
+++ b/h/views/api/profile.py
@@ -45,7 +45,7 @@ def profile_groups(request):
     versions=["v1", "v2"],
     route_name="api.profile",
     request_method="PATCH",
-    permission=Permission.Profile.UPDATE,
+    permission=Permission.PROFILE_UPDATE,
     link_name="profile.update",
     description="Update a user's preferences",
 )

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -16,7 +16,7 @@ from h.views.api.exceptions import PayloadError
     request_method="GET",
     link_name="user.read",
     description="Fetch a user",
-    permission=Permission.User.READ,
+    permission=Permission.USER_READ,
 )
 def read(context, _request):
     """
@@ -34,7 +34,7 @@ def read(context, _request):
     request_method="POST",
     link_name="user.create",
     description="Create a new user",
-    permission=Permission.User.CREATE,
+    permission=Permission.USER_CREATE,
 )
 def create(request):
     """
@@ -85,7 +85,7 @@ def create(request):
     request_method="PATCH",
     link_name="user.update",
     description="Update a user",
-    permission=Permission.User.UPDATE,
+    permission=Permission.USER_UPDATE,
 )
 def update(user, request):
     """

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -67,7 +67,7 @@ class GroupCreateController:
 @view_defaults(
     route_name="group_edit",
     renderer="h:templates/groups/edit.html.jinja2",
-    permission=Permission.Group.ADMIN,
+    permission=Permission.GROUP_ADMIN,
 )
 class GroupEditController:
     def __init__(self, context, request):

--- a/h/views/main.py
+++ b/h/views/main.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 @view_config(
     route_name="annotation",
-    permission=Permission.Annotation.READ,
+    permission=Permission.ANNOTATION_READ,
     renderer="h:templates/app.html.jinja2",
     csp_insecure_optout=True,
 )

--- a/tests/h/formatters/annotation_moderation_test.py
+++ b/tests/h/formatters/annotation_moderation_test.py
@@ -75,13 +75,13 @@ class TestAnnotationModerationFormatter:
     @pytest.fixture
     def permission_granted(self, group):
         has_permission = FakePermissionCheck()
-        has_permission.add_permission(Permission.Group.MODERATE, group, True)
+        has_permission.add_permission(Permission.GROUP_MODERATE, group, True)
         return has_permission
 
     @pytest.fixture
     def permission_denied(self, group):
         has_permission = FakePermissionCheck()
-        has_permission.add_permission(Permission.Group.MODERATE, group, False)
+        has_permission.add_permission(Permission.GROUP_MODERATE, group, False)
         return has_permission
 
     @pytest.fixture

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -247,7 +247,7 @@ class TestGroupACL:
         assert authz_policy.permits(
             group,
             ["flip", "client_authority:weewhack.com"],
-            Permission.Group.MEMBER_READ,
+            Permission.GROUP_MEMBER_READ,
         )
 
     def test_auth_client_without_matching_authority_may_not_read_members(
@@ -258,7 +258,7 @@ class TestGroupACL:
         assert not authz_policy.permits(
             group,
             ["flip", "client_authority:2weewhack.com"],
-            Permission.Group.MEMBER_READ,
+            Permission.GROUP_MEMBER_READ,
         )
 
     def test_auth_client_with_matching_authority_may_add_members(
@@ -269,7 +269,7 @@ class TestGroupACL:
         assert authz_policy.permits(
             group,
             ["flip", "client_authority:weewhack.com"],
-            Permission.Group.MEMBER_ADD,
+            Permission.GROUP_MEMBER_ADD,
         )
 
     def test_auth_client_without_matching_authority_may_not_add_members(
@@ -280,46 +280,46 @@ class TestGroupACL:
         assert not authz_policy.permits(
             group,
             ["flip", "client_authority:2weewhack.com"],
-            Permission.Group.MEMBER_ADD,
+            Permission.GROUP_MEMBER_ADD,
         )
 
     def test_user_with_authority_may_not_add_members(self, group, authz_policy):
         group.authority = "fabuloso.biz"
 
         assert not authz_policy.permits(
-            group, ["flip", "authority:fabuloso.biz"], Permission.Group.MEMBER_ADD
+            group, ["flip", "authority:fabuloso.biz"], Permission.GROUP_MEMBER_ADD
         )
 
     def test_authority_joinable(self, group, authz_policy):
         group.joinable_by = JoinableBy.authority
 
         assert authz_policy.permits(
-            group, ["userid", "authority:example.com"], Permission.Group.JOIN
+            group, ["userid", "authority:example.com"], Permission.GROUP_JOIN
         )
 
     def test_not_joinable(self, group, authz_policy):
         group.joinable_by = None
         assert not authz_policy.permits(
-            group, ["userid", "authority:example.com"], Permission.Group.JOIN
+            group, ["userid", "authority:example.com"], Permission.GROUP_JOIN
         )
 
     def test_world_readable(self, group, authz_policy):
         group.readable_by = ReadableBy.world
-        assert authz_policy.permits(group, [security.Everyone], Permission.Group.READ)
+        assert authz_policy.permits(group, [security.Everyone], Permission.GROUP_READ)
 
     def test_world_readable_allows_member_read_for_everyone(self, group, authz_policy):
         group.readable_by = ReadableBy.world
         assert authz_policy.permits(
-            group, [security.Everyone], Permission.Group.MEMBER_READ
+            group, [security.Everyone], Permission.GROUP_MEMBER_READ
         )
 
     def test_world_readable_grants_flag_permissions(self, group, authz_policy):
         group.readable_by = ReadableBy.world
         assert authz_policy.permits(
-            group, [security.Authenticated], Permission.Group.FLAG
+            group, [security.Authenticated], Permission.GROUP_FLAG
         )
         assert not authz_policy.permits(
-            group, [security.Everyone], Permission.Group.FLAG
+            group, [security.Everyone], Permission.GROUP_FLAG
         )
 
     def test_world_readable_does_not_grant_moderate_permissions(
@@ -327,38 +327,38 @@ class TestGroupACL:
     ):
         group.readable_by = ReadableBy.world
         assert not authz_policy.permits(
-            group, [security.Authenticated], Permission.Group.MODERATE
+            group, [security.Authenticated], Permission.GROUP_MODERATE
         )
         assert not authz_policy.permits(
-            group, [security.Everyone], Permission.Group.MODERATE
+            group, [security.Everyone], Permission.GROUP_MODERATE
         )
 
     def test_members_readable(self, group, authz_policy):
         group.readable_by = ReadableBy.members
-        assert authz_policy.permits(group, ["group:test-group"], Permission.Group.READ)
+        assert authz_policy.permits(group, ["group:test-group"], Permission.GROUP_READ)
 
     def test_members_should_be_readable_by_group_members(self, group, authz_policy):
         group.readable_by = ReadableBy.members
         assert authz_policy.permits(
-            group, ["group:test-group"], Permission.Group.MEMBER_READ
+            group, ["group:test-group"], Permission.GROUP_MEMBER_READ
         )
 
     def test_members_flaggable(self, group, authz_policy):
         group.readable_by = ReadableBy.members
-        assert authz_policy.permits(group, ["group:test-group"], Permission.Group.FLAG)
+        assert authz_policy.permits(group, ["group:test-group"], Permission.GROUP_FLAG)
 
     def test_non_creator_members_do_not_have_moderate_permission(
         self, group, authz_policy
     ):
         group.readable_by = ReadableBy.members
         assert not authz_policy.permits(
-            group, ["group:test-group"], Permission.Group.MODERATE
+            group, ["group:test-group"], Permission.GROUP_MODERATE
         )
 
     def test_not_readable(self, group, authz_policy):
         group.readable_by = None
         assert not authz_policy.permits(
-            group, [security.Everyone, "group:test-group"], Permission.Group.READ
+            group, [security.Everyone, "group:test-group"], Permission.GROUP_READ
         )
 
     def test_member_read_permission_not_granted_if_group_not_readable(
@@ -366,39 +366,39 @@ class TestGroupACL:
     ):
         group.readable_by = None
         assert not authz_policy.permits(
-            group, [security.Everyone, "group:test-group"], Permission.Group.MEMBER_READ
+            group, [security.Everyone, "group:test-group"], Permission.GROUP_MEMBER_READ
         )
 
     def test_not_flaggable(self, group, authz_policy):
         group.readable_by = None
         assert not authz_policy.permits(
-            group, [security.Authenticated, "group:test-group"], Permission.Group.FLAG
+            group, [security.Authenticated, "group:test-group"], Permission.GROUP_FLAG
         )
 
     def test_authority_writeable(self, group, authz_policy):
         group.writeable_by = WriteableBy.authority
         assert authz_policy.permits(
-            group, ["authority:example.com"], Permission.Group.WRITE
+            group, ["authority:example.com"], Permission.GROUP_WRITE
         )
 
     def test_members_writeable(self, group, authz_policy):
         group.writeable_by = WriteableBy.members
-        assert authz_policy.permits(group, ["group:test-group"], Permission.Group.WRITE)
+        assert authz_policy.permits(group, ["group:test-group"], Permission.GROUP_WRITE)
 
     def test_not_writeable(self, group, authz_policy):
         group.writeable_by = (None,)
         assert not authz_policy.permits(
-            group, ["authority:example.com", "group:test-group"], Permission.Group.WRITE
+            group, ["authority:example.com", "group:test-group"], Permission.GROUP_WRITE
         )
 
     def test_creator_has_moderate_permission(self, group, authz_policy):
         assert authz_policy.permits(
-            group, "acct:luke@example.com", Permission.Group.MODERATE
+            group, "acct:luke@example.com", Permission.GROUP_MODERATE
         )
 
     def test_creator_has_admin_permission(self, group, authz_policy):
         assert authz_policy.permits(
-            group, "acct:luke@example.com", Permission.Group.ADMIN
+            group, "acct:luke@example.com", Permission.GROUP_ADMIN
         )
 
     def test_auth_client_with_matching_authority_has_admin_permission(
@@ -407,7 +407,7 @@ class TestGroupACL:
         group.authority = "weewhack.com"
 
         assert authz_policy.permits(
-            group, ["flip", "client_authority:weewhack.com"], Permission.Group.ADMIN
+            group, ["flip", "client_authority:weewhack.com"], Permission.GROUP_ADMIN
         )
 
     def test_auth_client_without_matching_authority_does_not_have_admin_permission(
@@ -416,12 +416,12 @@ class TestGroupACL:
         group.authority = "weewhack.com"
 
         assert not authz_policy.permits(
-            group, ["flip", "client_authority:2weewhack.com"], Permission.Group.ADMIN
+            group, ["flip", "client_authority:2weewhack.com"], Permission.GROUP_ADMIN
         )
 
     def test_creator_has_upsert_permissions(self, group, authz_policy):
         assert authz_policy.permits(
-            group, "acct:luke@example.com", Permission.Group.UPSERT
+            group, "acct:luke@example.com", Permission.GROUP_UPSERT
         )
 
     def test_admin_allowed_only_for_authority_when_no_creator(
@@ -430,19 +430,19 @@ class TestGroupACL:
         group.creator = None
 
         principals = authz_policy.principals_allowed_by_permission(
-            group, Permission.Group.ADMIN
+            group, Permission.GROUP_ADMIN
         )
 
         assert "client_authority:example.com" in principals
         assert authz_policy.permits(
-            group, ["flip", "client_authority:example.com"], Permission.Group.ADMIN
+            group, ["flip", "client_authority:example.com"], Permission.GROUP_ADMIN
         )
 
     def test_no_moderate_permission_when_no_creator(self, group, authz_policy):
         group.creator = None
 
         principals = authz_policy.principals_allowed_by_permission(
-            group, Permission.Group.MODERATE
+            group, Permission.GROUP_MODERATE
         )
         assert len(principals) == 0
 
@@ -450,28 +450,28 @@ class TestGroupACL:
         group.creator = None
 
         principals = authz_policy.principals_allowed_by_permission(
-            group, Permission.Group.UPSERT
+            group, Permission.GROUP_UPSERT
         )
         assert len(principals) == 0
 
     def test_staff_user_has_admin_permission_on_any_group(self, group, authz_policy):
         principals = authz_policy.principals_allowed_by_permission(
-            group, Permission.Group.ADMIN
+            group, Permission.GROUP_ADMIN
         )
 
         assert role.Staff in principals
         assert authz_policy.permits(
-            group, ["whatever", "group:__staff__"], Permission.Group.ADMIN
+            group, ["whatever", "group:__staff__"], Permission.GROUP_ADMIN
         )
 
     def test_admin_user_has_admin_permission_on_any_group(self, group, authz_policy):
         principals = authz_policy.principals_allowed_by_permission(
-            group, Permission.Group.ADMIN
+            group, Permission.GROUP_ADMIN
         )
 
         assert role.Admin in principals
         assert authz_policy.permits(
-            group, ["whatever", "group:__admin__"], Permission.Group.ADMIN
+            group, ["whatever", "group:__admin__"], Permission.GROUP_ADMIN
         )
 
     def test_fallback_is_deny_all(self, group, authz_policy):

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -317,7 +317,7 @@ class TestUserACL:
         user.authority = "weewhack.com"
 
         assert authz_policy.permits(
-            user, ["flip", "client_authority:weewhack.com"], Permission.User.UPDATE
+            user, ["flip", "client_authority:weewhack.com"], Permission.USER_UPDATE
         )
 
     def test_auth_client_without_matching_authority_may_not_update_user(
@@ -326,14 +326,14 @@ class TestUserACL:
         user.authority = "weewhack.com"
 
         assert not authz_policy.permits(
-            user, ["flip", "client_authority:2weewhack.com"], Permission.User.UPDATE
+            user, ["flip", "client_authority:2weewhack.com"], Permission.USER_UPDATE
         )
 
     def test_user_with_authority_may_not_update_user(self, user, authz_policy):
         user.authority = "fabuloso.biz"
 
         assert not authz_policy.permits(
-            user, ["flip", "authority:fabuloso.biz"], Permission.User.UPDATE
+            user, ["flip", "authority:fabuloso.biz"], Permission.USER_UPDATE
         )
 
     @pytest.fixture

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -213,9 +213,9 @@ class TestAnnotationJSONPresenter:
             "members": (
                 security.Allow,
                 "group:{}".format(annotation.groupid),
-                Permission.Group.READ,
+                Permission.GROUP_READ,
             ),
-            "world": (security.Allow, security.Everyone, Permission.Group.READ),
+            "world": (security.Allow, security.Everyone, Permission.GROUP_READ),
             None: security.DENY_ALL,
         }
         group = mock.Mock(spec_set=["__acl__"])

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -31,7 +31,7 @@ class TestAnnotationJSONPresentationService:
         group = mock.Mock()
         moderator_check = formatters.AnnotationHiddenFormatter.call_args[0][1]
         moderator_check(group)
-        has_permission.assert_called_once_with(Permission.Group.MODERATE, group)
+        has_permission.assert_called_once_with(Permission.GROUP_MODERATE, group)
 
     def test_it_configures_hidden_formatter(self, services, formatters, svc):
         assert formatters.AnnotationHiddenFormatter.return_value in svc.formatters

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -223,8 +223,8 @@ class TestGetDefaultRedirectUri:
 class TestGetDefaultScopes:
     def test_returns_default_scopes(self, svc):
         assert svc.get_default_scopes("something", None) == [
-            Permission.Annotation.READ,
-            Permission.Annotation.WRITE,
+            Permission.ANNOTATION_READ.value,
+            Permission.ANNOTATION_WRITE.value,
         ]
 
 

--- a/tests/h/streamer/contexts_test.py
+++ b/tests/h/streamer/contexts_test.py
@@ -10,18 +10,18 @@ class TestAnnotationNotificationContext:
     def test_public_annotation_permissions(self, get_context_acl, factories):
         acl = get_context_acl(factories.Annotation(shared=True))
 
-        assert acl[0] == ("Allow", "system.Everyone", Permission.Annotation.READ)
+        assert acl[0] == ("Allow", "system.Everyone", Permission.ANNOTATION_READ)
 
     def test_private_annotation_permissions(self, get_context_acl, factories):
         annotation = factories.Annotation(shared=False)
         acl = get_context_acl(annotation)
 
-        assert acl[0] == ("Allow", annotation.userid, Permission.Annotation.READ)
+        assert acl[0] == ("Allow", annotation.userid, Permission.ANNOTATION_READ)
 
     def test_deleted_still_returns_read_permissions(self, get_context_acl, factories):
         acl = get_context_acl(factories.Annotation(deleted=True))
 
-        assert acl[0] == ("Allow", Any.string(), Permission.Annotation.READ)
+        assert acl[0] == ("Allow", Any.string(), Permission.ANNOTATION_READ)
 
     def test_it_always_adds_deny_last(self, get_context_acl, factories):
         acl = get_context_acl(factories.Annotation())

--- a/tests/h/traversal/annotation_test.py
+++ b/tests/h/traversal/annotation_test.py
@@ -21,23 +21,23 @@ class FakeGroup:
     def __init__(self, principals):
         acl = []
         for p in principals:
-            acl.append((security.Allow, p, Permission.Group.READ))
+            acl.append((security.Allow, p, Permission.GROUP_READ))
             if p == security.Everyone:
                 acl.append(
-                    (security.Allow, security.Authenticated, Permission.Group.FLAG)
+                    (security.Allow, security.Authenticated, Permission.GROUP_FLAG)
                 )
                 acl.append(
-                    (security.Allow, security.Authenticated, Permission.Group.MODERATE)
+                    (security.Allow, security.Authenticated, Permission.GROUP_MODERATE)
                 )
             else:
-                acl.append((security.Allow, p, Permission.Group.FLAG))
+                acl.append((security.Allow, p, Permission.GROUP_FLAG))
                 # Normally, the ``moderate`` permission would only be applied
                 # to the admin (creator) of a group, but this ``FakeGroup``
                 # is indeed fake. Tests in this module are merely around whether
                 # this permission is translated appropriately from a group
                 # to an annotation context (i.e. it should not be applied
                 # to private annotations)
-                acl.append((security.Allow, p, Permission.Group.MODERATE))
+                acl.append((security.Allow, p, Permission.GROUP_MODERATE))
         self.__acl__ = acl
 
 
@@ -50,7 +50,7 @@ class TestAnnotationRoot:
 
         context = AnnotationRoot(pyramid_request)
 
-        assert not pyramid_request.has_permission(Permission.Annotation.CREATE, context)
+        assert not pyramid_request.has_permission(Permission.ANNOTATION_CREATE, context)
 
     def test_it_assigns_create_permission_to_authenticated_request(
         self, set_permissions, pyramid_request
@@ -61,7 +61,7 @@ class TestAnnotationRoot:
 
         context = AnnotationRoot(pyramid_request)
 
-        assert pyramid_request.has_permission(Permission.Annotation.CREATE, context)
+        assert pyramid_request.has_permission(Permission.ANNOTATION_CREATE, context)
 
     def test_get_item_fetches_annotation(self, pyramid_request, storage):
         factory = AnnotationRoot(pyramid_request)
@@ -141,11 +141,11 @@ class TestAnnotationContext:
         actual = res.__acl__()
         # Note NOT the ``moderate`` permission
         expect = [
-            (security.Allow, "saoirse", Permission.Annotation.READ),
-            (security.Allow, "saoirse", Permission.Annotation.FLAG),
-            (security.Allow, "saoirse", Permission.Annotation.ADMIN),
-            (security.Allow, "saoirse", Permission.Annotation.UPDATE),
-            (security.Allow, "saoirse", Permission.Annotation.DELETE),
+            (security.Allow, "saoirse", Permission.ANNOTATION_READ),
+            (security.Allow, "saoirse", Permission.ANNOTATION_FLAG),
+            (security.Allow, "saoirse", Permission.ANNOTATION_ADMIN),
+            (security.Allow, "saoirse", Permission.ANNOTATION_UPDATE),
+            (security.Allow, "saoirse", Permission.ANNOTATION_DELETE),
             security.DENY_ALL,
         ]
         assert actual == expect
@@ -163,9 +163,9 @@ class TestAnnotationContext:
         res = AnnotationContext(ann, groupfinder_service, links_service)
 
         for perm in [
-            Permission.Annotation.ADMIN,
-            Permission.Annotation.UPDATE,
-            Permission.Annotation.DELETE,
+            Permission.ANNOTATION_ADMIN,
+            Permission.ANNOTATION_UPDATE,
+            Permission.ANNOTATION_DELETE,
         ]:
             assert policy.permits(res, ["saoirse"], perm)
             assert not policy.permits(res, ["someoneelse"], perm)
@@ -181,11 +181,11 @@ class TestAnnotationContext:
         res = AnnotationContext(ann, groupfinder_service, links_service)
 
         for perm in [
-            Permission.Annotation.READ,
-            Permission.Annotation.ADMIN,
-            Permission.Annotation.UPDATE,
-            Permission.Annotation.DELETE,
-            Permission.Annotation.MODERATE,
+            Permission.ANNOTATION_READ,
+            Permission.ANNOTATION_ADMIN,
+            Permission.ANNOTATION_UPDATE,
+            Permission.ANNOTATION_DELETE,
+            Permission.ANNOTATION_MODERATE,
         ]:
             assert not policy.permits(res, ["saiorse"], perm)
 
@@ -233,9 +233,9 @@ class TestAnnotationContext:
         res = AnnotationContext(ann, groupfinder_service, links_service)
 
         if permitted:
-            assert pyramid_request.has_permission(Permission.Annotation.READ, res)
+            assert pyramid_request.has_permission(Permission.ANNOTATION_READ, res)
         else:
-            assert not pyramid_request.has_permission(Permission.Annotation.READ, res)
+            assert not pyramid_request.has_permission(Permission.ANNOTATION_READ, res)
 
     @pytest.mark.parametrize(
         "groupid,userid,permitted",
@@ -281,9 +281,9 @@ class TestAnnotationContext:
         res = AnnotationContext(ann, groupfinder_service, links_service)
 
         if permitted:
-            assert pyramid_request.has_permission(Permission.Annotation.FLAG, res)
+            assert pyramid_request.has_permission(Permission.ANNOTATION_FLAG, res)
         else:
-            assert not pyramid_request.has_permission(Permission.Annotation.FLAG, res)
+            assert not pyramid_request.has_permission(Permission.ANNOTATION_FLAG, res)
 
     @pytest.mark.parametrize(
         "groupid,userid,permitted",
@@ -330,10 +330,10 @@ class TestAnnotationContext:
         res = AnnotationContext(ann, groupfinder_service, links_service)
 
         if permitted:
-            assert pyramid_request.has_permission(Permission.Annotation.MODERATE, res)
+            assert pyramid_request.has_permission(Permission.ANNOTATION_MODERATE, res)
         else:
             assert not pyramid_request.has_permission(
-                Permission.Annotation.MODERATE, res
+                Permission.ANNOTATION_MODERATE, res
             )
 
     @pytest.fixture

--- a/tests/h/traversal/bulk_api_test.py
+++ b/tests/h/traversal/bulk_api_test.py
@@ -26,6 +26,6 @@ class TestBulkAPIRoot:
         context = BulkAPIRoot(pyramid_request)
 
         assert (
-            pyramid_request.has_permission(Permission.API.BULK_ACTION, context)
+            pyramid_request.has_permission(Permission.API_BULK_ACTION, context)
             == permission_expected
         )

--- a/tests/h/traversal/group_test.py
+++ b/tests/h/traversal/group_test.py
@@ -28,7 +28,7 @@ class TestGroupContext:
 
         assert context.group is None
         assert (
-            bool(pyramid_request.has_permission(Permission.Group.UPSERT, context))
+            bool(pyramid_request.has_permission(Permission.GROUP_UPSERT, context))
             == has_upsert
         )
 
@@ -46,7 +46,7 @@ class TestGroupRoot:
         context = GroupRoot(pyramid_request)
 
         assert (
-            bool(pyramid_request.has_permission(Permission.Group.CREATE, context))
+            bool(pyramid_request.has_permission(Permission.GROUP_CREATE, context))
             == has_create
         )
 

--- a/tests/h/traversal/profile_test.py
+++ b/tests/h/traversal/profile_test.py
@@ -11,7 +11,7 @@ class TestProfileRoot:
 
         context = ProfileRoot(pyramid_request)
 
-        assert pyramid_request.has_permission(Permission.Profile.UPDATE, context)
+        assert pyramid_request.has_permission(Permission.PROFILE_UPDATE, context)
 
     def test_it_does_not_assign_update_permission_without_user_role(
         self, set_permissions, pyramid_request
@@ -20,4 +20,4 @@ class TestProfileRoot:
 
         context = ProfileRoot(pyramid_request)
 
-        assert not pyramid_request.has_permission(Permission.Profile.UPDATE, context)
+        assert not pyramid_request.has_permission(Permission.PROFILE_UPDATE, context)

--- a/tests/h/traversal/root_test.py
+++ b/tests/h/traversal/root_test.py
@@ -31,11 +31,11 @@ class TestRoot:
     @pytest.mark.parametrize(
         "permission",
         [
-            Permission.AdminPage.INDEX,
-            Permission.AdminPage.GROUPS,
-            Permission.AdminPage.MAILER,
-            Permission.AdminPage.ORGANIZATIONS,
-            Permission.AdminPage.USERS,
+            Permission.ADMINPAGE_INDEX,
+            Permission.ADMINPAGE_GROUPS,
+            Permission.ADMINPAGE_MAILER,
+            Permission.ADMINPAGE_ORGANIZATIONS,
+            Permission.ADMINPAGE_USERS,
         ],
     )
     def test_it_assigns_admin_permissions_to_requests_with_staff_role(

--- a/tests/h/traversal/user_test.py
+++ b/tests/h/traversal/user_test.py
@@ -16,7 +16,7 @@ class TestUserContext:
         res = UserContext(user)
         actual = res.__acl__()
         expect = [
-            (security.Allow, "client_authority:myauthority.com", Permission.User.READ)
+            (security.Allow, "client_authority:myauthority.com", Permission.USER_READ)
         ]
         assert actual == expect
 
@@ -27,10 +27,10 @@ class TestUserContext:
         res = UserContext(user)
 
         assert policy.permits(
-            res, ["client_authority:myauthority.com"], Permission.User.READ
+            res, ["client_authority:myauthority.com"], Permission.USER_READ
         )
         assert not policy.permits(
-            res, ["client_authority:example.com"], Permission.User.READ
+            res, ["client_authority:example.com"], Permission.USER_READ
         )
 
 
@@ -45,7 +45,7 @@ class TestUserRoot:
 
         context = UserRoot(pyramid_request)
 
-        assert not pyramid_request.has_permission(Permission.User.CREATE, context)
+        assert not pyramid_request.has_permission(Permission.USER_CREATE, context)
 
     def test_it_assigns_create_permission_to_auth_client_role(
         self, set_permissions, pyramid_request
@@ -54,7 +54,7 @@ class TestUserRoot:
 
         context = UserRoot(pyramid_request)
 
-        assert pyramid_request.has_permission(Permission.User.CREATE, context)
+        assert pyramid_request.has_permission(Permission.USER_CREATE, context)
 
     def test_it_fetches_the_requested_user(
         self, pyramid_request, user_factory, user_service

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -298,7 +298,7 @@ class TestGroupSearchController:
         self, controller, factories, test_group, test_user, pyramid_request
     ):
         def fake_has_permission(permission, context=None):
-            return permission != Permission.Group.ADMIN
+            return permission != Permission.GROUP_ADMIN
 
         pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
 

--- a/tests/h/views/api/auth_test.py
+++ b/tests/h/views/api/auth_test.py
@@ -217,7 +217,7 @@ class TestOAuthAuthorizeController:
     def oauth_provider(self, pyramid_config, auth_client, oauth_request):
         svc = mock.create_autospec(OAuthProviderService, instance=True)
 
-        scopes = [Permission.Annotation.READ, Permission.Annotation.WRITE]
+        scopes = [Permission.ANNOTATION_READ.value, Permission.ANNOTATION_WRITE.value]
         credentials = {
             "client_id": auth_client.id,
             "state": "foobar",


### PR DESCRIPTION
Use a real `Enum` instead of an `Enum`-like class for permissions.

This seems to work based on a little manual testing and all the unit and functional tests passed _except_ for three functests to do with client OAuth stuff. `OAuthValidatorService` uses the strings `"annotation:read"` and `"annotation:write"` as `DEFAULT_SCOPES`. I'm not sure whether this has anything to do with Pyramid permissions or not. I think these scopes are getting passed in to `oauthlib`. Anyway if you replace these default scopes with `Permission.ANNOTATION_READ` and `Permission.ANNOTATION_WRITE` (when `Permission` is an `Enum`) it breaks. But using `Permission.ANNOTATION_READ.value` and `Permission.ANNOTATION_WRITE.value` (which are strings) fixes it. As would just leaving them as literal strings.

https://github.com/hypothesis/h/blob/680038950932d7b28e37b3e16684d69c313e0faf/h/services/oauth_validator.py#L14