### PR TITLE
Split up the annotation JSON presentation service

### DIFF
--- a/h/services/annotation_json_presentation/__init__.py
+++ b/h/services/annotation_json_presentation/__init__.py
@@ -1,0 +1,6 @@
+from h.services.annotation_json_presentation.factory import (  # noqa: F401
+    annotation_json_presentation_service_factory,
+)
+from h.services.annotation_json_presentation.service import (  # noqa: F401
+    AnnotationJSONPresentationService,
+)

--- a/h/services/annotation_json_presentation/factory.py
+++ b/h/services/annotation_json_presentation/factory.py
@@ -1,0 +1,24 @@
+from h.interfaces import IGroupService
+from h.services.annotation_json_presentation.service import (
+    AnnotationJSONPresentationService,
+)
+
+
+def annotation_json_presentation_service_factory(_context, request):
+    group_svc = request.find_service(IGroupService)
+    links_svc = request.find_service(name="links")
+    flag_svc = request.find_service(name="flag")
+    flag_count_svc = request.find_service(name="flag_count")
+    moderation_svc = request.find_service(name="annotation_moderation")
+    user_svc = request.find_service(name="user")
+    return AnnotationJSONPresentationService(
+        session=request.db,
+        user=request.user,
+        group_svc=group_svc,
+        links_svc=links_svc,
+        flag_svc=flag_svc,
+        flag_count_svc=flag_count_svc,
+        moderation_svc=moderation_svc,
+        user_svc=user_svc,
+        has_permission=request.has_permission,
+    )

--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -1,7 +1,6 @@
 from sqlalchemy.orm import subqueryload
 
 from h import formatters, models, presenters, storage, traversal
-from h.interfaces import IGroupService
 from h.security.permissions import Permission
 
 
@@ -59,23 +58,3 @@ class AnnotationJSONPresentationService:
 
     def _get_presenter(self, annotation_resource):
         return presenters.AnnotationJSONPresenter(annotation_resource, self.formatters)
-
-
-def annotation_json_presentation_service_factory(_context, request):
-    group_svc = request.find_service(IGroupService)
-    links_svc = request.find_service(name="links")
-    flag_svc = request.find_service(name="flag")
-    flag_count_svc = request.find_service(name="flag_count")
-    moderation_svc = request.find_service(name="annotation_moderation")
-    user_svc = request.find_service(name="user")
-    return AnnotationJSONPresentationService(
-        session=request.db,
-        user=request.user,
-        group_svc=group_svc,
-        links_svc=links_svc,
-        flag_svc=flag_svc,
-        flag_count_svc=flag_count_svc,
-        moderation_svc=moderation_svc,
-        user_svc=user_svc,
-        has_permission=request.has_permission,
-    )

--- a/tests/h/services/annotation_json_presentation_test/factory_test.py
+++ b/tests/h/services/annotation_json_presentation_test/factory_test.py
@@ -1,0 +1,95 @@
+from unittest import mock
+
+import pytest
+
+from h.services.annotation_json_presentation import (
+    AnnotationJSONPresentationService,
+    annotation_json_presentation_service_factory,
+)
+
+
+@pytest.mark.usefixtures("services")
+class TestAnnotationJSONPresentationServiceFactory:
+    def test_returns_service(self, pyramid_request):
+        svc = annotation_json_presentation_service_factory(None, pyramid_request)
+
+        assert isinstance(svc, AnnotationJSONPresentationService)
+
+    def test_provides_session(self, pyramid_request, service_class):
+        annotation_json_presentation_service_factory(None, pyramid_request)
+
+        _, kwargs = service_class.call_args
+        assert kwargs["session"] == pyramid_request.db
+
+    def test_provides_user(self, pyramid_request, service_class):
+        annotation_json_presentation_service_factory(None, pyramid_request)
+
+        _, kwargs = service_class.call_args
+        assert kwargs["user"] == pyramid_request.user
+
+    def test_provides_group_service(self, pyramid_request, service_class, services):
+        annotation_json_presentation_service_factory(None, pyramid_request)
+
+        _, kwargs = service_class.call_args
+        assert kwargs["group_svc"] == services["group"]
+
+    def test_provides_links_service(self, pyramid_request, service_class, services):
+        annotation_json_presentation_service_factory(None, pyramid_request)
+
+        _, kwargs = service_class.call_args
+        assert kwargs["links_svc"] == services["links"]
+
+    def test_provides_flag_service(self, pyramid_request, service_class, services):
+        annotation_json_presentation_service_factory(None, pyramid_request)
+
+        _, kwargs = service_class.call_args
+        assert kwargs["flag_svc"] == services["flag"]
+
+    def test_provides_moderation_service(
+        self, pyramid_request, service_class, services
+    ):
+        annotation_json_presentation_service_factory(None, pyramid_request)
+
+        _, kwargs = service_class.call_args
+        assert kwargs["moderation_svc"] == services["annotation_moderation"]
+
+    def test_provides_flag_count_service(
+        self, pyramid_request, service_class, services
+    ):
+        annotation_json_presentation_service_factory(None, pyramid_request)
+
+        _, kwargs = service_class.call_args
+        assert kwargs["flag_count_svc"] == services["flag_count"]
+
+    def test_provides_has_permission(self, pyramid_request, service_class):
+        annotation_json_presentation_service_factory(None, pyramid_request)
+
+        _, kwargs = service_class.call_args
+        assert kwargs["has_permission"] == pyramid_request.has_permission
+
+    @pytest.fixture
+    def service_class(self, patch):
+        return patch(
+            "h.services.annotation_json_presentation.factory.AnnotationJSONPresentationService"
+        )
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.user = mock.Mock()
+        return pyramid_request
+
+
+@pytest.fixture
+def services(pyramid_config, user_service, links_service, groupfinder_service):
+    service_mocks = {
+        "user": user_service,
+        "links": links_service,
+        "group": groupfinder_service,
+    }
+
+    for name in ["flag", "flag_count", "annotation_moderation"]:
+        svc = mock.Mock()
+        service_mocks[name] = svc
+        pyramid_config.register_service(svc, name=name)
+
+    return service_mocks

--- a/tests/h/services/annotation_json_presentation_test/service_test.py
+++ b/tests/h/services/annotation_json_presentation_test/service_test.py
@@ -4,10 +4,7 @@ import pytest
 from h_matchers import Any
 
 from h.security.permissions import Permission
-from h.services.annotation_json_presentation import (
-    AnnotationJSONPresentationService,
-    annotation_json_presentation_service_factory,
-)
+from h.services.annotation_json_presentation import AnnotationJSONPresentationService
 
 
 @pytest.mark.usefixtures("presenters", "formatters")
@@ -142,96 +139,25 @@ class TestAnnotationJSONPresentationService:
 
     @pytest.fixture
     def presenters(self, patch):
-        return patch("h.services.annotation_json_presentation.presenters")
+        return patch("h.services.annotation_json_presentation.service.presenters")
 
     @pytest.fixture
     def storage(self, patch):
-        return patch("h.services.annotation_json_presentation.storage")
+        return patch("h.services.annotation_json_presentation.service.storage")
 
     @pytest.fixture
     def traversal(self, patch):
-        return patch("h.services.annotation_json_presentation.traversal")
+        return patch("h.services.annotation_json_presentation.service.traversal")
 
     @pytest.fixture
     def present(self, patch):
         return patch(
-            "h.services.annotation_json_presentation.AnnotationJSONPresentationService.present"
+            "h.services.annotation_json_presentation.service.AnnotationJSONPresentationService.present"
         )
 
     @pytest.fixture
     def formatters(self, patch):
-        return patch("h.services.annotation_json_presentation.formatters")
-
-
-@pytest.mark.usefixtures("services")
-class TestAnnotationJSONPresentationServiceFactory:
-    def test_returns_service(self, pyramid_request):
-        svc = annotation_json_presentation_service_factory(None, pyramid_request)
-
-        assert isinstance(svc, AnnotationJSONPresentationService)
-
-    def test_provides_session(self, pyramid_request, service_class):
-        annotation_json_presentation_service_factory(None, pyramid_request)
-
-        _, kwargs = service_class.call_args
-        assert kwargs["session"] == pyramid_request.db
-
-    def test_provides_user(self, pyramid_request, service_class):
-        annotation_json_presentation_service_factory(None, pyramid_request)
-
-        _, kwargs = service_class.call_args
-        assert kwargs["user"] == pyramid_request.user
-
-    def test_provides_group_service(self, pyramid_request, service_class, services):
-        annotation_json_presentation_service_factory(None, pyramid_request)
-
-        _, kwargs = service_class.call_args
-        assert kwargs["group_svc"] == services["group"]
-
-    def test_provides_links_service(self, pyramid_request, service_class, services):
-        annotation_json_presentation_service_factory(None, pyramid_request)
-
-        _, kwargs = service_class.call_args
-        assert kwargs["links_svc"] == services["links"]
-
-    def test_provides_flag_service(self, pyramid_request, service_class, services):
-        annotation_json_presentation_service_factory(None, pyramid_request)
-
-        _, kwargs = service_class.call_args
-        assert kwargs["flag_svc"] == services["flag"]
-
-    def test_provides_moderation_service(
-        self, pyramid_request, service_class, services
-    ):
-        annotation_json_presentation_service_factory(None, pyramid_request)
-
-        _, kwargs = service_class.call_args
-        assert kwargs["moderation_svc"] == services["annotation_moderation"]
-
-    def test_provides_flag_count_service(
-        self, pyramid_request, service_class, services
-    ):
-        annotation_json_presentation_service_factory(None, pyramid_request)
-
-        _, kwargs = service_class.call_args
-        assert kwargs["flag_count_svc"] == services["flag_count"]
-
-    def test_provides_has_permission(self, pyramid_request, service_class):
-        annotation_json_presentation_service_factory(None, pyramid_request)
-
-        _, kwargs = service_class.call_args
-        assert kwargs["has_permission"] == pyramid_request.has_permission
-
-    @pytest.fixture
-    def service_class(self, patch):
-        return patch(
-            "h.services.annotation_json_presentation.AnnotationJSONPresentationService"
-        )
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.user = mock.Mock()
-        return pyramid_request
+        return patch("h.services.annotation_json_presentation.service.formatters")
 
 
 @pytest.fixture


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/6769

This nests the service in one level to make room for the formatters to join it as collaborators.

This is a pretty straight split and doesn't try and tackle any of the weirdness of these tests.