### PR TITLE
Revert "Add a relationship between annotations and users"

### DIFF
--- a/h/formatters/__init__.py
+++ b/h/formatters/__init__.py
@@ -1,0 +1,11 @@
+from h.formatters.annotation_flag import AnnotationFlagFormatter
+from h.formatters.annotation_hidden import AnnotationHiddenFormatter
+from h.formatters.annotation_moderation import AnnotationModerationFormatter
+from h.formatters.annotation_user_info import AnnotationUserInfoFormatter
+
+__all__ = (
+    "AnnotationFlagFormatter",
+    "AnnotationHiddenFormatter",
+    "AnnotationModerationFormatter",
+    "AnnotationUserInfoFormatter",
+)

--- a/h/formatters/annotation_flag.py
+++ b/h/formatters/annotation_flag.py
@@ -1,0 +1,47 @@
+class AnnotationFlagFormatter:
+    """
+    Formatter for exposing a user's annotation flags.
+
+    If the passed-in user has flagged an annotation, this formatter will
+    add: `"flagged": true` to the payload, otherwise `"flagged": false`.
+    """
+
+    def __init__(self, flag_service, user=None):
+        self.flag_service = flag_service
+        self.user = user
+
+        # Local cache of flags. We don't need to care about detached
+        # instances because we only store the annotation id and a boolean flag.
+        self._cache = {}
+
+    def preload(self, annotation_ids):
+        if self.user is None:
+            return None
+
+        flagged_ids = self.flag_service.all_flagged(
+            user=self.user, annotation_ids=annotation_ids
+        )
+
+        flags = {
+            annotation_id: (annotation_id in flagged_ids)
+            for annotation_id in annotation_ids
+        }
+        self._cache.update(flags)
+        return flags
+
+    def format(self, annotation):
+        flagged = self._load(annotation)
+        return {"flagged": flagged}
+
+    def _load(self, annotation):
+        if self.user is None:
+            return False
+
+        id_ = annotation.id
+
+        if id_ in self._cache:
+            return self._cache[id_]
+
+        flagged = self.flag_service.flagged(user=self.user, annotation=annotation)
+        self._cache[id_] = flagged
+        return self._cache[id_]

--- a/h/formatters/annotation_hidden.py
+++ b/h/formatters/annotation_hidden.py
@@ -2,7 +2,7 @@ from h.security.permissions import Permission
 from h.traversal import AnnotationContext
 
 
-class HiddenFormatter:
+class AnnotationHiddenFormatter:
     """
     Formatter for dealing with annotations that a moderator has hidden.
 
@@ -44,4 +44,4 @@ class HiddenFormatter:
         )
 
     def _current_user_is_author(self, annotation):
-        return self._user and self._user == annotation.user
+        return self._user and self._user.userid == annotation.userid

--- a/h/formatters/annotation_moderation.py
+++ b/h/formatters/annotation_moderation.py
@@ -2,7 +2,7 @@ from h.security.permissions import Permission
 from h.traversal import AnnotationContext
 
 
-class ModerationFormatter:
+class AnnotationModerationFormatter:
     """
     Formatter for exposing an annotation's moderation information.
 

--- a/h/formatters/annotation_user_info.py
+++ b/h/formatters/annotation_user_info.py
@@ -1,0 +1,24 @@
+from h import models
+from h.session import user_info
+
+
+class AnnotationUserInfoFormatter:
+    def __init__(self, session, user_svc):
+        self.session = session
+        self.user_svc = user_svc
+
+    def preload(self, annotation_ids):
+        if not annotation_ids:
+            return
+
+        userids = {
+            t[0]
+            for t in self.session.query(models.Annotation.userid).filter(
+                models.Annotation.id.in_(annotation_ids)
+            )
+        }
+        self.user_svc.fetch_all(userids)
+
+    def format(self, annotation):
+        user = self.user_svc.fetch(annotation.userid)
+        return user_info(user)

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -7,7 +7,6 @@ from sqlalchemy.ext.mutable import MutableDict, MutableList
 
 from h.db import Base, types
 from h.models.group import Group
-from h.models.user import User, join_userid
 from h.util import markdown, uri
 from h.util.user import split_user
 
@@ -57,20 +56,6 @@ class Annotation(Base):
     #: The full userid (e.g. 'acct:foo@example.com') of the owner of this
     #: annotation.
     userid = sa.Column(sa.UnicodeText, nullable=False, index=True)
-    user = sa.orm.relationship(
-        User,
-        primaryjoin=(userid == join_userid(User.username, User.authority)),
-        foreign_keys=[userid],
-        lazy="select",
-        # WARNING! - This relationship can only be used one way, which is from
-        # the `userid` to the User object. You cannot set it the other way.
-        # It would be very nice if that worked, but from what I can tell it
-        # doesn't. Instead of setting the whole `acct:{username}@{authority}`
-        # we only get the authority. Or whichever column is last referenced
-        # if you express it a different way.
-        viewonly=True,
-    )
-
     #: The string id of the group in which this annotation is published.
     #: Defaults to the global public group, "__world__".
     groupid = sa.Column(
@@ -80,6 +65,7 @@ class Annotation(Base):
         nullable=False,
         index=True,
     )
+
     group = sa.orm.relationship(
         Group,
         primaryjoin=(Group.pubid == groupid),

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -22,16 +22,6 @@ def _normalise_username(username):
     return sa.func.lower(sa.func.replace(username, sa.text("'.'"), sa.text("''")))
 
 
-def join_userid(username, authority):
-    """Return a server side function to create userids.
-
-    :param username: The username
-    :param username: The authority
-    :return: An SQL function which returns a userid string
-    """
-    return sa.func.concat("acct:", _normalise_username(username), "@", authority)
-
-
 class UsernameComparator(Comparator):  # pylint: disable=abstract-method
     """
     Custom comparator for :py:attr:`~h.models.user.User.username`.

--- a/h/services/annotation_json_presentation/_formatters/__init__.py
+++ b/h/services/annotation_json_presentation/_formatters/__init__.py
@@ -1,6 +1,0 @@
-from h.services.annotation_json_presentation._formatters.hidden import HiddenFormatter
-from h.services.annotation_json_presentation._formatters.moderation import (
-    ModerationFormatter,
-)
-
-__all__ = ("HiddenFormatter", "ModerationFormatter")

--- a/h/services/annotation_json_presentation/factory.py
+++ b/h/services/annotation_json_presentation/factory.py
@@ -11,4 +11,5 @@ def annotation_json_presentation_service_factory(_context, request):
         # Services
         links_svc=request.find_service(name="links"),
         flag_svc=request.find_service(name="flag"),
+        user_svc=request.find_service(name="user"),
     )

--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -1,64 +1,42 @@
 from sqlalchemy.orm import subqueryload
 
-from h import storage
+from h import formatters, storage
 from h.models import Annotation
 from h.presenters import AnnotationJSONPresenter
-from h.services.annotation_json_presentation import _formatters
 
 
 class AnnotationJSONPresentationService:
-    def __init__(self, session, user, links_svc, flag_svc, has_permission):
-        self.user = user
+    def __init__(self, session, user, links_svc, flag_svc, user_svc, has_permission):
         self.session = session
         self.links_svc = links_svc
-        self.flag_svc = flag_svc
 
         self.formatters = [
-            _formatters.HiddenFormatter(has_permission, user),
-            _formatters.ModerationFormatter(flag_svc, user, has_permission),
+            formatters.AnnotationFlagFormatter(flag_svc, user),
+            formatters.AnnotationHiddenFormatter(has_permission, user),
+            formatters.AnnotationModerationFormatter(flag_svc, user, has_permission),
+            formatters.AnnotationUserInfoFormatter(self.session, user_svc),
         ]
 
     def present(self, annotation):
-        model = AnnotationJSONPresenter(
-            annotation, links_service=self.links_svc
+        return AnnotationJSONPresenter(
+            annotation, links_service=self.links_svc, formatters=self.formatters
         ).asdict()
 
-        model.update(self._get_user_dependent_content(self.user, annotation))
-
-        return model
-
     def present_all(self, annotation_ids):
-        annotations = self._preload_data(self.user, annotation_ids)
-
-        return [self.present(annotation) for annotation in annotations]
-
-    def _get_user_dependent_content(self, user, annotation):
-        model = {"flagged": self.flag_svc.flagged(user=user, annotation=annotation)}
-
-        for formatter in self.formatters:
-            model.update(formatter.format(annotation))
-
-        return model
-
-    def _preload_data(self, user, annotation_ids):
         def eager_load_related_items(query):
             return query.options(
                 # Ensure that accessing `annotation.document` or `.moderation`
-                # etc. doesn't trigger any more queries by pre-loading these
+                # doesn't trigger any more queries by pre-loading these
                 subqueryload(Annotation.document),
                 subqueryload(Annotation.moderation),
-                subqueryload(Annotation.user),
             )
 
         annotations = storage.fetch_ordered_annotations(
             self.session, annotation_ids, query_processor=eager_load_related_items
         )
 
-        # This primes the cache for `flagged()`
-        self.flag_svc.all_flagged(user, annotation_ids)
-
         # preload formatters, so they can optimize database access
         for formatter in self.formatters:
             formatter.preload(annotation_ids)
 
-        return annotations
+        return [self.present(annotation) for annotation in annotations]

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -7,7 +7,36 @@ class FlagService:
     def __init__(self, session):
         self._session = session
 
-        self._flagged_cache = {}
+    def flagged(self, user: User, annotation: Annotation):
+        """
+        Check if a given user has flagged a given annotation.
+
+        :param user: The user to check for a flag.
+        :param annotation: The annotation to check for a flag.
+        :returns: True/False depending on the existence of a flag.
+        """
+        query = self._session.query(Flag).filter_by(user=user, annotation=annotation)
+        return query.count() > 0
+
+    def all_flagged(self, user: User, annotation_ids):
+        """
+        Check which of the given annotation IDs the given user has flagged.
+
+        :param user: The user to check for a flag.
+        :param annotation_ids: The IDs of the annotations to check.
+        :returns The subset of the IDs that the given user has flagged.
+        """
+
+        # SQLAlchemy doesn't behave in the way we might expect when handed an
+        # `in_` condition with an empty sequence
+        if not annotation_ids:
+            return set()
+
+        query = self._session.query(Flag.annotation_id).filter(
+            Flag.annotation_id.in_(annotation_ids), Flag.user == user
+        )
+
+        return {f.annotation_id for f in query}
 
     def create(self, user: User, annotation: Annotation):
         """
@@ -25,60 +54,6 @@ class FlagService:
             return
 
         self._session.add(Flag(user=user, annotation=annotation))
-
-    def flagged(self, user: User, annotation: Annotation):
-        """
-        Check if a given user has flagged a given annotation.
-
-        You can make this more efficient for a large batch of annotations by
-        calling `all_flagged()` which will prime a cache of results.
-
-        :param user: The user to check for a flag.
-        :param annotation: The annotation to check for a flag.
-        :returns: True/False depending on the existence of a flag.
-        """
-        if not user or not annotation:
-            return False
-
-        # This cache can be primed by calling `all_flagged()`
-        key = user.id, annotation.id
-        if key in self._flagged_cache:
-            return self._flagged_cache[key]
-
-        is_flagged = bool(
-            self._session.query(Flag)
-            .filter_by(user=user, annotation=annotation)
-            .first()
-        )
-        self._flagged_cache[key] = is_flagged
-
-        return is_flagged
-
-    def all_flagged(self, user: User, annotation_ids):
-        """
-        Check which of the given annotation IDs the given user has flagged.
-
-        :param user: The user to check for a flag.
-        :param annotation_ids: The IDs of the annotations to check.
-        :returns The subset of the IDs that the given user has flagged.
-        """
-
-        # SQLAlchemy doesn't behave in the way we might expect when handed an
-        # `in_` condition with an empty sequence
-        if not annotation_ids or not user:
-            return set()
-
-        query = self._session.query(Flag.annotation_id).filter(
-            Flag.annotation_id.in_(annotation_ids), Flag.user == user
-        )
-
-        flagged_ids = {f.annotation_id for f in query}
-
-        # Fill out the cache, so we can make use of it in flagged()
-        for annotation_id in annotation_ids:
-            self._flagged_cache[(user.id, annotation_id)] = annotation_id in flagged_ids
-
-        return {f.annotation_id for f in query}
 
     def flag_count(self, annotation: Annotation):
         """

--- a/tests/h/formatters/annotation_flag_test.py
+++ b/tests/h/formatters/annotation_flag_test.py
@@ -1,0 +1,58 @@
+import pytest
+
+from h.formatters.annotation_flag import AnnotationFlagFormatter
+from h.services.flag import FlagService
+
+
+class TestAnnotationFlagFormatter:
+    def test_preload_sets_found_flags_to_true(self, flags, formatter, current_user):
+        annotation_ids = [f.annotation_id for f in flags[current_user]]
+
+        expected = {id_: True for id_ in annotation_ids}
+        assert formatter.preload(annotation_ids) == expected
+
+    def test_preload_sets_missing_flags_to_false(self, flags, formatter, other_user):
+        annotation_ids = [f.annotation_id for f in flags[other_user]]
+
+        expected = {id_: False for id_ in annotation_ids}
+        assert formatter.preload(annotation_ids) == expected
+
+    def test_format_for_existing_flag(self, formatter, factories, current_user):
+        flag = factories.Flag(user=current_user)
+
+        assert formatter.format(flag.annotation) == {"flagged": True}
+
+    def test_format_for_missing_flag(self, formatter, factories):
+        annotation = factories.Annotation()
+
+        assert formatter.format(annotation) == {"flagged": False}
+
+    def test_format_for_unauthenticated_user(self, flag_service, factories):
+        annotation = factories.Annotation()
+
+        formatter = AnnotationFlagFormatter(flag_service, user=None)
+
+        assert formatter.format(annotation) == {"flagged": False}
+
+    @pytest.fixture
+    def current_user(self, factories):
+        return factories.User()
+
+    @pytest.fixture
+    def other_user(self, factories):
+        return factories.User()
+
+    @pytest.fixture
+    def formatter(self, flag_service, current_user):
+        return AnnotationFlagFormatter(flag_service, current_user)
+
+    @pytest.fixture
+    def flag_service(self, db_session):
+        return FlagService(db_session)
+
+    @pytest.fixture
+    def flags(self, factories, current_user, other_user):
+        return {
+            current_user: factories.Flag.create_batch(3, user=current_user),
+            other_user: factories.Flag.create_batch(2, user=other_user),
+        }

--- a/tests/h/formatters/annotation_hidden_test.py
+++ b/tests/h/formatters/annotation_hidden_test.py
@@ -3,19 +3,19 @@ from unittest.mock import create_autospec
 import pytest
 from h_matchers import Any
 
+from h.formatters.annotation_hidden import AnnotationHiddenFormatter
 from h.security.permissions import Permission
-from h.services.annotation_json_presentation._formatters.hidden import HiddenFormatter
 from h.traversal import AnnotationContext
 
 
-class TestHiddenFormatter:
+class TestAnnotationHiddenFormatter:
     def test_it_hides_moderated(self, formatter, annotation):
         annotation.moderation = None
 
         assert formatter.format(annotation) == {"hidden": False}
 
     def test_the_author_can_see_it(self, formatter, annotation, user):
-        annotation.user = user
+        annotation.userid = user.userid
 
         assert formatter.format(annotation) == {"hidden": False}
 
@@ -50,4 +50,4 @@ class TestHiddenFormatter:
 
     @pytest.fixture
     def formatter(self, has_permission, user):
-        return HiddenFormatter(has_permission, user)
+        return AnnotationHiddenFormatter(has_permission, user)

--- a/tests/h/formatters/annotation_moderation_test.py
+++ b/tests/h/formatters/annotation_moderation_test.py
@@ -2,11 +2,11 @@ from unittest.mock import create_autospec, sentinel
 
 import pytest
 
+from h.formatters.annotation_moderation import AnnotationModerationFormatter
 from h.security.permissions import Permission
-from h.services.annotation_json_presentation._formatters import ModerationFormatter
 
 
-class TestModerationFormatter:
+class TestAnnotationModerationFormatter:
     def test_preload_sets_flag_counts(self, formatter, flag_service):
         flag_service.flag_counts.return_value = {"flagged": 2, "unflagged": 0}
 
@@ -18,7 +18,7 @@ class TestModerationFormatter:
         assert formatter._cache == flag_service.flag_counts.return_value
 
     def test_preload_skipped_without_user(self, flag_service):
-        formatter = ModerationFormatter(
+        formatter = AnnotationModerationFormatter(
             flag_service, user=None, has_permission=sentinel.has_permission
         )
 
@@ -76,10 +76,10 @@ class TestModerationFormatter:
 
     @pytest.fixture
     def formatter(self, flag_service, factories, has_permission):
-        return ModerationFormatter(flag_service, factories.User(), has_permission)
+        return AnnotationModerationFormatter(
+            flag_service, factories.User(), has_permission
+        )
 
     @pytest.fixture
     def AnnotationContext(self, patch):
-        return patch(
-            "h.services.annotation_json_presentation._formatters.moderation.AnnotationContext"
-        )
+        return patch("h.formatters.annotation_moderation.AnnotationContext")

--- a/tests/h/formatters/annotation_user_info_test.py
+++ b/tests/h/formatters/annotation_user_info_test.py
@@ -1,0 +1,53 @@
+import pytest
+
+from h.formatters.annotation_user_info import AnnotationUserInfoFormatter
+
+
+class TestAnnotationUserInfoFormatter:
+    def test_preload_fetches_users_by_id(self, formatter, factories, user_service):
+        annotation_1 = factories.Annotation()
+        annotation_2 = factories.Annotation()
+
+        formatter.preload([annotation_1.id, annotation_2.id])
+
+        user_service.fetch_all.assert_called_once_with(
+            {annotation_1.userid, annotation_2.userid}
+        )
+
+    def test_preload_skips_fetching_for_empty_ids(self, formatter, user_service):
+        formatter.preload([])
+        assert not user_service.fetch_all.called
+
+    def test_format_fetches_user_by_id(
+        self, formatter, annotation, factories, user_service
+    ):
+        formatter.format(annotation)
+
+        user_service.fetch.assert_called_once_with(annotation.userid)
+
+    def test_format_uses_user_info(
+        self, formatter, annotation, user_service, user_info, factories
+    ):
+        user = factories.User()
+        user_service.fetch.return_value = user
+
+        formatter.format(annotation)
+
+        user_info.assert_called_once_with(user)
+
+    def test_format_returns_formatted_user_info(self, formatter, annotation, user_info):
+        result = formatter.format(annotation)
+
+        assert result == user_info.return_value
+
+    @pytest.fixture
+    def annotation(self, factories):
+        return factories.Annotation.build()
+
+    @pytest.fixture
+    def formatter(self, db_session, user_service):
+        return AnnotationUserInfoFormatter(db_session, user_service)
+
+    @pytest.fixture
+    def user_info(self, patch):
+        return patch("h.formatters.annotation_user_info.user_info")

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -185,37 +185,6 @@ class TestAnnotationGroup:
         return factories.Group(pubid="12345678")
 
 
-class TestAnnotationUser:
-    @pytest.mark.xfail(message="This direction has been disabled as it's not reliable")
-    def test_it(self, user, factories):
-        annotation = factories.Annotation(user=user)
-
-        assert annotation.userid == user.userid
-
-    def test_it_works_with_userid(self, user, factories):
-        annotation = factories.Annotation(userid=user.userid)
-
-        assert annotation.user == user
-
-    @pytest.mark.parametrize(
-        "bad_userid",
-        (
-            "missing@acct.com",
-            "acct:no_authority",
-            "acct:no_authority@",
-            "acct:@no_user.com",
-        ),
-    )
-    def test_it_returns_None_invalid_userids(self, factories, bad_userid):
-        annotation = factories.Annotation(userid=bad_userid)
-
-        assert annotation.user is None
-
-    @pytest.fixture
-    def user(self, factories):
-        return factories.User()
-
-
 class TestThread:
     def test_empty_thread(self, root):
         assert root.thread == []

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -1,64 +1,57 @@
 import datetime
+from unittest.mock import create_autospec
 
 import pytest
+from h_matchers import Any
 from pyramid import security
 
+from h.formatters import AnnotationFlagFormatter
 from h.presenters.annotation_json import AnnotationJSONPresenter
 
 
 class TestAnnotationJSONPresenter:
-    def test_asdict(
-        self, presenter, annotation, links_service, DocumentJSONPresenter, factories
-    ):
+    def test_asdict(self, presenter, annotation, links_service, DocumentJSONPresenter):
         annotation.created = datetime.datetime(2016, 2, 24, 18, 3, 25, 768)
         annotation.updated = datetime.datetime(2016, 2, 29, 10, 24, 5, 564)
-        annotation.references = (
-            [reference.id for reference in factories.Annotation.create_batch(size=2)],
-        )
+        annotation.references = ["referenced-id-1", "referenced-id-2"]
         annotation.extra = {"extra-1": "foo", "extra-2": "bar"}
 
         result = presenter.asdict()
 
         links_service.get_all.assert_called_once_with(annotation)
 
-        assert result == {
-            "id": annotation.id,
-            "created": "2016-02-24T18:03:25.000768+00:00",
-            "updated": "2016-02-29T10:24:05.000564+00:00",
-            "user": annotation.userid,
-            "uri": annotation.target_uri,
-            "group": annotation.groupid,
-            "text": annotation.text,
-            "tags": annotation.tags,
-            "permissions": {
-                "read": [annotation.userid],
-                "admin": [annotation.userid],
-                "update": [annotation.userid],
-                "delete": [annotation.userid],
-            },
-            "target": [
-                {
-                    "source": annotation.target_uri,
-                    "selector": annotation.target_selectors,
-                }
-            ],
-            "document": DocumentJSONPresenter.return_value.asdict.return_value,
-            "links": links_service.get_all.return_value,
-            "references": annotation.references,
-            "user_info": {"display_name": annotation.user.display_name},
-            "extra-1": "foo",
-            "extra-2": "bar",
-        }
+        assert result == Any.dict.containing(
+            {
+                "id": annotation.id,
+                "created": "2016-02-24T18:03:25.000768+00:00",
+                "updated": "2016-02-29T10:24:05.000564+00:00",
+                "user": annotation.userid,
+                "uri": annotation.target_uri,
+                "group": annotation.groupid,
+                "text": annotation.text,
+                "tags": annotation.tags,
+                "permissions": {
+                    "read": [annotation.userid],
+                    "admin": [annotation.userid],
+                    "update": [annotation.userid],
+                    "delete": [annotation.userid],
+                },
+                "target": [
+                    {
+                        "source": annotation.target_uri,
+                        "selector": annotation.target_selectors,
+                    }
+                ],
+                "document": DocumentJSONPresenter.return_value.asdict.return_value,
+                "links": links_service.get_all.return_value,
+                "references": annotation.references,
+                "extra-1": "foo",
+                "extra-2": "bar",
+            }
+        )
 
         DocumentJSONPresenter.assert_called_once_with(annotation.document)
         DocumentJSONPresenter.return_value.asdict.assert_called_once_with()
-
-    def test_asdict_without_references(self, presenter, annotation):
-        annotation.references = None
-
-        result = presenter.asdict()
-
-        assert "references" not in result
 
     def test_asdict_extra_inherits_correctly(self, presenter, annotation):
         annotation.extra = {"id": "DIFFERENT"}
@@ -69,6 +62,22 @@ class TestAnnotationJSONPresenter:
         assert presented["id"] == annotation.id
         # And we aren't mutated
         assert annotation.extra == {"id": "DIFFERENT"}
+
+    def test_asdict_merges_formatters(self, annotation, links_service, get_formatter):
+        formatters = [
+            get_formatter({"flagged": "nope"}),
+            get_formatter({"nipsa": "maybe"}),
+        ]
+
+        presented = AnnotationJSONPresenter(
+            annotation, links_service=links_service, formatters=formatters
+        ).asdict()
+
+        assert presented["flagged"] == "nope"
+        assert presented["nipsa"] == "maybe"
+
+        for formatter in formatters:
+            formatter.format.assert_called_once_with(annotation)
 
     @pytest.mark.parametrize(
         "shared,readable_by,permission_template",
@@ -101,10 +110,20 @@ class TestAnnotationJSONPresenter:
 
     @pytest.fixture
     def annotation(self, factories):
-        return factories.Annotation(
-            groupid="NOT WORLD",
-            user=factories.User(),
-        )
+        return factories.Annotation(groupid="NOT WORLD")
+
+    @pytest.fixture
+    def get_formatter(self):
+        def get_formatter(payload=None):
+            # All formatters should have the same interface. We'll pick one at
+            # random to act as an exemplar
+            formatter = create_autospec(
+                AnnotationFlagFormatter, spec_set=True, instance=True
+            )
+            formatter.format.return_value = payload or {}
+            return formatter
+
+        return get_formatter
 
     @pytest.fixture(autouse=True)
     def DocumentJSONPresenter(self, patch):

--- a/tests/h/services/annotation_json_presentation_test/factory_test.py
+++ b/tests/h/services/annotation_json_presentation_test/factory_test.py
@@ -15,6 +15,7 @@ class TestAnnotationJSONPresentationServiceFactory:
         AnnotationJSONPresentationService,
         flag_service,
         links_service,
+        user_service,
     ):
         service = annotation_json_presentation_service_factory(
             sentinel.context, pyramid_request
@@ -28,6 +29,7 @@ class TestAnnotationJSONPresentationServiceFactory:
             has_permission=pyramid_request.has_permission,
             links_svc=links_service,
             flag_svc=flag_service,
+            user_svc=user_service,
         )
 
     @pytest.fixture

--- a/tests/h/services/flag_test.py
+++ b/tests/h/services/flag_test.py
@@ -4,58 +4,40 @@ from h import models
 from h.services import flag
 
 
+@pytest.mark.usefixtures("flags")
 class TestFlagServiceFlagged:
-    def test_it_returns_true_when_flag_exists(self, svc, flag):
-        assert svc.flagged(flag.user, flag.annotation) is True
+    def test_it_returns_true_when_flag_exists(self, svc, flags):
+        user = flags[-1].user
+        annotation = flags[-1].annotation
 
-    def test_it_returns_false_when_flag_does_not_exist(self, svc, user, annotation):
+        assert svc.flagged(user, annotation) is True
+
+    def test_it_returns_false_when_flag_does_not_exist(self, svc, factories):
+        user = factories.User()
+        annotation = factories.Annotation(userid=user.userid)
+
         assert not svc.flagged(user, annotation)
 
-    def test_it_handles_missing_values(self, svc, user, annotation):
-        assert not svc.flagged(None, annotation)
-        assert not svc.flagged(user, None)
+    def test_it_lists_flagged_ids(self, svc, flags):
+        user = flags[-1].user
 
-    def test_it_uses_the_cache_if_possible(self, svc, user, annotation):
-        assert not svc.flagged(user, annotation)
+        all_flagged = svc.all_flagged(user, [f.annotation_id for f in flags])
 
-        svc._flagged_cache[(user.id, annotation.id)] = True
+        assert all_flagged == {flags[-1].annotation_id}
 
-        assert svc.flagged(user, annotation)
-
-    def test_it_lists_flagged_ids(self, svc, user, flag, noise):
-        annotation_ids = [flag.annotation_id for flag in noise]
-        annotation_ids.append(flag.annotation_id)
-
-        all_flagged = svc.all_flagged(user, annotation_ids)
-
-        assert all_flagged == {flag.annotation_id}
-        assert svc._flagged_cache == {
-            (user.id, noise[0].annotation_id): False,
-            (user.id, noise[1].annotation_id): False,
-            (user.id, flag.annotation_id): True,
-        }
-
-    def test_it_handles_all_flagged_with_no_ids(self, svc, user):
+    @pytest.mark.usefixtures("flags")
+    def test_it_handles_all_flagged_with_no_ids(self, svc, factories):
+        user = factories.User()
         assert svc.all_flagged(user, []) == set()
 
-    def test_it_handles_all_flagged_with_no_user(self, svc, annotation):
-        assert svc.all_flagged(None, [annotation.id]) == set()
+    def test_it_handles_all_flagged_with_no_user(self, svc, flags):
+        annotation_ids = [f.annotation_id for f in flags]
+
+        assert svc.all_flagged(None, annotation_ids) == set()
 
     @pytest.fixture
-    def flag(self, factories, user, annotation):
-        return factories.Flag(user=user, annotation=annotation)
-
-    @pytest.fixture
-    def user(self, factories):
-        return factories.User()
-
-    @pytest.fixture
-    def annotation(self, factories):
-        return factories.Annotation()
-
-    @pytest.fixture(autouse=True)
-    def noise(self, factories):
-        return factories.Flag.create_batch(2)
+    def flags(self, factories):
+        return factories.Flag.create_batch(3)
 
 
 class TestFlagServiceCreate:

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -127,12 +127,15 @@ class TestHandleAnnotationEvent:
         handle_annotation_event,
         fetch_annotation,
         links_service,
+        AnnotationUserInfoFormatter,
         AnnotationJSONPresenter,
     ):
         handle_annotation_event()
 
         AnnotationJSONPresenter.assert_called_once_with(
-            fetch_annotation.return_value, links_service=links_service
+            fetch_annotation.return_value,
+            links_service=links_service,
+            formatters=[AnnotationUserInfoFormatter.return_value],
         )
         assert AnnotationJSONPresenter.return_value.asdict.called
 
@@ -285,6 +288,10 @@ class TestHandleAnnotationEvent:
     @pytest.fixture
     def principals_allowed_by_permission(self, patch):
         return patch("h.streamer.messages.principals_allowed_by_permission")
+
+    @pytest.fixture
+    def AnnotationUserInfoFormatter(self, patch):
+        return patch("h.streamer.messages.AnnotationUserInfoFormatter")
 
     @pytest.fixture
     def AnnotationContext(self, patch):


### PR DESCRIPTION
This reverts commit 87cf419b0fd7faf056db820d27ecaafba8af0fb2 and many more that came after.

This undoes:

 * https://github.com/hypothesis/h/pull/6932
  * https://github.com/hypothesis/h/pull/6936
  * https://github.com/hypothesis/h/pull/6939