### PR TITLE
Faster but non-isolated functional tests

### DIFF
--- a/tests/common/factories/user.py
+++ b/tests/common/factories/user.py
@@ -48,4 +48,5 @@ class User(ModelFactory):
     authority = "example.com"
     username = factory.LazyAttribute(unique_username)
     email = factory.LazyAttribute(unique_email)
+    display_name = factory.Faker("name")
     registered_date = factory.Faker("date_time_this_decade")

--- a/tests/functional/api/groups/test_update.py
+++ b/tests/functional/api/groups/test_update.py
@@ -170,7 +170,7 @@ class TestUpdateGroup:
         headers["X-Forwarded-User"] = third_party_user.userid
         group_payload = {
             "name": "My Group",
-            "groupid": "group:333vcdfkj~@thirdparty.com",
+            "groupid": "group:98762557@thirdparty.com",
         }
 
         path = "/api/groups/{id}".format(id=group.pubid)
@@ -178,9 +178,7 @@ class TestUpdateGroup:
 
         assert res.status_code == 200
         assert "groupid" in res.json_body
-        assert res.json_body["groupid"] == "group:{groupid}@thirdparty.com".format(
-            groupid="333vcdfkj~"
-        )
+        assert res.json_body["groupid"] == "group:98762557@thirdparty.com"
 
     def test_it_returns_HTTP_Conflict_if_groupid_is_duplicate(
         self, app, auth_client_header, third_party_user, factories, db_session
@@ -188,18 +186,18 @@ class TestUpdateGroup:
         group1 = factories.Group(
             creator=third_party_user,
             authority=third_party_user.authority,
-            groupid="group:one@thirdparty.com",
+            groupid="group:update_one@thirdparty.com",
         )
         group2 = factories.Group(
             creator=third_party_user,
             authority=third_party_user.authority,
-            groupid="group:two@thirdparty.com",
+            groupid="group:update_two@thirdparty.com",
         )
         db_session.commit()
 
         headers = auth_client_header
         headers["X-Forwarded-User"] = third_party_user.userid
-        group_payload = {"groupid": "group:one@thirdparty.com"}
+        group_payload = {"groupid": "group:update_one@thirdparty.com"}
 
         # Attempting to set group2's `groupid` to one already taken by group1
         path = "/api/groups/{id}".format(id=group2.pubid)

--- a/tests/functional/api/groups/test_upsert.py
+++ b/tests/functional/api/groups/test_upsert.py
@@ -137,7 +137,7 @@ class TestUpsertGroupUpdate:
         headers["X-Forwarded-User"] = third_party_user.userid
         group_payload = {
             "name": "My Group",
-            "groupid": "group:333vcdfkj~@thirdparty.com",
+            "groupid": "group:34567845@thirdparty.com",
         }
 
         path = "/api/groups/{id}".format(id=group.pubid)
@@ -145,9 +145,7 @@ class TestUpsertGroupUpdate:
 
         assert res.status_code == 200
         assert "groupid" in res.json_body
-        assert res.json_body["groupid"] == "group:{groupid}@thirdparty.com".format(
-            groupid="333vcdfkj~"
-        )
+        assert res.json_body["groupid"] == "group:34567845@thirdparty.com"
 
     def test_it_supersedes_groupid_with_value_in_payload(
         self, app, auth_client_header, third_party_user, factories, db_session
@@ -183,18 +181,21 @@ class TestUpsertGroupUpdate:
         group1 = factories.Group(
             creator=third_party_user,
             authority=third_party_user.authority,
-            groupid="group:one@thirdparty.com",
+            groupid="group:upsert_one@thirdparty.com",
         )
         group2 = factories.Group(
             creator=third_party_user,
             authority=third_party_user.authority,
-            groupid="group:two@thirdparty.com",
+            groupid="group:upsert_two@thirdparty.com",
         )
         db_session.commit()
 
         headers = auth_client_header
         headers["X-Forwarded-User"] = third_party_user.userid
-        group_payload = {"name": "Whatnot", "groupid": "group:one@thirdparty.com"}
+        group_payload = {
+            "name": "Whatnot",
+            "groupid": "group:upsert_one@thirdparty.com",
+        }
 
         # Attempting to set group2's `groupid` to one already taken by group1
         path = "/api/groups/{id}".format(id=group2.pubid)

--- a/tests/functional/api/test_bulk.py
+++ b/tests/functional/api/test_bulk.py
@@ -8,6 +8,7 @@ from h_matchers import Any
 from h.models import Group, GroupMembership, User
 
 
+@pytest.mark.usefixtures("with_clean_db")
 class TestBulk:
     AUTHORITY = "lms.hypothes.is"
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -24,23 +24,33 @@ TEST_SETTINGS = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def app(pyramid_app, db_engine):
+    return TestApp(pyramid_app)
+
+
+@pytest.fixture(autouse=True)
+def reset_app(app):
+    yield
+
+    app.reset()
+
+
+@pytest.fixture(autouse=True)
+def clean_db(db_engine):
     from h import db
 
     _clean_database(db_engine)
     db.init(db_engine, authority=TEST_SETTINGS["h.authority"])
-
-    return TestApp(pyramid_app)
 
 
 @pytest.fixture(scope="session")
 def db_engine():
     from h import db
 
-    engine = db.make_engine(TEST_SETTINGS)
-    yield engine
-    engine.dispose()
+    db_engine = db.make_engine(TEST_SETTINGS)
+    yield db_engine
+    db_engine.dispose()
 
 
 @pytest.fixture

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -57,7 +57,7 @@ def db_engine():
     from h import db
 
     db_engine = db.make_engine(TEST_SETTINGS)
-    db.init(db_engine, authority=TEST_SETTINGS["h.authority"])
+    db.init(db_engine, authority=TEST_SETTINGS["h.authority"], should_create=True)
 
     yield db_engine
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -8,7 +8,7 @@ class TestAccountSettings:
         res = app.get("/account/settings")
 
         email_form = res.forms["email"]
-        email_form["email"] = "new_email@example.com"
+        email_form["email"] = "new_email1@example.com"
         email_form["password"] = "pass"
 
         res = email_form.submit().follow()
@@ -19,7 +19,7 @@ class TestAccountSettings:
         res = app.get("/account/settings")
 
         email_form = res.forms["email"]
-        email_form["email"] = "new_email@example.com"
+        email_form["email"] = "new_email2@example.com"
         email_form["password"] = "pass"
 
         res = email_form.submit(xhr=True, status=200)
@@ -30,7 +30,7 @@ class TestAccountSettings:
         res = app.get("/account/settings")
 
         email_form = res.forms["email"]
-        email_form["email"] = "new_email@example.com"
+        email_form["email"] = "new_email3@example.com"
         email_form["password"] = "pass"
 
         res = email_form.submit(xhr=True)

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -1035,7 +1035,7 @@ class TestUserSearchController:
         result = controller.search()
 
         assert result["zero_message"] == (
-            "{name} has not made any annotations yet.".format(name=user.username)
+            "{name} has not made any annotations yet.".format(name=user.display_name)
         )
 
     def test_search_shows_the_getting_started_box_when_on_your_own_page(


### PR DESCRIPTION
This changes the functional tests to only clear the DB if the `with_clean_db` fixture is used. At the moment this is only used in the BulkAPI tests, as I didn't have time to work it out.

This has a few consequences:

 * Much faster execution time (2m35s -> 25s for me ~6x)
 * Most tested are now _not_ isolated
 * This means tests can be sensitive to each other / order

### Practical observations from fixing this

 * Most problems with tests are because they use fixed values and copy paste
 * Therefore using properly fixtured tests with factories and fakers, basically fixes it in all cases so far
 * IMHO, being able to run the tests 6 times faster is worth the cost of thinking about interactions