### PR TITLE
Use a distinct permission for websocket communications

### DIFF
--- a/h/security/permissions.py
+++ b/h/security/permissions.py
@@ -16,6 +16,7 @@ class Permission:
 
     class Annotation(Enum):
         READ = "annotation:read"
+        READ_REALTIME_UPDATES = "annotation:read_realtime_updates"
         UPDATE = "annotation:update"
         CREATE = "annotation:create"
         DELETE = "annotation:delete"

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -123,16 +123,9 @@ def handle_annotation_event(message, sockets, request, session):
         (first_socket,), matching_sockets
     )
 
-    annotation_context = AnnotationContext(
-        annotation,
-        # This is a bit clunky but we have one permission for reading
-        # annotations and reading notifications about deleted annotations.
-        # We could really do with two, as you don't get READ when things are
-        # deleted by default
-        allow_read_on_delete=True,
-    )
+    annotation_context = AnnotationContext(annotation)
     read_principals = principals_allowed_by_permission(
-        annotation_context, Permission.Annotation.READ
+        annotation_context, Permission.Annotation.READ_REALTIME_UPDATES
     )
     reply = _generate_annotation_event(session, request, message, annotation_context)
 

--- a/h/traversal/annotation.py
+++ b/h/traversal/annotation.py
@@ -26,7 +26,6 @@ class AnnotationContext:
     """Context for annotation-based views."""
 
     annotation: Annotation
-    allow_read_on_delete: bool = False
 
     def __acl__(self):
-        return ACL.for_annotation(self.annotation, self.allow_read_on_delete)
+        return ACL.for_annotation(self.annotation)

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -133,10 +133,7 @@ class TestHandleAnnotationEvent:
     ):
         handle_annotation_event()
 
-        AnnotationContext.assert_called_once_with(
-            fetch_annotation.return_value,
-            allow_read_on_delete=True,
-        )
+        AnnotationContext.assert_called_once_with(fetch_annotation.return_value)
 
         AnnotationJSONPresenter.assert_called_once_with(
             AnnotationContext.return_value,
@@ -246,7 +243,7 @@ class TestHandleAnnotationEvent:
         handle_annotation_event(sockets=[socket])
 
         principals_allowed_by_permission.assert_called_with(
-            AnnotationContext.return_value, Permission.Annotation.READ
+            AnnotationContext.return_value, Permission.Annotation.READ_REALTIME_UPDATES
         )
         assert bool(socket.send_json.call_count) == can_see
 

--- a/tests/h/traversal/annotation_test.py
+++ b/tests/h/traversal/annotation_test.py
@@ -52,15 +52,10 @@ class TestAnnotationRoot:
 class TestAnnotationContext:
     def test__acl__(self, factories, ACL):
         annotation = factories.Annotation()
-        context = AnnotationContext(
-            annotation, allow_read_on_delete=sentinel.allow_read_on_delete
-        )
 
-        acl = context.__acl__()
+        acl = AnnotationContext(annotation).__acl__()
 
-        ACL.for_annotation.assert_called_once_with(
-            annotation, sentinel.allow_read_on_delete
-        )
+        ACL.for_annotation.assert_called_once_with(annotation)
         assert acl == ACL.for_annotation.return_value
 
 


### PR DESCRIPTION
### Background

Currently we use the `Permission.Annotation.READ` for two quite different things. 

In the normal context it relates to whether you can see the annotation, and isn't available when the annotation is deleted.

In the websocket context it relates to whether you can see updates about the annotation, including information that it's been deleted.

In order to maintain the difference we have to pass a boolean along with the context all the way down to the ACL generation for the WS to distinguish between the two.

### In this PR

 * We introduce a new permission which can be emitted unconditionally
 * This means there is only one `AnnotationContext` which is the same between `h` and the websocket

### Implementation notes

In the first commit I solved this in the dumbest way possible. In the second once the tests are in place I've refactored this to be a bit cleaner.

### Testing notes

 * Start `h`, `via`, `viahtml` and the `client`
 * Visit: http://localhost:9083/https://example.com/
 * Login as a user
 * Open the same page in another tab
 * Make an annotation in one tab
 * The red-update circle should appear -  Click it
 * The new annotation should appear
 * Delete the anotation
 * Visit the other tab
 * The red-update circle should appear - Click it
 * The annotation should disappear