### PR TITLE
Simplify the annotation traversal

### DIFF
--- a/h/presenters/annotation_base.py
+++ b/h/presenters/annotation_base.py
@@ -23,11 +23,6 @@ class AnnotationBasePresenter:
         return utc_iso8601(self.annotation.updated)
 
     @property
-    def links(self):
-        """A dictionary of named hypermedia links for this annotation."""
-        return self.annotation_context.links
-
-    @property
     def text(self):
         if self.annotation.text:
             return self.annotation.text

--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -40,7 +40,7 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
                 },
                 "target": self.target,
                 "document": DocumentJSONPresenter(self.annotation.document).asdict(),
-                "links": self.links,
+                "links": self.annotation_context.annotation_links,
             }
         )
 

--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -11,9 +11,10 @@ from h.security.permissions import Permission
 class AnnotationJSONPresenter(AnnotationBasePresenter):
     """Present an annotation in the JSON format returned by API requests."""
 
-    def __init__(self, annotation_context, formatters=None):
+    def __init__(self, annotation_context, links_service, formatters=None):
         super().__init__(annotation_context)
 
+        self._links_service = links_service
         self._formatters = tuple(formatters or [])
 
     def asdict(self):
@@ -40,7 +41,7 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
                 },
                 "target": self.target,
                 "document": DocumentJSONPresenter(self.annotation.document).asdict(),
-                "links": self.annotation_context.annotation_links,
+                "links": self._links_service.get_all(self.annotation),
             }
         )
 

--- a/h/presenters/annotation_jsonld.py
+++ b/h/presenters/annotation_jsonld.py
@@ -10,35 +10,36 @@ class AnnotationJSONLDPresenter(AnnotationBasePresenter):
       https://www.w3.org/TR/annotation-model/
     """
 
+    def __init__(self, annotation_context, links_service):
+        super().__init__(annotation_context)
+
+        self._links_service = links_service
+
     CONTEXT_URL = "http://www.w3.org/ns/anno.jsonld"
 
     def asdict(self):
         return {
             "@context": self.CONTEXT_URL,
             "type": "Annotation",
-            "id": self.id,
+            "id": self._links_service.get(self.annotation, "jsonld_id"),
             "created": self.created,
             "modified": self.updated,
             "creator": self.annotation.userid,
-            "body": self.bodies,
-            "target": self.target,
+            "body": self._bodies,
+            "target": self._target,
         }
 
     @property
-    def id(self):
-        return self.annotation_context.get_annotation_link("jsonld_id")
-
-    @property
-    def bodies(self):
+    def _bodies(self):
         bodies = [
             {"type": "TextualBody", "value": self.text, "format": "text/markdown"}
         ]
-        for t in self.tags:
-            bodies.append({"type": "TextualBody", "value": t, "purpose": "tagging"})
+        for tag in self.tags:
+            bodies.append({"type": "TextualBody", "value": tag, "purpose": "tagging"})
         return bodies
 
     @property
-    def target(self):
+    def _target(self):
         target = {"source": self.annotation.target_uri}
         selectors = []
 

--- a/h/presenters/annotation_jsonld.py
+++ b/h/presenters/annotation_jsonld.py
@@ -26,7 +26,7 @@ class AnnotationJSONLDPresenter(AnnotationBasePresenter):
 
     @property
     def id(self):
-        return self.annotation_context.link("jsonld_id")
+        return self.annotation_context.get_annotation_link("jsonld_id")
 
     @property
     def bodies(self):

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -58,9 +58,3 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
         nipsa_service = self.request.find_service(name="nipsa")
         if nipsa_service.is_flagged(user_id):
             result["nipsa"] = True
-
-    @property
-    def links(self):
-        # The search index presenter has no need to generate links, and so the
-        # `links_service` parameter has been removed from the constructor.
-        raise NotImplementedError("search index presenter doesn't have links")

--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -31,7 +31,9 @@ class AnnotationJSONPresentationService:
         ]
 
     def present(self, annotation_context):
-        return AnnotationJSONPresenter(annotation_context, self.formatters).asdict()
+        return AnnotationJSONPresenter(
+            annotation_context, links_service=self.links_svc, formatters=self.formatters
+        ).asdict()
 
     def present_all(self, annotation_ids):
         def eager_load_documents(query):

--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -48,6 +48,5 @@ class AnnotationJSONPresentationService:
             formatter.preload(annotation_ids)
 
         return [
-            self.present(AnnotationContext(annotation, self.links_svc))
-            for annotation in annotations
+            self.present(AnnotationContext(annotation)) for annotation in annotations
         ]

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -172,7 +172,9 @@ def _generate_annotation_event(session, request, message, annotation_context):
         user_service = request.find_service(name="user")
         formatters = [AnnotationUserInfoFormatter(session, user_service)]
         payload = presenters.AnnotationJSONPresenter(
-            annotation_context, formatters=formatters
+            annotation_context,
+            links_service=request.find_service(name="links"),
+            formatters=formatters,
         ).asdict()
 
     return {

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -125,7 +125,6 @@ def handle_annotation_event(message, sockets, request, session):
 
     annotation_context = AnnotationContext(
         annotation,
-        links_service=request.find_service(name="links"),
         # This is a bit clunky but we have one permission for reading
         # annotations and reading notifications about deleted annotations.
         # We could really do with two, as you don't get READ when things are

--- a/h/traversal/annotation.py
+++ b/h/traversal/annotation.py
@@ -29,11 +29,6 @@ class AnnotationContext:
         self.annotation = annotation
         self.allow_read_on_delete = allow_read_on_delete
 
-    @property
-    def annotation_links(self):
-        """A dictionary of named hypermedia links for this annotation."""
-        return self.links_service.get_all(self.annotation)
-
     def get_annotation_link(self, name):
         return self.links_service.get(self.annotation, name)
 

--- a/h/traversal/annotation.py
+++ b/h/traversal/annotation.py
@@ -1,4 +1,7 @@
+from dataclasses import dataclass
+
 from h import storage
+from h.models import Annotation
 from h.security.acl import ACL
 from h.traversal.root import RootFactory
 
@@ -11,23 +14,19 @@ class AnnotationRoot(RootFactory):
         if annotation is None:
             raise KeyError()
 
-        links_service = self.request.find_service(name="links")
-        return AnnotationContext(annotation, links_service)
+        return AnnotationContext(annotation)
 
     @classmethod
     def __acl__(cls):
         return ACL.for_annotation(annotation=None)
 
 
+@dataclass
 class AnnotationContext:
     """Context for annotation-based views."""
 
-    annotation = None
-
-    def __init__(self, annotation, links_service, allow_read_on_delete=False):
-        self.links_service = links_service
-        self.annotation = annotation
-        self.allow_read_on_delete = allow_read_on_delete
+    annotation: Annotation
+    allow_read_on_delete: bool = False
 
     def __acl__(self):
         return ACL.for_annotation(self.annotation, self.allow_read_on_delete)

--- a/h/traversal/annotation.py
+++ b/h/traversal/annotation.py
@@ -30,10 +30,6 @@ class AnnotationContext:
         self.allow_read_on_delete = allow_read_on_delete
 
     @property
-    def group(self):
-        return self.annotation.group
-
-    @property
     def links(self):
         return self.links_service.get_all(self.annotation)
 

--- a/h/traversal/annotation.py
+++ b/h/traversal/annotation.py
@@ -29,8 +29,5 @@ class AnnotationContext:
         self.annotation = annotation
         self.allow_read_on_delete = allow_read_on_delete
 
-    def get_annotation_link(self, name):
-        return self.links_service.get(self.annotation, name)
-
     def __acl__(self):
         return ACL.for_annotation(self.annotation, self.allow_read_on_delete)

--- a/h/traversal/annotation.py
+++ b/h/traversal/annotation.py
@@ -30,10 +30,11 @@ class AnnotationContext:
         self.allow_read_on_delete = allow_read_on_delete
 
     @property
-    def links(self):
+    def annotation_links(self):
+        """A dictionary of named hypermedia links for this annotation."""
         return self.links_service.get_all(self.annotation)
 
-    def link(self, name):
+    def get_annotation_link(self, name):
         return self.links_service.get(self.annotation, name)
 
     def __acl__(self):

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -107,7 +107,10 @@ def read_jsonld(context, request):
         "charset": "UTF-8",
         "profile": str(AnnotationJSONLDPresenter.CONTEXT_URL),
     }
-    presenter = AnnotationJSONLDPresenter(context)
+
+    presenter = AnnotationJSONLDPresenter(
+        context, links_service=request.find_service(name="links")
+    )
     return presenter.asdict()
 
 

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -77,8 +77,7 @@ def create(request):
     _publish_annotation_event(request, annotation, "create")
 
     svc = request.find_service(name="annotation_json_presentation")
-    annotation_context = _annotation_context(request, annotation)
-    return svc.present(annotation_context)
+    return svc.present(AnnotationContext(annotation))
 
 
 @api_config(
@@ -134,8 +133,7 @@ def update(context, request):
     _publish_annotation_event(request, annotation, "update")
 
     svc = request.find_service(name="annotation_json_presentation")
-    annotation_context = _annotation_context(request, annotation)
-    return svc.present(annotation_context)
+    return svc.present(AnnotationContext(annotation))
 
 
 @api_config(
@@ -171,8 +169,3 @@ def _publish_annotation_event(request, annotation, action):
     """Publish an event to the annotations queue for this annotation action."""
     event = AnnotationEvent(request, annotation.id, action)
     request.notify_after_commit(event)
-
-
-def _annotation_context(request, annotation):
-    links_service = request.find_service(name="links")
-    return AnnotationContext(annotation, links_service)

--- a/tests/h/presenters/annotation_base_test.py
+++ b/tests/h/presenters/annotation_base_test.py
@@ -48,13 +48,6 @@ class TestAnnotationBasePresenter:
 
         assert updated == "1983-08-31T07:18:20.098763+00:00"
 
-    def test_links(self):
-        annotation = mock.Mock()
-        context = mock.Mock(annotation=annotation)
-
-        links = AnnotationBasePresenter(context).links
-        assert links == context.links
-
     def test_text(self):
         annotation = mock.Mock(text="It is magical!")
         context = mock.Mock(annotation=annotation)

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -43,7 +43,7 @@ class TestAnnotationJSONPresenter:
                     }
                 ],
                 "document": DocumentJSONPresenter.return_value.asdict.return_value,
-                "links": context.links,
+                "links": context.annotation_links,
                 "references": annotation.references,
                 "extra-1": "foo",
                 "extra-2": "bar",

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -117,9 +117,7 @@ class TestAnnotationJSONPresenter:
 
     @pytest.fixture
     def context(self, annotation):
-        return create_autospec(
-            AnnotationContext, instance=True, spec_set=True, annotation=annotation
-        )
+        return AnnotationContext(annotation)
 
     @pytest.fixture
     def get_formatter(self):

--- a/tests/h/services/annotation_json_presentation_test/service_test.py
+++ b/tests/h/services/annotation_json_presentation_test/service_test.py
@@ -51,7 +51,7 @@ class TestAnnotationJSONPresentationService:
         for formatter in svc.formatters:
             formatter.preload.assert_called_once_with(annotation_ids)
 
-        AnnotationContext.assert_called_once_with(annotation, svc.links_svc)
+        AnnotationContext.assert_called_once_with(annotation)
         AnnotationJSONPresenter.assert_called_once_with(
             AnnotationContext.return_value,
             links_service=svc.links_svc,

--- a/tests/h/services/annotation_json_presentation_test/service_test.py
+++ b/tests/h/services/annotation_json_presentation_test/service_test.py
@@ -33,7 +33,9 @@ class TestAnnotationJSONPresentationService:
         result = svc.present(AnnotationContext.return_value)
 
         AnnotationJSONPresenter.assert_called_once_with(
-            AnnotationContext.return_value, svc.formatters
+            AnnotationContext.return_value,
+            links_service=svc.links_svc,
+            formatters=svc.formatters,
         )
 
         assert result == AnnotationJSONPresenter.return_value.asdict.return_value
@@ -51,7 +53,9 @@ class TestAnnotationJSONPresentationService:
 
         AnnotationContext.assert_called_once_with(annotation, svc.links_svc)
         AnnotationJSONPresenter.assert_called_once_with(
-            AnnotationContext.return_value, svc.formatters
+            AnnotationContext.return_value,
+            links_service=svc.links_svc,
+            formatters=svc.formatters,
         )
         assert result == [
             AnnotationJSONPresenter.return_value.asdict.return_value,

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -135,7 +135,6 @@ class TestHandleAnnotationEvent:
 
         AnnotationContext.assert_called_once_with(
             fetch_annotation.return_value,
-            links_service,
             allow_read_on_delete=True,
         )
 

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -141,6 +141,7 @@ class TestHandleAnnotationEvent:
 
         AnnotationJSONPresenter.assert_called_once_with(
             AnnotationContext.return_value,
+            links_service=links_service,
             formatters=[AnnotationUserInfoFormatter.return_value],
         )
         assert AnnotationJSONPresenter.return_value.asdict.called

--- a/tests/h/traversal/annotation_test.py
+++ b/tests/h/traversal/annotation_test.py
@@ -63,12 +63,6 @@ class TestAnnotationContext:
         )
         assert acl == ACL.for_annotation.return_value
 
-    def test_annotation_links(self, annotation, context, links_service):
-        result = context.annotation_links
-
-        links_service.get_all.assert_called_once_with(annotation)
-        assert result == links_service.get_all.return_value
-
     def test_get_annotation_link(self, annotation, context, links_service):
         result = context.get_annotation_link("json")
 

--- a/tests/h/traversal/annotation_test.py
+++ b/tests/h/traversal/annotation_test.py
@@ -63,14 +63,14 @@ class TestAnnotationContext:
         )
         assert acl == ACL.for_annotation.return_value
 
-    def test_links(self, annotation, context, links_service):
-        result = context.links
+    def test_annotation_links(self, annotation, context, links_service):
+        result = context.annotation_links
 
         links_service.get_all.assert_called_once_with(annotation)
         assert result == links_service.get_all.return_value
 
-    def test_link(self, annotation, context, links_service):
-        result = context.link("json")
+    def test_get_annotation_link(self, annotation, context, links_service):
+        result = context.get_annotation_link("json")
 
         links_service.get.assert_called_once_with(annotation, "json")
         assert result == links_service.get.return_value

--- a/tests/h/traversal/annotation_test.py
+++ b/tests/h/traversal/annotation_test.py
@@ -25,9 +25,7 @@ class TestAnnotationRoot:
         storage.fetch_annotation.assert_called_once_with(
             pyramid_request.db, sentinel.annotation_id
         )
-        AnnotationContext.assert_called_once_with(
-            storage.fetch_annotation.return_value, links_service
-        )
+        AnnotationContext.assert_called_once_with(storage.fetch_annotation.return_value)
         assert context == AnnotationContext.return_value
 
     def test_getting_by_subscript_raises_KeyError_if_annotation_missing(

--- a/tests/h/traversal/annotation_test.py
+++ b/tests/h/traversal/annotation_test.py
@@ -63,12 +63,6 @@ class TestAnnotationContext:
         )
         assert acl == ACL.for_annotation.return_value
 
-    def test_get_annotation_link(self, annotation, context, links_service):
-        result = context.get_annotation_link("json")
-
-        links_service.get.assert_called_once_with(annotation, "json")
-        assert result == links_service.get.return_value
-
     @pytest.fixture
     def context(self, annotation, links_service):
         return AnnotationContext(annotation, links_service)

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -214,7 +214,7 @@ class TestReadJSONLD:
         }
 
     def test_it_returns_presented_annotation(
-        self, AnnotationJSONLDPresenter, pyramid_request
+        self, AnnotationJSONLDPresenter, pyramid_request, links_service
     ):
         context = mock.Mock()
         presenter = mock.Mock()
@@ -223,7 +223,9 @@ class TestReadJSONLD:
 
         result = views.read_jsonld(context, pyramid_request)
 
-        AnnotationJSONLDPresenter.assert_called_once_with(context)
+        AnnotationJSONLDPresenter.assert_called_once_with(
+            context, links_service=links_service
+        )
         assert result == presenter.asdict()
 
     @pytest.fixture

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -154,7 +154,7 @@ class TestCreate:
 
         views.create(pyramid_request)
 
-        annotation_context.assert_called_once_with(annotation, links_service)
+        annotation_context.assert_called_once_with(annotation)
 
     def test_it_presents_annotation(
         self, annotation_context, presentation_service, pyramid_request
@@ -321,7 +321,7 @@ class TestUpdate:
 
         views.update(mock.Mock(), pyramid_request)
 
-        annotation_context.assert_called_once_with(annotation, links_service)
+        annotation_context.assert_called_once_with(annotation)
 
     def test_it_presents_annotation(
         self, annotation_context, presentation_service, pyramid_request


### PR DESCRIPTION
This moves the active portions of the annotation traversal into the presenters that need them directly.

This means:

 * The presenters calling the links service directly 
 * The links service being removed from the annotation traversal
 * Turning the annotation context into a dataclass