### PR TITLE
Use the admin page permission not the group edit one

### DIFF
--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -126,7 +126,7 @@ class GroupCreateViews:  # pylint: disable=too-many-instance-attributes
 
 @view_defaults(
     route_name="admin.groups_edit",
-    permission=Permission.Group.ADMIN,
+    permission=Permission.AdminPage.GROUPS,
     renderer="h:templates/admin/groups_edit.html.jinja2",
 )
 class GroupEditViews:  # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
I don't think this is ever granted to Staff as it should be, but they are granted `AdminPage.GROUPS`.

This certainly seems correct to me, but I'd like to try and scry out why this is / isn't a problem currently.