### PR TITLE
Use the group context to get ACLs not the group

### DIFF
--- a/h/traversal/annotation.py
+++ b/h/traversal/annotation.py
@@ -8,6 +8,7 @@ from pyramid.security import (
 from h import storage
 from h.interfaces import IGroupService
 from h.security.permissions import Permission
+from h.traversal.group import GroupContext
 from h.traversal.root import RootFactory
 
 
@@ -95,4 +96,4 @@ class AnnotationContext:
         if group is None:
             return []
 
-        return principals_allowed_by_permission(group, permission)
+        return principals_allowed_by_permission(GroupContext(group), permission)


### PR DESCRIPTION
This needs these two to be merged first:

 * https://github.com/hypothesis/h/pull/6874 
 * https://github.com/hypothesis/h/pull/6873 

As otherwise those tests will fall over because of messy non-mocked tests.

