### PR TITLE
Merge remaining user permissions into `security.ACL`

### DIFF
--- a/h/security/acl.py
+++ b/h/security/acl.py
@@ -8,7 +8,12 @@ from h.security.permissions import Permission
 
 class ACL:
     @classmethod
-    def for_user(cls, user):
+    def for_user(cls, user=None):
+        yield Allow, role.AuthClient, Permission.User.CREATE
+
+        if not user:
+            return
+
         client_authority = "client_authority:{}".format(user.authority)
 
         # auth_clients with the same authority as the user may update the user

--- a/h/traversal/user.py
+++ b/h/traversal/user.py
@@ -1,14 +1,11 @@
 from dataclasses import dataclass
 
 from pyramid.httpexceptions import HTTPBadRequest
-from pyramid.security import Allow
 
-from h.auth import role
 from h.auth.util import client_authority
 from h.exceptions import InvalidUserId
 from h.models import User
 from h.security.acl import ACL
-from h.security.permissions import Permission
 from h.traversal.root import RootFactory
 
 
@@ -19,14 +16,10 @@ class UserContext:
     user: User
 
     def __acl__(self):
-        """Return user access control lists."""
-
         return ACL.for_user(self.user)
 
 
 class UserRoot(RootFactory):
-    __acl__ = [(Allow, role.AuthClient, Permission.User.CREATE)]
-
     def __init__(self, request):
         super().__init__(request)
 
@@ -45,6 +38,9 @@ class UserRoot(RootFactory):
             raise KeyError()
 
         return UserContext(user)
+
+    def __acl__(self):
+        return ACL.for_user(user=None)
 
 
 class UserByNameRoot(UserRoot):

--- a/tests/h/security/test_acl.py
+++ b/tests/h/security/test_acl.py
@@ -30,6 +30,11 @@ class TestACLForUser:
         principal = principal_template.format(user=user)
         assert bool(user_permits([principal, "some_noise"], permission)) == is_permitted
 
+    def test_a_user_is_not_required_for_create(self, permits):
+        acl_object = ObjectWithACL(ACL.for_user(user=None))
+
+        permits(acl_object, [role.AuthClient], Permission.User.CREATE)
+
     @pytest.fixture
     def user_permits(self, permits, user):
         return functools.partial(permits, ObjectWithACL(ACL.for_user(user)))


### PR DESCRIPTION
This PR moves the static user permissions which are granted at the root level into the security module. This leaves the ACL class as the final word on user permissions.

This is a slight change of style (but not behavior) as we previously only emitted this permission item when it _could_ be used. We'll emit it now in all user situations. This doesn't change anything unless you are trying to use it.