### PR TITLE
Gut the annotation moderation service

### DIFF
--- a/h/formatters/annotation_hidden.py
+++ b/h/formatters/annotation_hidden.py
@@ -58,11 +58,7 @@ class AnnotationHiddenFormatter:
         return self._user and self._user.userid == annotation.userid
 
     def _is_hidden(self, annotation):
-        id_ = annotation.id
+        if annotation.id not in self._cache:
+            self._cache[annotation.id] = annotation.is_hidden
 
-        if id_ in self._cache:
-            return self._cache[id_]
-
-        hidden = self._moderation_svc.hidden(annotation)
-        self._cache[id_] = hidden
-        return self._cache[id_]
+        return self._cache[annotation.id]

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -221,5 +221,11 @@ class Annotation(Base):
             return None
         return split_user(self.userid)["domain"]
 
+    @property
+    def is_hidden(self):
+        """Check if this annotation id is hidden."""
+
+        return self.moderation is not None
+
     def __repr__(self):
         return "<Annotation %s>" % self.id

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -1,73 +1,25 @@
-from h import models
+from h.models import AnnotationModeration
 
 
 class AnnotationModerationService:
     def __init__(self, session):
-        self.session = session
-
-    @staticmethod
-    def hidden(annotation):
-        """
-        Check if an annotation id is hidden.
-
-        :param annotation: The annotation to check.
-        :type annotation: h.models.Annotation
-
-        :returns: true/false boolean
-        :rtype: bool
-        """
-        return annotation.moderation is not None
+        self._session = session
 
     def all_hidden(self, annotation_ids):
         """
         Check which of the given annotation ids is hidden.
 
         :param annotation_ids: The ids of the annotations to check.
-        :type annotation_ids: list of unicode
-
         :returns: The subset of the annotation ids that are hidden.
-        :rtype: set of unicode
         """
         if not annotation_ids:
             return set()
 
-        query = self.session.query(models.AnnotationModeration.annotation_id).filter(
-            models.AnnotationModeration.annotation_id.in_(annotation_ids)
+        query = self._session.query(AnnotationModeration.annotation_id).filter(
+            AnnotationModeration.annotation_id.in_(annotation_ids)
         )
 
         return {m.annotation_id for m in query}
-
-    def hide(self, annotation):
-        """
-        Hide an annotation from other users.
-
-        This hides the given annotation from anybody except its author and the
-        group moderators.
-
-        In case the given annotation already has a moderation flag, this method
-        is a no-op.
-
-        :param annotation: The annotation to hide from others.
-        :type annotation: h.models.Annotation
-        """
-
-        if self.hidden(annotation):
-            return
-
-        annotation.moderation = models.AnnotationModeration()
-
-    @staticmethod
-    def unhide(annotation):
-        """
-        Show a hidden annotation again to other users.
-
-        In case the given annotation is not moderated, this method is a no-op.
-
-        :param annotation: The annotation to unhide.
-        :type annotation: h.models.Annotation
-        """
-
-        annotation.moderation = None
 
 
 def annotation_moderation_service_factory(_context, request):

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -1,6 +1,7 @@
 from pyramid.httpexceptions import HTTPNoContent
 
 from h import events
+from h.models import AnnotationModeration
 from h.security.permissions import Permission
 from h.views.api.config import api_config
 
@@ -14,9 +15,10 @@ from h.views.api.config import api_config
     permission=Permission.Annotation.MODERATE,
 )
 def create(context, request):
+    annotation = context.annotation
 
-    svc = request.find_service(name="annotation_moderation")
-    svc.hide(context.annotation)
+    if not annotation.is_hidden:
+        annotation.moderation = AnnotationModeration()
 
     event = events.AnnotationEvent(request, context.annotation.id, "update")
     request.notify_after_commit(event)
@@ -33,9 +35,7 @@ def create(context, request):
     permission=Permission.Annotation.MODERATE,
 )
 def delete(context, request):
-
-    svc = request.find_service(name="annotation_moderation")
-    svc.unhide(context.annotation)
+    context.annotation.moderation = None
 
     event = events.AnnotationEvent(request, context.annotation.id, "update")
     request.notify_after_commit(event)

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -219,6 +219,15 @@ class TestThread:
         return factories.Annotation(references=[root.id, reply.id])
 
 
+@pytest.mark.parametrize("has_moderation", (True, False))
+def test_is_hidden(factories, has_moderation):
+    annotation = factories.Annotation(
+        moderation=factories.AnnotationModeration() if has_moderation else None
+    )
+
+    assert annotation.is_hidden == has_moderation
+
+
 @pytest.fixture
 def markdown(patch):
     return patch("h.models.annotation.markdown")

--- a/tests/h/services/annotation_moderation_test.py
+++ b/tests/h/services/annotation_moderation_test.py
@@ -1,25 +1,11 @@
 import pytest
 
-from h import models
 from h.services.annotation_moderation import (
     AnnotationModerationService,
     annotation_moderation_service_factory,
 )
 
 
-class TestAnnotationModerationServiceHidden:
-    def test_it_returns_true_for_moderated_annotation(self, svc, factories):
-        mod = factories.AnnotationModeration()
-
-        assert svc.hidden(mod.annotation) is True
-
-    def test_it_returns_false_for_non_moderated_annotation(self, svc, factories):
-        annotation = factories.Annotation()
-
-        assert not svc.hidden(annotation)
-
-
-@pytest.mark.usefixtures("mods")
 class TestAnnotationModerationServiceAllHidden:
     def test_it_lists_moderated_annotation_ids(self, svc, mods):
         ids = [m.annotation.id for m in mods[0:-1]]
@@ -33,74 +19,15 @@ class TestAnnotationModerationServiceAllHidden:
     def test_it_handles_with_no_ids(self, svc):
         assert svc.all_hidden([]) == set()
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def mods(self, factories):
         return factories.AnnotationModeration.create_batch(3)
 
 
-class TestAnnotationModerationServiceHide:
-    def test_it_creates_annotation_moderation(self, svc, factories, db_session):
-        annotation = factories.Annotation()
-        svc.hide(annotation)
-
-        mod = (
-            db_session.query(models.AnnotationModeration)
-            .filter_by(annotation=annotation)
-            .first()
-        )
-
-        assert mod is not None
-
-    def test_it_skips_creating_moderation_when_already_exists(
-        self, svc, factories, db_session
-    ):
-        existing = factories.AnnotationModeration()
-
-        svc.hide(existing.annotation)
-
-        count = (
-            db_session.query(models.AnnotationModeration)
-            .filter_by(annotation=existing.annotation)
-            .count()
-        )
-
-        assert count == 1
-
-
-class TestAnnotationModerationServiceUnhide:
-    def test_it_unhides_given_annotation(self, svc, factories, db_session):
-        mod = factories.AnnotationModeration()
-        annotation = mod.annotation
-
-        svc.unhide(annotation)
-
-        assert not svc.hidden(annotation)
-
-    def test_it_leaves_othes_annotations_hidden(self, svc, factories, db_session):
-        mod1, mod2 = factories.AnnotationModeration(), factories.AnnotationModeration()
-
-        svc.unhide(mod1.annotation)
-
-        assert svc.hidden(mod2.annotation) is True
-
-    def test_it_skips_hiding_annotation_when_not_hidden(
-        self, svc, factories, db_session
-    ):
-        annotation = factories.Annotation()
-
-        svc.unhide(annotation)
-
-        assert not svc.hidden(annotation)
-
-
-class TestAnnotationNipsaServiceFactory:
+class TestAnnotationModerationServiceFactory:
     def test_it_returns_service(self, pyramid_request):
         svc = annotation_moderation_service_factory(None, pyramid_request)
         assert isinstance(svc, AnnotationModerationService)
-
-    def test_it_provides_request_db_as_session(self, pyramid_request):
-        svc = annotation_moderation_service_factory(None, pyramid_request)
-        assert svc.session == pyramid_request.db
 
 
 @pytest.fixture

--- a/tests/h/views/api/moderation_test.py
+++ b/tests/h/views/api/moderation_test.py
@@ -3,62 +3,87 @@ from unittest import mock
 import pytest
 from pyramid.httpexceptions import HTTPNoContent
 
+from h.models import AnnotationModeration
+from h.traversal import AnnotationContext
 from h.views.api import moderation as views
 
 
-@pytest.mark.usefixtures("moderation_service")
 class TestCreate:
     def test_it_hides_the_annotation(
-        self, pyramid_request, resource, moderation_service
+        self, pyramid_request, annotation, annotation_context
     ):
-        views.create(resource, pyramid_request)
+        annotation.moderation = None
 
-        moderation_service.hide.assert_called_once_with(resource.annotation)
+        views.create(annotation_context, pyramid_request)
 
-    def test_it_publishes_update_event(self, pyramid_request, resource, events):
-        views.create(resource, pyramid_request)
+        assert annotation.is_hidden
+
+    def test_it_does_not_modify_an_already_hidden_annotation(
+        self, pyramid_request, annotation, annotation_context
+    ):
+        moderation = AnnotationModeration()
+        annotation.moderation = moderation
+
+        views.create(annotation_context, pyramid_request)
+
+        assert annotation.is_hidden
+        # It's the same one not a new one
+        assert annotation.moderation == moderation
+
+    def test_it_publishes_update_event(
+        self, pyramid_request, annotation_context, events
+    ):
+        views.create(annotation_context, pyramid_request)
 
         events.AnnotationEvent.assert_called_once_with(
-            pyramid_request, resource.annotation.id, "update"
+            pyramid_request, annotation_context.annotation.id, "update"
         )
 
         pyramid_request.notify_after_commit.assert_called_once_with(
             events.AnnotationEvent.return_value
         )
 
-    def test_it_renders_no_content(self, pyramid_request, resource):
-        response = views.create(resource, pyramid_request)
+    def test_it_renders_no_content(self, pyramid_request, annotation_context):
+        response = views.create(annotation_context, pyramid_request)
         assert isinstance(response, HTTPNoContent)
 
 
-@pytest.mark.usefixtures("moderation_service")
 class TestDelete:
     def test_it_unhides_the_annotation(
-        self, pyramid_request, resource, moderation_service
+        self, pyramid_request, annotation, annotation_context
     ):
-        views.delete(resource, pyramid_request)
+        annotation.moderation = AnnotationModeration()
 
-        moderation_service.unhide.assert_called_once_with(resource.annotation)
+        views.delete(annotation_context, pyramid_request)
 
-    def test_it_publishes_update_event(self, pyramid_request, resource, events):
-        views.delete(resource, pyramid_request)
+        assert not annotation.is_hidden
+
+    def test_it_publishes_update_event(
+        self, pyramid_request, annotation_context, events
+    ):
+        views.delete(annotation_context, pyramid_request)
 
         events.AnnotationEvent.assert_called_once_with(
-            pyramid_request, resource.annotation.id, "update"
+            pyramid_request, annotation_context.annotation.id, "update"
         )
 
         pyramid_request.notify_after_commit.assert_called_once_with(
             events.AnnotationEvent.return_value
         )
 
-    def test_it_renders_no_content(self, pyramid_request, resource):
-        response = views.delete(resource, pyramid_request)
+    def test_it_renders_no_content(self, pyramid_request, annotation_context):
+        response = views.delete(annotation_context, pyramid_request)
         assert isinstance(response, HTTPNoContent)
 
 
 @pytest.fixture
-def resource():
-    return mock.Mock(spec_set=["annotation", "group"])
+def annotation(factories):
+    return factories.Annotation()
+
+
+@pytest.fixture
+def annotation_context(annotation):
+    return AnnotationContext(annotation)
 
 
 @pytest.fixture


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/6769

The annotation moderation service is really weird and has a number of methods that look like they could be static on the model object. In this PR I've removed three methods by:

* Moving `hidden` to `is_hidden` on the annotation as a property
* Moving `hide` and `unhide` inside the views which were the only places that used them

This removes most of the code and makes each of the places where it's used more local and doesn't require you to look up (or us) the moderation service to understand it.

This is part of a one-two punch to remove the moderation service as a dependency for the json presenter service along with:

* https://github.com/hypothesis/h/pull/6926