### PR TITLE
Move the ACLs for the user model to a separate file

### DIFF
--- a/h/models/user.py
+++ b/h/models/user.py
@@ -333,8 +333,5 @@ class User(Base):
             .first()
         )
 
-    def __acl__(self):
-        return ACL.for_user(self)
-
     def __repr__(self):
         return "<User: %s>" % self.username

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -2,13 +2,11 @@ import datetime
 import re
 
 import sqlalchemy as sa
-from pyramid import security
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import Comparator, hybrid_property
 
 from h.db import Base
 from h.exceptions import InvalidUserId
-from h.security.permissions import Permission
 from h.util.user import split_user
 
 USERNAME_MIN_LENGTH = 3
@@ -336,16 +334,7 @@ class User(Base):
         )
 
     def __acl__(self):
-        client_authority = "client_authority:{}".format(self.authority)
-
-        return [
-            # auth_clients that have the same authority as the user may update
-            # the user
-            (security.Allow, client_authority, Permission.User.UPDATE),
-            (security.Allow, client_authority, Permission.User.READ),
-            # This is for inheriting security policies... do we inherit?
-            security.DENY_ALL,
-        ]
+        return ACL.for_user(self)
 
     def __repr__(self):
         return "<User: %s>" % self.username

--- a/h/security/acl.py
+++ b/h/security/acl.py
@@ -8,6 +8,17 @@ from h.security.permissions import Permission
 
 class ACL:
     @classmethod
+    def for_user(cls, user):
+        client_authority = "client_authority:{}".format(user.authority)
+
+        # auth_clients with the same authority as the user may update the user
+        yield Allow, client_authority, Permission.User.UPDATE
+        yield Allow, client_authority, Permission.User.READ
+
+        # This is for inheriting security policies... do we inherit?
+        yield security.DENY_ALL
+
+    @classmethod
     def for_group(cls, group):
         # This principal is given to clients which log in using an OAuth client
         # and secret to a particular authority

--- a/h/traversal/user.py
+++ b/h/traversal/user.py
@@ -7,6 +7,7 @@ from h.auth import role
 from h.auth.util import client_authority
 from h.exceptions import InvalidUserId
 from h.models import User
+from h.security.acl import ACL
 from h.security.permissions import Permission
 from h.traversal.root import RootFactory
 
@@ -20,7 +21,7 @@ class UserContext:
     def __acl__(self):
         """Return user access control lists."""
 
-        return self.user.__acl__()
+        return ACL.for_user(self.user)
 
 
 class UserRoot(RootFactory):

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -1,11 +1,9 @@
 from datetime import datetime, timedelta
 
 import pytest
-from pyramid.authorization import ACLAuthorizationPolicy
 from sqlalchemy import exc
 
 from h import models
-from h.security.permissions import Permission
 
 
 class TestUserModelDataConstraints:
@@ -308,27 +306,3 @@ class TestUserGetByUsername:
         }
         db_session.flush()
         return users
-
-
-class TestUserACL:
-    @pytest.mark.parametrize(
-        "principal,permits",
-        (
-            # The right client authority has permissions
-            ("client_authority:user_authority", True),
-            ("client_authority:DIFFERENT", False),
-            # User's don't by just being in the authority
-            ("authority:user_authority", False),
-        ),
-    )
-    @pytest.mark.parametrize(
-        "permission", (Permission.User.UPDATE, Permission.User.READ)
-    )
-    def test_it(self, principal, permission, permits):
-        policy = ACLAuthorizationPolicy()
-
-        user = models.User(authority="user_authority")
-
-        assert (
-            bool(policy.permits(user, [principal, "some_noise"], permission)) == permits
-        )

--- a/tests/h/traversal/user_test.py
+++ b/tests/h/traversal/user_test.py
@@ -10,12 +10,17 @@ from h.traversal.user import UserByIDRoot, UserByNameRoot, UserContext, UserRoot
 
 
 class TestUserContext:
-    def test_acl_matching_user(self, factories):
+    def test_acl_matching_user(self, factories, ACL):
         user = factories.User()
 
         acl = UserContext(user).__acl__()
 
-        assert acl == user.__acl__()
+        ACL.for_user.assert_called_once_with(user)
+        assert acl == ACL.for_user.return_value
+
+    @pytest.fixture
+    def ACL(self, patch):
+        return patch("h.traversal.user.ACL")
 
 
 @pytest.mark.usefixtures("user_service")


### PR DESCRIPTION
This PR removes the user ACLs from the model object and into their own file in `h.security`. This isn't the intended final state, but it does mean we are much free-er to move with this stuff than before.

It's also very easy to explicitly search for anywhere `ACL.from_user` is used to see where we need to change things.