### PR TITLE
Use standard names for things in the formatters

### DIFF
--- a/h/formatters/annotation_flag.py
+++ b/h/formatters/annotation_flag.py
@@ -24,8 +24,8 @@ class AnnotationFlagFormatter:
         self._cache.update(flags)
         return flags
 
-    def format(self, annotation_resource):
-        flagged = self._load(annotation_resource.annotation)
+    def format(self, annotation_context):
+        flagged = self._load(annotation_context.annotation)
         return {"flagged": flagged}
 
     def _load(self, annotation):

--- a/h/formatters/annotation_flag.py
+++ b/h/formatters/annotation_flag.py
@@ -14,13 +14,18 @@ class AnnotationFlagFormatter:
         # instances because we only store the annotation id and a boolean flag.
         self._cache = {}
 
-    def preload(self, ids):
+    def preload(self, annotation_ids):
         if self.user is None:
             return
 
-        flagged_ids = self.flag_service.all_flagged(user=self.user, annotation_ids=ids)
+        flagged_ids = self.flag_service.all_flagged(
+            user=self.user, annotation_ids=annotation_ids
+        )
 
-        flags = {id_: (id_ in flagged_ids) for id_ in ids}
+        flags = {
+            annotation_id: (annotation_id in flagged_ids)
+            for annotation_id in annotation_ids
+        }
         self._cache.update(flags)
         return flags
 

--- a/h/formatters/annotation_hidden.py
+++ b/h/formatters/annotation_hidden.py
@@ -30,9 +30,9 @@ class AnnotationHiddenFormatter:
         self._cache.update(hidden)
         return hidden
 
-    def format(self, annotation_resource):
-        annotation = annotation_resource.annotation
-        group = annotation_resource.group
+    def format(self, annotation_context):
+        annotation = annotation_context.annotation
+        group = annotation_context.group
 
         if self._current_user_is_moderator(group):
             return {"hidden": self._is_hidden(annotation)}

--- a/h/formatters/annotation_hidden.py
+++ b/h/formatters/annotation_hidden.py
@@ -23,10 +23,13 @@ class AnnotationHiddenFormatter:
         # instances because we only store the annotation id and a boolean flag.
         self._cache = {}
 
-    def preload(self, ids):
-        hidden_ids = self._moderation_svc.all_hidden(ids)
+    def preload(self, annotation_ids):
+        hidden_ids = self._moderation_svc.all_hidden(annotation_ids)
 
-        hidden = {id_: (id_ in hidden_ids) for id_ in ids}
+        hidden = {
+            annotation_id: (annotation_id in hidden_ids)
+            for annotation_id in annotation_ids
+        }
         self._cache.update(hidden)
         return hidden
 

--- a/h/formatters/annotation_moderation.py
+++ b/h/formatters/annotation_moderation.py
@@ -20,14 +20,14 @@ class AnnotationModerationFormatter:
         # instances because we only store the annotation id and a count.
         self._cache = {}
 
-    def preload(self, ids):
+    def preload(self, annotation_ids):
         if self._user is None:
             return
 
-        if not ids:
+        if not annotation_ids:
             return
 
-        flag_counts = self._flag_count_svc.flag_counts(ids)
+        flag_counts = self._flag_count_svc.flag_counts(annotation_ids)
         self._cache.update(flag_counts)
         return flag_counts
 

--- a/h/formatters/annotation_moderation.py
+++ b/h/formatters/annotation_moderation.py
@@ -31,13 +31,13 @@ class AnnotationModerationFormatter:
         self._cache.update(flag_counts)
         return flag_counts
 
-    def format(self, annotation_resource):
+    def format(self, annotation_context):
         if not self._has_permission(
-            Permission.Group.MODERATE, annotation_resource.group
+            Permission.Group.MODERATE, annotation_context.group
         ):
             return {}
 
-        flag_count = self._load(annotation_resource.annotation)
+        flag_count = self._load(annotation_context.annotation)
         return {"moderation": {"flagCount": flag_count}}
 
     def _load(self, annotation):

--- a/h/formatters/annotation_user_info.py
+++ b/h/formatters/annotation_user_info.py
@@ -19,6 +19,6 @@ class AnnotationUserInfoFormatter:
         }
         self.user_svc.fetch_all(userids)
 
-    def format(self, annotation_resource):
-        user = self.user_svc.fetch(annotation_resource.annotation.userid)
+    def format(self, annotation_context):
+        user = self.user_svc.fetch(annotation_context.annotation.userid)
         return user_info(user)

--- a/h/formatters/annotation_user_info.py
+++ b/h/formatters/annotation_user_info.py
@@ -7,14 +7,14 @@ class AnnotationUserInfoFormatter:
         self.session = session
         self.user_svc = user_svc
 
-    def preload(self, ids):
-        if not ids:
+    def preload(self, annotation_ids):
+        if not annotation_ids:
             return
 
         userids = {
             t[0]
             for t in self.session.query(models.Annotation.userid).filter(
-                models.Annotation.id.in_(ids)
+                models.Annotation.id.in_(annotation_ids)
             )
         }
         self.user_svc.fetch_all(userids)

--- a/h/presenters/annotation_base.py
+++ b/h/presenters/annotation_base.py
@@ -6,9 +6,9 @@ from h.util.datetime import utc_iso8601
 
 
 class AnnotationBasePresenter:
-    def __init__(self, annotation_resource):
-        self.annotation_resource = annotation_resource
-        self.annotation = annotation_resource.annotation
+    def __init__(self, annotation_context):
+        self.annotation_context = annotation_context
+        self.annotation = annotation_context.annotation
 
     @property
     def created(self):
@@ -23,7 +23,7 @@ class AnnotationBasePresenter:
     @property
     def links(self):
         """A dictionary of named hypermedia links for this annotation."""
-        return self.annotation_resource.links
+        return self.annotation_context.links
 
     @property
     def text(self):

--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -12,8 +12,8 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
 
     """Present an annotation in the JSON format returned by API requests."""
 
-    def __init__(self, annotation_resource, formatters=None):
-        super().__init__(annotation_resource)
+    def __init__(self, annotation_context, formatters=None):
+        super().__init__(annotation_context)
 
         self._formatters = []
 
@@ -45,7 +45,7 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
         annotation.update(base)
 
         for formatter in self._formatters:
-            annotation.update(formatter.format(self.annotation_resource))
+            annotation.update(formatter.format(self.annotation_context))
 
         return annotation
 
@@ -63,7 +63,7 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
             read = "group:{}".format(self.annotation.groupid)
 
             principals = principals_allowed_by_permission(
-                self.annotation_resource, Permission.Annotation.READ
+                self.annotation_context, Permission.Annotation.READ
             )
             if security.Everyone in principals:
                 read = "group:__world__"

--- a/h/presenters/annotation_jsonld.py
+++ b/h/presenters/annotation_jsonld.py
@@ -26,7 +26,7 @@ class AnnotationJSONLDPresenter(AnnotationBasePresenter):
 
     @property
     def id(self):
-        return self.annotation_resource.link("jsonld_id")
+        return self.annotation_context.link("jsonld_id")
 
     @property
     def bodies(self):

--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -36,8 +36,8 @@ class AnnotationJSONPresentationService:
             formatters.AnnotationUserInfoFormatter(self.session, user_svc),
         ]
 
-    def present(self, annotation_resource):
-        return AnnotationJSONPresenter(annotation_resource, self.formatters).asdict()
+    def present(self, annotation_context):
+        return AnnotationJSONPresenter(annotation_context, self.formatters).asdict()
 
     def present_all(self, annotation_ids):
         def eager_load_documents(query):

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -78,8 +78,8 @@ def create(request):
     _publish_annotation_event(request, annotation, "create")
 
     svc = request.find_service(name="annotation_json_presentation")
-    annotation_resource = _annotation_resource(request, annotation)
-    return svc.present(annotation_resource)
+    annotation_context = _annotation_context(request, annotation)
+    return svc.present(annotation_context)
 
 
 @api_config(
@@ -135,8 +135,8 @@ def update(context, request):
     _publish_annotation_event(request, annotation, "update")
 
     svc = request.find_service(name="annotation_json_presentation")
-    annotation_resource = _annotation_resource(request, annotation)
-    return svc.present(annotation_resource)
+    annotation_context = _annotation_context(request, annotation)
+    return svc.present(annotation_context)
 
 
 @api_config(
@@ -174,7 +174,7 @@ def _publish_annotation_event(request, annotation, action):
     request.notify_after_commit(event)
 
 
-def _annotation_resource(request, annotation):
+def _annotation_context(request, annotation):
     group_service = request.find_service(IGroupService)
     links_service = request.find_service(name="links")
     return AnnotationContext(annotation, group_service, links_service)

--- a/tests/h/formatters/annotation_flag_test.py
+++ b/tests/h/formatters/annotation_flag_test.py
@@ -23,21 +23,21 @@ class TestAnnotationFlagFormatter:
 
     def test_format_for_existing_flag(self, formatter, factories, current_user):
         flag = factories.Flag(user=current_user)
-        annotation_resource = FakeAnnotationContext(flag.annotation)
-        assert formatter.format(annotation_resource) == {"flagged": True}
+        annotation_context = FakeAnnotationContext(flag.annotation)
+        assert formatter.format(annotation_context) == {"flagged": True}
 
     def test_format_for_missing_flag(self, formatter, factories):
         annotation = factories.Annotation()
-        annotation_resource = FakeAnnotationContext(annotation)
+        annotation_context = FakeAnnotationContext(annotation)
 
-        assert formatter.format(annotation_resource) == {"flagged": False}
+        assert formatter.format(annotation_context) == {"flagged": False}
 
     def test_format_for_unauthenticated_user(self, flag_service, factories):
         annotation = factories.Annotation()
-        annotation_resource = FakeAnnotationContext(annotation)
+        annotation_context = FakeAnnotationContext(annotation)
         formatter = AnnotationFlagFormatter(flag_service, user=None)
 
-        assert formatter.format(annotation_resource) == {"flagged": False}
+        assert formatter.format(annotation_context) == {"flagged": False}
 
     @pytest.fixture
     def current_user(self, factories):

--- a/tests/h/formatters/annotation_hidden_test.py
+++ b/tests/h/formatters/annotation_hidden_test.py
@@ -36,14 +36,14 @@ class TestAnonymousUserHiding:
     """An anonymous user will see redacted annotations when they're hidden."""
 
     def test_format_for_unhidden_annotation(self, formatter, annotation, group):
-        resource = FakeAnnotationContext(annotation, group)
-        assert formatter.format(resource) == {"hidden": False}
+        context = FakeAnnotationContext(annotation, group)
+        assert formatter.format(context) == {"hidden": False}
 
     def test_format_for_hidden_annotation(self, formatter, hidden_annotation, group):
-        resource = FakeAnnotationContext(hidden_annotation, group)
+        context = FakeAnnotationContext(hidden_annotation, group)
 
         censored = {"hidden": True, "text": "", "tags": []}
-        assert formatter.format(resource) == censored
+        assert formatter.format(context) == censored
 
     @pytest.fixture
     def current_user(self):
@@ -54,18 +54,18 @@ class TestNonAuthorHiding:
     """Regular users see redacted annotations, unless they are a moderator."""
 
     def test_format_for_unhidden_annotation(self, formatter, annotation, group):
-        resource = FakeAnnotationContext(annotation, group)
-        assert formatter.format(resource) == {"hidden": False}
+        context = FakeAnnotationContext(annotation, group)
+        assert formatter.format(context) == {"hidden": False}
 
     def test_format_for_non_moderator(self, formatter, hidden_annotation, group):
-        resource = FakeAnnotationContext(hidden_annotation, group)
+        context = FakeAnnotationContext(hidden_annotation, group)
 
         censored = {"hidden": True, "text": "", "tags": []}
-        assert formatter.format(resource) == censored
+        assert formatter.format(context) == censored
 
     def test_format_for_moderator(self, formatter, hidden_annotation, moderated_group):
-        resource = FakeAnnotationContext(hidden_annotation, moderated_group)
-        assert formatter.format(resource) == {"hidden": True}
+        context = FakeAnnotationContext(hidden_annotation, moderated_group)
+        assert formatter.format(context) == {"hidden": True}
 
 
 class TestAuthorHiding:
@@ -75,16 +75,16 @@ class TestAuthorHiding:
     """
 
     def test_format_for_public_annotation(self, formatter, annotation, group):
-        resource = FakeAnnotationContext(annotation, group)
-        assert formatter.format(resource) == {"hidden": False}
+        context = FakeAnnotationContext(annotation, group)
+        assert formatter.format(context) == {"hidden": False}
 
     def test_format_for_non_moderator(self, formatter, hidden_annotation, group):
-        resource = FakeAnnotationContext(hidden_annotation, group)
-        assert formatter.format(resource) == {"hidden": False}
+        context = FakeAnnotationContext(hidden_annotation, group)
+        assert formatter.format(context) == {"hidden": False}
 
     def test_format_for_moderator(self, formatter, hidden_annotation, moderated_group):
-        resource = FakeAnnotationContext(hidden_annotation, moderated_group)
-        assert formatter.format(resource) == {"hidden": True}
+        context = FakeAnnotationContext(hidden_annotation, moderated_group)
+        assert formatter.format(context) == {"hidden": True}
 
     @pytest.fixture
     def annotation(self, factories, current_user):

--- a/tests/h/formatters/annotation_moderation_test.py
+++ b/tests/h/formatters/annotation_moderation_test.py
@@ -41,27 +41,27 @@ class TestAnnotationModerationFormatter:
         formatter = AnnotationModerationFormatter(
             flag_count_svc, user, permission_denied
         )
-        annotation_resource = FakeAnnotationContext(flagged, group)
+        annotation_context = FakeAnnotationContext(flagged, group)
 
-        assert formatter.format(annotation_resource) == {}
+        assert formatter.format(annotation_context) == {}
 
     def test_format_returns_flag_count_for_moderator(self, formatter, group, flagged):
-        annotation_resource = FakeAnnotationContext(flagged, group)
+        annotation_context = FakeAnnotationContext(flagged, group)
 
-        output = formatter.format(annotation_resource)
+        output = formatter.format(annotation_context)
         assert output == {"moderation": {"flagCount": 2}}
 
     def test_format_returns_zero_flag_count(self, formatter, group, unflagged):
-        annotation_resource = FakeAnnotationContext(unflagged, group)
+        annotation_context = FakeAnnotationContext(unflagged, group)
 
-        output = formatter.format(annotation_resource)
+        output = formatter.format(annotation_context)
         assert output == {"moderation": {"flagCount": 0}}
 
     def test_format_for_preloaded_annotation(self, formatter, group, flagged):
-        annotation_resource = FakeAnnotationContext(flagged, group)
+        annotation_context = FakeAnnotationContext(flagged, group)
 
         formatter.preload([flagged.id])
-        output = formatter.format(annotation_resource)
+        output = formatter.format(annotation_context)
         assert output == {"moderation": {"flagCount": 2}}
 
     @pytest.fixture

--- a/tests/h/formatters/annotation_user_info_test.py
+++ b/tests/h/formatters/annotation_user_info_test.py
@@ -25,9 +25,9 @@ class TestAnnotationUserInfoFormatter:
 
     def test_format_fetches_user_by_id(self, formatter, factories, user_svc):
         annotation = factories.Annotation.build()
-        resource = FakeAnnotationContext(annotation)
+        context = FakeAnnotationContext(annotation)
 
-        formatter.format(resource)
+        formatter.format(context)
 
         user_svc.fetch.assert_called_once_with(annotation.userid)
 

--- a/tests/h/presenters/annotation_base_test.py
+++ b/tests/h/presenters/annotation_base_test.py
@@ -7,79 +7,79 @@ from h.presenters.annotation_base import AnnotationBasePresenter, utc_iso8601
 class TestAnnotationBasePresenter:
     def test_constructor_args(self):
         annotation = mock.Mock()
-        resource = mock.Mock(annotation=annotation)
+        context = mock.Mock(annotation=annotation)
 
-        presenter = AnnotationBasePresenter(resource)
+        presenter = AnnotationBasePresenter(context)
 
-        assert presenter.annotation_resource == resource
+        assert presenter.annotation_context == context
         assert presenter.annotation == annotation
 
     def test_created_returns_none_if_missing(self):
         annotation = mock.Mock(created=None)
-        resource = mock.Mock(annotation=annotation)
+        context = mock.Mock(annotation=annotation)
 
-        created = AnnotationBasePresenter(resource).created
+        created = AnnotationBasePresenter(context).created
 
         assert created is None
 
     def test_created_uses_iso_format(self):
         when = datetime.datetime(2012, 3, 14, 23, 34, 47, 12)
         annotation = mock.Mock(created=when)
-        resource = mock.Mock(annotation=annotation)
+        context = mock.Mock(annotation=annotation)
 
-        created = AnnotationBasePresenter(resource).created
+        created = AnnotationBasePresenter(context).created
 
         assert created == "2012-03-14T23:34:47.000012+00:00"
 
     def test_updated_returns_none_if_missing(self):
         annotation = mock.Mock(updated=None)
-        resource = mock.Mock(annotation=annotation)
+        context = mock.Mock(annotation=annotation)
 
-        updated = AnnotationBasePresenter(resource).updated
+        updated = AnnotationBasePresenter(context).updated
 
         assert updated is None
 
     def test_updated_uses_iso_format(self):
         when = datetime.datetime(1983, 8, 31, 7, 18, 20, 98763)
         annotation = mock.Mock(updated=when)
-        resource = mock.Mock(annotation=annotation)
+        context = mock.Mock(annotation=annotation)
 
-        updated = AnnotationBasePresenter(resource).updated
+        updated = AnnotationBasePresenter(context).updated
 
         assert updated == "1983-08-31T07:18:20.098763+00:00"
 
     def test_links(self):
         annotation = mock.Mock()
-        resource = mock.Mock(annotation=annotation)
+        context = mock.Mock(annotation=annotation)
 
-        links = AnnotationBasePresenter(resource).links
-        assert links == resource.links
+        links = AnnotationBasePresenter(context).links
+        assert links == context.links
 
     def test_text(self):
         annotation = mock.Mock(text="It is magical!")
-        resource = mock.Mock(annotation=annotation)
-        presenter = AnnotationBasePresenter(resource)
+        context = mock.Mock(annotation=annotation)
+        presenter = AnnotationBasePresenter(context)
 
         assert "It is magical!" == presenter.text
 
     def test_text_missing(self):
         annotation = mock.Mock(text=None)
-        resource = mock.Mock(annotation=annotation)
-        presenter = AnnotationBasePresenter(resource)
+        context = mock.Mock(annotation=annotation)
+        presenter = AnnotationBasePresenter(context)
 
         assert "" == presenter.text
 
     def test_tags(self):
         annotation = mock.Mock(tags=["interesting", "magic"])
-        resource = mock.Mock(annotation=annotation)
-        presenter = AnnotationBasePresenter(resource)
+        context = mock.Mock(annotation=annotation)
+        presenter = AnnotationBasePresenter(context)
 
         assert ["interesting", "magic"] == presenter.tags
 
     def test_tags_missing(self):
         annotation = mock.Mock(tags=None)
-        resource = mock.Mock(annotation=annotation)
-        presenter = AnnotationBasePresenter(resource)
+        context = mock.Mock(annotation=annotation)
+        presenter = AnnotationBasePresenter(context)
 
         assert [] == presenter.tags
 
@@ -88,7 +88,7 @@ class TestAnnotationBasePresenter:
             target_uri="http://example.com",
             target_selectors={"PositionSelector": {"start": 0, "end": 12}},
         )
-        resource = mock.Mock(annotation=annotation)
+        context = mock.Mock(annotation=annotation)
 
         expected = [
             {
@@ -96,15 +96,15 @@ class TestAnnotationBasePresenter:
                 "selector": {"PositionSelector": {"start": 0, "end": 12}},
             }
         ]
-        actual = AnnotationBasePresenter(resource).target
+        actual = AnnotationBasePresenter(context).target
         assert expected == actual
 
     def test_target_missing_selectors(self):
         annotation = mock.Mock(target_uri="http://example.com", target_selectors=None)
-        resource = mock.Mock(annotation=annotation)
+        context = mock.Mock(annotation=annotation)
 
         expected = [{"source": "http://example.com"}]
-        actual = AnnotationBasePresenter(resource).target
+        actual = AnnotationBasePresenter(context).target
         assert expected == actual
 
 

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -28,7 +28,7 @@ class TestAnnotationJSONPresenter:
             references=["referenced-id-1", "referenced-id-2"],
             extra={"extra-1": "foo", "extra-2": "bar"},
         )
-        resource = AnnotationContext(ann, groupfinder_service, links_service)
+        context = AnnotationContext(ann, groupfinder_service, links_service)
 
         document_asdict.return_value = {"foo": "bar"}
 
@@ -60,7 +60,7 @@ class TestAnnotationJSONPresenter:
             "extra-2": "bar",
         }
 
-        result = AnnotationJSONPresenter(resource).asdict()
+        result = AnnotationJSONPresenter(context).asdict()
 
         assert result == expected
 
@@ -68,10 +68,10 @@ class TestAnnotationJSONPresenter:
         self, document_asdict, groupfinder_service, links_service
     ):
         ann = mock.Mock(id="the-real-id", extra={"id": "the-extra-id"})
-        resource = AnnotationContext(ann, groupfinder_service, links_service)
+        context = AnnotationContext(ann, groupfinder_service, links_service)
         document_asdict.return_value = {}
 
-        presented = AnnotationJSONPresenter(resource).asdict()
+        presented = AnnotationJSONPresenter(context).asdict()
         assert presented["id"] == "the-real-id"
 
     def test_asdict_extra_uses_copy_of_extra(
@@ -79,10 +79,10 @@ class TestAnnotationJSONPresenter:
     ):
         extra = {"foo": "bar"}
         ann = mock.Mock(id="my-id", extra=extra)
-        resource = AnnotationContext(ann, groupfinder_service, links_service)
+        context = AnnotationContext(ann, groupfinder_service, links_service)
         document_asdict.return_value = {}
 
-        AnnotationJSONPresenter(resource).asdict()
+        AnnotationJSONPresenter(context).asdict()
 
         # Presenting the annotation shouldn't change the "extra" dict.
         assert extra == {"foo": "bar"}
@@ -91,9 +91,9 @@ class TestAnnotationJSONPresenter:
         self, groupfinder_service, links_service, get_formatter
     ):
         ann = mock.Mock(id="the-real-id", extra={})
-        resource = AnnotationContext(ann, groupfinder_service, links_service)
+        context = AnnotationContext(ann, groupfinder_service, links_service)
         presenter = AnnotationJSONPresenter(
-            resource,
+            context,
             formatters=[
                 get_formatter({"flagged": "nope"}),
                 get_formatter({"nipsa": "maybe"}),
@@ -116,26 +116,26 @@ class TestAnnotationJSONPresenter:
 
         """
         ann = mock.Mock(id="the-real-id", extra={})
-        resource = AnnotationContext(ann, groupfinder_service, links_service)
+        context = AnnotationContext(ann, groupfinder_service, links_service)
         formatters = []
 
-        presenter = AnnotationJSONPresenter(resource, formatters)
+        presenter = AnnotationJSONPresenter(context, formatters)
         formatters.append(get_formatter({"enterprise": "synergy"}))
         presented = presenter.asdict()
 
         assert "enterprise" not in presented
 
-    def test_formatter_uses_annotation_resource(
+    def test_formatter_uses_annotation_context(
         self, groupfinder_service, links_service, get_formatter
     ):
         annotation = mock.Mock(id="the-id", extra={})
-        resource = AnnotationContext(annotation, groupfinder_service, links_service)
+        context = AnnotationContext(annotation, groupfinder_service, links_service)
         formatter = get_formatter()
 
-        presenter = AnnotationJSONPresenter(resource, formatters=[formatter])
+        presenter = AnnotationJSONPresenter(context, formatters=[formatter])
         presenter.asdict()
 
-        formatter.format.assert_called_once_with(resource)
+        formatter.format.assert_called_once_with(context)
 
     @pytest.mark.usefixtures("policy")
     @pytest.mark.parametrize(
@@ -200,8 +200,8 @@ class TestAnnotationJSONPresenter:
         group.__acl__.return_value = [group_principals[group_readable]]
         groupfinder_service.find.return_value = group
 
-        resource = AnnotationContext(annotation, groupfinder_service, links_service)
-        presenter = AnnotationJSONPresenter(resource)
+        context = AnnotationContext(annotation, groupfinder_service, links_service)
+        presenter = AnnotationJSONPresenter(context)
         assert expected == presenter.permissions[action]
 
     @pytest.fixture

--- a/tests/h/presenters/annotation_jsonld_test.py
+++ b/tests/h/presenters/annotation_jsonld_test.py
@@ -42,15 +42,15 @@ class TestAnnotationJSONLDPresenter:
             ],
         }
 
-        resource = AnnotationContext(annotation, groupfinder_service, links_service)
-        result = AnnotationJSONLDPresenter(resource).asdict()
+        context = AnnotationContext(annotation, groupfinder_service, links_service)
+        result = AnnotationJSONLDPresenter(context).asdict()
 
         assert result == expected
 
     def test_id_returns_jsonld_id_link(self, groupfinder_service, links_service):
         annotation = mock.Mock(id="foobar")
-        resource = AnnotationContext(annotation, groupfinder_service, links_service)
-        presenter = AnnotationJSONLDPresenter(resource)
+        context = AnnotationContext(annotation, groupfinder_service, links_service)
+        presenter = AnnotationJSONLDPresenter(context)
 
         result = presenter.id
 
@@ -59,9 +59,9 @@ class TestAnnotationJSONLDPresenter:
 
     def test_bodies_returns_textual_body(self, groupfinder_service, links_service):
         annotation = mock.Mock(text="Flib flob flab", tags=None)
-        resource = AnnotationContext(annotation, groupfinder_service, links_service)
+        context = AnnotationContext(annotation, groupfinder_service, links_service)
 
-        bodies = AnnotationJSONLDPresenter(resource).bodies
+        bodies = AnnotationJSONLDPresenter(context).bodies
 
         assert bodies == [
             {
@@ -73,9 +73,9 @@ class TestAnnotationJSONLDPresenter:
 
     def test_bodies_appends_tag_bodies(self, groupfinder_service, links_service):
         annotation = mock.Mock(text="Flib flob flab", tags=["giraffe", "lion"])
-        resource = AnnotationContext(annotation, groupfinder_service, links_service)
+        context = AnnotationContext(annotation, groupfinder_service, links_service)
 
-        bodies = AnnotationJSONLDPresenter(resource).bodies
+        bodies = AnnotationJSONLDPresenter(context).bodies
 
         assert {
             "type": "TextualBody",
@@ -90,9 +90,9 @@ class TestAnnotationJSONLDPresenter:
             {"type": "TestSelector", "test": "foobar"},
             {"something": "else"},
         ]
-        resource = AnnotationContext(annotation, groupfinder_service, links_service)
+        context = AnnotationContext(annotation, groupfinder_service, links_service)
 
-        selectors = AnnotationJSONLDPresenter(resource).target[0]["selector"]
+        selectors = AnnotationJSONLDPresenter(context).target[0]["selector"]
 
         assert selectors == [{"type": "TestSelector", "test": "foobar"}]
 
@@ -114,9 +114,9 @@ class TestAnnotationJSONLDPresenter:
                 "endOffset": 43,
             }
         ]
-        resource = AnnotationContext(annotation, groupfinder_service, links_service)
+        context = AnnotationContext(annotation, groupfinder_service, links_service)
 
-        selectors = AnnotationJSONLDPresenter(resource).target[0]["selector"]
+        selectors = AnnotationJSONLDPresenter(context).target[0]["selector"]
 
         assert selectors == [
             {
@@ -144,9 +144,9 @@ class TestAnnotationJSONLDPresenter:
                 "endOffset": 72,
             }
         ]
-        resource = AnnotationContext(annotation, groupfinder_service, links_service)
+        context = AnnotationContext(annotation, groupfinder_service, links_service)
 
-        selectors = AnnotationJSONLDPresenter(resource).target[0]["selector"]
+        selectors = AnnotationJSONLDPresenter(context).target[0]["selector"]
 
         assert selectors == [
             {
@@ -178,8 +178,8 @@ class TestAnnotationJSONLDPresenter:
                 "endContainer": "/div[1]/main[1]/article[1]/div[2]/p[339]",
             }
         ]
-        resource = AnnotationContext(annotation, groupfinder_service, links_service)
+        context = AnnotationContext(annotation, groupfinder_service, links_service)
 
-        target = AnnotationJSONLDPresenter(resource).target[0]
+        target = AnnotationJSONLDPresenter(context).target[0]
 
         assert "selector" not in target

--- a/tests/h/traversal/annotation_test.py
+++ b/tests/h/traversal/annotation_test.py
@@ -69,7 +69,7 @@ class TestAnnotationRoot:
         factory["123"]
         storage.fetch_annotation.assert_called_once_with(pyramid_request.db, "123")
 
-    def test_get_item_returns_annotation_resource(self, pyramid_request, storage):
+    def test_get_item_returns_annotation_context(self, pyramid_request, storage):
         factory = AnnotationRoot(pyramid_request)
         storage.fetch_annotation.return_value = mock.Mock()
 

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -148,10 +148,10 @@ class TestCreate:
             AnnotationEvent.return_value
         )
 
-    def test_it_initialises_annotation_resource(
+    def test_it_initialises_annotation_context(
         self,
         storage,
-        annotation_resource,
+        annotation_context,
         pyramid_request,
         groupfinder_service,
         links_service,
@@ -161,17 +161,17 @@ class TestCreate:
 
         views.create(pyramid_request)
 
-        annotation_resource.assert_called_once_with(
+        annotation_context.assert_called_once_with(
             annotation, groupfinder_service, links_service
         )
 
     def test_it_presents_annotation(
-        self, annotation_resource, presentation_service, pyramid_request
+        self, annotation_context, presentation_service, pyramid_request
     ):
         views.create(pyramid_request)
 
         presentation_service.present.assert_called_once_with(
-            annotation_resource.return_value
+            annotation_context.return_value
         )
 
     def test_it_returns_presented_annotation(
@@ -324,10 +324,10 @@ class TestUpdate:
             AnnotationEvent.return_value
         )
 
-    def test_it_initialises_annotation_resource(
+    def test_it_initialises_annotation_context(
         self,
         storage,
-        annotation_resource,
+        annotation_context,
         pyramid_request,
         groupfinder_service,
         links_service,
@@ -337,17 +337,17 @@ class TestUpdate:
 
         views.update(mock.Mock(), pyramid_request)
 
-        annotation_resource.assert_called_once_with(
+        annotation_context.assert_called_once_with(
             annotation, groupfinder_service, links_service
         )
 
     def test_it_presents_annotation(
-        self, annotation_resource, presentation_service, pyramid_request
+        self, annotation_context, presentation_service, pyramid_request
     ):
         views.update(mock.Mock(), pyramid_request)
 
         presentation_service.present.assert_called_once_with(
-            annotation_resource.return_value
+            annotation_context.return_value
         )
 
     def test_it_returns_a_presented_dict(self, presentation_service, pyramid_request):
@@ -393,7 +393,7 @@ def AnnotationEvent(patch):
 
 
 @pytest.fixture
-def annotation_resource(patch):
+def annotation_context(patch):
     return patch("h.views.api.annotations.AnnotationContext")
 
 


### PR DESCRIPTION
For: #6769

This changes references to the `AnnotationContext` to be either `annotation_context` or `context`. Previously it was `resource` in a lot of places which is unnecessarily confusing.

This also refers to annotation ids as `annotation_id` rather than just `ids` or `id_` as soon these methods might be accepting user ids as well.