### PR TITLE
Fix pylint's no-self-use

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -233,11 +233,11 @@ class AuthClientPolicy:
         """
         return self._basic_auth_policy.effective_principals(request)
 
-    def remember(self, _request, _userid, **_kwargs):
+    def remember(self, _request, _userid, **_kwargs):  # pylint: disable=no-self-use
         """Not implemented for basic auth client policy."""
         return []
 
-    def forget(self, _request):
+    def forget(self, _request):  # pylint: disable=no-self-use
         """Not implemented for basic auth client policy."""
         return []
 
@@ -317,15 +317,15 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
         self.callback = callback
         self.debug = debug
 
-    def remember(self, _request, _userid, **_kwargs):
+    def remember(self, _request, _userid, **_kwargs):  # pylint: disable=no-self-use
         """Not implemented for token auth policy."""
         return []
 
-    def forget(self, _request):
+    def forget(self, _request):  # pylint: disable=no-self-use
         """Not implemented for token auth policy."""
         return []
 
-    def unauthenticated_userid(self, request):
+    def unauthenticated_userid(self, request):  # pylint: disable=no-self-use
         """
         Return the userid implied by the token in the passed request, if any.
 

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -153,7 +153,7 @@ class Group(Base, mixins.Timestamps):
     organization = sa.orm.relationship("Organization")
 
     @sa.orm.validates("name")
-    def validate_name(self, _key, name):
+    def validate_name(self, _key, name):  # pylint:disable=no-self-use
         if not GROUP_NAME_MIN_LENGTH <= len(name) <= GROUP_NAME_MAX_LENGTH:
             raise ValueError(
                 "name must be between {min} and {max} characters "
@@ -162,7 +162,9 @@ class Group(Base, mixins.Timestamps):
         return name
 
     @sa.orm.validates("authority_provided_id")
-    def validate_authority_provided_id(self, _key, authority_provided_id):
+    def validate_authority_provided_id(  # pylint:disable=no-self-use
+        self, _key, authority_provided_id
+    ):
         if not authority_provided_id:
             return None
 

--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -25,7 +25,7 @@ class Organization(Base, mixins.Timestamps):
     authority = sa.Column(sa.UnicodeText(), nullable=False)
 
     @sa.orm.validates("name")
-    def validate_name(self, _key, name):
+    def validate_name(self, _key, name):  # pylint: disable=no-self-use
         if not (
             Organization.NAME_MIN_CHARS <= len(name) <= Organization.NAME_MAX_CHARS
         ):

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -126,7 +126,7 @@ class User(Base):
     __tablename__ = "user"
 
     @declared_attr
-    def __table_args__(cls):  # noqa: N805 pylint:disable=no-self-argument
+    def __table_args__(cls):  # noqa: N805 pylint:disable=no-self-argument, no-self-use
         return (
             # (email, authority) must be unique
             sa.UniqueConstraint("email", "authority"),
@@ -277,7 +277,7 @@ class User(Base):
     salt = sa.Column(sa.UnicodeText(), nullable=True)
 
     @sa.orm.validates("email")
-    def validate_email(self, _key, email):
+    def validate_email(self, _key, email):  # pylint:disable=no-self-use
         if email is None:
             return email
 
@@ -289,7 +289,7 @@ class User(Base):
         return email
 
     @sa.orm.validates("_username")
-    def validate_username(self, _key, username):
+    def validate_username(self, _key, username):  # pylint: disable=no-self-use
         if not USERNAME_MIN_LENGTH <= len(username) <= USERNAME_MAX_LENGTH:
             raise ValueError(
                 "username must be between {min} and {max} "

--- a/h/realtime.py
+++ b/h/realtime.py
@@ -53,7 +53,8 @@ class Consumer(ConsumerMixin):
         message.ack()
         self.handler(body)
 
-    def _random_id(self):
+    @staticmethod
+    def _random_id():
         """Generate a short random string"""
         data = struct.pack("Q", random.getrandbits(64))
         return base64.urlsafe_b64encode(data).strip(b"=")

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -441,7 +441,8 @@ class SearchParamsSchema(colander.Schema):
             # offset must be set to 0 if search_after is specified.
             cstruct["offset"] = 0
 
-    def _date_is_parsable(self, value):
+    @staticmethod
+    def _date_is_parsable(value):
         """Return True if date is parsable and False otherwise."""
 
         # Dates like "2017" can also be cast as floats so if a number is less

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -96,7 +96,8 @@ class GroupAPISchema(JSONSchema):
                 )
             )
 
-    def _whitelisted_fields_only(self, appstruct):
+    @staticmethod
+    def _whitelisted_fields_only(appstruct):
         """Return a new appstruct containing only schema-defined fields"""
 
         new_appstruct = {}

--- a/h/schemas/api/user.py
+++ b/h/schemas/api/user.py
@@ -70,7 +70,8 @@ class UpdateUserAPISchema(JSONSchema):
         appstruct = self._whitelisted_properties_only(appstruct)
         return appstruct
 
-    def _whitelisted_properties_only(self, appstruct):
+    @staticmethod
+    def _whitelisted_properties_only(appstruct):
         """Return a new appstruct containing only schema-defined fields"""
 
         new_appstruct = {}

--- a/h/schemas/base.py
+++ b/h/schemas/base.py
@@ -36,7 +36,7 @@ class CSRFSchema(colander.Schema):
         missing=None,
     )
 
-    def validator(self, node, _value):
+    def validator(self, node, _value):  # pylint: disable=no-self-use
         request = node.bindings["request"]
         check_csrf_token(request)
 
@@ -84,7 +84,7 @@ def enum_type(enum_cls):
     """
 
     class EnumType(colander.SchemaType):
-        def deserialize(self, node, cstruct):
+        def deserialize(self, node, cstruct):  # pylint: disable= no-self-use
             if cstruct == colander.null:
                 return None
 
@@ -94,7 +94,7 @@ def enum_type(enum_cls):
                 msg = '"{}" is not a known value'.format(cstruct)
                 raise colander.Invalid(node, msg) from err
 
-        def serialize(self, _node, appstruct):
+        def serialize(self, _node, appstruct):  # pylint: disable= no-self-use
             if not appstruct:
                 return ""
             return appstruct.name

--- a/h/schemas/forms/accounts/reset_password.py
+++ b/h/schemas/forms/accounts/reset_password.py
@@ -13,7 +13,7 @@ _ = i18n.TranslationString
 class ResetCode(colander.SchemaType):
     """Schema type transforming a reset code to a user and back."""
 
-    def serialize(self, node, appstruct):
+    def serialize(self, node, appstruct):  # pylint: disable=no-self-use
         if appstruct is colander.null:
             return colander.null
         if not isinstance(appstruct, models.User):
@@ -22,7 +22,7 @@ class ResetCode(colander.SchemaType):
         serializer = request.registry.password_reset_serializer
         return serializer.dumps(appstruct.username)
 
-    def deserialize(self, node, cstruct):
+    def deserialize(self, node, cstruct):  # pylint: disable=no-self-use
         if cstruct is colander.null:
             return colander.null
 

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -50,7 +50,8 @@ class Limiter:
         ending_offset = starting_offset + self._extract_limit(params)
         return search[starting_offset:ending_offset]
 
-    def _extract_offset(self, params):
+    @staticmethod
+    def _extract_offset(params):
         offset = params.pop("offset", 0)
         try:
             val = int(offset)
@@ -61,7 +62,8 @@ class Limiter:
             return 0
         return val
 
-    def _extract_limit(self, params):
+    @staticmethod
+    def _extract_limit(params):
         limit = params.pop("limit", LIMIT_DEFAULT)
         try:
             val = int(limit)
@@ -118,7 +120,8 @@ class Sorter:
             }
         )
 
-    def _parse_date(self, str_value):
+    @staticmethod
+    def _parse_date(str_value):
         """
         Converts a string to a float representing miliseconds since the epoch.
 
@@ -291,7 +294,8 @@ class UriCombinedWildcardFilter:
             uris.update(us)
         return list(uris)
 
-    def _wildcard_uri_normalized(self, wildcard_uri):
+    @staticmethod
+    def _wildcard_uri_normalized(wildcard_uri):
         """
         Same as uri.normalized but it replaces _'s with ?'s after normalization.
 

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -5,7 +5,8 @@ class AnnotationModerationService:
     def __init__(self, session):
         self.session = session
 
-    def hidden(self, annotation):
+    @staticmethod
+    def hidden(annotation):
         """
         Check if an annotation id is hidden.
 
@@ -55,7 +56,8 @@ class AnnotationModerationService:
 
         annotation.moderation = models.AnnotationModeration()
 
-    def unhide(self, annotation):
+    @staticmethod
+    def unhide(annotation):
         """
         Show a hidden annotation again to other users.
 

--- a/h/services/delete_user.py
+++ b/h/services/delete_user.py
@@ -63,7 +63,8 @@ class DeleteUserService:
         for group in groups:
             self.request.db.delete(group)
 
-    def _unassign_groups_creator(self, groups):
+    @staticmethod
+    def _unassign_groups_creator(groups):
         for group in groups:
             group.creator = None
 

--- a/h/services/developer_token.py
+++ b/h/services/developer_token.py
@@ -71,7 +71,8 @@ class DeveloperTokenService:
             .one_or_none()
         )
 
-    def _generate_token(self):
+    @staticmethod
+    def _generate_token():
         return PREFIX + security.token_urlsafe()
 
 

--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -142,7 +142,8 @@ class GroupCreateService:
 
         return group
 
-    def _validate_authorities_match(self, group_authority, org_authority):
+    @staticmethod
+    def _validate_authorities_match(group_authority, org_authority):
         if group_authority != org_authority:
             raise ValueError(
                 "Organization's authority {} must match the group creator's authority {}.".format(

--- a/h/services/group_list.py
+++ b/h/services/group_list.py
@@ -205,7 +205,8 @@ class GroupListService:
             .one_or_none()
         )
 
-    def _sort(self, groups):
+    @staticmethod
+    def _sort(groups):
         """sort a list of groups of a single type"""
         return sorted(groups, key=lambda group: (group.name.lower(), group.pubid))
 

--- a/h/services/oauth_provider.py
+++ b/h/services/oauth_provider.py
@@ -126,10 +126,12 @@ class OAuthProviderService(AuthorizationEndpoint, RevocationEndpoint, TokenEndpo
         else:
             raise InvalidRefreshTokenError()
 
-    def generate_access_token(self, _oauth_request):
+    @staticmethod
+    def generate_access_token(oauth_request):
         return ACCESS_TOKEN_PREFIX + token_urlsafe()
 
-    def generate_refresh_token(self, _oauth_request):
+    @staticmethod
+    def generate_refresh_token(_oauth_request):
         return REFRESH_TOKEN_PREFIX + token_urlsafe()
 
 

--- a/h/services/search_index/service.py
+++ b/h/services/search_index/service.py
@@ -65,7 +65,8 @@ class SearchIndexService:
 
         self._index_annotation_body(annotation.id, body, refresh=False)
 
-    def add_annotations_between_times(self, start_time, end_time, tag):
+    @staticmethod
+    def add_annotations_between_times(start_time, end_time, tag):
         """
         Add all annotations between two times to the search index.
 
@@ -78,13 +79,15 @@ class SearchIndexService:
         """
         indexer.add_annotations_between_times.delay(start_time, end_time, tag)
 
-    def add_users_annotations(self, userid, tag, force=False, schedule_in=None):
+    @staticmethod
+    def add_users_annotations(userid, tag, force=False, schedule_in=None):
         """Add all of a users annotations to the search index."""
         indexer.add_users_annotations.delay(
             userid, tag, force=force, schedule_in=schedule_in
         )
 
-    def add_group_annotations(self, groupid, tag, force=False, schedule_in=None):
+    @staticmethod
+    def add_group_annotations(groupid, tag, force=False, schedule_in=None):
         """Add all annotations in a group to the search index."""
         indexer.add_group_annotations.delay(
             groupid, tag, force=force, schedule_in=schedule_in

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -163,7 +163,8 @@ class UserService:
 
         return user
 
-    def update_preferences(self, user, **kwargs):
+    @staticmethod
+    def update_preferences(user, **kwargs):
         invalid_keys = set(kwargs.keys()) - UPDATE_PREFS_ALLOWED_KEYS
         if invalid_keys:
             keys = ", ".join(sorted(invalid_keys))

--- a/h/util/markdown.py
+++ b/h/util/markdown.py
@@ -80,10 +80,10 @@ class MathBlockLexer(mistune.BlockLexer):
 
 
 class MathRenderer(mistune.Renderer):
-    def block_math(self, text):
+    def block_math(self, text):  # pylint: disable=no-self-use
         return "<p>$$%s$$</p>\n" % text
 
-    def inline_math(self, text):
+    def inline_math(self, text):  # pylint: disable=no-self-use
         return "\\(%s\\)" % text
 
 

--- a/h/views/admin/search.py
+++ b/h/views/admin/search.py
@@ -22,7 +22,7 @@ class SearchAdminViews:
         self.request = request
 
     @view_config(request_method="GET", renderer="h:templates/admin/search.html.jinja2")
-    def get(self):
+    def get(self):  # pylint: disable=no-self-use
         return {}
 
     @view_config(


### PR DESCRIPTION
It might seem a bit random but I added the inline `disable` for methods that are part of an interface or similar.