### PR TITLE
Simpler date formatting

### DIFF
--- a/h/feeds/atom.py
+++ b/h/feeds/atom.py
@@ -3,6 +3,7 @@ from pyramid import i18n
 
 import h.feeds.util
 from h import presenters, util
+from h.util.datetime import utc_iso8601
 
 _ = i18n.TranslationStringFactory(__package__)
 
@@ -28,8 +29,8 @@ def _feed_entry_from_annotation(annotation, annotation_url, annotation_api_url=N
         ),
         "author": {"name": name},
         "title": annotation.title,
-        "updated": _utc_iso8601_string(annotation.updated),
-        "published": _utc_iso8601_string(annotation.created),
+        "updated": utc_iso8601(annotation.updated),
+        "published": utc_iso8601(annotation.created),
         "content": annotation.description,
         "links": [
             {
@@ -49,10 +50,6 @@ def _feed_entry_from_annotation(annotation, annotation_url, annotation_api_url=N
         )
 
     return entry
-
-
-def _utc_iso8601_string(timestamp):
-    return timestamp.strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
 
 
 def feed_from_annotations(
@@ -94,6 +91,6 @@ def feed_from_annotations(
     }
 
     if annotations:
-        feed["updated"] = _utc_iso8601_string(annotations[0].updated)
+        feed["updated"] = utc_iso8601(annotations[0].updated)
 
     return feed

--- a/h/presenters/annotation_base.py
+++ b/h/presenters/annotation_base.py
@@ -1,19 +1,9 @@
 """A base presenter for common properties needed when rendering annotations."""
 
-from h.util.datetime import utc_iso8601
-
 
 class AnnotationBasePresenter:
     def __init__(self, annotation):
         self.annotation = annotation
-
-    @property
-    def created(self):
-        return utc_iso8601(self.annotation.created)
-
-    @property
-    def updated(self):
-        return utc_iso8601(self.annotation.updated)
 
     @property
     def text(self):

--- a/h/presenters/annotation_base.py
+++ b/h/presenters/annotation_base.py
@@ -9,14 +9,10 @@ class AnnotationBasePresenter:
 
     @property
     def created(self):
-        if not self.annotation.created:
-            return None
         return utc_iso8601(self.annotation.created)
 
     @property
     def updated(self):
-        if not self.annotation.updated:
-            return None
         return utc_iso8601(self.annotation.updated)
 
     @property

--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -7,6 +7,7 @@ from h.presenters.annotation_base import AnnotationBasePresenter
 from h.presenters.document_json import DocumentJSONPresenter
 from h.security.permissions import Permission
 from h.traversal import AnnotationContext
+from h.util.datetime import utc_iso8601
 
 
 class AnnotationJSONPresenter(AnnotationBasePresenter):
@@ -24,8 +25,8 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
         annotation.update(
             {
                 "id": self.annotation.id,
-                "created": self.created,
-                "updated": self.updated,
+                "created": utc_iso8601(self.annotation.created),
+                "updated": utc_iso8601(self.annotation.updated),
                 "user": self.annotation.userid,
                 "uri": self.annotation.target_uri,
                 "text": self.text,

--- a/h/presenters/annotation_jsonld.py
+++ b/h/presenters/annotation_jsonld.py
@@ -1,4 +1,5 @@
 from h.presenters.annotation_base import AnnotationBasePresenter
+from h.util.datetime import utc_iso8601
 
 
 class AnnotationJSONLDPresenter(AnnotationBasePresenter):
@@ -22,8 +23,8 @@ class AnnotationJSONLDPresenter(AnnotationBasePresenter):
             "@context": self.CONTEXT_URL,
             "type": "Annotation",
             "id": self._links_service.get(self.annotation, "jsonld_id"),
-            "created": self.created,
-            "modified": self.updated,
+            "created": utc_iso8601(self.annotation.created),
+            "modified": utc_iso8601(self.annotation.updated),
             "creator": self.annotation.userid,
             "body": self._bodies,
             "target": self._target,

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -1,5 +1,6 @@
 from h.presenters.annotation_base import AnnotationBasePresenter
 from h.presenters.document_searchindex import DocumentSearchIndexPresenter
+from h.util.datetime import utc_iso8601
 from h.util.user import split_user
 
 
@@ -17,8 +18,8 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
         result = {
             "authority": userid_parts["domain"],
             "id": self.annotation.id,
-            "created": self.created,
-            "updated": self.updated,
+            "created": utc_iso8601(self.annotation.created),
+            "updated": utc_iso8601(self.annotation.updated),
             "user": self.annotation.userid,
             "user_raw": self.annotation.userid,
             "uri": self.annotation.target_uri,

--- a/h/util/datetime.py
+++ b/h/util/datetime.py
@@ -3,6 +3,10 @@
 
 def utc_iso8601(datetime):
     """Convert a UTC datetime into an ISO8601 timestamp string."""
+
+    if not datetime:
+        return None
+
     return datetime.strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
 
 

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -272,7 +272,7 @@ def api_token_error(context, request):
 def _present_debug_token(token):
     data = {
         "userid": token.userid,
-        "expires_at": utc_iso8601(token.expires) if token.expires else None,
+        "expires_at": utc_iso8601(token.expires),
         "issued_at": utc_iso8601(token.created),
         "expired": token.expired,
     }

--- a/tests/h/presenters/annotation_base_test.py
+++ b/tests/h/presenters/annotation_base_test.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from h.presenters.annotation_base import AnnotationBasePresenter, utc_iso8601
+from h.presenters.annotation_base import AnnotationBasePresenter
 
 
 class TestAnnotationBasePresenter:
@@ -80,20 +80,3 @@ class TestAnnotationBasePresenter:
     @pytest.fixture
     def annotation(self, factories):
         return factories.Annotation.build()
-
-
-class Berlin(datetime.tzinfo):
-    """Berlin timezone, without DST support."""
-
-    def dst(self, dt):
-        return datetime.timedelta()
-
-
-def test_utc_iso8601():
-    t = datetime.datetime(2016, 2, 24, 18, 3, 25, 7685)
-    assert utc_iso8601(t) == "2016-02-24T18:03:25.007685+00:00"
-
-
-def test_utc_iso8601_ignores_timezone():
-    t = datetime.datetime(2016, 2, 24, 18, 3, 25, 7685, Berlin())
-    assert utc_iso8601(t) == "2016-02-24T18:03:25.007685+00:00"

--- a/tests/h/presenters/annotation_base_test.py
+++ b/tests/h/presenters/annotation_base_test.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 
 from h.presenters.annotation_base import AnnotationBasePresenter
@@ -10,40 +8,6 @@ class TestAnnotationBasePresenter:
         presenter = AnnotationBasePresenter(annotation)
 
         assert presenter.annotation == annotation
-
-    @pytest.mark.parametrize(
-        "created,expected",
-        (
-            (None, None),
-            (
-                datetime.datetime(2012, 3, 14, 23, 34, 47, 12),
-                "2012-03-14T23:34:47.000012+00:00",
-            ),
-        ),
-    )
-    def test_created(self, annotation, created, expected):
-        annotation.created = created
-
-        created = AnnotationBasePresenter(annotation).created
-
-        assert created == expected
-
-    @pytest.mark.parametrize(
-        "updated,expected",
-        (
-            (None, None),
-            (
-                datetime.datetime(1983, 8, 31, 7, 18, 20, 98763),
-                "1983-08-31T07:18:20.098763+00:00",
-            ),
-        ),
-    )
-    def test_updated_returns_none_if_missing(self, annotation, updated, expected):
-        annotation.updated = updated
-
-        updated = AnnotationBasePresenter(annotation).updated
-
-        assert updated == expected
 
     @pytest.mark.parametrize("text,expected", ((None, ""), ("text", "text")))
     def test_text(self, annotation, text, expected):

--- a/tests/h/util/datetime_test.py
+++ b/tests/h/util/datetime_test.py
@@ -1,29 +1,29 @@
 import datetime
 
+import pytest
+
 from h.util.datetime import utc_iso8601, utc_us_style_date
 
-
-class Berlin(datetime.tzinfo):
-    """Berlin timezone, without DST support."""
-
-    def utcoffset(self, dt):
-        return datetime.timedelta(hours=1)
-
-    def tzname(self, dt):
-        return "Berlin"
-
-    def dst(self, dt):
-        return datetime.timedelta()
+TIMEZONE = datetime.timezone(offset=datetime.timedelta(hours=1), name="Berlin")
 
 
-def test_utc_iso8601():
-    t = datetime.datetime(2016, 2, 24, 18, 3, 25, 7685)
-    assert utc_iso8601(t) == "2016-02-24T18:03:25.007685+00:00"
-
-
-def test_utc_iso8601_ignores_timezone():
-    t = datetime.datetime(2016, 2, 24, 18, 3, 25, 7685, Berlin())
-    assert utc_iso8601(t) == "2016-02-24T18:03:25.007685+00:00"
+@pytest.mark.parametrize(
+    "date,expected",
+    (
+        (
+            datetime.datetime(2016, 2, 24, 18, 3, 25, 7685),
+            "2016-02-24T18:03:25.007685+00:00",
+        ),
+        # We ignore timezones
+        (
+            datetime.datetime(2016, 2, 24, 18, 3, 25, 7685, TIMEZONE),
+            "2016-02-24T18:03:25.007685+00:00",
+        ),
+        (None, None),
+    ),
+)
+def test_utc_iso8601(date, expected):
+    assert utc_iso8601(date) == expected
 
 
 def test_utc_us_style_date():


### PR DESCRIPTION
We have a date formatting function `utc_iso8601` which in numerous places we wrap with a call like:

```python
if not date:
    return None
return utc_iso8601(date)
```

This PR moves that logic inside the function allowing us to use it directly in more places.