### PR TITLE
Move the final ACLs to the security module

### DIFF
--- a/h/security/acl.py
+++ b/h/security/acl.py
@@ -34,6 +34,17 @@ class ACL:
         yield DENY_ALL
 
     @classmethod
+    def for_bulk_api(cls, client_authority=None):
+        if not client_authority:
+            return
+
+        # Currently only LMS uses this end-point
+        if client_authority.startswith("lms.") and client_authority.endswith(
+            ".hypothes.is"
+        ):
+            yield Allow, f"client_authority:{client_authority}", Permission.API.BULK_ACTION
+
+    @classmethod
     def for_profile(cls):
         # A user can always update their own profile
         yield Allow, role.User, Permission.Profile.UPDATE

--- a/h/security/acl.py
+++ b/h/security/acl.py
@@ -34,6 +34,11 @@ class ACL:
         yield DENY_ALL
 
     @classmethod
+    def for_profile(cls):
+        # A user can always update their own profile
+        yield Allow, role.User, Permission.Profile.UPDATE
+
+    @classmethod
     def for_group(cls, group=None):
         # Any logged in user may create a group
         yield Allow, role.User, Permission.Group.CREATE

--- a/h/security/acl.py
+++ b/h/security/acl.py
@@ -8,6 +8,16 @@ from h.security.permissions import Permission
 
 class ACL:
     @classmethod
+    def for_admin_pages(cls):
+        yield Allow, role.Staff, Permission.AdminPage.INDEX
+        yield Allow, role.Staff, Permission.AdminPage.GROUPS
+        yield Allow, role.Staff, Permission.AdminPage.MAILER
+        yield Allow, role.Staff, Permission.AdminPage.ORGANIZATIONS
+        yield Allow, role.Staff, Permission.AdminPage.USERS
+        yield Allow, role.Admin, security.ALL_PERMISSIONS
+        yield DENY_ALL
+
+    @classmethod
     def for_user(cls, user=None):
         yield Allow, role.AuthClient, Permission.User.CREATE
 

--- a/h/traversal/bulk_api.py
+++ b/h/traversal/bulk_api.py
@@ -1,7 +1,5 @@
-from pyramid.security import Allow
-
 from h.auth.util import client_authority
-from h.security.permissions import Permission
+from h.security.acl import ACL
 from h.traversal.root import RootFactory
 
 
@@ -9,13 +7,4 @@ class BulkAPIRoot(RootFactory):
     """Root factory for the Bulk API."""
 
     def __acl__(self):
-        """Return ACL for bulk end-points."""
-
-        if authority := client_authority(self.request):
-            # Currently only LMS uses this end-point
-            if authority.startswith("lms.") and authority.endswith(".hypothes.is"):
-                return [
-                    (Allow, f"client_authority:{authority}", Permission.API.BULK_ACTION)
-                ]
-
-        return []
+        return ACL.for_bulk_api(client_authority=client_authority(self.request))

--- a/h/traversal/group.py
+++ b/h/traversal/group.py
@@ -23,11 +23,7 @@ class GroupRoot(RootFactory):
 
 
 class GroupRequiredRoot(GroupRoot):
-    """
-    Root factory for routes dealing with groups which must exist.
-
-    FIXME: This class should return GroupContext objects, not Group objects.
-    """
+    """Root factory for routes dealing with groups which must exist."""
 
     def __getitem__(self, pubid_or_groupid):
         group_context = super().__getitem__(pubid_or_groupid)

--- a/h/traversal/profile.py
+++ b/h/traversal/profile.py
@@ -1,13 +1,10 @@
-from pyramid.security import Allow
-
-from h.auth import role
-from h.security.permissions import Permission
+from h.security.acl import ACL
 from h.traversal.root import RootFactory
 
 
 class ProfileRoot(RootFactory):
-    """
-    Simple Root for API profile endpoints
-    """
+    """Simple Root for API profile endpoints."""
 
-    __acl__ = [(Allow, role.User, Permission.Profile.UPDATE)]
+    @classmethod
+    def __acl__(cls):
+        return ACL.for_profile()

--- a/h/traversal/root.py
+++ b/h/traversal/root.py
@@ -1,7 +1,4 @@
-from pyramid.security import ALL_PERMISSIONS, DENY_ALL, Allow
-
-from h.auth import role
-from h.security.permissions import Permission
+from h.security.acl import ACL
 
 
 class RootFactory:
@@ -14,12 +11,6 @@ class RootFactory:
 class Root(RootFactory):
     """This app's default root factory."""
 
-    __acl__ = [
-        (Allow, role.Staff, Permission.AdminPage.INDEX),
-        (Allow, role.Staff, Permission.AdminPage.GROUPS),
-        (Allow, role.Staff, Permission.AdminPage.MAILER),
-        (Allow, role.Staff, Permission.AdminPage.ORGANIZATIONS),
-        (Allow, role.Staff, Permission.AdminPage.USERS),
-        (Allow, role.Admin, ALL_PERMISSIONS),
-        DENY_ALL,
-    ]
+    @classmethod
+    def __acl__(cls):
+        return ACL.for_admin_pages()

--- a/tests/h/security/test_acl.py
+++ b/tests/h/security/test_acl.py
@@ -12,6 +12,48 @@ from h.security.acl import ACL
 from h.security.permissions import Permission
 
 
+class TestACLForAdminPages:
+    @pytest.mark.parametrize(
+        "permission",
+        (
+            Permission.AdminPage.INDEX,
+            Permission.AdminPage.GROUPS,
+            Permission.AdminPage.MAILER,
+            Permission.AdminPage.ORGANIZATIONS,
+            Permission.AdminPage.USERS,
+        ),
+    )
+    def test_staff_permissions(self, admin_page_permits, permission):
+        assert not admin_page_permits([], permission)
+        assert admin_page_permits([role.Staff], permission)
+        assert admin_page_permits([role.Admin], permission)
+
+    @pytest.mark.parametrize(
+        "permission",
+        (
+            Permission.AdminPage.ADMINS,
+            Permission.AdminPage.BADGE,
+            Permission.AdminPage.FEATURES,
+            Permission.AdminPage.OAUTH_CLIENTS,
+            Permission.AdminPage.NIPSA,
+            Permission.AdminPage.SEARCH,
+            Permission.AdminPage.STAFF,
+        ),
+    )
+    def test_admin_only_permissions(self, admin_page_permits, permission):
+        assert not admin_page_permits([], permission)
+        assert not admin_page_permits([role.Staff], permission)
+        assert admin_page_permits([role.Admin], permission)
+
+    @pytest.fixture
+    def admin_page_permits(self, permits):
+        # Wrap this in a list as we ask for more than one permission per
+        # context. This is an artefact of `ObjectWithACL` not how it really
+        # works
+        acl = list(ACL.for_admin_pages())
+        return functools.partial(permits, ObjectWithACL(acl))
+
+
 class TestACLForUser:
     @pytest.mark.parametrize(
         "principal_template,is_permitted",

--- a/tests/h/security/test_acl.py
+++ b/tests/h/security/test_acl.py
@@ -86,6 +86,26 @@ class TestACLForUser:
         return factories.User.create()
 
 
+class TestForBulkAPI:
+    @pytest.mark.parametrize(
+        "client_authority,principal,is_permitted",
+        (
+            ("lms.hypothes.is", "client_authority:lms.hypothes.is", True),
+            ("lms.ca.hypothes.is", "client_authority:lms.ca.hypothes.is", True),
+            ("lms.hypothes.is", "client_authority:MISMATCH.hypothes.is", False),
+            ("lms.other", "client_authority:lms.other", False),
+            ("hypothes.is", "client_authority:hypothes.is", False),
+        ),
+    )
+    def test_it(self, permits, client_authority, principal, is_permitted):
+        acl = ACL.for_bulk_api(client_authority=client_authority)
+
+        assert (
+            permits(ObjectWithACL(acl), [principal], Permission.API.BULK_ACTION)
+            == is_permitted
+        )
+
+
 class TestACLForProfile:
     def test_it(self, permits):
         acl = ACL.for_profile()

--- a/tests/h/security/test_acl.py
+++ b/tests/h/security/test_acl.py
@@ -86,6 +86,14 @@ class TestACLForUser:
         return factories.User.create()
 
 
+class TestACLForProfile:
+    def test_it(self, permits):
+        acl = ACL.for_profile()
+
+        assert permits(ObjectWithACL(acl), [role.User], Permission.Profile.UPDATE)
+        assert not permits(ObjectWithACL(acl), [], Permission.Profile.UPDATE)
+
+
 class TestACLForGroup:
     def test_logged_in_users_get_create_permission(
         self, group_permits, no_group_permits

--- a/tests/h/traversal/profile_test.py
+++ b/tests/h/traversal/profile_test.py
@@ -1,23 +1,17 @@
-from h.auth import role
-from h.security.permissions import Permission
+from unittest.mock import sentinel
+
+import pytest
+
 from h.traversal.profile import ProfileRoot
 
 
 class TestProfileRoot:
-    def test_it_assigns_update_permission_with_user_role(
-        self, set_permissions, pyramid_request
-    ):
-        set_permissions("acct:adminuser@foo", principals=[role.User])
+    def test_acl_matching_user(self, ACL):
+        acl = ProfileRoot(sentinel.request).__acl__()
 
-        context = ProfileRoot(pyramid_request)
+        ACL.for_profile.assert_called_once_with()
+        assert acl == ACL.for_profile.return_value
 
-        assert pyramid_request.has_permission(Permission.Profile.UPDATE, context)
-
-    def test_it_does_not_assign_update_permission_without_user_role(
-        self, set_permissions, pyramid_request
-    ):
-        set_permissions("acct:adminuser@foo", principals=["whatever"])
-
-        context = ProfileRoot(pyramid_request)
-
-        assert not pyramid_request.has_permission(Permission.Profile.UPDATE, context)
+    @pytest.fixture
+    def ACL(self, patch):
+        return patch("h.traversal.profile.ACL")

--- a/tests/h/traversal/root_test.py
+++ b/tests/h/traversal/root_test.py
@@ -1,57 +1,17 @@
-import pyramid.authorization
-import pyramid.security
+from unittest.mock import sentinel
+
 import pytest
 
-from h.auth import role
-from h.security.permissions import Permission
 from h.traversal.root import Root
 
 
 class TestRoot:
-    @pytest.mark.parametrize(
-        "permission",
-        [
-            "admin_index",
-            "admin_groups",
-            "admin_mailer",
-            "admin_organizations",
-            "admin_users",
-            pyramid.security.ALL_PERMISSIONS,
-        ],
-    )
-    def test_it_denies_all_permissions_for_unauthed_request(
-        self, set_permissions, pyramid_request, permission
-    ):
-        set_permissions(None, principals=None)
+    def test_acl_matching_user(self, ACL):
+        acl = Root(sentinel.request).__acl__()
 
-        context = Root(pyramid_request)
+        ACL.for_admin_pages.assert_called_once_with()
+        assert acl == ACL.for_admin_pages.return_value
 
-        assert not pyramid_request.has_permission(permission, context)
-
-    @pytest.mark.parametrize(
-        "permission",
-        [
-            Permission.AdminPage.INDEX,
-            Permission.AdminPage.GROUPS,
-            Permission.AdminPage.MAILER,
-            Permission.AdminPage.ORGANIZATIONS,
-            Permission.AdminPage.USERS,
-        ],
-    )
-    def test_it_assigns_admin_permissions_to_requests_with_staff_role(
-        self, set_permissions, pyramid_request, permission
-    ):
-        set_permissions("acct:adminuser@foo", principals=[role.Staff])
-
-        context = Root(pyramid_request)
-
-        assert pyramid_request.has_permission(permission, context)
-
-    def test_it_assigns_all_permissions_to_requests_with_admin_role(
-        self, set_permissions, pyramid_request
-    ):
-        set_permissions("acct:adminuser@foo", principals=[role.Admin])
-
-        context = Root(pyramid_request)
-
-        assert pyramid_request.has_permission(pyramid.security.ALL_PERMISSIONS, context)
+    @pytest.fixture
+    def ACL(self, patch):
+        return patch("h.traversal.root.ACL")


### PR DESCRIPTION
This moves all the remaining ACL things into the security module from the traversals. This includes:

* Admin pages / default rules - They are applied universally, but are mostly concerned with admin pages
* Bulk API
* Profile