### PR TITLE
Hopefully fix the Queue test by making an order invariant comparison

### DIFF
--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -35,40 +35,26 @@ class TestQueue:
             schedule_in=ONE_WEEK_IN_SECONDS,
         )
 
-        jobs = db_session.query(Job).all()
-
-        # This is a temporary duplication of the test below. This formulation
-        # is a bit ugly and less declarative but will hopefully give us fine
-        # grained detail about why the match failed while we work on adding
-        # `assert_on_comparison` support to Any.object.with_attrs.
-        # This is to address this test being flaky for reasons we don't
-        # understand
-        for i in range(2):
-            assert isinstance(jobs[i], Job)
-            assert jobs[i].enqueued_at == Any.instance_of(datetime_.datetime)
-            assert jobs[i].scheduled_at == now + ONE_WEEK
-            assert jobs[i].tag == "test_tag"
-            assert jobs[i].priority == 1234
-            assert jobs[i].kwargs == {
-                "annotation_id": self.database_id(matching[i]),
-                "force": False,
-            }
-
-        assert jobs == [
-            Any.instance_of(Job).with_attrs(
-                dict(
-                    enqueued_at=Any.instance_of(datetime_.datetime),
-                    scheduled_at=now + ONE_WEEK,
-                    tag="test_tag",
-                    priority=1234,
-                    kwargs={
-                        "annotation_id": self.database_id(annotation),
-                        "force": False,
-                    },
-                )
-            )
-            for annotation in matching
-        ]
+        assert (
+            db_session.query(Job).all()
+            == Any.list.containing(
+                [
+                    Any.instance_of(Job).with_attrs(
+                        dict(
+                            enqueued_at=Any.instance_of(datetime_.datetime),
+                            scheduled_at=now + ONE_WEEK,
+                            tag="test_tag",
+                            priority=1234,
+                            kwargs={
+                                "annotation_id": self.database_id(annotation),
+                                "force": False,
+                            },
+                        )
+                    )
+                    for annotation in matching
+                ]
+            ).only()
+        )
 
     @pytest.mark.parametrize(
         "force,expected_force",


### PR DESCRIPTION
I think this is just a sorting issue, where the DB insertion order and the order in Python don't match. The element they were failing on was the ID, which is the only thing that differs between the two cases.

Although `h-matchers` obscured the cause of the issue here, it's also quite helpful in solving it if that's what it was.