### PR TITLE
Inline the tags and text functions into the respective presenters

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,5 +12,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 97.09
+fail_under = 97.20
 skip_covered = True

--- a/h/presenters/annotation_base.py
+++ b/h/presenters/annotation_base.py
@@ -6,18 +6,6 @@ class AnnotationBasePresenter:
         self.annotation = annotation
 
     @property
-    def text(self):
-        if self.annotation.text:
-            return self.annotation.text
-        return ""
-
-    @property
-    def tags(self):
-        if self.annotation.tags:
-            return self.annotation.tags
-        return []
-
-    @property
     def target(self):
         target = {"source": self.annotation.target_uri}
         if self.annotation.target_selectors:

--- a/h/presenters/annotation_html.py
+++ b/h/presenters/annotation_html.py
@@ -14,14 +14,6 @@ class AnnotationHTMLPresenter:
         else:
             self.document = None
 
-    def _get_selection(self):
-        selectors = self.annotation.target_selectors
-        for selector in selectors:
-            if "exact" in selector:
-                return selector["exact"]
-
-        return None
-
     @property
     def uri(self):
         return jinja2.escape(self.annotation.target_uri)
@@ -157,3 +149,11 @@ class AnnotationHTMLPresenter:
     @property
     def tags(self):
         return self.annotation.tags
+
+    def _get_selection(self):
+        selectors = self.annotation.target_selectors
+        for selector in selectors:
+            if "exact" in selector:
+                return selector["exact"]
+
+        return None

--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -30,8 +30,8 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
                 "updated": utc_iso8601(self.annotation.updated),
                 "user": self.annotation.userid,
                 "uri": self.annotation.target_uri,
-                "text": self.text,
-                "tags": self.tags,
+                "text": self.annotation.text or "",
+                "tags": self.annotation.tags or [],
                 "group": self.annotation.groupid,
                 #  Convert our simple internal annotation storage format into the
                 #  legacy complex permissions dict format that is still used in

--- a/h/presenters/annotation_jsonld.py
+++ b/h/presenters/annotation_jsonld.py
@@ -33,10 +33,18 @@ class AnnotationJSONLDPresenter(AnnotationBasePresenter):
     @property
     def _bodies(self):
         bodies = [
-            {"type": "TextualBody", "value": self.text, "format": "text/markdown"}
+            {
+                "type": "TextualBody",
+                "value": self.annotation.text or "",
+                "format": "text/markdown",
+            }
         ]
-        for tag in self.tags:
-            bodies.append({"type": "TextualBody", "value": tag, "purpose": "tagging"})
+        if self.annotation.tags:
+            for tag in self.annotation.tags:
+                bodies.append(
+                    {"type": "TextualBody", "value": tag, "purpose": "tagging"}
+                )
+
         return bodies
 
     @property

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -15,6 +15,8 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
         docpresenter = DocumentSearchIndexPresenter(self.annotation.document)
         userid_parts = split_user(self.annotation.userid)
 
+        tags = self.annotation.tags or []
+
         result = {
             "authority": userid_parts["domain"],
             "id": self.annotation.id,
@@ -23,9 +25,9 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
             "user": self.annotation.userid,
             "user_raw": self.annotation.userid,
             "uri": self.annotation.target_uri,
-            "text": self.text,
-            "tags": self.tags,
-            "tags_raw": self.tags,
+            "text": self.annotation.text or "",
+            "tags": tags,
+            "tags_raw": tags,
             "group": self.annotation.groupid,
             "shared": self.annotation.shared,
             "target": self.target,

--- a/tests/h/presenters/annotation_base_test.py
+++ b/tests/h/presenters/annotation_base_test.py
@@ -9,24 +9,6 @@ class TestAnnotationBasePresenter:
 
         assert presenter.annotation == annotation
 
-    @pytest.mark.parametrize("text,expected", ((None, ""), ("text", "text")))
-    def test_text(self, annotation, text, expected):
-        annotation.text = text
-
-        presenter = AnnotationBasePresenter(annotation)
-
-        assert presenter.text == expected
-
-    @pytest.mark.parametrize(
-        "tags,expected",
-        ((None, []), (["interesting", "magic"], ["interesting", "magic"])),
-    )
-    def test_tags(self, annotation, tags, expected):
-        annotation.tags = tags
-        presenter = AnnotationBasePresenter(annotation)
-
-        assert presenter.tags == expected
-
     def test_target(self, annotation):
         target = AnnotationBasePresenter(annotation).target
 


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/6769

These just did thing or default, and are easy enough in place.

This was running into mystery coverage issues. As I've been changing the presenters I thought I'd just get the annotation HTML presenter tests to 100%. That way I don't need to guess if I've messed things up.