### PR TITLE
Refactor annotation JSON presenter tests

### DIFF
--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -1,4 +1,4 @@
-import copy
+from copy import deepcopy
 
 from pyramid import security
 from pyramid.security import principals_allowed_by_permission
@@ -9,68 +9,59 @@ from h.security.permissions import Permission
 
 
 class AnnotationJSONPresenter(AnnotationBasePresenter):
-
     """Present an annotation in the JSON format returned by API requests."""
 
     def __init__(self, annotation_context, formatters=None):
         super().__init__(annotation_context)
 
-        self._formatters = []
-
-        if formatters is not None:
-            self._formatters.extend(formatters)
+        self._formatters = tuple(formatters or [])
 
     def asdict(self):
-        docpresenter = DocumentJSONPresenter(self.annotation.document)
+        annotation = deepcopy(self.annotation.extra) or {}
 
-        base = {
-            "id": self.annotation.id,
-            "created": self.created,
-            "updated": self.updated,
-            "user": self.annotation.userid,
-            "uri": self.annotation.target_uri,
-            "text": self.text,
-            "tags": self.tags,
-            "group": self.annotation.groupid,
-            "permissions": self.permissions,
-            "target": self.target,
-            "document": docpresenter.asdict(),
-            "links": self.links,
-        }
+        annotation.update(
+            {
+                "id": self.annotation.id,
+                "created": self.created,
+                "updated": self.updated,
+                "user": self.annotation.userid,
+                "uri": self.annotation.target_uri,
+                "text": self.text,
+                "tags": self.tags,
+                "group": self.annotation.groupid,
+                #  Convert our simple internal annotation storage format into the
+                #  legacy complex permissions dict format that is still used in
+                #  some places.
+                "permissions": {
+                    "read": [self._get_read_permission()],
+                    "admin": [self.annotation.userid],
+                    "update": [self.annotation.userid],
+                    "delete": [self.annotation.userid],
+                },
+                "target": self.target,
+                "document": DocumentJSONPresenter(self.annotation.document).asdict(),
+                "links": self.links,
+            }
+        )
 
         if self.annotation.references:
-            base["references"] = self.annotation.references
-
-        annotation = copy.copy(self.annotation.extra) or {}
-        annotation.update(base)
+            annotation["references"] = self.annotation.references
 
         for formatter in self._formatters:
             annotation.update(formatter.format(self.annotation_context))
 
         return annotation
 
-    @property
-    def permissions(self):
-        """
-        Return a permissions dict for the given annotation.
+    def _get_read_permission(self):
+        if not self.annotation.shared:
+            # It's not shared so only the owner can read it
+            return self.annotation.userid
 
-        Converts our simple internal annotation storage format into the legacy
-        complex permissions dict format that is still used in some places.
+        if security.Everyone in principals_allowed_by_permission(
+            self.annotation_context, Permission.Annotation.READ
+        ):
+            # Anyone in the world can read this
+            return "group:__world__"
 
-        """
-        read = self.annotation.userid
-        if self.annotation.shared:
-            read = "group:{}".format(self.annotation.groupid)
-
-            principals = principals_allowed_by_permission(
-                self.annotation_context, Permission.Annotation.READ
-            )
-            if security.Everyone in principals:
-                read = "group:__world__"
-
-        return {
-            "read": [read],
-            "admin": [self.annotation.userid],
-            "update": [self.annotation.userid],
-            "delete": [self.annotation.userid],
-        }
+        # Only people in the group can read it
+        return "group:{}".format(self.annotation.groupid)

--- a/h/traversal/annotation.py
+++ b/h/traversal/annotation.py
@@ -29,6 +29,8 @@ class AnnotationRoot(RootFactory):
 class AnnotationContext:
     """Context for annotation-based views."""
 
+    annotation = None
+
     def __init__(self, annotation, group_service, links_service):
         self.group_service = group_service
         self.links_service = links_service

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -125,10 +125,10 @@ class TestAnnotationJSONPresenter:
 
         return get_formatter
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def DocumentJSONPresenter(self, patch):
         return patch("h.presenters.annotation_json.DocumentJSONPresenter")
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def principals_allowed_by_permission(self, patch):
         return patch("h.presenters.annotation_json.principals_allowed_by_permission")

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -77,22 +77,6 @@ class TestAnnotationJSONPresenter:
         for formatter in formatters:
             formatter.format.assert_called_once_with(context)
 
-    def test_immutable_formatters(self, annotation, context, get_formatter):
-        """Double-check we can't mutate the formatters list after the fact.
-
-        This is an extra check just to make sure we can't accidentally change
-        the constructor so that it simply aliases the list that's passed in,
-        leaving us open to all kinds of mutability horrors.
-
-        """
-        formatters = []
-
-        presenter = AnnotationJSONPresenter(context, formatters)
-        formatters.append(get_formatter({"enterprise": "synergy"}))
-        presented = presenter.asdict()
-
-        assert "enterprise" not in presented
-
     @pytest.mark.parametrize(
         "shared,readable_by,permission",
         (

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -78,10 +78,10 @@ class TestAnnotationJSONPresenter:
             formatter.format.assert_called_once_with(context)
 
     @pytest.mark.parametrize(
-        "shared,readable_by,permission",
+        "shared,readable_by,permission_template",
         (
-            (False, [], "USER_ID"),
-            (True, [], "group:GROUP_ID"),
+            (False, [], "{annotation.userid}"),
+            (True, [], "group:{annotation.groupid}"),
             (True, [security.Everyone], "group:__world__"),
         ),
     )
@@ -92,22 +92,19 @@ class TestAnnotationJSONPresenter:
         principals_allowed_by_permission,
         shared,
         readable_by,
-        permission,
+        permission_template,
     ):
-        annotation.id = "ANNOTATION_ID"
-        annotation.groupid = "GROUP_ID"
-        annotation.userid = "USER_ID"
         annotation.shared = shared
-
         principals_allowed_by_permission.return_value = readable_by
 
         presented = AnnotationJSONPresenter(context).asdict()
 
+        permission = permission_template.format(annotation=annotation)
         assert presented["permissions"]["read"] == [permission]
 
     @pytest.fixture
     def annotation(self, factories):
-        return factories.Annotation()
+        return factories.Annotation(groupid="NOT WORLD")
 
     @pytest.fixture
     def context(self, annotation):


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/6769

This is to reduce the general level of crazy, but specifically:

* Stop testing code outside of this module (lots of permissions tests were duplicated here)
* Make this more isolated and not sensitive to changes in other code
* Make use of the boundary of the class for testing, instead of unpredictably mocking some stuff and not others

Also some minor shuffling and refactors of the code under test to make it more obvious