### PR TITLE
Rearrange the auth policy definitions to be less confusing

### DIFF
--- a/h/streamer/app.py
+++ b/h/streamer/app.py
@@ -26,7 +26,7 @@ def create_app(_global_config, **settings):
 
     config.include("h.auth")
     # Override the default authentication policy.
-    config.set_authentication_policy("h.auth.WEBSOCKET_POLICY")
+    config.set_authentication_policy("h.auth.TOKEN_POLICY")
 
     config.include("h.authz")
     config.include("h.db")


### PR DESCRIPTION
There was a real nest of global seeming variables here, and it's not at all obvious what's going on. I _think_ this is doing the same thing, and I think it:

* Creates a `TOKEN_POLICY` which is used locally and as the Websocket policy
* Creates another more complicated cascading policy and sets it by default