### PR TITLE
Only use the AnnotationContext for ACL + traversal reasons

### DIFF
--- a/h/formatters/annotation_flag.py
+++ b/h/formatters/annotation_flag.py
@@ -29,8 +29,8 @@ class AnnotationFlagFormatter:
         self._cache.update(flags)
         return flags
 
-    def format(self, annotation_context):
-        flagged = self._load(annotation_context.annotation)
+    def format(self, annotation):
+        flagged = self._load(annotation)
         return {"flagged": flagged}
 
     def _load(self, annotation):

--- a/h/formatters/annotation_hidden.py
+++ b/h/formatters/annotation_hidden.py
@@ -1,4 +1,5 @@
 from h.security.permissions import Permission
+from h.traversal import AnnotationContext
 
 
 class AnnotationHiddenFormatter:
@@ -36,10 +37,8 @@ class AnnotationHiddenFormatter:
         self._cache.update(hidden)
         return hidden
 
-    def format(self, annotation_context):
-        annotation = annotation_context.annotation
-
-        if self._current_user_is_moderator(annotation_context):
+    def format(self, annotation):
+        if self._current_user_is_moderator(annotation):
             return {"hidden": self._is_hidden(annotation)}
 
         if self._current_user_is_author(annotation):
@@ -50,9 +49,9 @@ class AnnotationHiddenFormatter:
 
         return {"hidden": False}
 
-    def _current_user_is_moderator(self, annotation_context):
+    def _current_user_is_moderator(self, annotation):
         return self._has_permission(
-            Permission.Annotation.MODERATE, context=annotation_context
+            Permission.Annotation.MODERATE, context=AnnotationContext(annotation)
         )
 
     def _current_user_is_author(self, annotation):

--- a/h/formatters/annotation_moderation.py
+++ b/h/formatters/annotation_moderation.py
@@ -1,4 +1,5 @@
 from h.security.permissions import Permission
+from h.traversal import AnnotationContext
 
 
 class AnnotationModerationFormatter:
@@ -31,13 +32,13 @@ class AnnotationModerationFormatter:
         self._cache.update(flag_counts)
         return flag_counts
 
-    def format(self, annotation_context):
+    def format(self, annotation):
         if not self._has_permission(
-            Permission.Annotation.MODERATE, context=annotation_context
+            Permission.Annotation.MODERATE, context=AnnotationContext(annotation)
         ):
             return {}
 
-        flag_count = self._load(annotation_context.annotation)
+        flag_count = self._load(annotation)
         return {"moderation": {"flagCount": flag_count}}
 
     def _load(self, annotation):

--- a/h/formatters/annotation_user_info.py
+++ b/h/formatters/annotation_user_info.py
@@ -19,6 +19,6 @@ class AnnotationUserInfoFormatter:
         }
         self.user_svc.fetch_all(userids)
 
-    def format(self, annotation_context):
-        user = self.user_svc.fetch(annotation_context.annotation.userid)
+    def format(self, annotation):
+        user = self.user_svc.fetch(annotation.userid)
         return user_info(user)

--- a/h/presenters/annotation_base.py
+++ b/h/presenters/annotation_base.py
@@ -6,9 +6,8 @@ from h.util.datetime import utc_iso8601
 
 
 class AnnotationBasePresenter:
-    def __init__(self, annotation_context):
-        self.annotation_context = annotation_context
-        self.annotation = annotation_context.annotation
+    def __init__(self, annotation):
+        self.annotation = annotation
 
     @property
     def created(self):

--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -6,13 +6,14 @@ from pyramid.security import principals_allowed_by_permission
 from h.presenters.annotation_base import AnnotationBasePresenter
 from h.presenters.document_json import DocumentJSONPresenter
 from h.security.permissions import Permission
+from h.traversal import AnnotationContext
 
 
 class AnnotationJSONPresenter(AnnotationBasePresenter):
     """Present an annotation in the JSON format returned by API requests."""
 
-    def __init__(self, annotation_context, links_service, formatters=None):
-        super().__init__(annotation_context)
+    def __init__(self, annotation, links_service, formatters=None):
+        super().__init__(annotation)
 
         self._links_service = links_service
         self._formatters = tuple(formatters or [])
@@ -49,7 +50,7 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
             annotation["references"] = self.annotation.references
 
         for formatter in self._formatters:
-            annotation.update(formatter.format(self.annotation_context))
+            annotation.update(formatter.format(self.annotation))
 
         return annotation
 
@@ -59,7 +60,7 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
             return self.annotation.userid
 
         if security.Everyone in principals_allowed_by_permission(
-            self.annotation_context, Permission.Annotation.READ
+            AnnotationContext(self.annotation), Permission.Annotation.READ
         ):
             # Anyone in the world can read this
             return "group:__world__"

--- a/h/presenters/annotation_jsonld.py
+++ b/h/presenters/annotation_jsonld.py
@@ -10,8 +10,8 @@ class AnnotationJSONLDPresenter(AnnotationBasePresenter):
       https://www.w3.org/TR/annotation-model/
     """
 
-    def __init__(self, annotation_context, links_service):
-        super().__init__(annotation_context)
+    def __init__(self, annotation, links_service):
+        super().__init__(annotation)
 
         self._links_service = links_service
 

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -7,7 +7,7 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
     """Present an annotation in the JSON format used in the search index."""
 
     def __init__(self, annotation, request):
-        self.annotation = annotation
+        super().__init__(annotation)
         self.request = request
 
     def asdict(self):

--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -3,7 +3,6 @@ from sqlalchemy.orm import subqueryload
 from h import formatters, storage
 from h.models import Annotation
 from h.presenters import AnnotationJSONPresenter
-from h.traversal import AnnotationContext
 
 
 class AnnotationJSONPresentationService:
@@ -30,9 +29,9 @@ class AnnotationJSONPresentationService:
             formatters.AnnotationUserInfoFormatter(self.session, user_svc),
         ]
 
-    def present(self, annotation_context):
+    def present(self, annotation):
         return AnnotationJSONPresenter(
-            annotation_context, links_service=self.links_svc, formatters=self.formatters
+            annotation, links_service=self.links_svc, formatters=self.formatters
         ).asdict()
 
     def present_all(self, annotation_ids):
@@ -47,6 +46,4 @@ class AnnotationJSONPresentationService:
         for formatter in self.formatters:
             formatter.preload(annotation_ids)
 
-        return [
-            self.present(AnnotationContext(annotation)) for annotation in annotations
-        ]
+        return [self.present(annotation) for annotation in annotations]

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -123,11 +123,10 @@ def handle_annotation_event(message, sockets, request, session):
         (first_socket,), matching_sockets
     )
 
-    annotation_context = AnnotationContext(annotation)
     read_principals = principals_allowed_by_permission(
-        annotation_context, Permission.Annotation.READ_REALTIME_UPDATES
+        AnnotationContext(annotation), Permission.Annotation.READ_REALTIME_UPDATES
     )
-    reply = _generate_annotation_event(session, request, message, annotation_context)
+    reply = _generate_annotation_event(session, request, message, annotation)
 
     annotator_nipsad = request.find_service(name="nipsa").is_flagged(annotation.userid)
 
@@ -147,7 +146,7 @@ def handle_annotation_event(message, sockets, request, session):
         socket.send_json(reply)
 
 
-def _generate_annotation_event(session, request, message, annotation_context):
+def _generate_annotation_event(session, request, message, annotation):
     """
     Get message about annotation event `message` to be sent to `socket`.
 
@@ -164,7 +163,7 @@ def _generate_annotation_event(session, request, message, annotation_context):
         user_service = request.find_service(name="user")
         formatters = [AnnotationUserInfoFormatter(session, user_service)]
         payload = presenters.AnnotationJSONPresenter(
-            annotation_context,
+            annotation,
             links_service=request.find_service(name="links"),
             formatters=formatters,
         ).asdict()

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -27,7 +27,6 @@ from h.schemas.annotation import (
 )
 from h.schemas.util import validate_query_params
 from h.security.permissions import Permission
-from h.traversal import AnnotationContext
 from h.views.api.config import api_config
 from h.views.api.exceptions import PayloadError
 
@@ -77,7 +76,7 @@ def create(request):
     _publish_annotation_event(request, annotation, "create")
 
     svc = request.find_service(name="annotation_json_presentation")
-    return svc.present(AnnotationContext(annotation))
+    return svc.present(annotation)
 
 
 @api_config(
@@ -90,8 +89,9 @@ def create(request):
 )
 def read(context, request):
     """Return the annotation (simply how it was stored in the database)."""
-    svc = request.find_service(name="annotation_json_presentation")
-    return svc.present(context)
+    return request.find_service(name="annotation_json_presentation").present(
+        context.annotation
+    )
 
 
 @api_config(
@@ -107,10 +107,9 @@ def read_jsonld(context, request):
         "profile": str(AnnotationJSONLDPresenter.CONTEXT_URL),
     }
 
-    presenter = AnnotationJSONLDPresenter(
-        context, links_service=request.find_service(name="links")
-    )
-    return presenter.asdict()
+    return AnnotationJSONLDPresenter(
+        context.annotation, links_service=request.find_service(name="links")
+    ).asdict()
 
 
 @api_config(
@@ -132,8 +131,7 @@ def update(context, request):
 
     _publish_annotation_event(request, annotation, "update")
 
-    svc = request.find_service(name="annotation_json_presentation")
-    return svc.present(AnnotationContext(annotation))
+    return request.find_service(name="annotation_json_presentation").present(annotation)
 
 
 @api_config(

--- a/tests/h/formatters/annotation_flag_test.py
+++ b/tests/h/formatters/annotation_flag_test.py
@@ -1,11 +1,7 @@
-from collections import namedtuple
-
 import pytest
 
 from h.formatters.annotation_flag import AnnotationFlagFormatter
 from h.services.flag import FlagService
-
-FakeAnnotationContext = namedtuple("FakeAnnotationContext", ["annotation"])
 
 
 class TestAnnotationFlagFormatter:
@@ -23,21 +19,20 @@ class TestAnnotationFlagFormatter:
 
     def test_format_for_existing_flag(self, formatter, factories, current_user):
         flag = factories.Flag(user=current_user)
-        annotation_context = FakeAnnotationContext(flag.annotation)
-        assert formatter.format(annotation_context) == {"flagged": True}
+
+        assert formatter.format(flag.annotation) == {"flagged": True}
 
     def test_format_for_missing_flag(self, formatter, factories):
         annotation = factories.Annotation()
-        annotation_context = FakeAnnotationContext(annotation)
 
-        assert formatter.format(annotation_context) == {"flagged": False}
+        assert formatter.format(annotation) == {"flagged": False}
 
     def test_format_for_unauthenticated_user(self, flag_service, factories):
         annotation = factories.Annotation()
-        annotation_context = FakeAnnotationContext(annotation)
+
         formatter = AnnotationFlagFormatter(flag_service, user=None)
 
-        assert formatter.format(annotation_context) == {"flagged": False}
+        assert formatter.format(annotation) == {"flagged": False}
 
     @pytest.fixture
     def current_user(self, factories):

--- a/tests/h/formatters/annotation_user_info_test.py
+++ b/tests/h/formatters/annotation_user_info_test.py
@@ -1,57 +1,53 @@
-from collections import namedtuple
-from unittest import mock
-
 import pytest
 
 from h.formatters.annotation_user_info import AnnotationUserInfoFormatter
 
-FakeAnnotationContext = namedtuple("FakeAnnotationContext", ["annotation"])
-
 
 class TestAnnotationUserInfoFormatter:
-    def test_preload_fetches_users_by_id(self, formatter, factories, user_svc):
+    def test_preload_fetches_users_by_id(self, formatter, factories, user_service):
         annotation_1 = factories.Annotation()
         annotation_2 = factories.Annotation()
 
         formatter.preload([annotation_1.id, annotation_2.id])
 
-        user_svc.fetch_all.assert_called_once_with(
+        user_service.fetch_all.assert_called_once_with(
             {annotation_1.userid, annotation_2.userid}
         )
 
-    def test_preload_skips_fetching_for_empty_ids(self, formatter, user_svc):
+    def test_preload_skips_fetching_for_empty_ids(self, formatter, user_service):
         formatter.preload([])
-        assert not user_svc.fetch_all.called
+        assert not user_service.fetch_all.called
 
-    def test_format_fetches_user_by_id(self, formatter, factories, user_svc):
-        annotation = factories.Annotation.build()
-        context = FakeAnnotationContext(annotation)
+    def test_format_fetches_user_by_id(
+        self, formatter, annotation, factories, user_service
+    ):
+        formatter.format(annotation)
 
-        formatter.format(context)
+        user_service.fetch.assert_called_once_with(annotation.userid)
 
-        user_svc.fetch.assert_called_once_with(annotation.userid)
+    def test_format_uses_user_info(
+        self, formatter, annotation, user_service, user_info, factories
+    ):
+        user = factories.User()
+        user_service.fetch.return_value = user
 
-    def test_format_uses_user_info(self, formatter, user_svc, user_info):
-        user = mock.Mock(display_name="Jane Doe")
-        user_svc.fetch.return_value = user
-
-        formatter.format(FakeAnnotationContext(mock.Mock()))
+        formatter.format(annotation)
 
         user_info.assert_called_once_with(user)
 
-    def test_format_returns_formatted_user_info(self, formatter, user_info):
-        result = formatter.format(FakeAnnotationContext(mock.Mock()))
+    def test_format_returns_formatted_user_info(self, formatter, annotation, user_info):
+        result = formatter.format(annotation)
 
         assert result == user_info.return_value
 
     @pytest.fixture
-    def formatter(self, db_session, user_svc):
-        return AnnotationUserInfoFormatter(db_session, user_svc)
+    def annotation(self, factories):
+        return factories.Annotation.build()
+
+    @pytest.fixture
+    def formatter(self, db_session, user_service):
+        return AnnotationUserInfoFormatter(db_session, user_service)
 
     @pytest.fixture
     def user_info(self, patch):
         return patch("h.formatters.annotation_user_info.user_info")
-
-    @pytest.fixture
-    def user_svc(self):
-        return mock.Mock(spec_set=["fetch_all", "fetch"])

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -7,7 +7,6 @@ from pyramid import security
 
 from h.formatters import AnnotationFlagFormatter
 from h.presenters.annotation_json import AnnotationJSONPresenter
-from h.traversal import AnnotationContext
 
 
 class TestAnnotationJSONPresenter:
@@ -64,23 +63,21 @@ class TestAnnotationJSONPresenter:
         # And we aren't mutated
         assert annotation.extra == {"id": "DIFFERENT"}
 
-    def test_asdict_merges_formatters(
-        self, annotation, context, links_service, get_formatter
-    ):
+    def test_asdict_merges_formatters(self, annotation, links_service, get_formatter):
         formatters = [
             get_formatter({"flagged": "nope"}),
             get_formatter({"nipsa": "maybe"}),
         ]
 
         presented = AnnotationJSONPresenter(
-            context, links_service=links_service, formatters=formatters
+            annotation, links_service=links_service, formatters=formatters
         ).asdict()
 
         assert presented["flagged"] == "nope"
         assert presented["nipsa"] == "maybe"
 
         for formatter in formatters:
-            formatter.format.assert_called_once_with(context)
+            formatter.format.assert_called_once_with(annotation)
 
     @pytest.mark.parametrize(
         "shared,readable_by,permission_template",
@@ -108,16 +105,12 @@ class TestAnnotationJSONPresenter:
         assert presented["permissions"]["read"] == [permission]
 
     @pytest.fixture
-    def presenter(self, context, links_service):
-        return AnnotationJSONPresenter(context, links_service=links_service)
+    def presenter(self, annotation, links_service):
+        return AnnotationJSONPresenter(annotation, links_service=links_service)
 
     @pytest.fixture
     def annotation(self, factories):
         return factories.Annotation(groupid="NOT WORLD")
-
-    @pytest.fixture
-    def context(self, annotation):
-        return AnnotationContext(annotation)
 
     @pytest.fixture
     def get_formatter(self):

--- a/tests/h/presenters/annotation_jsonld_test.py
+++ b/tests/h/presenters/annotation_jsonld_test.py
@@ -4,7 +4,6 @@ import pytest
 from h_matchers import Any
 
 from h.presenters.annotation_jsonld import AnnotationJSONLDPresenter
-from h.traversal import AnnotationContext
 
 
 class TestAnnotationJSONLDPresenter:
@@ -142,8 +141,8 @@ class TestAnnotationJSONLDPresenter:
 
     @pytest.fixture
     def annotation(self, factories):
-        return factories.Annotation()
+        return factories.Annotation.build()
 
     @pytest.fixture
     def presenter(self, annotation, links_service):
-        return AnnotationJSONLDPresenter(AnnotationContext(annotation), links_service)
+        return AnnotationJSONLDPresenter(annotation, links_service)

--- a/tests/h/services/annotation_json_presentation_test/service_test.py
+++ b/tests/h/services/annotation_json_presentation_test/service_test.py
@@ -29,21 +29,16 @@ class TestAnnotationJSONPresentationService:
             formatters.AnnotationUserInfoFormatter.return_value,
         ]
 
-    def test_present(self, svc, AnnotationJSONPresenter, AnnotationContext):
-        result = svc.present(AnnotationContext.return_value)
+    def test_present(self, svc, annotation, AnnotationJSONPresenter):
+        result = svc.present(annotation)
 
         AnnotationJSONPresenter.assert_called_once_with(
-            AnnotationContext.return_value,
-            links_service=svc.links_svc,
-            formatters=svc.formatters,
+            annotation, links_service=svc.links_svc, formatters=svc.formatters
         )
 
         assert result == AnnotationJSONPresenter.return_value.asdict.return_value
 
-    def test_present_all(
-        self, svc, factories, AnnotationJSONPresenter, AnnotationContext
-    ):
-        annotation = factories.Annotation()
+    def test_present_all(self, svc, factories, annotation, AnnotationJSONPresenter):
         annotation_ids = [annotation.id]
 
         result = svc.present_all(annotation_ids)
@@ -51,11 +46,8 @@ class TestAnnotationJSONPresentationService:
         for formatter in svc.formatters:
             formatter.preload.assert_called_once_with(annotation_ids)
 
-        AnnotationContext.assert_called_once_with(annotation)
         AnnotationJSONPresenter.assert_called_once_with(
-            AnnotationContext.return_value,
-            links_service=svc.links_svc,
-            formatters=svc.formatters,
+            annotation, links_service=svc.links_svc, formatters=svc.formatters
         )
         assert result == [
             AnnotationJSONPresenter.return_value.asdict.return_value,
@@ -75,10 +67,8 @@ class TestAnnotationJSONPresentationService:
         )
 
     @pytest.fixture
-    def AnnotationContext(self, patch):
-        return patch(
-            "h.services.annotation_json_presentation.service.AnnotationContext"
-        )
+    def annotation(self, factories):
+        return factories.Annotation()
 
     @pytest.fixture(autouse=True)
     def formatters(self, patch):

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -127,16 +127,13 @@ class TestHandleAnnotationEvent:
         handle_annotation_event,
         fetch_annotation,
         links_service,
-        AnnotationContext,
         AnnotationUserInfoFormatter,
         AnnotationJSONPresenter,
     ):
         handle_annotation_event()
 
-        AnnotationContext.assert_called_once_with(fetch_annotation.return_value)
-
         AnnotationJSONPresenter.assert_called_once_with(
-            AnnotationContext.return_value,
+            fetch_annotation.return_value,
             links_service=links_service,
             formatters=[AnnotationUserInfoFormatter.return_value],
         )


### PR DESCRIPTION
Before all of this work the `AnnotationContext` did a lot of different types of work:

 * Acted like a service to look up things
 * Had lots of functionally private methods for specific formatters
 * Was used as the primary vehicle as input to the presenters / formatters
 * Carried state to modify the meaning of permissions for the websocket
 * Used to look up permissions using the ACL on it
 * Used as a context in traversal to carry the ACL and be provided to views

Previous PRs had removed the methods and lookups from the context, which was the reason it was passed to the presenters. A previous PR has also removed the permission modifying state for the websocket meaning the context can now be the same. This finally gets us in a position to pass the annotation directly to presenters (and so formatters) instead of the annotation context.

At this point the context is only involved if:

 * It's used during traversal
 * It's used for making permissions queries

This unfortunately meant we hit a lot of grotty tests everywhere which had two prominent issues which are quite common in `h` tests:

 * Extremely aggressively splitting so we have one assertion per test, not one situation
 * Mocking models and context with plain `Mock` objects or using `namedtuple`s instead of autospecs or factories

### Review notes

 * The first PR contains all the changes to code - It's not actually _all_ that much
 * The real fun comes with trying to get the tests in a state to alter them
 * I've split all of the individual types of test fixes into separate commits