### PR TITLE
Refactor the annotation JSON service and it's tests

### DIFF
--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -1,7 +1,10 @@
 from sqlalchemy.orm import subqueryload
 
-from h import formatters, models, presenters, storage, traversal
+from h import formatters, storage
+from h.models import Annotation
+from h.presenters import AnnotationJSONPresenter
 from h.security.permissions import Permission
+from h.traversal import AnnotationContext
 
 
 class AnnotationJSONPresentationService:
@@ -39,7 +42,7 @@ class AnnotationJSONPresentationService:
 
     def present_all(self, annotation_ids):
         def eager_load_documents(query):
-            return query.options(subqueryload(models.Annotation.document))
+            return query.options(subqueryload(Annotation.document))
 
         annotations = storage.fetch_ordered_annotations(
             self.session, annotation_ids, query_processor=eager_load_documents
@@ -50,11 +53,9 @@ class AnnotationJSONPresentationService:
             formatter.preload(annotation_ids)
 
         return [
-            self.present(
-                traversal.AnnotationContext(ann, self.group_svc, self.links_svc)
-            )
+            self.present(AnnotationContext(ann, self.group_svc, self.links_svc))
             for ann in annotations
         ]
 
     def _get_presenter(self, annotation_resource):
-        return presenters.AnnotationJSONPresenter(annotation_resource, self.formatters)
+        return AnnotationJSONPresenter(annotation_resource, self.formatters)

--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -52,6 +52,6 @@ class AnnotationJSONPresentationService:
             formatter.preload(annotation_ids)
 
         return [
-            self.present(AnnotationContext(ann, self.group_svc, self.links_svc))
-            for ann in annotations
+            self.present(AnnotationContext(annotation, self.group_svc, self.links_svc))
+            for annotation in annotations
         ]

--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -37,8 +37,7 @@ class AnnotationJSONPresentationService:
         ]
 
     def present(self, annotation_resource):
-        presenter = self._get_presenter(annotation_resource)
-        return presenter.asdict()
+        return AnnotationJSONPresenter(annotation_resource, self.formatters).asdict()
 
     def present_all(self, annotation_ids):
         def eager_load_documents(query):
@@ -56,6 +55,3 @@ class AnnotationJSONPresentationService:
             self.present(AnnotationContext(ann, self.group_svc, self.links_svc))
             for ann in annotations
         ]
-
-    def _get_presenter(self, annotation_resource):
-        return AnnotationJSONPresenter(annotation_resource, self.formatters)

--- a/tests/h/services/annotation_json_presentation_test/service_test.py
+++ b/tests/h/services/annotation_json_presentation_test/service_test.py
@@ -10,7 +10,13 @@ from h.services.annotation_json_presentation import AnnotationJSONPresentationSe
 
 class TestAnnotationJSONPresentationService:
     def test_it_configures_formatters(
-        self, svc, formatters, flag_service, moderation_service, has_permission
+        self,
+        svc,
+        formatters,
+        db_session,
+        flag_service,
+        moderation_service,
+        has_permission,
     ):
         formatters.AnnotationFlagFormatter.assert_called_once_with(
             sentinel.flag_svc, sentinel.user
@@ -22,7 +28,7 @@ class TestAnnotationJSONPresentationService:
             sentinel.flag_count_svc, sentinel.user, has_permission
         )
         formatters.AnnotationUserInfoFormatter.assert_called_once_with(
-            sentinel.db_session, sentinel.user_svc
+            db_session, sentinel.user_svc
         )
 
         assert svc.formatters == [
@@ -40,9 +46,7 @@ class TestAnnotationJSONPresentationService:
         moderator_check(group)
         has_permission.assert_called_once_with(Permission.Group.MODERATE, group)
 
-    def test_present_calls_presenter(
-        self, svc, AnnotationJSONPresenter, annotation_resource
-    ):
+    def test_present(self, svc, AnnotationJSONPresenter, annotation_resource):
         result = svc.present(annotation_resource)
 
         AnnotationJSONPresenter.assert_called_once_with(
@@ -92,9 +96,9 @@ class TestAnnotationJSONPresentationService:
         assert result == [present.return_value]
 
     @pytest.fixture
-    def svc(self, has_permission):
+    def svc(self, db_session, has_permission):
         return AnnotationJSONPresentationService(
-            session=sentinel.db_session,
+            session=db_session,
             user=sentinel.user,
             group_svc=sentinel.group_svc,
             links_svc=sentinel.links_svc,

--- a/tests/h/services/annotation_json_presentation_test/service_test.py
+++ b/tests/h/services/annotation_json_presentation_test/service_test.py
@@ -46,11 +46,11 @@ class TestAnnotationJSONPresentationService:
         moderator_check(group)
         has_permission.assert_called_once_with(Permission.Group.MODERATE, group)
 
-    def test_present(self, svc, AnnotationJSONPresenter, annotation_resource):
-        result = svc.present(annotation_resource)
+    def test_present(self, svc, AnnotationJSONPresenter, AnnotationContext):
+        result = svc.present(AnnotationContext.return_value)
 
         AnnotationJSONPresenter.assert_called_once_with(
-            annotation_resource, svc.formatters
+            AnnotationContext.return_value, svc.formatters
         )
 
         assert result == AnnotationJSONPresenter.return_value.asdict.return_value
@@ -93,10 +93,6 @@ class TestAnnotationJSONPresentationService:
     @pytest.fixture
     def has_permission(self):
         return mock.Mock()
-
-    @pytest.fixture
-    def annotation_resource(self):
-        return mock.Mock(spec_set=["annotation"], annotation=mock.Mock())
 
     @pytest.fixture
     def AnnotationContext(self, patch):


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/6769

Generally these refactors follow a few themes:

 * Using `sentinel` instead of real services when we don't care about them
 * Not mocking the DB and DB access, and using factories instead
 * Not having a separate test for every assertion we make