### PR TITLE
Use SQLAlchemy to preload the moderation information instead of the service

### DIFF
--- a/h/services/annotation_json_presentation/factory.py
+++ b/h/services/annotation_json_presentation/factory.py
@@ -12,6 +12,5 @@ def annotation_json_presentation_service_factory(_context, request):
         links_svc=request.find_service(name="links"),
         flag_svc=request.find_service(name="flag"),
         flag_count_svc=request.find_service(name="flag_count"),
-        moderation_svc=request.find_service(name="annotation_moderation"),
         user_svc=request.find_service(name="user"),
     )

--- a/tests/h/formatters/annotation_hidden_test.py
+++ b/tests/h/formatters/annotation_hidden_test.py
@@ -1,126 +1,53 @@
 from unittest.mock import create_autospec
 
 import pytest
+from h_matchers import Any
 
 from h.formatters.annotation_hidden import AnnotationHiddenFormatter
 from h.security.permissions import Permission
-from h.services.annotation_moderation import AnnotationModerationService
+from h.traversal import AnnotationContext
 
 
 class TestAnnotationHiddenFormatter:
-    def test_preload_sets_founds_hidden_annotations_to_true(
-        self, annotations, formatter
-    ):
-        annotation_ids = [a.id for a in annotations["hidden"]]
+    def test_it_hides_moderated(self, formatter, annotation):
+        annotation.moderation = None
 
-        expected = {id_: True for id_ in annotation_ids}
-        assert formatter.preload(annotation_ids) == expected
-
-    def test_preload_sets_missing_flags_to_false(self, annotations, formatter):
-        annotation_ids = [a.id for a in annotations["public"]]
-
-        expected = {id_: False for id_ in annotation_ids}
-        assert formatter.preload(annotation_ids) == expected
-
-    @pytest.fixture
-    def annotations(self, factories):
-        hidden = [
-            mod.annotation for mod in factories.AnnotationModeration.create_batch(3)
-        ]
-        public = factories.Annotation.create_batch(2)
-        return {"hidden": hidden, "public": public}
-
-
-class TestAnonymousUserHiding:
-    """An anonymous user will see redacted annotations when they're hidden."""
-
-    def test_format_for_unhidden_annotation(self, formatter, annotation):
         assert formatter.format(annotation) == {"hidden": False}
 
-    def test_format_for_hidden_annotation(self, formatter, hidden_annotation):
+    def test_the_author_can_see_it(self, formatter, annotation, user):
+        annotation.userid = user.userid
 
-        censored = {"hidden": True, "text": "", "tags": []}
-        assert formatter.format(hidden_annotation) == censored
-
-    @pytest.fixture
-    def current_user(self):
-        return None
-
-
-class TestNonAuthorHiding:
-    """Regular users see redacted annotations, unless they are a moderator."""
-
-    def test_format_for_unhidden_annotation(self, formatter, annotation):
         assert formatter.format(annotation) == {"hidden": False}
 
-    def test_format_for_non_moderator(self, formatter, hidden_annotation):
-        assert formatter.format(hidden_annotation) == {
-            "hidden": True,
-            "text": "",
-            "tags": [],
-        }
-
-
-class TestAuthorHiding:
-    """
-    The author usually does not see their annotations have been hidden.
-
-    The one exception is when they are also a moderator for the group.
-    """
-
-    def test_format_for_public_annotation(self, formatter, annotation):
-        assert formatter.format(annotation) == {"hidden": False}
-
-    def test_format_for_non_moderator(self, formatter, hidden_annotation):
-        assert formatter.format(hidden_annotation) == {"hidden": False}
-
-    def test_format_for_moderator(
-        self, formatter, hidden_annotation, has_permission, AnnotationContext
-    ):
+    def test_moderators_see_everything(self, formatter, annotation, has_permission):
         has_permission.return_value = True
 
-        assert formatter.format(hidden_annotation) == {"hidden": True}
-        AnnotationContext.assert_called_once_with(hidden_annotation)
+        result = formatter.format(annotation)
+
         has_permission.assert_called_once_with(
-            Permission.Annotation.MODERATE, context=AnnotationContext.return_value
+            Permission.Annotation.MODERATE,
+            Any.instance_of(AnnotationContext).with_attrs({"annotation": annotation}),
         )
 
-    @pytest.fixture
-    def annotation(self, factories, current_user):
-        return factories.Annotation(userid=current_user.userid)
+        assert result == {"hidden": True}
+
+    def test_others_see_it_hidden_and_censored(self, formatter, annotation):
+        assert formatter.format(annotation) == {"hidden": True, "text": "", "tags": []}
 
     @pytest.fixture
-    def AnnotationContext(self, patch):
-        return patch("h.formatters.annotation_hidden.AnnotationContext")
+    def has_permission(self, pyramid_request):
+        return create_autospec(pyramid_request.has_permission, return_value=False)
 
+    @pytest.fixture
+    def annotation(self, factories):
+        annotation = factories.Annotation.build()
+        annotation.moderation = factories.AnnotationModeration.build()
+        return annotation
 
-@pytest.fixture
-def current_user(factories):
-    return factories.User()
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User()
 
-
-@pytest.fixture
-def formatter(moderation_svc, has_permission, current_user):
-    return AnnotationHiddenFormatter(moderation_svc, has_permission, current_user)
-
-
-@pytest.fixture
-def moderation_svc(db_session):
-    # TODO! - This should be mocked - We are probably testing other code here
-    return AnnotationModerationService(db_session)
-
-
-@pytest.fixture
-def has_permission(pyramid_request):
-    return create_autospec(pyramid_request.has_permission, return_value=False)
-
-
-@pytest.fixture
-def annotation(factories):
-    return factories.Annotation()
-
-
-@pytest.fixture
-def hidden_annotation(factories, annotation):
-    factories.AnnotationModeration(annotation=annotation)
-    return annotation
+    @pytest.fixture
+    def formatter(self, has_permission, user):
+        return AnnotationHiddenFormatter(has_permission, user)

--- a/tests/h/services/annotation_json_presentation_test/factory_test.py
+++ b/tests/h/services/annotation_json_presentation_test/factory_test.py
@@ -16,7 +16,6 @@ class TestAnnotationJSONPresentationServiceFactory:
         flag_service,
         flag_count_service,
         links_service,
-        moderation_service,
         user_service,
     ):
         service = annotation_json_presentation_service_factory(
@@ -32,7 +31,6 @@ class TestAnnotationJSONPresentationServiceFactory:
             links_svc=links_service,
             flag_svc=flag_service,
             flag_count_svc=flag_count_service,
-            moderation_svc=moderation_service,
             user_svc=user_service,
         )
 

--- a/tests/h/services/annotation_json_presentation_test/service_test.py
+++ b/tests/h/services/annotation_json_presentation_test/service_test.py
@@ -13,7 +13,7 @@ class TestAnnotationJSONPresentationService:
             sentinel.flag_svc, sentinel.user
         )
         formatters.AnnotationHiddenFormatter.assert_called_once_with(
-            sentinel.moderation_svc, sentinel.has_permission, sentinel.user
+            sentinel.has_permission, sentinel.user
         )
         formatters.AnnotationModerationFormatter.assert_called_once_with(
             sentinel.flag_count_svc, sentinel.user, sentinel.has_permission
@@ -61,7 +61,6 @@ class TestAnnotationJSONPresentationService:
             links_svc=sentinel.links_svc,
             flag_svc=sentinel.flag_svc,
             flag_count_svc=sentinel.flag_count_svc,
-            moderation_svc=sentinel.moderation_svc,
             user_svc=sentinel.user_svc,
             has_permission=sentinel.has_permission,
         )


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/6769

This needs a good few things to go through first before it can be sensibly worked on