### PR TITLE
Ignore remaining pylint codes on H package while for transitioning away from pep8

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,7 +27,23 @@ disable=bad-continuation,
         bad-continuation,
         line-too-long,
 
-        too-few-public-methods
+        too-few-public-methods,
+
+        # Ignored during pep8 -> pylint transition
+        unused-argument,
+        too-many-arguments,
+        super-init-not-called,
+        protected-access,
+        no-name-in-module,
+        missing-return-doc,
+        missing-raises-doc,
+        missing-param-doc,
+        invalid-name,
+        inconsistent-return-statements,
+        fixme,
+        duplicate-code,
+
+
 
 [REPORTS]
 output-format=colorized

--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -4,13 +4,12 @@ from h.security import derive_key
 
 
 class Error(Exception):
-
     """Base class for this package's custom exception classes."""
 
 
 class JSONError(Error):
-
-    """Exception raised when there's a problem with a request's JSON body.
+    """
+    Exception raised when there's a problem with a request's JSON body.
 
     This is for pre-validation problems such as no JSON body, body cannot
     be parsed as JSON, or top-level keys missing from the JSON.
@@ -19,7 +18,8 @@ class JSONError(Error):
 
 
 def get_user(request):
-    """Return the user for the request or None.
+    """
+    Return the user for the request or None.
 
     :rtype: h.models.User or None
 
@@ -34,8 +34,6 @@ def get_user(request):
 
 
 def includeme(config):
-    """A local identity provider."""
-
     # Add a `request.user` property.
     #
     # N.B. we use `property=True` and not `reify=True` here because it is

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -83,7 +83,7 @@ def unblacklisted_username(node, value, blacklist=None):
 
 
 def privacy_acceptance_validator(node, value):
-    """Colander validator that ensures privacy acceptance checkbox checked"""
+    """Add colander validator that ensures privacy acceptance checkbox checked."""
     if not value:
         msg = _("Acceptance of the privacy policy is required")
         raise colander.Invalid(node, msg)

--- a/h/accounts/util.py
+++ b/h/accounts/util.py
@@ -1,6 +1,4 @@
-"""
-Helpers for account forms
-"""
+"""Helpers for account forms."""
 import re
 from urllib.parse import urlparse
 

--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -54,7 +54,7 @@ def extract(request, parse=parser.parse):
 
 def check_url(request, query, unparse=parser.unparse):
     """
-    Checks the request and raises a redirect if implied by the query.
+    Check the request and raises a redirect if implied by the query.
 
     If a query contains a single group or user term, then the user is
     redirected to the specific group or user search page with that term

--- a/h/assets.py
+++ b/h/assets.py
@@ -1,4 +1,4 @@
-"""View for serving static assets under `/assets`"""
+"""View for serving static assets under `/assets`."""
 
 import importlib_resources
 from h_assets import Environment, assets_view

--- a/h/auth/interfaces.py
+++ b/h/auth/interfaces.py
@@ -7,4 +7,4 @@ class IAuthenticationToken(Interface):  # pylint:disable=inherit-non-class
     userid = Attribute("""The userid to which this token was issued.""")
 
     def is_valid(self):
-        """Checks token validity (such as expiry date)."""
+        """Check token validity (such as expiry date)."""

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -60,7 +60,7 @@ class AuthenticationPolicy:
 @interface.implementer(interfaces.IAuthenticationPolicy)
 class APIAuthenticationPolicy:
     """
-    An authentication policy for Hypothesis API endpoints
+    An authentication policy for Hypothesis API endpoints.
 
     Two types of authentication apply to Hypothesis API endpoints:
 
@@ -93,7 +93,7 @@ class APIAuthenticationPolicy:
 
     def effective_principals(self, request):
         """
-        Return the request's effective principals
+        Return the request's effective principals.
 
         The ``effective_principals`` method of classes that implement
         Pyramid's Authentication Interface always returns at least one principal:
@@ -126,9 +126,8 @@ class APIAuthenticationPolicy:
 
 @interface.implementer(interfaces.IAuthenticationPolicy)
 class AuthClientPolicy:
-
     """
-    An authentication policy for registered AuthClients
+    An authentication policy for registered AuthClients.
 
     Authentication for a request to API routes with HTTP Basic Authentication
     credentials that represent a registered AuthClient with
@@ -166,7 +165,7 @@ class AuthClientPolicy:
 
     def unauthenticated_userid(self, request):
         """
-        Return the forwarded userid or the auth_client's id
+        Return the forwarded userid or the auth_client's id.
 
         If a forwarded user header is set, return the ``userid`` (its value)
         Otherwise return the username parsed from the Basic Auth header
@@ -184,7 +183,7 @@ class AuthClientPolicy:
 
     def authenticated_userid(self, request):
         """
-        Return any forwarded userid or None
+        Return any forwarded userid or None.
 
         Rely mostly on
         :py:meth:`pyramid.authentication.BasicAuthAuthenticationPolicy.authenticated_userid`,
@@ -219,7 +218,7 @@ class AuthClientPolicy:
 
     def effective_principals(self, request):
         """
-        Return a list of principals for the request
+        Return a list of principals for the request.
 
         This will concatenate the principals returned by
         :py:meth:`~h.auth.policy.AuthClientPolicy.check`
@@ -246,8 +245,7 @@ class AuthClientPolicy:
     @staticmethod
     def check(username, password, request):
         """
-        Return list of appropriate principals or None if authentication is
-        unsuccessful.
+        Return list of appropriate principals or None if authentication is unsuccessful.
 
         Validate the basic auth credentials from the request by matching them to
         an auth_client record in the DB.
@@ -293,13 +291,12 @@ class AuthClientPolicy:
 
     @staticmethod
     def _forwarded_userid(request):
-        """Return forwarded userid or None"""
+        """Return forwarded userid or None."""
         return request.headers.get("X-Forwarded-User", None)
 
 
 @interface.implementer(interfaces.IAuthenticationPolicy)
 class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
-
     """
     A bearer token authentication policy.
 
@@ -363,7 +360,7 @@ def _is_api_request(request):
 
 def _is_client_request(request):
     """
-    Is client_auth authentication valid for the given request?
+    Return if this is client_auth authentication valid for the given request.
 
     Uuthentication should be performed by
     :py:class:`~h.auth.policy.AuthClientPolicy` only for requests

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -60,7 +60,7 @@ def default_authority(request):
 
 def client_authority(request):
     """
-    Return the authority associated with an authenticated auth_client or None
+    Return the authority associated with an authenticated auth_client or None.
 
     Once a request with an auth_client is authenticated, a principal is set
     indicating the auth_client's verified authority
@@ -80,7 +80,7 @@ def client_authority(request):
 
 def verify_auth_client(client_id, client_secret, db_session):
     """
-    Return matching AuthClient or None
+    Return matching AuthClient or None.
 
     Attempt to retrieve the :py:class:`h.models.auth_client.AuthClient` record
     indicated by ``client_id`` and ``client_secret`` and perform some validation
@@ -115,7 +115,7 @@ def verify_auth_client(client_id, client_secret, db_session):
 
 def principals_for_auth_client(client):
     """
-    Return the list of additional principals for an auth client
+    Return the list of additional principals for an auth client.
 
     :type client: :py:class:`h.models.auth_client.AuthClient`
     :rtype: list
@@ -136,7 +136,7 @@ def principals_for_auth_client(client):
 
 def principals_for_auth_client_user(user, client):
     """
-    Return a union of client and user principals for forwarded user
+    Return a union of client and user principals for forwarded user.
 
     :type user: :py:class:`h.models.user.User`
     :type client: :py:class:`h.models.auth_client.AuthClient`

--- a/h/cli/commands/annotation_id.py
+++ b/h/cli/commands/annotation_id.py
@@ -7,7 +7,7 @@ from h.db.types import _get_hex_from_urlsafe, _get_urlsafe_from_hex
 
 @click.group("annotation-id")
 def annotation_id():
-    """Utility commands to convert annotation IDS."""
+    """Add sutility commands to convert annotation IDS."""
 
 
 @annotation_id.command("from-urlsafe")

--- a/h/cli/commands/annotation_id.py
+++ b/h/cli/commands/annotation_id.py
@@ -7,7 +7,7 @@ from h.db.types import _get_hex_from_urlsafe, _get_urlsafe_from_hex
 
 @click.group("annotation-id")
 def annotation_id():
-    """Add sutility commands to convert annotation IDS."""
+    """Add utility commands to convert annotation IDS."""
 
 
 @annotation_id.command("from-urlsafe")

--- a/h/cli/commands/authclient.py
+++ b/h/cli/commands/authclient.py
@@ -25,9 +25,7 @@ def authclient():
 )
 @click.pass_context
 def add(ctx, name, authority, type_):
-    """
-    Create a new OAuth client.
-    """
+    """Create a new OAuth client."""
     request = ctx.obj["bootstrap"]()
 
     client = models.AuthClient(name=name, authority=authority)

--- a/h/cli/commands/migrate.py
+++ b/h/cli/commands/migrate.py
@@ -6,7 +6,6 @@ from alembic.config import Config
 
 
 class CommandLine(_CommandLine):
-
     """
     A modified version of the default Alembic CommandLine.
 

--- a/h/cli/commands/normalize_uris.py
+++ b/h/cli/commands/normalize_uris.py
@@ -15,9 +15,7 @@ class Window(namedtuple("Window", ["start", "end"])):
 @click.command("normalize-uris")
 @click.pass_context
 def normalize_uris(ctx):
-    """
-    Normalize all URIs in the database and reindex the changed annotations.
-    """
+    """Normalize all URIs in the database and reindex the changed annotations."""
 
     request = ctx.obj["bootstrap"]()
 

--- a/h/cli/commands/user.py
+++ b/h/cli/commands/user.py
@@ -117,7 +117,7 @@ def password(ctx, username, authority, password):
 @click.pass_context
 def delete(ctx, username, authority):
     """
-    Deletes a user with all their group memberships and annotations.
+    Delete a user with all their group memberships and annotations.
 
     You must specify the username of a user to delete.
     """

--- a/h/db/types.py
+++ b/h/db/types.py
@@ -33,7 +33,6 @@ class InvalidUUID(Exception, DontWrapMixin):
 
 
 class URLSafeUUID(types.TypeDecorator):  # pylint:disable=abstract-method
-
     """
     Expose UUIDs as URL-safe base64-encoded strings.
 
@@ -83,8 +82,7 @@ class URLSafeUUID(types.TypeDecorator):  # pylint:disable=abstract-method
 
 
 class AnnotationSelectorJSONB(types.TypeDecorator):  # pylint:disable=abstract-method
-
-    """
+    r"""
     Special type for the Annotation selector column.
 
     It transparently escapes NULL (\u0000) bytes to \\u0000 when writing to the

--- a/h/feeds/atom.py
+++ b/h/feeds/atom.py
@@ -8,7 +8,8 @@ _ = i18n.TranslationStringFactory(__package__)
 
 
 def _feed_entry_from_annotation(annotation, annotation_url, annotation_api_url=None):
-    """Return an Atom feed entry for the given annotation.
+    """
+    Return an Atom feed entry for the given annotation.
 
     :returns: A logical representation of the Atom feed entry as a dict,
         containing all of the data that a template would need to render the
@@ -63,7 +64,8 @@ def feed_from_annotations(
     title=None,
     subtitle=None,
 ):
-    """Return an Atom feed for the given list of annotations.
+    """
+    Return an Atom feed for the given list of annotations.
 
     :returns: A logical representation of an Atom feed as a Python dict
         containing all of the data that a template would need to render the

--- a/h/feeds/render.py
+++ b/h/feeds/render.py
@@ -4,7 +4,8 @@ from h.feeds import atom, rss
 
 
 def render_atom(request, annotations, atom_url, html_url, title, subtitle):
-    """Return a rendered Atom feed of the given annotations.
+    """
+    Return a rendered Atom feed of the given annotations.
 
     :param annotations: The list of annotations to render as the feed's entries
     :type annotations: list of dicts
@@ -51,7 +52,8 @@ def render_atom(request, annotations, atom_url, html_url, title, subtitle):
 
 
 def render_rss(request, annotations, rss_url, html_url, title, description):
-    """Return a rendered RSS feed of the given annotations.
+    """
+    Return a rendered RSS feed of the given annotations.
 
     :param annotations: The list of annotations to render as the feed's items
     :type annotations: list of dicts

--- a/h/feeds/rss.py
+++ b/h/feeds/rss.py
@@ -11,7 +11,8 @@ _ = i18n.TranslationStringFactory(__package__)
 
 
 def _pubdate_string(timestamp):
-    """Return a RFC2822-formatted pubDate string for the given timestamp.
+    """
+    Return a RFC2822-formatted pubDate string for the given timestamp.
 
     Return a pubDate string like 'Tue, 03 Jun 2003 09:39:21 -0000'.
 
@@ -23,7 +24,8 @@ def _pubdate_string(timestamp):
 
 
 def _feed_item_from_annotation(annotation, annotation_url):
-    """Return an RSS feed item for the given annotation.
+    """
+    Return an RSS feed item for the given annotation.
 
     :returns: A logical representation of the RSS feed item as a dict,
         containing all of the data that a template would need to render the
@@ -48,7 +50,8 @@ def _feed_item_from_annotation(annotation, annotation_url):
 def feed_from_annotations(
     annotations, annotation_url, rss_url, html_url, title, description
 ):
-    """Return an RSS feed for the given list of annotations.
+    """
+    Return an RSS feed for the given list of annotations.
 
     :returns: A logical representation of an RSS feed as a Python dict
         containing all of the data that a template would need to render the

--- a/h/feeds/util.py
+++ b/h/feeds/util.py
@@ -9,7 +9,8 @@ FEED_TAG_DATE = "2015-09"
 
 
 def tag_uri_for_annotation(annotation, annotation_url):
-    """Return a tag URI (unique identifier) for the given annotation.
+    """
+    Return a tag URI (unique identifier) for the given annotation.
 
     Suitable for use as the value of the <id> element of an <entry> in an
     Atom feed, or the <guid> element of an <item> in an RSS feed.

--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -11,10 +11,7 @@ SVG_NAMESPACE_URI = "http://www.w3.org/2000/svg"
 
 
 class Filters(Extension):  # pylint:disable=abstract-method
-
-    """
-    Set up filters for Jinja2.
-    """
+    """Set up filters for Jinja2."""
 
     def __init__(self, environment):
         super().__init__(environment)
@@ -62,10 +59,7 @@ def to_json(value):
 
 
 class SvgIcon(Extension):  # pylint: disable=abstract-method
-
-    """
-    Setup helpers for rendering icons.
-    """
+    """Setup helpers for rendering icons."""
 
     def __init__(self, environment):
         super().__init__(environment)

--- a/h/links.py
+++ b/h/links.py
@@ -1,6 +1,4 @@
-"""
-Provides links to different representations of annotations.
-"""
+"""Provides links to different representations of annotations."""
 from urllib.parse import unquote, urljoin, urlparse
 
 

--- a/h/migrations/env.py
+++ b/h/migrations/env.py
@@ -35,7 +35,8 @@ def get_database_url():
 
 
 def run_migrations_offline():
-    """Run migrations in 'offline' mode.
+    """
+    Run migrations in 'offline' mode.
 
     This configures the context with just a URL
     and not an Engine, though an Engine is acceptable
@@ -52,7 +53,8 @@ def run_migrations_offline():
 
 
 def run_migrations_online():
-    """Run migrations in 'online' mode.
+    """
+    Run migrations in 'online' mode.
 
     In this scenario we need to create an Engine
     and associate a connection with the context.

--- a/h/migrations/versions/05bd63575f19_add_trusted_column_to_authclient_table.py
+++ b/h/migrations/versions/05bd63575f19_add_trusted_column_to_authclient_table.py
@@ -1,5 +1,5 @@
 """
-Add trusted column to authclient table
+Add trusted column to authclient table.
 
 Revision ID: 05bd63575f19
 Revises: dfb8b45674db

--- a/h/migrations/versions/0d1b3fd8807c_create_authzcode_table.py
+++ b/h/migrations/versions/0d1b3fd8807c_create_authzcode_table.py
@@ -1,5 +1,5 @@
 """
-Create authzcode table
+Create authzcode table.
 
 Revision ID: 0d1b3fd8807c
 Revises: b980b1a8f6af

--- a/h/migrations/versions/0d4755a0d88b_remove_status_column_from_user_table.py
+++ b/h/migrations/versions/0d4755a0d88b_remove_status_column_from_user_table.py
@@ -1,17 +1,17 @@
-"""Remove status column from user table
+"""
+Remove status column from user table.
 
 Revision ID: 0d4755a0d88b
 Revises: 2494fea98d2d
 Create Date: 2016-03-21 20:07:07.002482
 
 """
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "0d4755a0d88b"
 down_revision = "2494fea98d2d"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/140b450225cd_backfill_group_authority.py
+++ b/h/migrations/versions/140b450225cd_backfill_group_authority.py
@@ -1,11 +1,10 @@
 """
-Backfill group.authority
+Backfill group.authority.
 
 Revision ID: 140b450225cd
 Revises: 3acf258322d5
 Create Date: 2016-11-25 15:17:22.792448
 """
-
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/178270e3ee58_add_user_privacy_agreement_column.py
+++ b/h/migrations/versions/178270e3ee58_add_user_privacy_agreement_column.py
@@ -1,5 +1,5 @@
 """
-Add user privacy agreement column
+Add user privacy agreement column.
 
 Add a column to track user's most recent acceptance of privacy policy
 """

--- a/h/migrations/versions/18dfed902c9e_remove_unused_user_indices.py
+++ b/h/migrations/versions/18dfed902c9e_remove_unused_user_indices.py
@@ -1,5 +1,5 @@
 """
-Remove unused user indices
+Remove unused user indices.
 
 Revision ID: 18dfed902c9e
 Revises: 7e2443f8d7d6

--- a/h/migrations/versions/1a40e75a524d_add_normalised_username_index.py
+++ b/h/migrations/versions/1a40e75a524d_add_normalised_username_index.py
@@ -1,5 +1,5 @@
 """
-Add normalised username index
+Add normalised username index.
 
 Revision ID: 1a40e75a524d
 Revises: 02db2fa6ea98

--- a/h/migrations/versions/1c995723a271_add_world_group.py
+++ b/h/migrations/versions/1c995723a271_add_world_group.py
@@ -1,5 +1,5 @@
 """
-Add world group
+Add world group.
 
 Revision ID: 1c995723a271
 Revises: 21b1ce37e327

--- a/h/migrations/versions/1e88c31d8b1a_add_authticket_table.py
+++ b/h/migrations/versions/1e88c31d8b1a_add_authticket_table.py
@@ -1,5 +1,5 @@
 """
-Add authticket table
+Add authticket table.
 
 Revision ID: 1e88c31d8b1a
 Revises: f9d3058bec5f

--- a/h/migrations/versions/1ef80156ee4_add_sidebar_tutorial_dismissed_column_.py
+++ b/h/migrations/versions/1ef80156ee4_add_sidebar_tutorial_dismissed_column_.py
@@ -1,17 +1,17 @@
-"""Add the sidebar_tutorial_dismissed column to user table.
+"""
+Add the sidebar_tutorial_dismissed column to user table.
 
 Revision ID: 1ef80156ee4
 Revises: 43645baa68b2
 Create Date: 2015-12-21 18:49:15.688177
 
 """
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "1ef80156ee4"
 down_revision = "43e7c4ed2fd7"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/21b1ce37e327_allow_null_group_creator.py
+++ b/h/migrations/versions/21b1ce37e327_allow_null_group_creator.py
@@ -1,5 +1,5 @@
 """
-Allow null group.creator
+Allow null group.creator.
 
 Revision ID: 21b1ce37e327
 Revises: 9389d52b037d

--- a/h/migrations/versions/21f87f395e26_add_group_name_index.py
+++ b/h/migrations/versions/21f87f395e26_add_group_name_index.py
@@ -1,4 +1,5 @@
-"""Add index to group.name column
+"""
+Add index to group.name column.
 
 Revision ID: 21f87f395e26
 Revises: 0d4755a0d88b
@@ -6,12 +7,12 @@ Create Date: 2016-03-24 15:12:59.803179
 
 """
 
+import sqlalchemy as sa
+from alembic import op
+
 # revision identifiers, used by Alembic.
 revision = "21f87f395e26"
 down_revision = "0d4755a0d88b"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/2494fea98d2d_add_the_token_table.py
+++ b/h/migrations/versions/2494fea98d2d_add_the_token_table.py
@@ -1,17 +1,17 @@
-"""Add the token table.
+"""
+Add the token table.
 
 Revision ID: 2494fea98d2d
 Revises: 4886d7a14074
 Create Date: 2016-02-15 11:20:00.787358
 
 """
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "2494fea98d2d"
 down_revision = "4886d7a14074"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/296573bb30b3_add_feature_featurecohort_association_table.py
+++ b/h/migrations/versions/296573bb30b3_add_feature_featurecohort_association_table.py
@@ -1,17 +1,17 @@
-"""add feature_featurecohort association table
+"""
+Add feature_featurecohort association table.
 
 Revision ID: 296573bb30b3
 Revises: f6ffcfc50583
 Create Date: 2016-06-09 16:35:09.065224
 
 """
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "296573bb30b3"
 down_revision = "f6ffcfc50583"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/2d0ad2b1bf07_add_enforce_scope_column_to_group_table.py
+++ b/h/migrations/versions/2d0ad2b1bf07_add_enforce_scope_column_to_group_table.py
@@ -1,4 +1,4 @@
-"""Add enforce_scope column to group table"""
+"""Add enforce_scope column to group table."""
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/2e2cc6a0c521_fill_in_user_authority_column.py
+++ b/h/migrations/versions/2e2cc6a0c521_fill_in_user_authority_column.py
@@ -1,5 +1,5 @@
 """
-Fill in user authority column
+Fill in user authority column.
 
 Revision ID: 2e2cc6a0c521
 Revises: f48100c9af86

--- a/h/migrations/versions/39b1935d9e7b_add_annotation_text_rendered.py
+++ b/h/migrations/versions/39b1935d9e7b_add_annotation_text_rendered.py
@@ -1,4 +1,5 @@
-"""Add the text_rendered column to the annotation table
+"""
+Add the text_rendered column to the annotation table.
 
 Revision ID: 39b1935d9e7b
 Revises: 6b801ecc60f1

--- a/h/migrations/versions/3acf258322d5_add_authority_column_to_group.py
+++ b/h/migrations/versions/3acf258322d5_add_authority_column_to_group.py
@@ -1,5 +1,5 @@
 """
-Add authority column to group
+Add authority column to group.
 
 Revision ID: 3acf258322d5
 Revises: c36369fe730f

--- a/h/migrations/versions/3bcd62dd7260_add_featurecohort_table.py
+++ b/h/migrations/versions/3bcd62dd7260_add_featurecohort_table.py
@@ -1,4 +1,5 @@
-"""add cohort table
+"""
+Add cohort table.
 
 Revision ID: 3bcd62dd7260
 Revises: dfa82518915a
@@ -6,12 +7,12 @@ Create Date: 2016-05-10 17:01:02.704596
 
 """
 
+import sqlalchemy as sa
+from alembic import op
+
 # revision identifiers, used by Alembic.
 revision = "3bcd62dd7260"
 down_revision = "dfa82518915a"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/3e1727613916_add_document_web_uri_column.py
+++ b/h/migrations/versions/3e1727613916_add_document_web_uri_column.py
@@ -1,5 +1,5 @@
 """
-Add document web_uri column
+Add document web_uri column.
 
 Revision ID: 3e1727613916
 Revises: a001b7b4c78e

--- a/h/migrations/versions/40740282ae9e_add_default_to_document_uri_types.py
+++ b/h/migrations/versions/40740282ae9e_add_default_to_document_uri_types.py
@@ -1,15 +1,15 @@
 """
-Add default to document_uri type fields
+Add default to document_uri type fields.
 
 Revision ID: 40740282ae9e
 Revises: 296575bb30b3
 Create Date: 2016-06-29 11:01:40.936313
 """
 
+from alembic import op
+
 revision = "40740282ae9e"
 down_revision = "296573bb30b3"
-
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/42bd46b9b1ea_fill_in_missing_password_updated_fields.py
+++ b/h/migrations/versions/42bd46b9b1ea_fill_in_missing_password_updated_fields.py
@@ -1,20 +1,21 @@
-"""fill in missing password_updated fields
+"""
+Fill in missing password_updated fields.
 
 Revision ID: 42bd46b9b1ea
 Revises: 43e7c4ed2fd7
 Create Date: 2016-01-07 14:20:44.094611
 
 """
-
-# revision identifiers, used by Alembic.
-revision = "42bd46b9b1ea"
-down_revision = None
-
 import datetime
 
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.orm import sessionmaker
+
+# revision identifiers, used by Alembic.
+revision = "42bd46b9b1ea"
+down_revision = None
+
 
 Session = sessionmaker()
 
@@ -33,7 +34,7 @@ def upgrade():
         op.execute(
             user.update()
             .where(user.c.id == id_)
-            .where(user.c.password_updated == None)
+            .where(user.c.password_updated == None)  # noqa
             .values(password_updated=datetime.datetime.utcnow())
         )
 

--- a/h/migrations/versions/43e7c4ed2fd7_make_user_password_updated_non_nullable.py
+++ b/h/migrations/versions/43e7c4ed2fd7_make_user_password_updated_non_nullable.py
@@ -1,17 +1,17 @@
-"""make user password_updated non-nullable
+"""
+Make user password_updated non-nullable.
 
 Revision ID: 43e7c4ed2fd7
 Revises: 530268a1937c
 Create Date: 2015-12-22 15:48:14.867487
 
 """
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "43e7c4ed2fd7"
 down_revision = "42bd46b9b1ea"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/467ea2898660_fix_document_uri_unique_constraint.py
+++ b/h/migrations/versions/467ea2898660_fix_document_uri_unique_constraint.py
@@ -1,20 +1,20 @@
 """
-Fix document_uri type fields
+Fix document_uri type fields.
 
 Revision ID: 467ea2898660
 Revises: 40740282ae9e
 Create Date: 2016-06-16 18:37:20.703447
 """
-
-revision = "467ea2898660"
-down_revision = "40740282ae9e"
-
 import logging
 
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+
+revision = "467ea2898660"
+down_revision = "40740282ae9e"
+
 
 log = logging.getLogger(__name__)
 

--- a/h/migrations/versions/46a22db075d5_add_organization_id_to_group_table.py
+++ b/h/migrations/versions/46a22db075d5_add_organization_id_to_group_table.py
@@ -1,11 +1,10 @@
 """
-Add organization_id to group table
+Add organization_id to group table.
 
 Revision ID: 46a22db075d5
 Revises: 628c53b07
 Create Date: 2018-03-21 09:47:47.642578
 """
-
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/4886d7a14074_add_constraints_to_sidebar_tutorial_.py
+++ b/h/migrations/versions/4886d7a14074_add_constraints_to_sidebar_tutorial_.py
@@ -1,4 +1,5 @@
-"""Add constraints to user.sidebar_tutorial_dismissed column.
+"""
+Add constraints to user.sidebar_tutorial_dismissed column.
 
 Revision ID: 4886d7a14074
 Revises: 6f6a853fa2a
@@ -6,12 +7,12 @@ Create Date: 2016-01-07 12:51:33.807404
 
 """
 
+import sqlalchemy as sa
+from alembic import op
+
 # revision identifiers, used by Alembic.
 revision = "4886d7a14074"
 down_revision = "6f6a853fa2a"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/4c0c44605c09_create_annotation_table.py
+++ b/h/migrations/versions/4c0c44605c09_create_annotation_table.py
@@ -1,4 +1,5 @@
-"""Create annotation table
+"""
+Create annotation table.
 
 Revision ID: 4c0c44605c09
 Revises: 4886d7a14074
@@ -6,15 +7,15 @@ Create Date: 2016-01-20 12:58:16.249481
 
 """
 
-# revision identifiers, used by Alembic.
-revision = "4c0c44605c09"
-down_revision = "21f87f395e26"
-
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
 from h.db import types
+
+# revision identifiers, used by Alembic.
+revision = "4c0c44605c09"
+down_revision = "21f87f395e26"
 
 
 def upgrade():

--- a/h/migrations/versions/504a6a4db06d_relax_password_constraints.py
+++ b/h/migrations/versions/504a6a4db06d_relax_password_constraints.py
@@ -1,5 +1,5 @@
 """
-Relax password constraints
+Relax password constraints.
 
 Revision ID: 504a6a4db06d
 Revises: de42d613c18d

--- a/h/migrations/versions/50df3e6782aa_add_annotation_moderation_table.py
+++ b/h/migrations/versions/50df3e6782aa_add_annotation_moderation_table.py
@@ -1,5 +1,5 @@
 """
-add annotation moderation table
+Add annotation moderation table.
 
 Revision ID: 50df3e6782aa
 Revises: e554d862135f

--- a/h/migrations/versions/52a0b2e5a9c2_add_authclient_redirect_uri_check.py
+++ b/h/migrations/versions/52a0b2e5a9c2_add_authclient_redirect_uri_check.py
@@ -1,5 +1,5 @@
 """
-Add authclient redirect_uri check
+Add authclient redirect_uri check.
 
 Revision ID: 52a0b2e5a9c2
 Revises: a2295c2bbe29

--- a/h/migrations/versions/53a74d7ae1b0_remove_nipsa_table.py
+++ b/h/migrations/versions/53a74d7ae1b0_remove_nipsa_table.py
@@ -1,5 +1,5 @@
 """
-Remove NIPSA table
+Remove NIPSA table.
 
 Revision ID: 53a74d7ae1b0
 Revises: 1e88c31d8b1a

--- a/h/migrations/versions/5655d56d7c29_add_flag_table.py
+++ b/h/migrations/versions/5655d56d7c29_add_flag_table.py
@@ -1,5 +1,5 @@
 """
-Add flag table
+Add flag table.
 
 Revision ID: 5655d56d7c29
 Revises: c322c57b49db

--- a/h/migrations/versions/58bb601c390f_fill_in_missing_denormalized_document_title.py
+++ b/h/migrations/versions/58bb601c390f_fill_in_missing_denormalized_document_title.py
@@ -1,5 +1,5 @@
 """
-Fill in missing denormalized Document.title
+Fill in missing denormalized Document.title.
 
 Revision ID: 58bb601c390f
 Revises: 3e1727613916

--- a/h/migrations/versions/5bfdfde681ea_add_annotation_deleted_column.py
+++ b/h/migrations/versions/5bfdfde681ea_add_annotation_deleted_column.py
@@ -1,5 +1,5 @@
 """
-Add annotation deleted column
+Add annotation deleted column.
 
 Revision ID: 5bfdfde681ea
 Revises: 90412d879d1f

--- a/h/migrations/versions/5d256923d642_make_organization_relation_nullable_on_.py
+++ b/h/migrations/versions/5d256923d642_make_organization_relation_nullable_on_.py
@@ -1,4 +1,4 @@
-"""Make organization relation nullable on group"""
+"""Make organization relation nullable on group."""
 from alembic import op
 
 revision = "5d256923d642"

--- a/h/migrations/versions/5dce9a8c42c2_disallow_null_annotation_document_id.py
+++ b/h/migrations/versions/5dce9a8c42c2_disallow_null_annotation_document_id.py
@@ -1,5 +1,5 @@
 """
-Disallow null annotation document_id
+Disallow null annotation document_id.
 
 Revision ID: 5dce9a8c42c2
 Revises: bcdd81e23920

--- a/h/migrations/versions/5ed9c8c105f6_add_authority_provided_id_field_to_group.py
+++ b/h/migrations/versions/5ed9c8c105f6_add_authority_provided_id_field_to_group.py
@@ -1,5 +1,5 @@
 """
-Add authority_provided_id field, index to group
+Add authority_provided_id field, index to group.
 
 This will allow clients of the API, in certain circumstances, to set a
 unique-to-authority identifier on a group, versus having to use the

--- a/h/migrations/versions/64cf31f9f721_add_expires_column_to_token_table.py
+++ b/h/migrations/versions/64cf31f9f721_add_expires_column_to_token_table.py
@@ -1,5 +1,5 @@
 """
-Add expires column to token table
+Add expires column to token table.
 
 Revision ID: 64cf31f9f721
 Revises: d536d9a342f3

--- a/h/migrations/versions/6964a8237c88_strip_whitespace_from_document_titles.py
+++ b/h/migrations/versions/6964a8237c88_strip_whitespace_from_document_titles.py
@@ -1,5 +1,5 @@
 """
-strip whitespace from document titles
+Strip whitespace from document titles.
 
 Revision ID: 6964a8237c88
 Revises: 5e535a075f16

--- a/h/migrations/versions/6f6a853fa2a_fill_in_sidebar_tutorial_dismissed_.py
+++ b/h/migrations/versions/6f6a853fa2a_fill_in_sidebar_tutorial_dismissed_.py
@@ -1,4 +1,5 @@
-"""Fill in user.sidebar_tutorial_dismissed column default values.
+"""
+Fill in user.sidebar_tutorial_dismissed column default values.
 
 Revision ID: 6f6a853fa2a
 Revises: 1ef80156ee4
@@ -6,13 +7,14 @@ Create Date: 2016-01-06 19:12:14.402260
 
 """
 
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import orm
+
 # revision identifiers, used by Alembic.
 revision = "6f6a853fa2a"
 down_revision = "1ef80156ee4"
 
-import sqlalchemy as sa
-from alembic import op
-from sqlalchemy import orm
 
 Session = orm.sessionmaker()
 

--- a/h/migrations/versions/6f86796f64e0_add_user_profile_columns.py
+++ b/h/migrations/versions/6f86796f64e0_add_user_profile_columns.py
@@ -1,5 +1,5 @@
 """
-Add user profile columns
+Add user profile columns.
 
 Revision ID: 6f86796f64e0
 Revises: 7cf52a00822b

--- a/h/migrations/versions/74bff6a7d9de_make_feature_flag_deletions_cascade.py
+++ b/h/migrations/versions/74bff6a7d9de_make_feature_flag_deletions_cascade.py
@@ -1,5 +1,5 @@
 """
-Make feature flag deletions cascade
+Make feature flag deletions cascade.
 
 Revision ID: 74bff6a7d9de
 Revises: 52a0b2e5a9c2

--- a/h/migrations/versions/77c2af032aca_add_document_uri_and_meta_docid_ix.py
+++ b/h/migrations/versions/77c2af032aca_add_document_uri_and_meta_docid_ix.py
@@ -1,4 +1,5 @@
-"""Add Document URI and Meta document_id index
+"""
+Add Document URI and Meta document_id index.
 
 Revision ID: 77c2af032aca
 Revises: f3b8e76ae9f5
@@ -6,12 +7,12 @@ Create Date: 2016-05-13 15:06:55.496502
 
 """
 
+import sqlalchemy as sa
+from alembic import op
+
 # revision identifiers, used by Alembic.
 revision = "77c2af032aca"
 down_revision = "f3b8e76ae9f5"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/7cf52a00822b_add_group_description_column.py
+++ b/h/migrations/versions/7cf52a00822b_add_group_description_column.py
@@ -1,5 +1,5 @@
 """
-Add group.description column
+Add group.description column.
 
 Revision ID: 7cf52a00822b
 Revises: 9e6b4f70f588

--- a/h/migrations/versions/7e2443f8d7d6_make_userid_index_unique.py
+++ b/h/migrations/versions/7e2443f8d7d6_make_userid_index_unique.py
@@ -1,5 +1,5 @@
 """
-Make userid index unique
+Make userid index unique.
 
 Revision ID: 7e2443f8d7d6
 Revises: faefe3b614db

--- a/h/migrations/versions/7fe5d688edd9_add_index_to_user_nipsa.py
+++ b/h/migrations/versions/7fe5d688edd9_add_index_to_user_nipsa.py
@@ -1,4 +1,4 @@
-"""Add index to user.nipsa"""
+"""Add index to user.nipsa."""
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/8990247b876c_disallow_group_authority_null.py
+++ b/h/migrations/versions/8990247b876c_disallow_group_authority_null.py
@@ -1,5 +1,5 @@
 """
-Disallow group.authority null
+Disallow group.authority null.
 
 Revision ID: 8990247b876c
 Revises: 140b450225cd

--- a/h/migrations/versions/8ae9d103551f_backfill_group_access_flags.py
+++ b/h/migrations/versions/8ae9d103551f_backfill_group_access_flags.py
@@ -1,5 +1,5 @@
 """
-Backfill group access flags
+Backfill group access flags.
 
 Revision ID: 8ae9d103551f
 Revises: af88524994ce

--- a/h/migrations/versions/8bd83598ad77_add_path_column_to_groupscope.py
+++ b/h/migrations/versions/8bd83598ad77_add_path_column_to_groupscope.py
@@ -1,4 +1,3 @@
-"""Add path column to groupscope, and a composite index for the (origin, path) columns"""
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/90412d879d1f_add_setting_table.py
+++ b/h/migrations/versions/90412d879d1f_add_setting_table.py
@@ -1,5 +1,5 @@
 """
-Add `setting` table
+Add `setting` table.
 
 Revision ID: 90412d879d1f
 Revises: 8ae9d103551f

--- a/h/migrations/versions/9389d52b037d_add_index_to_annotation_thread_root.py
+++ b/h/migrations/versions/9389d52b037d_add_index_to_annotation_thread_root.py
@@ -1,5 +1,5 @@
 """
-Add index to annotation thread root
+Add index to annotation thread root.
 
 Revision ID: 9389d52b037d
 Revises: b102c50b1133

--- a/h/migrations/versions/94c989e06363_remove_old_user_constraints.py
+++ b/h/migrations/versions/94c989e06363_remove_old_user_constraints.py
@@ -1,5 +1,5 @@
 """
-Remove old user constraints
+Remove old user constraints.
 
 These were created in b0e1a12de5e8 in order to avoid making that migration
 irreversible. This is the irreversible part.

--- a/h/migrations/versions/98157e28a7e1_make_annotation_extra_non_nullable.py
+++ b/h/migrations/versions/98157e28a7e1_make_annotation_extra_non_nullable.py
@@ -1,17 +1,17 @@
-"""Make annotation.extra non-nullable.
+"""
+Make annotation.extra non-nullable.
 
 Revision ID: 98157e28a7e1
 Revises: 77c2af032aca
 Create Date: 2016-06-06 14:52:41.277688
 
 """
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "98157e28a7e1"
 down_revision = "77c2af032aca"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/9bcc39244e82_add_token_refresh_token_expires.py
+++ b/h/migrations/versions/9bcc39244e82_add_token_refresh_token_expires.py
@@ -1,5 +1,5 @@
 """
-Add token refresh_token_expires
+Add token refresh_token_expires.
 
 Revision ID: 9bcc39244e82
 Revises: 74bff6a7d9de

--- a/h/migrations/versions/9cbc5c5ad23d_fill_in_missing_annotation_deleted.py
+++ b/h/migrations/versions/9cbc5c5ad23d_fill_in_missing_annotation_deleted.py
@@ -1,11 +1,10 @@
 """
-Fill in missing Annotation.deleted
+Fill in missing Annotation.deleted.
 
 Revision ID: 9cbc5c5ad23d
 Revises: 5bfdfde681ea
 Create Date: 2016-12-19 12:41:25.269188
 """
-
 import sqlalchemy as sa
 from alembic import op
 
@@ -17,7 +16,9 @@ annotation = sa.table("annotation", sa.column("deleted", sa.Boolean))
 
 def upgrade():
     op.execute(
-        annotation.update().where(annotation.c.deleted == None).values(deleted=False)
+        annotation.update()
+        .where(annotation.c.deleted == None)
+        .values(deleted=False)  # noqa
     )
 
 

--- a/h/migrations/versions/9e6b4f70f588_removing_trailing_from_pdf_urns.py
+++ b/h/migrations/versions/9e6b4f70f588_removing_trailing_from_pdf_urns.py
@@ -1,4 +1,5 @@
-"""Remove trailing # from PDF URNs.
+"""
+Remove trailing # from PDF URNs.
 
 Revision ID: 9e6b4f70f588
 Revises: 467ea2898660

--- a/h/migrations/versions/a001b7b4c78e_add_document_title_column.py
+++ b/h/migrations/versions/a001b7b4c78e_add_document_title_column.py
@@ -1,5 +1,5 @@
 """
-Add document title column
+Add document title column.
 
 Revision ID: a001b7b4c78e
 Revises: 94c989e06363

--- a/h/migrations/versions/a2295c2bbe29_make_client_secret_nullable.py
+++ b/h/migrations/versions/a2295c2bbe29_make_client_secret_nullable.py
@@ -1,5 +1,5 @@
 """
-Make Client.secret nullable
+Make Client.secret nullable.
 
 Revision ID: a2295c2bbe29
 Revises: 05bd63575f19

--- a/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
+++ b/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
@@ -1,5 +1,5 @@
 """
-Fill in missing denormalized Document.web_uri
+Fill in missing denormalized Document.web_uri.
 
 Revision ID: a44ef07b085a
 Revises: 58bb601c390f

--- a/h/migrations/versions/addee5d1686f_add_annotation_document_id_column.py
+++ b/h/migrations/versions/addee5d1686f_add_annotation_document_id_column.py
@@ -1,5 +1,5 @@
 """
-Add annotation document_id column
+Add annotation document_id column.
 
 Revision ID: addee5d1686f
 Revises: 63e8b1fe1d4b

--- a/h/migrations/versions/af88524994ce_add_group_access_flags.py
+++ b/h/migrations/versions/af88524994ce_add_group_access_flags.py
@@ -1,5 +1,5 @@
 """
-Add group access flags
+Add group access flags.
 
 Revision ID: af88524994ce
 Revises: 8990247b876c

--- a/h/migrations/versions/afd433075707_add_index_to_user_authority_column.py
+++ b/h/migrations/versions/afd433075707_add_index_to_user_authority_column.py
@@ -1,11 +1,10 @@
 """
-Add index to user authority column
+Add index to user authority column.
 
 Revision ID: afd433075707
 Revises: 504a6a4db06d
 Create Date: 2016-08-19 14:26:08.706027
 """
-
 from alembic import op
 
 revision = "afd433075707"

--- a/h/migrations/versions/b0e1a12de5e8_update_user_unique_constraints.py
+++ b/h/migrations/versions/b0e1a12de5e8_update_user_unique_constraints.py
@@ -1,5 +1,5 @@
 """
-Update user unique constraints
+Update user unique constraints.
 
 Revision ID: b0e1a12de5e8
 Revises: bdaa06b14557

--- a/h/migrations/versions/b102c50b1133_clean_up_moderation_extra_key.py
+++ b/h/migrations/versions/b102c50b1133_clean_up_moderation_extra_key.py
@@ -1,5 +1,5 @@
 """
-Clean up moderation extra key
+Clean up moderation extra key.
 
 Revision ID: b102c50b1133
 Revises: 50df3e6782aa
@@ -40,7 +40,9 @@ class Annotation(Base):
 def upgrade():
     session = Session(bind=op.get_bind())
 
-    anns = session.query(Annotation).filter(Annotation.extra.has_key("moderation"))
+    anns = session.query(Annotation).filter(
+        Annotation.extra.has_key("moderation"),  # noqa
+    )
     found = 0
     for ann in anns:
         del ann.extra["moderation"]

--- a/h/migrations/versions/b7117b569f8b_fill_user_nipsa_column.py
+++ b/h/migrations/versions/b7117b569f8b_fill_user_nipsa_column.py
@@ -1,5 +1,5 @@
 """
-Fill user NIPSA column
+Fill user NIPSA column.
 
 Revision ID: b7117b569f8b
 Revises: ddb5f0baa429

--- a/h/migrations/versions/b980b1a8f6af_add_authclient_grant_response_type_columns.py
+++ b/h/migrations/versions/b980b1a8f6af_add_authclient_grant_response_type_columns.py
@@ -1,5 +1,5 @@
 """
-Add AuthClient grant/response type columns
+Add AuthClient grant/response type columns.
 
 Revision ID: b980b1a8f6af
 Revises: 1c995723a271

--- a/h/migrations/versions/b9de5c897f73_add_user_activation_date.py
+++ b/h/migrations/versions/b9de5c897f73_add_user_activation_date.py
@@ -1,4 +1,4 @@
-"""Add user activation date"""
+"""Add user activation date."""
 import sqlalchemy as sa
 from alembic import op
 

--- a/h/migrations/versions/bcdd81e23920_fill_in_missing_annotation_document_id.py
+++ b/h/migrations/versions/bcdd81e23920_fill_in_missing_annotation_document_id.py
@@ -1,5 +1,5 @@
 """
-Fill in missing Annotation.document_id
+Fill in missing Annotation.document_id.
 
 Revision ID: bcdd81e23920
 Revises: addee5d1686f

--- a/h/migrations/versions/bdaa06b14557_add_authclient_table.py
+++ b/h/migrations/versions/bdaa06b14557_add_authclient_table.py
@@ -1,5 +1,5 @@
 """
-Add AuthClient table
+Add AuthClient table.
 
 Revision ID: bdaa06b14557
 Revises: afd433075707

--- a/h/migrations/versions/c322c57b49db_remove_user_uid_column.py
+++ b/h/migrations/versions/c322c57b49db_remove_user_uid_column.py
@@ -1,5 +1,5 @@
 """
-Remove user uid column
+Remove user uid column.
 
 Revision ID: c322c57b49db
 Revises: 18dfed902c9e

--- a/h/migrations/versions/c36369fe730f_add_token_client_id_column.py
+++ b/h/migrations/versions/c36369fe730f_add_token_client_id_column.py
@@ -1,5 +1,5 @@
 """
-Add token.client_id column
+Add token.client_id column.
 
 Revision ID: c36369fe730f
 Revises: e15e47228c43

--- a/h/migrations/versions/c739ee2ae59c_add_refresh_token_column_to_token_table.py
+++ b/h/migrations/versions/c739ee2ae59c_add_refresh_token_column_to_token_table.py
@@ -1,5 +1,5 @@
 """
-add refresh_token column to token table
+Add refresh_token column to token table.
 
 Revision ID: c739ee2ae59c
 Revises: 9f5e274b202c

--- a/h/migrations/versions/ccebe818f8e0_add_not_null_constraint_to_docuri_types.py
+++ b/h/migrations/versions/ccebe818f8e0_add_not_null_constraint_to_docuri_types.py
@@ -1,15 +1,15 @@
 """
-Add NOT NULL constraint to document_uri type fields
+Add NOT NULL constraint to document_uri type fields.
 
 Revision ID: ccebe818f8e0
 Revises: 467ea2898660
 Create Date: 2016-06-29 10:57:37.466053
 """
 
+from alembic import op
+
 revision = "ccebe818f8e0"
 down_revision = "467ea2898660"
-
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/d536d9a342f3_fill_in_annotation_text_rendered_column.py
+++ b/h/migrations/versions/d536d9a342f3_fill_in_annotation_text_rendered_column.py
@@ -1,5 +1,5 @@
 """
-Fill in annotation text_rendered column
+Fill in annotation text_rendered column.
 
 Revision ID: d536d9a342f3
 Revises: 39b1935d9e7b

--- a/h/migrations/versions/dba81a22ea75_add_redirect_uri_column_to_authclient.py
+++ b/h/migrations/versions/dba81a22ea75_add_redirect_uri_column_to_authclient.py
@@ -1,5 +1,5 @@
 """
-Add redirect_uri column to authclient
+Add redirect_uri column to authclient.
 
 Revision ID: dba81a22ea75
 Revises: 0d1b3fd8807c

--- a/h/migrations/versions/ddb5f0baa429_add_nipsa_column_to_user_table.py
+++ b/h/migrations/versions/ddb5f0baa429_add_nipsa_column_to_user_table.py
@@ -1,5 +1,5 @@
 """
-Add NIPSA column to user table
+Add NIPSA column to user table.
 
 Revision ID: ddb5f0baa429
 Revises: 6d9257ad610d

--- a/h/migrations/versions/de42d613c18d_add_constraints_to_user_authority_column.py
+++ b/h/migrations/versions/de42d613c18d_add_constraints_to_user_authority_column.py
@@ -1,5 +1,5 @@
 """
-Add constraints to user authority column
+Add constraints to user authority column.
 
 Revision ID: de42d613c18d
 Revises: 2e2cc6a0c521

--- a/h/migrations/versions/dfa82518915a_create_document_tables.py
+++ b/h/migrations/versions/dfa82518915a_create_document_tables.py
@@ -1,4 +1,5 @@
-"""Create document tables
+"""
+Create document tables.
 
 Revision ID: dfa82518915a
 Revises: 4c0c44605c09
@@ -6,13 +7,13 @@ Create Date: 2016-02-10 14:52:08.236839
 
 """
 
-# revision identifiers, used by Alembic.
-revision = "dfa82518915a"
-down_revision = "4c0c44605c09"
-
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "dfa82518915a"
+down_revision = "4c0c44605c09"
 
 
 def upgrade():

--- a/h/migrations/versions/e10ce4472966_add_index_to_group_readable_by.py
+++ b/h/migrations/versions/e10ce4472966_add_index_to_group_readable_by.py
@@ -1,5 +1,5 @@
 """
-Add index to group.readable_by
+Add index to group.readable_by.
 
 Revision ID: e10ce4472966
 Revises: f0f42ffaa27d

--- a/h/migrations/versions/e15e47228c43_remove_token_userid_uniqueness.py
+++ b/h/migrations/versions/e15e47228c43_remove_token_userid_uniqueness.py
@@ -1,5 +1,5 @@
 """
-Remove uniqueness constraint on token.userid
+Remove uniqueness constraint on token.userid.
 
 Revision ID: e15e47228c43
 Revises: 5dce9a8c42c2

--- a/h/migrations/versions/e554d862135f_add_index_to_flag_user_id.py
+++ b/h/migrations/versions/e554d862135f_add_index_to_flag_user_id.py
@@ -1,5 +1,5 @@
 """
-Add index to flag.user_id
+Add index to flag.user_id.
 
 Revision ID: e554d862135f
 Revises: 5655d56d7c29

--- a/h/migrations/versions/f0f42ffaa27d_add_annotation_deleted_constraints.py
+++ b/h/migrations/versions/f0f42ffaa27d_add_annotation_deleted_constraints.py
@@ -1,5 +1,5 @@
 """
-Add constraints and defaults to annotation deleted column
+Add constraints and defaults to annotation deleted column.
 
 Revision ID: f0f42ffaa27d
 Revises: 9cbc5c5ad23d

--- a/h/migrations/versions/f3b8e76ae9f5_add_document_uri_and_meta_updated_index.py
+++ b/h/migrations/versions/f3b8e76ae9f5_add_document_uri_and_meta_updated_index.py
@@ -1,17 +1,17 @@
-"""Add Document URI and Meta updated index
+"""
+Add Document URI and Meta updated index.
 
 Revision ID: f3b8e76ae9f5
 Revises: fde6cdcdd39a
 Create Date: 2016-05-13 14:58:37.679724
 
 """
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "f3b8e76ae9f5"
 down_revision = "fde6cdcdd39a"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/f48100c9af86_add_authority_column_to_user_table.py
+++ b/h/migrations/versions/f48100c9af86_add_authority_column_to_user_table.py
@@ -1,5 +1,5 @@
 """
-Add authority column to user table
+Add authority column to user table.
 
 Revision ID: f48100c9af86
 Revises: 64cf31f9f721

--- a/h/migrations/versions/f6ffcfc50583_add_annotation_extra_server_default.py
+++ b/h/migrations/versions/f6ffcfc50583_add_annotation_extra_server_default.py
@@ -1,4 +1,5 @@
-"""add annotation.extra server default
+"""
+Add annotation.extra server default.
 
 Revision ID: f6ffcfc50583
 Revises: 98157e28a7e1
@@ -6,12 +7,12 @@ Create Date: 2016-06-06 15:14:36.642775
 
 """
 
+import sqlalchemy as sa
+from alembic import op
+
 # revision identifiers, used by Alembic.
 revision = "f6ffcfc50583"
 down_revision = "98157e28a7e1"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/migrations/versions/f9d3058bec5f_add_constraints_to_user_nipsa_column.py
+++ b/h/migrations/versions/f9d3058bec5f_add_constraints_to_user_nipsa_column.py
@@ -1,5 +1,5 @@
 """
-Add constraints to user NIPSA column
+Add constraints to user NIPSA column.
 
 Revision ID: f9d3058bec5f
 Revises: b7117b569f8b

--- a/h/migrations/versions/faefe3b614db_make_user_uid_nullable.py
+++ b/h/migrations/versions/faefe3b614db_make_user_uid_nullable.py
@@ -1,5 +1,5 @@
 """
-Make user uid nullable
+Make user uid nullable.
 
 Revision ID: faefe3b614db
 Revises: 1a40e75a524d
@@ -26,7 +26,7 @@ def downgrade():
     # rolled back.
     op.execute(
         user.update()
-        .where(user.c.uid == None)
+        .where(user.c.uid == None)  # noqa
         .values(uid=sa.func.lower(sa.func.replace(user.c.username, ".", "")))
     )
     op.alter_column("user", "uid", nullable=False)

--- a/h/migrations/versions/fde6cdcdd39a_add_annotation_updated_index.py
+++ b/h/migrations/versions/fde6cdcdd39a_add_annotation_updated_index.py
@@ -1,4 +1,5 @@
-"""add annotation.updated index
+"""
+Add annotation.updated index.
 
 Revision ID: fde6cdcdd39a
 Revises: 3bcd62dd7260
@@ -6,12 +7,12 @@ Create Date: 2016-04-27 13:42:14.201644
 
 """
 
+import sqlalchemy as sa
+from alembic import op
+
 # revision identifiers, used by Alembic.
 revision = "fde6cdcdd39a"
 down_revision = "3bcd62dd7260"
-
-import sqlalchemy as sa
-from alembic import op
 
 
 def upgrade():

--- a/h/models/activation.py
+++ b/h/models/activation.py
@@ -18,7 +18,6 @@ def _generate_random_string(length=12):
 
 
 class Activation(Base):
-
     """
     Handles activations for users.
 

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -12,7 +12,6 @@ from h.util.user import split_user
 
 
 class Annotation(Base):
-
     """Model class representing a single annotation."""
 
     __tablename__ = "annotation"

--- a/h/models/blocklist.py
+++ b/h/models/blocklist.py
@@ -5,8 +5,8 @@ from h.db import Base
 
 
 class Blocklist(Base):
-
-    """A list of URIs for which the badge API will always return 0.
+    """
+    A list of URIs for which the badge API will always return 0.
 
     This means that the Chrome extension will never show a number of
     annotations on its badge for these URIs.

--- a/h/models/document/_document.py
+++ b/h/models/document/_document.py
@@ -125,8 +125,7 @@ class Document(Base, mixins.Timestamps):
 
 def merge_documents(session, documents, updated=None):
     """
-    Takes a list of documents and merges them together. It returns the new
-    master document.
+    Take a list of documents and merges them together. It returns the new master document.
 
     The support for setting a specific value for the `updated` should only
     be used during the Postgres migration. It should be removed afterwards.

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -37,7 +37,6 @@ FEATURES_PENDING_REMOVAL = {}
 
 
 class Feature(Base):
-
     """A feature flag for the application."""
 
     __tablename__ = "feature"

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -118,8 +118,7 @@ class Group(Base, mixins.Timestamps):
     @groupid.setter
     def groupid(self, value):
         """
-        Deconstruct a formatted ``groupid`` and set its constituent properties
-        on the instance.
+        Deconstruct a formatted ``groupid`` and set its constituent properties on the instance.
 
         If ``groupid`` is set to None, set ``authority_provided_id`` to None
         but leave authority untouched—this allows a caller to nullify the
@@ -182,13 +181,13 @@ class Group(Base, mixins.Timestamps):
 
     @property
     def slug(self):
-        """A version of this group's name suitable for use in a URL."""
+        """Get a version of this group's name suitable for use in a URL."""
         return slugify.slugify(self.name)
 
     @property
     def type(self):
         """
-        The "type" of this group, e.g. "open" or "private".
+        Get the "type" of this group, e.g. "open" or "private".
 
         :rtype: string
         :raises ValueError: if the type of the group isn't recognized

--- a/h/models/group_scope.py
+++ b/h/models/group_scope.py
@@ -55,12 +55,13 @@ class GroupScope(Base):
 
     @property
     def scope(self):
-        """Return a URL composed from the origin and path attrs"""
+        """Return a URL composed from the origin and path attrs."""
         return urljoin(self._origin, self._path)
 
     @scope.setter
     def scope(self, value):
-        """Take a URL and split it into origin, path
+        """
+        Take a URL and split it into origin and path.
 
         :raises ValueError: if URL is invalid (origin cannot be parsed)
         """

--- a/h/models/setting.py
+++ b/h/models/setting.py
@@ -4,7 +4,6 @@ from h.db import Base, mixins
 
 
 class Setting(Base, mixins.Timestamps):
-
     """A setting set by the application and shared with other processes."""
 
     __tablename__ = "setting"

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -7,8 +7,7 @@ from h.db import Base, mixins
 
 
 class Token(Base, mixins.Timestamps):
-
-    """
+    r"""
     An API access token for a user.
 
     These fall into two categories:
@@ -56,7 +55,7 @@ class Token(Base, mixins.Timestamps):
 
     @property
     def expired(self):
-        """True if this access token has expired, False otherwise."""
+        """Return True if this access token has expired, False otherwise."""
         if self.expires:
             return datetime.datetime.utcnow() > self.expires
 
@@ -64,7 +63,7 @@ class Token(Base, mixins.Timestamps):
 
     @property
     def refresh_token_expired(self):
-        """True if this refresh token has expired, False otherwise."""
+        """Return True if this refresh token has expired, False otherwise."""
         if self.refresh_token_expires:
             return datetime.datetime.utcnow() > self.refresh_token_expires
 
@@ -72,7 +71,7 @@ class Token(Base, mixins.Timestamps):
 
     @property
     def ttl(self):
-        """The amount of time from now until this token expires, in seconds."""
+        """Get the amount of time from now until this token expires, in seconds."""
         if not self.expires:
             return None
 

--- a/h/oauth/jwt_grant.py
+++ b/h/oauth/jwt_grant.py
@@ -82,7 +82,7 @@ class JWTAuthorizationGrant(GrantTypeBase):  # pylint: disable=abstract-method
 
     def validate_token_request(self, request):
         """
-        Validates a token request.
+        Validate a token request.
 
         Sets the ``client_id`` property on the passed-in request to the JWT
         issuer, and finds the user based on the JWT subject and sets it as

--- a/h/panels/back_link.py
+++ b/h/panels/back_link.py
@@ -9,9 +9,7 @@ from h.i18n import TranslationString as _  # noqa
 
 @panel_config(name="back_link", renderer="h:templates/panels/back_link.html.jinja2")
 def back_link(_context, request):
-    """
-    A link which takes the user back to the previous page on the site.
-    """
+    """Get a link which takes the user back to the previous page on the site."""
 
     referrer_path = urlparse(request.referrer or "").path
     current_username = request.user.username
@@ -29,9 +27,7 @@ def back_link(_context, request):
 
 
 def _matches_route(path, request, route_name):
-    """
-    Return ``True`` if ``path`` matches the URL pattern for a given route.
-    """
+    """Return ``True`` if ``path`` matches the URL pattern for a given route."""
 
     introspector = request.registry.introspector
 

--- a/h/panels/navbar.py
+++ b/h/panels/navbar.py
@@ -8,7 +8,7 @@ from h.i18n import TranslationString as _  # noqa
 @panel_config(name="navbar", renderer="h:templates/panels/navbar.html.jinja2")
 def navbar(_context, request, search=None, opts=None):
     """
-    The navigation bar displayed at the top of the page.
+    Get the navigation bar displayed at the top of the page.
 
     :param search: The current page's search state, if relevant.
     :type search: h.activity.query.ActivityResults

--- a/h/presenters/__init__.py
+++ b/h/presenters/__init__.py
@@ -1,8 +1,3 @@
-"""
-Code responsible for rendering domain objects into various output
-formats.
-"""
-
 from h.presenters.annotation_html import AnnotationHTMLPresenter
 from h.presenters.annotation_json import AnnotationJSONPresenter
 from h.presenters.annotation_jsonld import AnnotationJSONLDPresenter

--- a/h/presenters/annotation_base.py
+++ b/h/presenters/annotation_base.py
@@ -1,6 +1,4 @@
-"""
-A base presenter for common properties needed when rendering annotations.
-"""
+"""A base presenter for common properties needed when rendering annotations."""
 
 from h.util.datetime import utc_iso8601
 

--- a/h/presenters/annotation_html.py
+++ b/h/presenters/annotation_html.py
@@ -29,7 +29,7 @@ class AnnotationHTMLPresenter:
     @property
     def text_rendered(self):
         """
-        The body text of this annotation.
+        Get the body text of this annotation.
 
         This return value of this field is marked safe because it is rendered
         to HTML on write by :py:func:`h.util.markdown.render`, which must take
@@ -41,7 +41,7 @@ class AnnotationHTMLPresenter:
 
     @property
     def quote(self):
-        """The text in the document which this annotation refers to."""
+        """Get the text in the document which this annotation refers to."""
         selection = self._get_selection()
         if selection:
             return jinja2.escape(selection)
@@ -50,7 +50,8 @@ class AnnotationHTMLPresenter:
 
     @property
     def description(self):
-        """An HTML-formatted description of this annotation.
+        """
+        Get an HTML-formatted description of this annotation.
 
         The description contains the target text that the user selected to
         annotate, as a <blockquote>, and the body text of the annotation
@@ -76,7 +77,8 @@ class AnnotationHTMLPresenter:
 
     @property
     def created_day_string(self):
-        """A simple created day string for this annotation.
+        """
+        Get a simple created day string for this annotation.
 
         Returns a day string like '2015-03-11' from the annotation's 'created'
         date.

--- a/h/presenters/annotation_jsonld.py
+++ b/h/presenters/annotation_jsonld.py
@@ -2,10 +2,10 @@ from h.presenters.annotation_base import AnnotationBasePresenter
 
 
 class AnnotationJSONLDPresenter(AnnotationBasePresenter):
-
     """
-    Presenter for annotations that renders a JSON-LD format compatible with the
-    draft Web Annotation Data Model, as defined at:
+    Presenter for annotations that renders JSON-LD.
+
+    JSON-LD compatible with the draft Web Annotation Data Model, as defined at:
 
       https://www.w3.org/TR/annotation-model/
     """

--- a/h/presenters/document_html.py
+++ b/h/presenters/document_html.py
@@ -62,7 +62,6 @@ class DocumentHTMLPresenter:
 
         If it contains escaped characters the returned value will be a Markup
         object so that it doesn't get double-escaped.
-
         """
         if self.filename:
             return jinja2.escape(unquote(self.filename))
@@ -80,7 +79,6 @@ class DocumentHTMLPresenter:
         Return a link to this document.
 
         Returns HTML strings like:
-
           <a href="{href}" title="{title}">{link_text}</a> {hostname}
 
           <em>Local file:</em> {title}<br>{hostname}
@@ -109,7 +107,6 @@ class DocumentHTMLPresenter:
         User-supplied values are escaped so the string is safe for raw
         rendering (the returned string is actually a Markup object and
         won't be escaped by Jinja2 when rendering).
-
         """
         return _format_document_link(
             self.href, self.title, self.link_text, self.hostname_or_filename
@@ -188,7 +185,8 @@ class DocumentHTMLPresenter:
 
 
 def _format_document_link(href, title, link_text, host_or_filename):
-    """Return a document link for the given components.
+    """
+    Return a document link for the given components.
 
     Helper function for the .document_link property below.
 

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -49,7 +49,7 @@ class GroupJSONPresenter:
 
 
 class GroupsJSONPresenter:
-    """Present a list of groups as JSON"""
+    """Present a list of groups as JSON."""
 
     def __init__(self, groups, request):
         self.groups = groups

--- a/h/presenters/user_json.py
+++ b/h/presenters/user_json.py
@@ -1,5 +1,6 @@
 class UserJSONPresenter:
-    """Present a user.
+    """
+    Present a user.
 
     Format a user's data in JSON for use in API services. Only include
     properties that are public-facing.
@@ -18,7 +19,8 @@ class UserJSONPresenter:
 
 
 class TrustedUserJSONPresenter:
-    """Present a user to a trusted consumer.
+    """
+    Present a user to a trusted consumer.
 
     Format a user's data in JSON for use in API services, including any
     sensitive/private properties.

--- a/h/realtime.py
+++ b/h/realtime.py
@@ -13,7 +13,9 @@ from h.tasks import RETRY_POLICY_QUICK, RETRY_POLICY_VERY_QUICK
 
 class Consumer(ConsumerMixin):
     """
-    A realtime consumer that listens to the configured routing key and calls
+    A realtime consumer.
+
+    Listens to the configured routing key and calls
     the wrapped handler function on receiving a matching message.
 
     Conforms to the :py:class:`kombu.mixins.ConsumerMixin` interface.
@@ -46,16 +48,13 @@ class Consumer(ConsumerMixin):
         return "realtime-{}-{}".format(self.routing_key, self._random_id())
 
     def handle_message(self, body, message):
-        """
-        Handles a realtime message by acknowledging it and then calling the
-        wrapped handler.
-        """
+        """Handle a realtime message by acknowledging it and then calling the wrapped handler."""
         message.ack()
         self.handler(body)
 
     @staticmethod
     def _random_id():
-        """Generate a short random string"""
+        """Generate a short random string."""
         data = struct.pack("Q", random.getrandbits(64))
         return base64.urlsafe_b64encode(data).strip(b"=")
 
@@ -75,14 +74,16 @@ class Publisher:
         self.exchange = get_exchange()
 
     def publish_annotation(self, payload):
-        """Publish an annotation message with the routing key 'annotation'.
+        """
+        Publish an annotation message with the routing key 'annotation'.
 
         :raise RealtimeMessageQueueError: When we cannot queue the message
         """
         self._publish("annotation", payload)
 
     def publish_user(self, payload):
-        """Publish a user message with the routing key 'user'.
+        """
+        Publish a user message with the routing key 'user'.
 
         :raise RealtimeMessageQueueError: When we cannot queue the message
         """
@@ -111,7 +112,7 @@ class Publisher:
 
 
 def get_exchange():
-    """Returns a configures `kombu.Exchange` to use for realtime messages."""
+    """Return and configures `kombu.Exchange` to use for realtime messages."""
 
     return kombu.Exchange(
         "realtime", type="direct", durable=False, delivery_mode="transient"
@@ -119,7 +120,8 @@ def get_exchange():
 
 
 def get_connection(settings, fail_fast=False):
-    """Returns a `kombu.Connection` based on the application's settings.
+    """
+    Return a `kombu.Connection` based on the application's settings.
 
     :param settings: Application settings
     :param fail_fast: Make the connection fail if we cannot get a connection

--- a/h/realtime.py
+++ b/h/realtime.py
@@ -112,7 +112,7 @@ class Publisher:
 
 
 def get_exchange():
-    """Return and configures `kombu.Exchange` to use for realtime messages."""
+    """Get a configured `kombu.Exchange` to use for realtime messages."""
 
     return kombu.Exchange(
         "realtime", type="direct", durable=False, delivery_mode="transient"

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -25,7 +25,6 @@ def _validate_wildcard_uri(node, value):
 
 
 class AnnotationSchema(JSONSchema):
-
     """Validate an annotation object."""
 
     schema = {
@@ -98,7 +97,6 @@ class AnnotationSchema(JSONSchema):
 
 
 class CreateAnnotationSchema:
-
     """Validate the POSTed data of a create annotation request."""
 
     def __init__(self, request):
@@ -152,7 +150,6 @@ class CreateAnnotationSchema:
 
 
 class UpdateAnnotationSchema:
-
     """Validate the POSTed data of an update annotation request."""
 
     def __init__(self, request, existing_target_uri, groupid):

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -1,4 +1,4 @@
-"""Schema for validating API group resources"""
+"""Schema for validating API group resources."""
 
 from h.i18n import TranslationString as _
 from h.models.group import (
@@ -21,7 +21,7 @@ GROUP_SCHEMA_PROPERTIES = {
 
 
 class GroupAPISchema(JSONSchema):
-    """Base class for validating group resource API data"""
+    """Base class for validating group resource API data."""
 
     schema = {"type": "object", "properties": GROUP_SCHEMA_PROPERTIES}
 
@@ -98,7 +98,7 @@ class GroupAPISchema(JSONSchema):
 
     @staticmethod
     def _whitelisted_fields_only(appstruct):
-        """Return a new appstruct containing only schema-defined fields"""
+        """Return a new appstruct containing only schema-defined fields."""
 
         new_appstruct = {}
 
@@ -110,7 +110,7 @@ class GroupAPISchema(JSONSchema):
 
 
 class CreateGroupAPISchema(GroupAPISchema):
-    """Schema for validating create-group API data"""
+    """Schema for validating create-group API data."""
 
     schema = {
         "type": "object",
@@ -121,7 +121,7 @@ class CreateGroupAPISchema(GroupAPISchema):
 
 class UpdateGroupAPISchema(GroupAPISchema):
     """
-    Class for validating update-group API data
+    Class for validating update-group API data.
 
     Currently identical to base schema
     """

--- a/h/schemas/api/user.py
+++ b/h/schemas/api/user.py
@@ -72,7 +72,7 @@ class UpdateUserAPISchema(JSONSchema):
 
     @staticmethod
     def _whitelisted_properties_only(appstruct):
-        """Return a new appstruct containing only schema-defined fields"""
+        """Return a new appstruct containing only schema-defined fields."""
 
         new_appstruct = {}
 

--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -89,7 +89,7 @@ def _validate_creator(creator_username, authority, user_svc, parent_exc):
 
 
 def url_with_origin_validator(node, val):
-    """Validate that entered URL can be parsed into a scope"""
+    """Validate that entered URL can be parsed into a scope."""
     if not group_scope.parse_origin(val):
         raise colander.Invalid(
             node,

--- a/h/schemas/forms/group.py
+++ b/h/schemas/forms/group.py
@@ -24,7 +24,6 @@ def unblacklisted_group_name_slug(node, value):
 
 
 def group_schema(autofocus_name=False):
-
     """Return a schema for the form for creating or editing a group."""
 
     schema = CSRFSchema()

--- a/h/search/client.py
+++ b/h/search/client.py
@@ -2,7 +2,6 @@ import elasticsearch
 
 
 class Client:
-
     """
     A convenience wrapper around a connection to Elasticsearch.
 
@@ -57,7 +56,7 @@ class Client:
 
     @property
     def version(self):
-        """The version of the elasticsearch library."""
+        """Get the version of the elasticsearch library."""
         return self._version
 
 

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -64,7 +64,7 @@ class Search:
 
     def run(self, params):
         """
-        Execute the search query
+        Execute the search query.
 
         :param params: the search parameters that will be popped by each of the filters.
         :type params: webob.multidict.MultiDict
@@ -95,9 +95,7 @@ class Search:
         self._aggregations.append(aggregation)
 
     def _search(self, modifiers, aggregations, params):
-        """
-        Applies the modifiers, aggregations, and executes the search.
-        """
+        """Apply the modifiers, aggregations, and executes the search."""
         # Don't return any fields, just the metadata so set _source=False.
         search = elasticsearch_dsl.Search(
             using=self.es.conn, index=self.es.index

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -16,10 +16,7 @@ PG_WINDOW_SIZE = 2500
 
 
 class BatchIndexer:
-    """
-    A convenience class for reindexing all annotations from the database to
-    the search index.
-    """
+    """A convenience class for reindexing all annotations from the database to the search index."""
 
     def __init__(self, session, es_client, request, target_index=None, op_type="index"):
         self.session = session
@@ -121,7 +118,7 @@ def _filtered_annotations(session, ids):
 
 
 def _annotation_filter():
-    """Default filter for all search indexing operations."""
+    """Set the default filter for all search indexing operations."""
     return sa.not_(models.Annotation.deleted)
 
 

--- a/h/search/parser.py
+++ b/h/search/parser.py
@@ -1,4 +1,6 @@
 """
+Parser for Lucene syntax.
+
 The query parser which converts our subset of the Apache Lucene syntax and
 transforms it into a MultiDict structure that h.search understands.
 """
@@ -47,7 +49,8 @@ Match = namedtuple("Match", ["key", "value"])
 
 
 def parse(q):
-    """Parse a free text, Lucene-like, query string into a MultiDict.
+    """
+    Parse a free text, Lucene-like, query string into a MultiDict.
 
     "user:luke tag:foobar tag:news hello world" is parsed into::
 

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -17,7 +17,7 @@ DEFAULT_DATE = dt(1970, 1, 1, 0, 0, 0, 0).replace(tzinfo=tz.tzutc())
 
 
 def popall(multidict, key):
-    """Pop and returns all values of the key in multidict."""
+    """Pop and return all values of the key in multidict."""
     values = multidict.getall(key)
     if values:
         del multidict[key]
@@ -162,7 +162,7 @@ class TopLevelAnnotationsFilter:
 
 
 class AuthorityFilter:
-    """Match only annotations created by users belonging to a specific authority."""
+    """Match annotations created by users belonging to a specific authority."""
 
     def __init__(self, authority):
         self.authority = authority
@@ -296,7 +296,7 @@ class UriCombinedWildcardFilter:
     @staticmethod
     def _wildcard_uri_normalized(wildcard_uri):
         r"""
-        Get the same as uri.normalized but it replaces _'s with ?'s after normalization.
+        Normalize a URL (like `uri.normalized`) replacing "_" with "?" after normalization.
 
         Although elasticsearch uses ? we use _ since ? is a special reserved url
         character and this means we can avoid dealing with normalization headaches.

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -17,7 +17,7 @@ DEFAULT_DATE = dt(1970, 1, 1, 0, 0, 0, 0).replace(tzinfo=tz.tzutc())
 
 
 def popall(multidict, key):
-    """Pops and returns all values of the key in multidict"""
+    """Pop and returns all values of the key in multidict."""
     values = multidict.getall(key)
     if values:
         del multidict[key]
@@ -126,7 +126,7 @@ class Sorter:
     @staticmethod
     def _parse_date(str_value):
         """
-        Converts a string to a float representing miliseconds since the epoch.
+        Convert a string to a float representing miliseconds since the epoch.
 
         Since the elasticsearch date parser is not run on search_after,
         the date must be converted to ms since the epoch as that is how
@@ -155,7 +155,6 @@ class Sorter:
 
 
 class TopLevelAnnotationsFilter:
-
     """Matches top-level annotations only, filters out replies."""
 
     def __call__(self, search, _):
@@ -163,10 +162,7 @@ class TopLevelAnnotationsFilter:
 
 
 class AuthorityFilter:
-
-    """
-    Match only annotations created by users belonging to a specific authority.
-    """
+    """Match only annotations created by users belonging to a specific authority."""
 
     def __init__(self, authority):
         self.authority = authority
@@ -176,7 +172,6 @@ class AuthorityFilter:
 
 
 class AuthFilter:
-
     """
     A filter that selects only annotations the user is authorised to see.
 
@@ -203,7 +198,6 @@ class AuthFilter:
 
 
 class GroupFilter:
-
     """
     Filter that limits which groups annotations are returned from.
 
@@ -226,7 +220,6 @@ class GroupFilter:
 
 
 class UriCombinedWildcardFilter:
-
     """
     A filter that selects only annotations where the uri matches.
 
@@ -243,7 +236,8 @@ class UriCombinedWildcardFilter:
     """
 
     def __init__(self, request, separate_keys=False):
-        """Initialize a new UriFilter.
+        """
+        Initialize a new UriFilter.
 
         :param request: the pyramid.request object
         :param separate_keys: if True will treat wildcard_uri as wildcards and uri/url
@@ -301,8 +295,8 @@ class UriCombinedWildcardFilter:
 
     @staticmethod
     def _wildcard_uri_normalized(wildcard_uri):
-        """
-        Same as uri.normalized but it replaces _'s with ?'s after normalization.
+        r"""
+        Get the same as uri.normalized but it replaces _'s with ?'s after normalization.
 
         Although elasticsearch uses ? we use _ since ? is a special reserved url
         character and this means we can avoid dealing with normalization headaches.
@@ -324,10 +318,7 @@ class UriCombinedWildcardFilter:
 
 
 class UserFilter:
-
-    """
-    A filter that selects only annotations where the 'user' parameter matches.
-    """
+    """A filter that selects only annotations where the 'user' parameter matches."""
 
     def __call__(self, search, params):
         if "user" not in params:
@@ -339,7 +330,6 @@ class UserFilter:
 
 
 class DeletedFilter:
-
     """
     A filter that only returns non-deleted documents.
 
@@ -375,10 +365,7 @@ class HiddenFilter:
 
 
 class AnyMatcher:
-
-    """
-    Matches the contents of a selection of fields against the `any` parameter.
-    """
+    """Match the contents of a selection of fields against the `any` parameter."""
 
     def __call__(self, search, params):
         if "any" not in params:
@@ -394,8 +381,7 @@ class AnyMatcher:
 
 
 class TagsMatcher:
-
-    """Matches the tags field against 'tag' or 'tags' parameters."""
+    """Match the tags field against 'tag' or 'tags' parameters."""
 
     def __call__(self, search, params):
         tags = set(popall(params, "tag") + popall(params, "tags"))
@@ -406,8 +392,7 @@ class TagsMatcher:
 
 
 class RepliesMatcher:
-
-    """Matches any replies to any of the given annotation ids."""
+    """Match any replies to any of the given annotation ids."""
 
     def __init__(self, ids):
         self.annotation_ids = ids

--- a/h/search/util.py
+++ b/h/search/util.py
@@ -32,6 +32,8 @@ def wildcard_uri_is_valid(wildcard_uri):
 
 def add_default_scheme(uri):
     """
+    Add scheme to URI.
+
     In order to not prepend an extra http:// in cases where
     there may be wildcard characters in the scheme, add _ and *
     to the list of valid scheme characters.

--- a/h/security/acl.py
+++ b/h/security/acl.py
@@ -112,7 +112,8 @@ class ACL:
 
     @classmethod
     def for_annotation(cls, annotation):
-        """Return a Pyramid ACL for this annotation.
+        """
+        Return a Pyramid ACL for this annotation.
 
         :param annotation: Annotation in question
         """
@@ -166,7 +167,7 @@ class ACL:
         acls = ACL.for_group(annotation.group)
 
         for action, principal, permission in acls:
-            try:
+            try:  # pylint: disable=too-many-try-statements
                 for mapped_permission in permission_map.get(permission, []):
                     yield action, principal, mapped_permission
 

--- a/h/services/annotation_stats.py
+++ b/h/services/annotation_stats.py
@@ -44,9 +44,7 @@ class AnnotationStatsService:
         return search_result.total
 
     def group_annotation_count(self, pubid):
-        """
-        Return the count of searchable top level annotations for this group.
-        """
+        """Return the count of searchable top level annotations for this group."""
         params = MultiDict({"limit": 0, "group": pubid})
         return self._search(params)
 

--- a/h/services/auth_ticket.py
+++ b/h/services/auth_ticket.py
@@ -41,7 +41,7 @@ class AuthTicketService:
         return self._userid
 
     def groups(self):
-        """Returns security principals of the logged-in user."""
+        """Return security principals of the logged-in user."""
 
         if self._userid is None:
             raise AuthTicketNotLoadedError("auth ticket is not loaded yet")
@@ -51,8 +51,7 @@ class AuthTicketService:
 
     def verify_ticket(self, principal, ticket_id):
         """
-        Verifies an authentication claim (usually extracted from a cookie)
-        against the stored tickets.
+        Verify an authentication claim (usually extracted from a cookie) against the stored tickets.
 
         This will only successfully verify a ticket when it is found in the
         database, the principal is the same, and it hasn't expired yet.

--- a/h/services/bulk_executor/_actions.py
+++ b/h/services/bulk_executor/_actions.py
@@ -17,7 +17,8 @@ from h.models.group import PRIVATE_GROUP_TYPE_FLAGS
 
 
 class DBAction:
-    """Base class for all DB actions.
+    """
+    Base class for all DB actions.
 
     Provides an interface and a couple of useful methods.
     """
@@ -26,7 +27,8 @@ class DBAction:
         self.db = db
 
     def execute(self, batch, **kwargs):
-        """Process a series of commands.
+        """
+        Process a series of commands.
 
         The commands are assumed to be appropriate for this action type.
         """
@@ -35,7 +37,8 @@ class DBAction:
 
     @staticmethod
     def _check_upsert_queries(batch, expected_keys):
-        """Validate the query for each command in `batch`.
+        """
+        Validate the query for each command in `batch`.
 
         This method allows you to assert that:
 
@@ -150,7 +153,8 @@ class GroupUpsertAction(DBAction):
 
 
 class GroupMembershipCreateAction(DBAction):
-    """Perform a bulk group membership create.
+    """
+    Perform a bulk group membership create.
 
     :raises ConflictingDataError: Upon trying to create a membership to a user
                                   or group that does not exist
@@ -160,6 +164,8 @@ class GroupMembershipCreateAction(DBAction):
         self, batch, on_duplicate="continue", **_
     ):
         """
+        Execute GroupMembershipCreateAction.
+
         :param on_duplicate: Specify behavior when a record already exists. The
                              default is "continue"
         """
@@ -203,7 +209,8 @@ class GroupMembershipCreateAction(DBAction):
 
 
 class UserUpsertAction(DBAction):
-    """Perform a bulk user upsert.
+    """
+    Perform a bulk user upsert.
 
     :raise ConflictingDataError: If two users attempt to use the same identity
     """

--- a/h/services/bulk_executor/_executor.py
+++ b/h/services/bulk_executor/_executor.py
@@ -18,6 +18,8 @@ class BulkExecutor(Executor):
 
     def __init__(self, db, authority):
         """
+        Initialize BulkExecutor.
+
         :param db: DB session object
         :param authority: Restrict all request to this authority
         """

--- a/h/services/delete_group.py
+++ b/h/services/delete_group.py
@@ -12,8 +12,9 @@ class DeleteGroupService:
 
     def delete(self, group):
         """
-        Deletes a group, its membership relations and all annotations in the
-        group.
+        Delete a group.
+
+        Including its membership relations and all annotations in the group.
         """
 
         self._delete_annotations(group)

--- a/h/services/delete_user.py
+++ b/h/services/delete_user.py
@@ -8,7 +8,7 @@ class DeleteUserService:
 
     def delete(self, user):
         """
-        Deletes a user with all their group memberships and annotations.
+        Delete a user with all their group memberships and annotations.
 
         If a user owns groups with collaborators, meaning there are annotations
         in the group that have been made by other users, the user is unassigned
@@ -29,6 +29,7 @@ class DeleteUserService:
     def _groups_that_have_collaborators(self, groups, user):
         """
         Return list of groups that have annotations from other users.
+
         :param groups: List of group objects to evaluate.
         :type groups: list[h.models.Group]
         :param user: The user object and creator of the groups.

--- a/h/services/developer_token.py
+++ b/h/services/developer_token.py
@@ -31,7 +31,7 @@ class DeveloperTokenService:
 
     def create(self, userid):
         """
-        Creates a developer token for the given userid.
+        Create a developer token for the given userid.
 
         :param userid: The userid for which the developer token gets created.
         :type userid: unicode

--- a/h/services/feature.py
+++ b/h/services/feature.py
@@ -67,10 +67,7 @@ class FeatureService:
         return features[name]
 
     def all(self, user=None):
-        """
-        Returns a dict mapping feature flag names to enabled states
-        for the specified `user`.
-        """
+        """Return a dict mapping feature flag names to enabled states for the specified `user`."""
         return {f.name: self._state(f, user=user) for f in self._cached_load()}
 
     def _load(self):

--- a/h/services/group_links.py
+++ b/h/services/group_links.py
@@ -1,8 +1,5 @@
 class GroupLinksService:
-
-    """
-    A service for providing appropriate links (URLs) for a given group object
-    """
+    """A service for providing appropriate links (URLs) for a given group object."""
 
     def __init__(self, default_authority, route_url):
         """
@@ -15,7 +12,7 @@ class GroupLinksService:
         self._route_url = route_url
 
     def get_all(self, group):
-        """Return a dict of all applicable links for this group"""
+        """Return a dict of all applicable links for this group."""
         links = {}
         if group.authority == self._default_authority:
             # Only groups for the default authority should have an activity page

--- a/h/services/group_list.py
+++ b/h/services/group_list.py
@@ -3,7 +3,6 @@ from h.models import group
 
 
 class GroupListService:
-
     """
     A service for providing filtered lists of groups.
 
@@ -24,7 +23,8 @@ class GroupListService:
         self.default_authority = default_authority
 
     def _authority(self, user=None, authority=None):
-        """Determine which authority to use.
+        """
+        Determine which authority to use.
 
         Determine the appropriate authority to use for querying groups.
         User's authority will always supersede if present; otherwise provide
@@ -37,8 +37,9 @@ class GroupListService:
 
     def session_groups(self, authority, user=None):
         """
-        Return a list of groups relevant to the user-session combination,
-        in this order:
+        Return a list of groups relevant to the user-session combination.
+
+        In this order:
 
         - WORLD GROUP:
           The special world group is returned if `authority` is the default
@@ -207,7 +208,7 @@ class GroupListService:
 
     @staticmethod
     def _sort(groups):
-        """sort a list of groups of a single type"""
+        """Sort a list of groups of a single type."""
         return sorted(groups, key=lambda group: (group.name.lower(), group.pubid))
 
 

--- a/h/services/group_members.py
+++ b/h/services/group_members.py
@@ -4,12 +4,11 @@ from h import session
 
 
 class GroupMembersService:
-
     """A service for manipulating group membership."""
 
     def __init__(self, db, user_fetcher, publish):
         """
-        Create a new GroupMembersService
+        Create a new GroupMembersService.
 
         :param db: the SQLAlchemy db object
         :param user_fetcher: a callable for fetching users by userid
@@ -33,8 +32,7 @@ class GroupMembersService:
 
     def update_members(self, group, userids):
         """
-        Update this group's membership to be the list of users indicated by
-        userids.
+        Update this group's membership to be the list of users indicated by userids.
 
         The users indicated by userids will *replace* the members of this group.
         Any pre-existing member whose userid is not present in userids will

--- a/h/services/group_scope.py
+++ b/h/services/group_scope.py
@@ -7,7 +7,8 @@ class GroupScopeService:
         self._session = session
 
     def fetch_by_scope(self, url):
-        """Return GroupScope records that match the given URL
+        """
+        Return GroupScope records that match the given URL.
 
         :arg url: URL to find matching scopes for
         :type url: str

--- a/h/services/group_update.py
+++ b/h/services/group_update.py
@@ -6,7 +6,7 @@ from h.services.exceptions import ConflictError, ValidationError
 class GroupUpdateService:
     def __init__(self, session):
         """
-        Create a new GroupUpdateService
+        Create a new GroupUpdateService.
 
         :param session: the SQLAlchemy session object
         """

--- a/h/services/links.py
+++ b/h/services/links.py
@@ -1,4 +1,4 @@
-"""Tools for generating links to domain objects. """
+"""Tools for generating links to domain objects."""
 
 from pyramid.request import Request
 
@@ -8,7 +8,6 @@ LINK_GENERATORS_KEY = "h.links.link_generators"
 
 
 class LinksService:
-
     """A service for generating links to annotations."""
 
     def __init__(self, base_url, registry):
@@ -75,7 +74,7 @@ def links_factory(_context, request):
 
 def add_annotation_link_generator(config, name, generator, hidden=False):
     """
-    Registers a function which generates a named link for an annotation.
+    Register a function which generates a named link for an annotation.
 
     Annotation hypermedia links are added to the rendered annotations in a
     `links` property or similar. `name` is the unique identifier for the link

--- a/h/services/list_organizations.py
+++ b/h/services/list_organizations.py
@@ -2,10 +2,7 @@ from h.models.organization import Organization
 
 
 class ListOrganizationsService:
-
-    """
-    A service for providing a list of organizations.
-    """
+    """A service for providing a list of organizations."""
 
     def __init__(self, session):
         """
@@ -17,8 +14,9 @@ class ListOrganizationsService:
 
     def organizations(self, authority=None):
         """
-        Return a list of organizations filtered on authority and
-        sorted by name. If authority is None, return a list of
+        Return a list of organizations filtered on authority and sorted by name.
+
+        If authority is None, return a list of
         all organizations.
         """
         filter_args = {}
@@ -34,8 +32,5 @@ class ListOrganizationsService:
 
 
 def list_organizations_factory(_context, request):
-    """
-    Return a ListOrganizationsService instance for the passed
-    context.
-    """
+    """Return a ListOrganizationsService instance for the passed context."""
     return ListOrganizationsService(session=request.db)

--- a/h/services/nipsa.py
+++ b/h/services/nipsa.py
@@ -2,11 +2,7 @@ from h.models import User
 
 
 class NipsaService:
-
-    """
-    A service which provides access to the state of "not-in-public-site-areas"
-    (NIPSA) flags on userids.
-    """
+    """A service which provides access to the state of "not-in-public-site-areas" (NIPSA) flags on userids."""
 
     def __init__(self, session, get_search_index):
         self.session = session

--- a/h/services/oauth_provider.py
+++ b/h/services/oauth_provider.py
@@ -71,8 +71,8 @@ class OAuthProviderService(AuthorizationEndpoint, RevocationEndpoint, TokenEndpo
         # WARNING! - Don't think because this is here it should be. This is
         # almost certainly a hack on a hack here to prevent the overloaded
         # method from throwing a fit. If you can get rid of this you should.
-
-        """Ensure the request is valid.
+        """
+        Ensure the request is valid.
 
         We are overriding the base class here to ensure that client_id is in
         place to allow 'unauthenticated' access to the revocation end-point.
@@ -103,7 +103,7 @@ class OAuthProviderService(AuthorizationEndpoint, RevocationEndpoint, TokenEndpo
 
     def load_client_id_from_refresh_token(self, request):
         """
-        Custom validator which sets the client_id from a given refresh token
+        Add a custom validator which sets the client_id from a given refresh token.
 
         For the refresh token flow, RFC 6749 states that public clients only need
         to be verified when the `client_id` is provided. oauthlib seems to be

--- a/h/services/oauth_validator.py
+++ b/h/services/oauth_validator.py
@@ -26,7 +26,7 @@ class OAuthValidatorService(  # pylint: disable=too-many-public-methods, abstrac
     RequestValidator
 ):
     """
-    Validates OAuth requests
+    Validates OAuth requests.
 
     This implements the ``oauthlib.oauth2.RequestValidator`` interface.
     """
@@ -50,7 +50,7 @@ class OAuthValidatorService(  # pylint: disable=too-many-public-methods, abstrac
         )
 
     def authenticate_client(self, request, *args, **kwargs):
-        """Authenticates a client, returns True if the client exists and its secret matches the request."""
+        """Authenticate a client, returns True if the client exists and its secret matches the request."""
         client = self.find_client(request.client_id)
 
         if client is None:
@@ -68,7 +68,7 @@ class OAuthValidatorService(  # pylint: disable=too-many-public-methods, abstrac
         return True
 
     def authenticate_client_id(self, client_id, request, *args, **kwargs):
-        """Authenticates a client_id, returns True if the client_id exists."""
+        """Authenticate a client_id, returns True if the client_id exists."""
         client = self.find_client(client_id)
 
         if client is None:
@@ -144,7 +144,7 @@ class OAuthValidatorService(  # pylint: disable=too-many-public-methods, abstrac
         return self._cached_find_token(value)
 
     def get_default_redirect_uri(self, client_id, request, *args, **kwargs):
-        """Returns the ``redirect_uri`` stored on the client with the given id."""
+        """Return the ``redirect_uri`` stored on the client with the given id."""
 
         client = self.find_client(client_id)
         if not client:
@@ -217,7 +217,7 @@ class OAuthValidatorService(  # pylint: disable=too-many-public-methods, abstrac
         return authzcode
 
     def save_bearer_token(self, token, request, *args, **kwargs):
-        """Saves a generated bearer token for the authenticated user to the database."""
+        """Save a generated bearer token for the authenticated user to the database."""
         expires = utcnow() + datetime.timedelta(seconds=token["expires_in"])
 
         refresh_token_expires = utcnow() + datetime.timedelta(
@@ -244,7 +244,7 @@ class OAuthValidatorService(  # pylint: disable=too-many-public-methods, abstrac
         return oauth_token
 
     def validate_client_id(self, client_id, request, *args, **kwargs):
-        """Checks if the provided client_id belongs to a valid AuthClient."""
+        """Check if the provided client_id belongs to a valid AuthClient."""
 
         client = self.find_client(client_id)
         return client is not None
@@ -281,7 +281,7 @@ class OAuthValidatorService(  # pylint: disable=too-many-public-methods, abstrac
     def validate_grant_type(
         self, client_id, grant_type, client, request, *args, **kwargs
     ):
-        """Validates that the given client is allowed to use the give grant type."""
+        """Validate that the given client is allowed to use the give grant type."""
         if client.authclient.grant_type is None:
             return False
 
@@ -375,7 +375,7 @@ class OAuthValidatorService(  # pylint: disable=too-many-public-methods, abstrac
         )
 
     def _find_token(self, value):
-        """Retrieve a token without knowing which kind it is"""
+        """Retrieve a token without knowing which kind it is."""
 
         if value is None:
             return None

--- a/h/services/organization.py
+++ b/h/services/organization.py
@@ -4,7 +4,6 @@ from h.models import Organization
 
 
 class OrganizationService:
-
     """A service for manipulating organizations."""
 
     def __init__(self, session):
@@ -41,7 +40,8 @@ class OrganizationService:
         return self.session.query(Organization).filter_by(pubid=pubid).one_or_none()
 
     def get_default(self, authority=None):
-        """Get the default org with an option to create it if missing.
+        """
+        Get the default org with an option to create it if missing.
 
         :param authority: Create an org with this authority if none is found
         :return: The public organization or None.

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -12,7 +12,6 @@ class UserNotActivated(Exception):
 
 
 class UserService:
-
     """A service for retrieving and performing common operations on users."""
 
     def __init__(self, default_authority, session):

--- a/h/services/user_password.py
+++ b/h/services/user_password.py
@@ -5,7 +5,7 @@ from h.security import password_context
 
 class UserPasswordService:
     """
-    Adds a service for checking and updating user passwords.
+    A service for checking and updating user passwords.
 
     This service is responsible for verifying and updating user passwords, and
     specifically for ensuring that we automatically upgrade user password

--- a/h/services/user_password.py
+++ b/h/services/user_password.py
@@ -4,9 +4,8 @@ from h.security import password_context
 
 
 class UserPasswordService:
-
     """
-    A service for checking and updating user passwords.
+    Adds a service for checking and updating user passwords.
 
     This service is responsible for verifying and updating user passwords, and
     specifically for ensuring that we automatically upgrade user password

--- a/h/services/user_signup.py
+++ b/h/services/user_signup.py
@@ -12,7 +12,6 @@ log = logging.getLogger(__name__)
 
 
 class UserSignupService:
-
     """A service for registering users."""
 
     def __init__(

--- a/h/services/user_unique.py
+++ b/h/services/user_unique.py
@@ -3,15 +3,11 @@ from h.i18n import TranslationString as _  # noqa: N813
 
 
 class DuplicateUserError(Exception):
-    """Indicates that data violates user uniqueness constraints"""
+    """Indicates that data violates user uniqueness constraints."""
 
 
 class UserUniqueService:
-
-    """
-    A service for ensuring that data represents a unique user and will
-    not constitute a duplicate user.
-    """
+    """A service for ensuring that data represents a unique user and will not constitute a duplicate user."""
 
     def __init__(self, session, user_service):
         """
@@ -24,8 +20,9 @@ class UserUniqueService:
 
     def ensure_unique(self, data, authority):
         """
-        Ensure the provided `data` would constitute a new, non-duplicate
-        user. Check for conflicts in email, username, identity.
+        Ensure the provided `data` would constitute a new, non-duplicate user.
+
+        Check for conflicts in email, username, identity.
 
         :param data: dictionary of new-user data. Will check `email`, `username`
                      and any `identities` dictionaries provided

--- a/h/services/user_update.py
+++ b/h/services/user_update.py
@@ -6,7 +6,7 @@ from h.services.exceptions import ConflictError, ValidationError
 class UserUpdateService:
     def __init__(self, session):
         """
-        Create a new UserUpdateService
+        Create a new UserUpdateService.
 
         :param session: the SQLAlchemy session object
         """

--- a/h/session.py
+++ b/h/session.py
@@ -44,7 +44,7 @@ def profile(request, authority=None):
 
 def user_info(user):
     """
-    Returns the `user_info` JSON object.
+    Return the `user_info` JSON object.
 
     This is being used in the JSON representation of an annotation,
     and for the user profile.
@@ -62,10 +62,10 @@ def pop_flash(request):
 
 
 def _current_groups(request, authority):
-    """Return a list of the groups the current user is a member of.
+    """
+    Return a list of the groups the current user is a member of.
 
     This list is meant to be returned to the client in the "session" model.
-
     """
 
     user = request.user

--- a/h/storage.py
+++ b/h/storage.py
@@ -51,8 +51,7 @@ def fetch_annotation(session, id_):
 
 def fetch_ordered_annotations(session, ids, query_processor=None):
     """
-    Fetch all annotations with the given ids and order them based on the list
-    of ids.
+    Fetch all annotations with the given ids and order them based on the list of ids.
 
     The optional `query_processor` parameter allows for passing in a function
     that can change the query before it is run, especially useful for

--- a/h/streamer/filter.py
+++ b/h/streamer/filter.py
@@ -30,7 +30,8 @@ class SocketFilter:
 
     @classmethod
     def matching(cls, sockets, annotation, session):
-        """Find sockets with matching filters for the given annotation.
+        """
+        Find sockets with matching filters for the given annotation.
 
         For this to work, the sockets must have first had `set_filter()` called
         on them.
@@ -70,7 +71,8 @@ class SocketFilter:
 
     @classmethod
     def set_filter(cls, socket, filter_):
-        """Add filtering information to a socket for use with `matching()`.
+        """
+        Add filtering information to a socket for use with `matching()`.
 
         :param socket: Socket to add filtering information too
         :param filter_: Filter JSON to process

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -23,8 +23,7 @@ Message = namedtuple("Message", ["topic", "payload"])
 
 def process_messages(settings, routing_key, work_queue, raise_error=True):
     """
-    Configure, start, and monitor a realtime consumer for the specified
-    routing key.
+    Configure, start, and monitor a realtime consumer for the specified routing key.
 
     This sets up a :py:class:`h.realtime.Consumer` to route messages from
     `routing_key` to the passed `work_queue`, and starts it. The consumer

--- a/h/streamer/tweens.py
+++ b/h/streamer/tweens.py
@@ -5,7 +5,8 @@ def close_db_session_tween_factory(handler, _registry):
     """Return the close_db_session_tween."""
 
     def close_db_session_tween(request):
-        """Close the sqlalchemy session.
+        """
+        Close the sqlalchemy session.
 
         This tween runs late in the websocket app's Pyramid request processing
         cycle and makes sure that any DB connections that were opened during

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -171,7 +171,7 @@ MESSAGE_HANDLERS["filter"] = handle_filter_message  # noqa: E305
 
 
 def handle_ping_message(message, session=None):
-    """Answer to a client requesting a pong."""
+    """Reply to a client requesting a pong."""
     message.reply({"type": "pong"})
 
 
@@ -179,7 +179,7 @@ MESSAGE_HANDLERS["ping"] = handle_ping_message  # noqa: E305
 
 
 def handle_whoami_message(message, session=None):
-    """Answer to a client requesting information on its auth state."""
+    """Reply to a client requesting information on its auth state."""
     message.reply({"type": "whoyouare", "userid": message.socket.authenticated_userid})
 
 
@@ -187,7 +187,7 @@ MESSAGE_HANDLERS["whoami"] = handle_whoami_message  # noqa: E305
 
 
 def handle_unknown_message(message, session=None):
-    """Handle message type missing or not recognised."""
+    """Handle the message type being missing or not recognised."""
     type_ = json.dumps(message.payload.get("type"))
     message.reply(
         {

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -120,7 +120,7 @@ def handle_message(message, session=None):
 
 
 def handle_client_id_message(message, session=None):
-    """A client telling us its client ID."""
+    """Answer to a client telling us its client ID."""
     if "value" not in message.payload:
         message.reply(
             {
@@ -137,7 +137,7 @@ MESSAGE_HANDLERS["client_id"] = handle_client_id_message  # noqa: E305
 
 
 def handle_filter_message(message, session=None):
-    """A client updating its streamer filter."""
+    """Answer to a client updating its streamer filter."""
     if "filter" not in message.payload:
         message.reply(
             {
@@ -171,7 +171,7 @@ MESSAGE_HANDLERS["filter"] = handle_filter_message  # noqa: E305
 
 
 def handle_ping_message(message, session=None):
-    """A client requesting a pong."""
+    """Answer to a client requesting a pong."""
     message.reply({"type": "pong"})
 
 
@@ -179,7 +179,7 @@ MESSAGE_HANDLERS["ping"] = handle_ping_message  # noqa: E305
 
 
 def handle_whoami_message(message, session=None):
-    """A client requesting information on its auth state."""
+    """Answer to a client requesting information on its auth state."""
     message.reply({"type": "whoyouare", "userid": message.socket.authenticated_userid})
 
 
@@ -187,7 +187,7 @@ MESSAGE_HANDLERS["whoami"] = handle_whoami_message  # noqa: E305
 
 
 def handle_unknown_message(message, session=None):
-    """Message type missing or not recognised."""
+    """Handle message type missing or not recognised."""
     type_ = json.dumps(message.payload.get("type"))
     message.reply(
         {

--- a/h/streamer/worker.py
+++ b/h/streamer/worker.py
@@ -47,10 +47,8 @@ log = logging.getLogger(__name__)
 
 
 class WebSocketWSGIHandler(PyWSGIHandler):
-
     """
-    A WSGI handler that will perform the :rfc:`6455` upgrade and handshake
-    before calling the WSGI application.
+    A WSGI handler that will perform the :rfc:`6455` upgrade and handshake before calling the WSGI application.
 
     If the incoming request doesn't have a `'Upgrade'` header, the handler will
     simply fallback to the gevent builtin's handler and process it as per
@@ -97,7 +95,6 @@ class WebSocketWSGIHandler(PyWSGIHandler):
 
 
 class GEventWebSocketPool(Pool):
-
     """
     Simple pool of bound websockets.
 
@@ -125,7 +122,9 @@ class GEventWebSocketPool(Pool):
 
 class WSGIServer(PyWSGIServer):
     """
-    WSGI server that simply tracks websockets and send them a proper closing
+    WSGI server that handles websockets.
+
+    It simply tracks websockets and send them a proper closing
     handshake when the server terminates.
 
     Other than that, the server is the same as its

--- a/h/traversal/root.py
+++ b/h/traversal/root.py
@@ -9,7 +9,7 @@ class RootFactory:
 
 
 class Root(RootFactory):
-    """This app's default root factory."""
+    """The app's default root factory."""
 
     @classmethod
     def __acl__(cls):

--- a/h/traversal/user.py
+++ b/h/traversal/user.py
@@ -39,7 +39,7 @@ class UserRoot(RootFactory):
 
         return UserContext(user)
 
-    def __acl__(self):
+    def __acl__(self):  # pylint: disable=no-self-use
         return ACL.for_user(user=None)
 
 

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -14,7 +14,7 @@ resolver = DottedNameResolver(None)
 
 
 def conditional_http_tween_factory(handler, registry):
-    """A tween that sets up conditional response handling for some requests."""
+    """Set up conditional response handling for some requests."""
 
     def conditional_http_tween(request):
         response = handler(request)
@@ -109,9 +109,7 @@ def security_header_tween_factory(handler, registry):
 
 
 def cache_header_tween_factory(handler, registry):
-    """
-    Sets default caching headers on responses depending on the content type.
-    """
+    """Set default caching headers on responses depending on the content type."""
 
     def cache_header_tween(request):
         resp = handler(request)
@@ -127,8 +125,9 @@ def cache_header_tween_factory(handler, registry):
 
 def rollback_db_session_on_exception_factory(handler, registry):
     """
-    Catches exceptions and rolls the database handle back so it can be reliably
-    used again regardless of what exception caused the error.
+    Catch exceptions and rolls the database back.
+
+    Thas way it can be reliably used again regardless of what exception caused the error.
     """
 
     # Intended to be run before excview_tween_factory here:

--- a/h/util/datetime.py
+++ b/h/util/datetime.py
@@ -7,5 +7,5 @@ def utc_iso8601(datetime):
 
 
 def utc_us_style_date(datetime):
-    """Convert a UTC datetime into a Month day, year (August 1, 1990)"""
+    """Convert a UTC datetime into a Month day, year (August 1, 1990)."""
     return "{d:%B} {d.day}, {d:%Y}".format(d=datetime)

--- a/h/util/db.py
+++ b/h/util/db.py
@@ -46,7 +46,7 @@ class lru_cache_in_transaction:  # noqa: N801
 
 def on_transaction_end(session):
     """
-    Add a decorator for a function which should run after a top-level transaction ended.
+    Decorate a function which should run after a top-level transaction ended.
 
     Transactions that are either implicitly or explicitly committed or rolled back will be
     closed at the end of a Pyramid view. This is here for cleaning up caches so that

--- a/h/util/db.py
+++ b/h/util/db.py
@@ -5,7 +5,9 @@ import sqlalchemy
 
 class lru_cache_in_transaction:  # noqa: N801
     """
-    Decorator to wrap a function with a memoizing callable that saves up to
+    Adds memoizing decorator.
+
+    Wrap a function with a memoizing callable that saves up to
     the `maxsize` most recent calls. The underlying cache is automatically
     cleared at the end of the database transaction.
 
@@ -44,7 +46,7 @@ class lru_cache_in_transaction:  # noqa: N801
 
 def on_transaction_end(session):
     """
-    Decorator for a function which should run after a top-level transaction ended.
+    Add a decorator for a function which should run after a top-level transaction ended.
 
     Transactions that are either implicitly or explicitly committed or rolled back will be
     closed at the end of a Pyramid view. This is here for cleaning up caches so that

--- a/h/util/group.py
+++ b/h/util/group.py
@@ -5,7 +5,8 @@ GROUPID_PATTERN = r"^group:([a-zA-Z0-9._\-+!~*()']{1,1024})@(.*)$"
 
 
 def split_groupid(groupid):
-    """Return the ``authority_provided_id`` and ``authority`` from a ``groupid``
+    """
+    Return the ``authority_provided_id`` and ``authority`` from a ``groupid``.
 
     For example if groupid is u'group:339ae9f33c@myauth.org' then return
     {'authority_provided_id': u'339ae9f33c', 'authority': u'myauth.org'}'

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -3,7 +3,7 @@ from urllib.parse import SplitResult, urlsplit
 
 def url_in_scope(url, scope_urls):
     """
-    Does the URL match any of the scopes represented by ``scope_urls``?
+    Return whether the URL match any of the scopes represented by ``scope_urls``.
 
     Return True if the URL matches one or more of the provided patterns (if the
     URL string begins with any of the scope URL strings)
@@ -18,7 +18,7 @@ def url_in_scope(url, scope_urls):
 
 def parse_scope_from_url(url):
     """
-    Return a tuple representing the origin and path of a URL
+    Return a tuple representing the origin and path of a URL.
 
     :arg url: The URL from which to derive scope
     :type url: str
@@ -30,7 +30,7 @@ def parse_scope_from_url(url):
 
 
 def _parse_path(url):
-    """Return the path component of a URL string"""
+    """Return the path component of a URL string."""
     if url is None:
         return None
     parsed = urlsplit(url)

--- a/h/util/logging_filters.py
+++ b/h/util/logging_filters.py
@@ -1,4 +1,3 @@
-"""Logging Filters."""
 import logging
 
 # logging levels from https://docs.python.org/2/library/logging.html#logging-levels
@@ -18,6 +17,7 @@ class ExceptionFilter(logging.Filter):
     def __init__(self, ignore_exceptions):
         """
         Configure filtering out of the specified exceptions with specified logging level.
+
         Note if there are multiple exceptions that have the same name this will filter
         out all exceptions with that name.
 

--- a/h/util/query.py
+++ b/h/util/query.py
@@ -4,8 +4,7 @@ import sqlalchemy as sa
 
 def column_windows(session, column, windowsize=2000, where=None):
     """
-    Return a series of WHERE clauses against a given column that break it into
-    windows.
+    Return a series of WHERE clauses against a given column that break it into windows.
 
     :param session: the SQLAlchemy session object
     :param column: the SQLAlchemy column object with which to generate windows

--- a/h/util/session_tracker.py
+++ b/h/util/session_tracker.py
@@ -12,9 +12,7 @@ class ObjectState(Enum):
 
 
 class Tracker:
-    """
-    Observer which tracks whether a SQLAlchemy `Session` has uncommitted changes.
-    """
+    """Observer which tracks whether a SQLAlchemy `Session` has uncommitted changes."""
 
     def __init__(self, session):
         self.session = session
@@ -30,8 +28,7 @@ class Tracker:
 
     def uncommitted_changes(self):
         """
-        Return a list of changes to the `Session` which have not yet been
-        _committed_ to the DB.
+        Return a list of changes to the `Session` which have not yet been _committed_ to the DB.
 
         The result is a list of (identity key, ObjectState) tuples.
         """

--- a/h/util/user.py
+++ b/h/util/user.py
@@ -5,7 +5,8 @@ from h.exceptions import InvalidUserId
 
 
 def split_user(userid):
-    """Return the user and domain parts from the given user id as a dict.
+    """
+    Return the user and domain parts from the given user id as a dict.
 
     For example if userid is u'acct:seanh@hypothes.is' then return
     {'username': u'seanh', 'domain': u'hypothes.is'}'

--- a/h/util/view.py
+++ b/h/util/view.py
@@ -19,7 +19,7 @@ def handle_exception(request, exception):  # pylint: disable=unused-argument
 
 
 def json_view(**settings):
-    """A view configuration decorator with JSON defaults."""
+    """Get the configuration decorator with JSON defaults."""
     settings.setdefault("accept", "application/json")
     settings.setdefault("renderer", "json")
     return view_config(**settings)

--- a/h/viewderivers.py
+++ b/h/viewderivers.py
@@ -1,6 +1,6 @@
 def csp_protected_view(view, info):
     """
-    A view deriver which adds Content-Security-Policy headers to responses.
+    Add Content-Security-Policy headers to responses.
 
     By default, a global policy is applied to every view.
 

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -164,7 +164,6 @@ class AuthController:
     renderer="h:templates/accounts/forgot_password.html.jinja2",
 )
 class ForgotPasswordController:
-
     """Controller for handling forgotten password forms."""
 
     def __init__(self, request):
@@ -214,7 +213,6 @@ class ForgotPasswordController:
     route_name="account_reset", renderer="h:templates/accounts/reset.html.jinja2"
 )
 class ResetController:
-
     """Controller for handling password reset forms."""
 
     def __init__(self, request):
@@ -430,7 +428,7 @@ class AccountController:
 
     @view_config(request_method="POST", request_param="__formid__=email")
     def post_email_form(self):
-        """Called by Pyramid when the change email form is submitted."""
+        # Called by Pyramid when the change email form is submitted.
         return form.handle_form_submission(
             self.request,
             self.forms["email"],
@@ -440,7 +438,7 @@ class AccountController:
 
     @view_config(request_method="POST", request_param="__formid__=password")
     def post_password_form(self):
-        """Called by Pyramid when the change password form is submitted."""
+        # Called by Pyramid when the change password form is submitted.
         return form.handle_form_submission(
             self.request,
             self.forms["password"],
@@ -483,7 +481,7 @@ class EditProfileController:
 
     @view_config(request_method="GET")
     def get(self):
-        """Render the 'Edit Profile' form"""
+        """Render the 'Edit Profile' form."""
         user = self.request.user
         self.form.set_appstruct(
             {

--- a/h/views/admin/admins.py
+++ b/h/views/admin/admins.py
@@ -13,7 +13,7 @@ from h.security.permissions import Permission
     permission=Permission.AdminPage.ADMINS,
 )
 def admins_index(request):
-    """A list of all the admin users as an HTML page."""
+    """Get a list of all the admin users as an HTML page."""
     admins = request.db.query(models.User).filter(models.User.admin)
     return {
         "admin_users": [u.userid for u in admins],

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -20,7 +20,7 @@ _ = i18n.TranslationString
 )
 @paginator.paginate_query
 def groups_index(_context, request):
-    """Retrieve a paginated list of all groups, filtered by optional group name parameter"""
+    """Retrieve a paginated list of all groups, filtered by optional group name parameter."""
 
     group_svc = request.find_service(name="group")
     name = request.params.get("q")
@@ -34,7 +34,7 @@ def groups_index(_context, request):
     permission=Permission.AdminPage.GROUPS,
 )
 class GroupCreateViews:  # pylint: disable=too-many-instance-attributes
-    """Views for admin create-group forms"""
+    """Views for admin create-group forms."""
 
     def __init__(self, request):
         self.request = request
@@ -56,7 +56,7 @@ class GroupCreateViews:  # pylint: disable=too-many-instance-attributes
 
     @view_config(request_method="GET")
     def get(self):
-        """Render the admin create-group form"""
+        """Render the admin create-group form."""
         self.form.set_appstruct(
             {
                 "creator": self.request.user.username,
@@ -69,7 +69,7 @@ class GroupCreateViews:  # pylint: disable=too-many-instance-attributes
     @view_config(request_method="POST")
     def post(self):
         def on_success(appstruct):
-            """Create a group on successful validation of POSTed form data"""
+            """Create a group on successful validation of POSTed form data."""
 
             organization = self.organizations[appstruct["organization"]]
             # We know this user exists because it is checked during schema validation
@@ -172,7 +172,7 @@ class GroupEditViews:  # pylint: disable=too-many-instance-attributes
         group = self.group
 
         def on_success(appstruct):
-            """Update the group resource on successful form validation"""
+            """Update the group resource on successful form validation."""
 
             organization = self.organizations[appstruct["organization"]]
             scopes = [GroupScope(scope=o) for o in appstruct["scopes"]]

--- a/h/views/admin/staff.py
+++ b/h/views/admin/staff.py
@@ -13,7 +13,7 @@ from h.security.permissions import Permission
     permission=Permission.AdminPage.STAFF,
 )
 def staff_index(request):
-    """A list of all the staff members as an HTML page."""
+    """Get a list of all the staff members as an HTML page."""
     staff = request.db.query(models.User).filter(models.User.staff)
     return {
         "staff": [u.userid for u in staff],

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -18,7 +18,8 @@ log = logging.getLogger(__name__)
 
 
 def handles_oauth_errors(wrapped):
-    """Catch oauthlib errors and raise an appropriate exception.
+    """
+    Catch oauthlib errors and raise an appropriate exception.
 
     This prevents unhandled errors from crashing the app.
     """

--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -37,7 +37,6 @@ def add_api_view(
     subtype="json",
     **settings
 ):
-
     """
     Add a view configuration for an API view.
 
@@ -102,7 +101,7 @@ def add_api_view(
 
 def api_config(versions, link_name=None, description=None, **settings):
     """
-    A view configuration decorator for API views.
+    Add a view configuration decorator for API views.
 
     This is similar to Pyramid's `view_config` except that it uses
     `add_api_view` to register the view instead of `context.add_view`.

--- a/h/views/api/decorators/client_errors.py
+++ b/h/views/api/decorators/client_errors.py
@@ -6,7 +6,7 @@ from h.views.api.helpers.media_types import valid_media_types
 
 
 def unauthorized_to_not_found(wrapped):
-    """Add view decorator to convert all 403 exceptions to 404s."""
+    """Decorate a view to convert all 403 exceptions to 404s."""
 
     def wrapper(_context, request):
         # We convert all 403s to 404s—replace the current context with a 404
@@ -18,7 +18,7 @@ def unauthorized_to_not_found(wrapped):
 
 
 def normalize_not_found(wrapped):
-    """Add view decorator to make 404 error messages more readable."""
+    """Decorate a view to make 404 error messages more readable."""
 
     def wrapper(_context, request):
         # Replace incoming 404 with one that has a sensible message
@@ -29,7 +29,7 @@ def normalize_not_found(wrapped):
 
 
 def validate_media_types(wrapped):
-    """Add view decorator to convert certain 4xx errors to 406s."""
+    """Decorate a view to convert certain 4xx errors to 406s."""
 
     def wrapper(context, request):
         # If Accept has been set

--- a/h/views/api/decorators/client_errors.py
+++ b/h/views/api/decorators/client_errors.py
@@ -1,4 +1,4 @@
-"""API view decorators for exception views"""
+"""API view decorators for exception views."""
 
 from pyramid.httpexceptions import HTTPNotAcceptable, HTTPNotFound
 
@@ -6,7 +6,7 @@ from h.views.api.helpers.media_types import valid_media_types
 
 
 def unauthorized_to_not_found(wrapped):
-    """View decorator to convert all 403 exceptions to 404s"""
+    """Add view decorator to convert all 403 exceptions to 404s."""
 
     def wrapper(_context, request):
         # We convert all 403s to 404s—replace the current context with a 404
@@ -18,7 +18,7 @@ def unauthorized_to_not_found(wrapped):
 
 
 def normalize_not_found(wrapped):
-    """View decorator to make 404 error messages more readable"""
+    """Add view decorator to make 404 error messages more readable."""
 
     def wrapper(_context, request):
         # Replace incoming 404 with one that has a sensible message
@@ -29,7 +29,7 @@ def normalize_not_found(wrapped):
 
 
 def validate_media_types(wrapped):
-    """View decorator to convert certain 4xx errors to 406s"""
+    """Add view decorator to convert certain 4xx errors to 406s."""
 
     def wrapper(context, request):
         # If Accept has been set

--- a/h/views/api/decorators/response.py
+++ b/h/views/api/decorators/response.py
@@ -1,11 +1,11 @@
-"""API view decorators for response headers"""
+"""API view decorators for response headers."""
 
 from h.views.api import API_VERSION_DEFAULT
 from h.views.api.helpers.media_types import media_type_for_version, version_media_types
 
 
 def version_media_type_header(subtype="json"):
-    """View decorator to add response header indicating API version"""
+    """Add view decorator to add response header indicating API version."""
 
     def deco(wrapped):
         def wrapper(context, request):

--- a/h/views/api/decorators/response.py
+++ b/h/views/api/decorators/response.py
@@ -5,7 +5,7 @@ from h.views.api.helpers.media_types import media_type_for_version, version_medi
 
 
 def version_media_type_header(subtype="json"):
-    """Add view decorator to add response header indicating API version."""
+    """Decorate a view to add response header indicating API version."""
 
     def deco(wrapped):
         def wrapper(context, request):

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -227,7 +227,8 @@ def remove_member(context, request):
     description="Add the user in the request params to a group.",
 )
 def add_member(context, request):
-    """Add a member to a given group.
+    """
+    Add a member to a given group.
 
     :raise HTTPNotFound: if the user is not found or if the use and group
       authorities don't match.
@@ -253,7 +254,8 @@ def add_member(context, request):
 
 # @TODO This is a duplication of code in h.views.api — move to a util module
 def _json_payload(request):
-    """Return a parsed JSON payload for the request.
+    """
+    Return a parsed JSON payload for the request.
 
     :raises PayloadError: if the body has no valid JSON body
     """

--- a/h/views/api/helpers/angular.py
+++ b/h/views/api/helpers/angular.py
@@ -1,6 +1,4 @@
-"""
-Support for providing Angular-compatible routes for the client.
-"""
+"""Support for providing Angular-compatible routes for the client."""
 
 
 class AngularRouteTemplater:
@@ -31,7 +29,8 @@ class AngularRouteTemplater:
             return ":{}".format(self.name)
 
     def __init__(self, route_url, params):
-        """Instantiate the templater with a route-generating function.
+        """
+        Instantiate the templater with a route-generating function.
 
         Typically, the route-generating function will be ``request.route_url``,
         but can be any function that takes a route name and keyword arguments

--- a/h/views/api/helpers/links.py
+++ b/h/views/api/helpers/links.py
@@ -1,8 +1,8 @@
-"""Helpers for generating and retrieving service link metadata"""
+"""Helpers for generating and retrieving service link metadata."""
 
 
 class ServiceLink:
-    """Encapsulate metadata about an API service"""
+    """Encapsulate metadata about an API service."""
 
     def __init__(self, name, route_name, method="GET", description=None):
         self.name = name
@@ -12,7 +12,7 @@ class ServiceLink:
 
     def primary_method(self):
         """
-        Determine the primary HTTP method for this service
+        Determine the primary HTTP method for this service.
 
         If the ``method`` indicated is a tuple, the first entry will be
         returned.
@@ -29,7 +29,7 @@ class ServiceLink:
 
 def register_link(link, versions, registry):
     """
-    Register an API service's metadata for its supported versions
+    Register an API service's metadata for its supported versions.
 
     Add an entry for the indicated ``link`` onto the ``registry`` for each
     of the versions it claims to supported. These entries include basic
@@ -55,7 +55,7 @@ def register_link(link, versions, registry):
 
 
 def format_nested_links(api_links, templater):
-    """Format API link metadata as nested dicts for V1 variant of API index"""
+    """Format API link metadata as nested dicts for V1 variant of API index."""
     formatted_links = {}
     for link in api_links:
         method_info = {

--- a/h/views/api/helpers/media_types.py
+++ b/h/views/api/helpers/media_types.py
@@ -3,7 +3,7 @@ from h.views.api import API_VERSIONS
 
 def media_type_for_version(version, subtype="json"):
     """
-    Return the media type corresponding to a particular version string
+    Return the media type corresponding to a particular version string.
 
     :arg version:  The major API version, e.g. ``"v1"``
     :type version: str
@@ -17,7 +17,7 @@ def media_type_for_version(version, subtype="json"):
 
 def valid_media_types():
     """
-    Return a list of all valid API media types
+    Return a list of all valid API media types.
 
     This represents a list of all of the Accept header values that are known to
     the API. This includes all version-specific media types.
@@ -36,7 +36,7 @@ def valid_media_types():
 
 def version_media_types(versions=None):
     """
-    Return the media types corresponding to versions
+    Return the media types corresponding to versions.
 
     :arg versions: media types will be returned for these versions, e.g. "v1",
                    defaults to all known versions

--- a/h/views/api/index.py
+++ b/h/views/api/index.py
@@ -11,7 +11,8 @@ from h.views.api.helpers.angular import AngularRouteTemplater
     http_cache=(60 * 5, {"public": True}),
 )
 def index(_context, request):
-    """Return the API descriptor document.
+    """
+    Return the API descriptor document.
 
     Clients may use this to discover endpoints for the API.
     """
@@ -38,7 +39,8 @@ def index(_context, request):
     http_cache=(60 * 5, {"public": True}),
 )
 def index_v2(_context, request):
-    """Return the API descriptor document.
+    """
+    Return the API descriptor document.
 
     Clients may use this to discover endpoints for the API.
     """

--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -72,7 +72,8 @@ class Blocklist:
 
 @json_view(route_name="badge")
 def badge(request):
-    """Return the number of public annotations on a given page.
+    """
+    Return the number of public annotations on a given page.
 
     This is for the number that's displayed on the Chrome extension's badge.
 

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -18,9 +18,7 @@ DEFAULT_CLIENT_URL = "https://cdn.hypothes.is/hypothesis"
 
 
 def _client_url(request):
-    """
-    Return the configured URL for the client.
-    """
+    """Return the configured URL for the client."""
     url = request.registry.settings.get("h.client_url", DEFAULT_CLIENT_URL)
     url = render_url_template(url, example_url=request.url)
 

--- a/h/views/feeds.py
+++ b/h/views/feeds.py
@@ -31,7 +31,7 @@ def stream_atom(request):
 
 @view_config(route_name="stream_rss")
 def stream_rss(request):
-    """Get a RSS feed of the /stream page."""
+    """Get an RSS feed of the /stream page."""
     return render_rss(
         request=request,
         annotations=_annotations(request),

--- a/h/views/feeds.py
+++ b/h/views/feeds.py
@@ -18,7 +18,7 @@ def _annotations(request):
 
 @view_config(route_name="stream_atom")
 def stream_atom(request):
-    """An Atom feed of the /stream page."""
+    """Get an Atom feed of the /stream page."""
     return render_atom(
         request=request,
         annotations=_annotations(request),
@@ -31,7 +31,7 @@ def stream_atom(request):
 
 @view_config(route_name="stream_rss")
 def stream_rss(request):
-    """An RSS feed of the /stream page."""
+    """Get a RSS feed of the /stream page."""
     return render_rss(
         request=request,
         annotations=_annotations(request),

--- a/h/views/main.py
+++ b/h/views/main.py
@@ -97,9 +97,7 @@ def stream_tag_redirect(request):
 
 @view_config(route_name="stream.user_query")
 def stream_user_redirect(request):
-    """
-    Redirect to a user's activity page.
-    """
+    """Redirect to a user's activity page."""
 
     user = request.matchdict["user"]
 

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -24,7 +24,6 @@ disable=
 
     # We don't always want to have to put a `:return:` in a docstring.
     missing-return-doc,
-
     # We don't always want to have to put an `:rtype:` in a docstring.
     missing-return-type-doc,
 

--- a/tests/h/formatters/annotation_moderation_test.py
+++ b/tests/h/formatters/annotation_moderation_test.py
@@ -69,6 +69,7 @@ class TestAnnotationModerationFormatter:
 
     @pytest.fixture
     def formatter(self, flag_count_svc, user, has_permission):
+        """Return a formatter with the most common configuration."""
         return AnnotationModerationFormatter(flag_count_svc, user, has_permission)
 
     @pytest.fixture

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -33,7 +33,6 @@ class TestSidebarApp:
         csp_header = pyramid_request.response.headers["Content-Security-Policy"]
 
         assert (
-            # pylint: disable=line-too-long
             csp_header
             == "script-src http://example.com; style-src http://example.com 'unsafe-inline'"
         )


### PR DESCRIPTION
With the new ignored rules on the config `make analyze` succeeds in both `h` and `tests`.

Lots of pydocstyle fixes here that I did with vim macros and not a lot of engaged neurons but now it passes so from here we can tune the config if we chose to.