### PR TITLE
Move the root annotation permissions to `security.ACL`

### DIFF
--- a/h/security/acl.py
+++ b/h/security/acl.py
@@ -94,6 +94,12 @@ class ACL:
 
     @classmethod
     def _for_annotation(cls, annotation, group, allow_read_on_delete):
+        # All authenticated users can create annotations
+        yield Allow, security.Authenticated, Permission.Annotation.CREATE
+
+        if not annotation:
+            return
+
         # If the annotation has been deleted, nobody has any privileges on it
         # any more.
         if annotation.deleted and not allow_read_on_delete:

--- a/h/traversal/annotation.py
+++ b/h/traversal/annotation.py
@@ -1,16 +1,11 @@
-from pyramid.security import Allow, Authenticated
-
 from h import storage
 from h.interfaces import IGroupService
 from h.security.acl import ACL
-from h.security.permissions import Permission
 from h.traversal.root import RootFactory
 
 
 class AnnotationRoot(RootFactory):
     """Root factory for routes whose context is an `AnnotationContext`."""
-
-    __acl__ = [(Allow, Authenticated, Permission.Annotation.CREATE)]
 
     def __getitem__(self, annotation_id):
         annotation = storage.fetch_annotation(self.request.db, annotation_id)
@@ -20,6 +15,10 @@ class AnnotationRoot(RootFactory):
         group_service = self.request.find_service(IGroupService)
         links_service = self.request.find_service(name="links")
         return AnnotationContext(annotation, group_service, links_service)
+
+    @classmethod
+    def __acl__(cls):
+        return ACL.for_annotation(annotation=None, group=None)
 
 
 class AnnotationContext:

--- a/tests/h/traversal/annotation_test.py
+++ b/tests/h/traversal/annotation_test.py
@@ -1,17 +1,16 @@
 from unittest.mock import sentinel
 
 import pytest
-from pyramid import security
-from pyramid.authorization import ACLAuthorizationPolicy
 
-from h.security.permissions import Permission
 from h.traversal import AnnotationContext, AnnotationRoot
 
 
 class TestAnnotationRoot:
-    def test_create_permission_requires_authenticated_user(self, root, permits):
-        assert permits(root, [security.Authenticated], Permission.Annotation.CREATE)
-        assert not permits(root, [], Permission.Annotation.CREATE)
+    def test_create_permission_requires_authenticated_user(self, root, ACL):
+        acl = root.__acl__()
+
+        ACL.for_annotation.assert_called_once_with(None, None)
+        assert acl == ACL.for_annotation.return_value
 
     def test_getting_by_subscript_returns_AnnotationContext(
         self,
@@ -86,14 +85,7 @@ class TestAnnotationContext:
     def annotation(self, factories):
         return factories.Annotation()
 
-    @pytest.fixture(autouse=True)
-    def ACL(self, patch):
-        return patch("h.traversal.annotation.ACL")
 
-
-@pytest.fixture
-def permits():
-    def permits(context, principals, permission):
-        return ACLAuthorizationPolicy().permits(context, principals, permission)
-
-    return permits
+@pytest.fixture(autouse=True)
+def ACL(patch):
+    return patch("h.traversal.annotation.ACL")


### PR DESCRIPTION
This should hopefully leave `ACL.for_annotation` as a the sole source of truth.