### PR TITLE
Fix tests which passed the wrong arguments to AnnotationContext

### DIFF
--- a/tests/h/presenters/annotation_jsonld_test.py
+++ b/tests/h/presenters/annotation_jsonld_test.py
@@ -145,9 +145,5 @@ class TestAnnotationJSONLDPresenter:
         return factories.Annotation()
 
     @pytest.fixture
-    def context(self, annotation, links_service):
-        return AnnotationContext(annotation, links_service)
-
-    @pytest.fixture
-    def presenter(self, context, links_service):
-        return AnnotationJSONLDPresenter(context, links_service)
+    def presenter(self, annotation, links_service):
+        return AnnotationJSONLDPresenter(AnnotationContext(annotation), links_service)

--- a/tests/h/traversal/annotation_test.py
+++ b/tests/h/traversal/annotation_test.py
@@ -50,24 +50,18 @@ class TestAnnotationRoot:
 
 
 class TestAnnotationContext:
-    def test__acl__(self, context, ACL):
-        context.allow_read_on_delete = sentinel.allow_read_on_delete
+    def test__acl__(self, factories, ACL):
+        annotation = factories.Annotation()
+        context = AnnotationContext(
+            annotation, allow_read_on_delete=sentinel.allow_read_on_delete
+        )
 
         acl = context.__acl__()
 
         ACL.for_annotation.assert_called_once_with(
-            context.annotation,
-            allow_read_on_delete=sentinel.allow_read_on_delete,
+            annotation, sentinel.allow_read_on_delete
         )
         assert acl == ACL.for_annotation.return_value
-
-    @pytest.fixture
-    def context(self, annotation, links_service):
-        return AnnotationContext(annotation, links_service)
-
-    @pytest.fixture
-    def annotation(self, factories):
-        return factories.Annotation()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -12,9 +12,9 @@ def _fake_sidebar_app(request, extra):
 
 
 @pytest.mark.usefixtures("routes")
-def test_og_document(factories, pyramid_request, links_service, sidebar_app):
+def test_og_document(factories, pyramid_request, sidebar_app):
     annotation = factories.Annotation(userid="acct:foo@example.com")
-    context = AnnotationContext(annotation, links_service)
+    context = AnnotationContext(annotation)
     sidebar_app.side_effect = _fake_sidebar_app
 
     ctx = main.annotation_page(context, pyramid_request)
@@ -34,9 +34,9 @@ def test_og_document(factories, pyramid_request, links_service, sidebar_app):
 
 
 @pytest.mark.usefixtures("routes")
-def test_og_no_document(pyramid_request, links_service, sidebar_app):
+def test_og_no_document(pyramid_request, sidebar_app):
     annotation = Annotation(id="123", userid="foo", target_uri="http://example.com")
-    context = AnnotationContext(annotation, links_service)
+    context = AnnotationContext(annotation)
     sidebar_app.side_effect = _fake_sidebar_app
 
     ctx = main.annotation_page(context, pyramid_request)


### PR DESCRIPTION
This was a mistake I introduced (or failed to remove) when removing the links service from the annotation service.

It turns out the tests were passing it in in a few places and this was getting masked by the fact they did this using a positional argument which was actually getting mapped to `allow_read_on_delete`.

When removing `allow_read_on_delete` these seemingly unconnected tests started failing.