### PR TITLE
Identity based principals

### DIFF
--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -10,7 +10,8 @@ from h.auth.policy import (
     AuthenticationPolicy,
     TokenAuthenticationPolicy,
 )
-from h.auth.util import default_authority, groupfinder
+from h.auth.util import default_authority
+from h.security import principals_for_userid
 from h.security.encryption import derive_key
 
 __all__ = ("TOKEN_POLICY",)
@@ -18,7 +19,7 @@ __all__ = ("TOKEN_POLICY",)
 log = logging.getLogger(__name__)
 
 # We export this for the websocket to use as it's main policy
-TOKEN_POLICY = TokenAuthenticationPolicy(callback=groupfinder)
+TOKEN_POLICY = TokenAuthenticationPolicy(callback=principals_for_userid)
 
 
 def includeme(config):  # pragma: no cover
@@ -56,7 +57,7 @@ def _get_policy(proxy_auth):  # pragma: no cover
         )
 
         fallback_policy = RemoteUserAuthenticationPolicy(
-            environ_key="HTTP_X_FORWARDED_USER", callback=groupfinder
+            environ_key="HTTP_X_FORWARDED_USER", callback=principals_for_userid
         )
 
     else:

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 TOKEN_POLICY = TokenAuthenticationPolicy(callback=groupfinder)
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     # Set up authsanity
     settings = config.registry.settings
     settings["authsanity.source"] = "cookie"
@@ -45,7 +45,7 @@ def includeme(config):
     config.add_request_method(".tokens.auth_token", reify=True)
 
 
-def _get_policy(proxy_auth):
+def _get_policy(proxy_auth):  # pragma: no cover
     if proxy_auth:
         log.warning(
             "Enabling proxy authentication mode: you MUST ensure that "

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -8,10 +8,10 @@ from zope import interface
 
 from h.auth import util
 from h.exceptions import InvalidUserId
-#: List of route name-method combinations that should
-#: allow AuthClient authentication
 from h.security import Identity, principals_for_identity
 
+#: List of route name-method combinations that should
+#: allow AuthClient authentication
 AUTH_CLIENT_API_WHITELIST = [
     ("api.groups", "POST"),
     ("api.group", "PATCH"),

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -276,6 +276,10 @@ class AuthClientPolicy:
             except InvalidUserId:  # raised if userid is invalidly formatted
                 return None  # invalid user, so we are failing here
 
+            # If you forward a user it must exist and match your authority
+            if not user or user.authority != client.authority:
+                return None
+
         return principals_for_identity(Identity(user=user, auth_client=client))
 
     @staticmethod

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -38,29 +38,6 @@ def principals_for_user(user):
     return principals_for_identity(Identity(user=user))
 
 
-def principals_for_auth_client(client):
-    """
-    Return the list of additional principals for an auth client.
-
-    :type client: :py:class:`h.models.auth_client.AuthClient`
-    :rtype: list
-    """
-
-    return principals_for_identity(Identity(auth_client=client))
-
-
-def principals_for_auth_client_user(user, client):
-    """
-    Return a union of client and user principals for forwarded user.
-
-    :type user: :py:class:`h.models.user.User`
-    :type client: :py:class:`h.models.auth_client.AuthClient`
-    :rtype: list
-    """
-
-    return principals_for_identity(Identity(user=user, auth_client=client))
-
-
 def default_authority(request):
     """
     Return the value of the h.authority config settings.

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -32,12 +32,6 @@ def groupfinder(userid, request):
     return principals_for_identity(Identity(user=user))
 
 
-def principals_for_user(user):
-    """Return the list of additional principals for a user, or None."""
-
-    return principals_for_identity(Identity(user=user))
-
-
 def default_authority(request):
     """
     Return the value of the h.authority config settings.

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -4,32 +4,6 @@ import re
 import sqlalchemy as sa
 
 from h.models.auth_client import AuthClient, GrantType
-from h.security.identity import Identity
-from h.security.principals import principals_for_identity
-
-
-def groupfinder(userid, request):
-    """
-    Return the list of additional principals for a userid, or None.
-
-    This loads the user and then calls ``principals_for_user``.
-
-    If `userid` identifies a valid user in the system, this function will
-    return the list of additional principals for that user. If `userid` is not
-    recognised as a valid user in the system, the function will return None.
-
-    :param userid: the userid claimed by the request.
-    :type userid: str
-    :param request: the request object
-    :type request: pyramid.request.Request
-
-    :returns: additional principals for the user (possibly empty) or None
-    :rtype: list or None
-    """
-    user_service = request.find_service(name="user")
-    user = user_service.fetch(userid)
-
-    return principals_for_identity(Identity(user=user))
 
 
 def default_authority(request):

--- a/h/security/__init__.py
+++ b/h/security/__init__.py
@@ -6,4 +6,7 @@ from h.security.encryption import (  # noqa:F401
 )
 from h.security.identity import Identity  # noqa:F401
 from h.security.permissions import Permission  # noqa:F401
-from h.security.principals import principals_for_identity  # noqa:F401
+from h.security.principals import (  # noqa:F401
+    principals_for_identity,
+    principals_for_userid,
+)

--- a/h/security/__init__.py
+++ b/h/security/__init__.py
@@ -4,4 +4,6 @@ from h.security.encryption import (  # noqa:F401
     password_context,
     token_urlsafe,
 )
+from h.security.identity import Identity  # noqa:F401
 from h.security.permissions import Permission  # noqa:F401
+from h.security.principals import principals_for_identity  # noqa:F401

--- a/h/security/identity.py
+++ b/h/security/identity.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from h.models import AuthClient, User
+
+
+@dataclass
+class Identity:
+    """
+    The identity of the logged in user/client.
+
+    This can include a user if the user is directly logged in, or provided via
+    a forwarded user. An `AuthClient` if this is a call is made using a
+    pre-shared key, or both.
+    """
+
+    user: User = None
+    auth_client: AuthClient = None

--- a/h/security/principals.py
+++ b/h/security/principals.py
@@ -2,6 +2,20 @@ from h.security.identity import Identity
 from h.security.role import Role
 
 
+def principals_for_userid(userid, request):
+    """
+    Return the list of additional principals for a valid userid, or None.
+
+    :param userid: Userid to get principals for
+    :param request: Pyramid request object
+    :returns: A list of principals or None
+    """
+
+    identity = Identity(user=request.find_service(name="user").fetch(userid))
+
+    return principals_for_identity(identity)
+
+
 def principals_for_identity(identity: Identity):
     """
     Get the security principals for a given identity.

--- a/h/security/principals.py
+++ b/h/security/principals.py
@@ -1,0 +1,45 @@
+from h.security.identity import Identity
+from h.security.role import Role
+
+
+def principals_for_identity(identity: Identity):
+    """
+    Get the security principals for a given identity.
+
+    :param identity: Identity to provide principals for
+    :returns: A list of principals or None
+    """
+    if not identity:
+        return None
+
+    principals = set()
+
+    if user := identity.user:
+        principals.add(Role.USER)
+        if user.admin:
+            principals.add(Role.ADMIN)
+        if user.staff:
+            principals.add(Role.STAFF)
+        for group in user.groups:
+            principals.add("group:{group.pubid}".format(group=group))
+        principals.add("authority:{authority}".format(authority=user.authority))
+
+    if auth_client := identity.auth_client:
+        principals.add(f"client:{auth_client.id}@{auth_client.authority}")
+        principals.add(f"client_authority:{auth_client.authority}")
+        principals.add(Role.AUTH_CLIENT)
+
+    if identity.auth_client and identity.user:
+        # Other auth policies that extend Pyramid auth policies, e.g.
+        # `pyramid.authentication.CallbackAuthenticationPolicy`, automatically
+        # get a `userid` principal via its `effective_principals` method.
+        # But `h.auth.policy.AuthClientPolicy` overrides `effective_principals`
+        # with its own method, so the `userid` principal needs to be added
+        # explicitly here for forwarded users
+        principals.add(identity.user.userid)
+        principals.add(Role.AUTH_CLIENT_FORWARDED_USER)
+
+    if not principals:
+        return None
+
+    return list(principals)

--- a/h/security/principals.py
+++ b/h/security/principals.py
@@ -28,17 +28,6 @@ def principals_for_identity(identity: Identity):
 
     principals = set()
 
-    if identity.auth_client and identity.user:
-        # We deny all principals if there's an authority mismatch
-        if identity.auth_client.authority != identity.user.authority:
-            return None
-
-        # Standard pyramid policies like`CallbackAuthenticationPolicy`
-        # automatically add the user id in `effective_principals`, but our
-        # `h.auth.policy.AuthClientPolicy` overrides it and it's missing
-        principals.add(identity.user.userid)
-        principals.add(Role.AUTH_CLIENT_FORWARDED_USER)
-
     if user := identity.user:
         principals.add(Role.USER)
         if user.admin:
@@ -53,6 +42,13 @@ def principals_for_identity(identity: Identity):
         principals.add(f"client:{auth_client.id}@{auth_client.authority}")
         principals.add(f"client_authority:{auth_client.authority}")
         principals.add(Role.AUTH_CLIENT)
+
+    if identity.auth_client and identity.user:
+        # Standard pyramid policies like`CallbackAuthenticationPolicy`
+        # automatically add the user id in `effective_principals`, but our
+        # `h.auth.policy.AuthClientPolicy` overrides it and it's missing
+        principals.add(identity.user.userid)
+        principals.add(Role.AUTH_CLIENT_FORWARDED_USER)
 
     if not principals:
         return None

--- a/h/services/auth_ticket.py
+++ b/h/services/auth_ticket.py
@@ -5,7 +5,7 @@ from pyramid_authsanity import interfaces
 from zope import interface
 
 from h import models
-from h.auth.util import principals_for_user
+from h.security import Identity, principals_for_identity
 
 TICKET_TTL = datetime.timedelta(days=7)
 
@@ -47,7 +47,7 @@ class AuthTicketService:
             raise AuthTicketNotLoadedError("auth ticket is not loaded yet")
 
         user = self.usersvc.fetch(self._userid)
-        return principals_for_user(user)
+        return principals_for_identity(Identity(user=user))
 
     def verify_ticket(self, principal, ticket_id):
         """

--- a/tests/functional/api/test_annotations.py
+++ b/tests/functional/api/test_annotations.py
@@ -102,8 +102,8 @@ class TestPostAnnotation:
         """
         Write an annotation to a group that doesn't allow writes.
 
-        This is a basic test to check that h is correctly configuring the
-        groupfinder.
+        This is a basic test to check that h is correctly configuring
+        principals_for_userid.
         """
 
         user, token = user_with_token

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -33,33 +33,9 @@ class TestPrincipalsForProxies:
         )
         assert result == principals_for_identity.return_value
 
-    def test_principals_for_auth_client(self, principals_for_identity, auth_client):
-        result = util.principals_for_auth_client(auth_client)
-
-        principals_for_identity.assert_called_once_with(
-            Any.instance_of(Identity).with_attrs({"auth_client": auth_client})
-        )
-        assert result == principals_for_identity.return_value
-
-    def test_principals_for_auth_client_user(
-        self, principals_for_identity, user, auth_client
-    ):
-        result = util.principals_for_auth_client_user(user, auth_client)
-
-        principals_for_identity.assert_called_once_with(
-            Any.instance_of(Identity).with_attrs(
-                {"user": user, "auth_client": auth_client}
-            )
-        )
-        assert result == principals_for_identity.return_value
-
     @pytest.fixture
     def user(self, factories):
         return factories.User()
-
-    @pytest.fixture
-    def auth_client(self, factories):
-        return factories.AuthClient()
 
     @pytest.fixture
     def principals_for_identity(self, patch):

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -1,37 +1,11 @@
 from unittest import mock
-from unittest.mock import sentinel
 
 import pytest
 import sqlalchemy as sa
-from h_matchers import Any
 
 from h.auth import util
 from h.models import AuthClient
 from h.models.auth_client import GrantType
-from h.security import Identity
-
-
-class TestPrincipalsForProxies:
-    def test_groupfinder(
-        self, principals_for_identity, user, pyramid_request, user_service
-    ):
-        result = util.groupfinder(sentinel.userid, pyramid_request)
-
-        user_service.fetch.assert_called_once_with(sentinel.userid)
-        principals_for_identity.assert_called_once_with(
-            Any.instance_of(Identity).with_attrs(
-                {"user": user_service.fetch.return_value}
-            )
-        )
-        assert result == principals_for_identity.return_value
-
-    @pytest.fixture
-    def user(self, factories):
-        return factories.User()
-
-    @pytest.fixture
-    def principals_for_identity(self, patch):
-        return patch("h.auth.util.principals_for_identity")
 
 
 class TestClientAuthority:

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -25,14 +25,6 @@ class TestPrincipalsForProxies:
         )
         assert result == principals_for_identity.return_value
 
-    def test_principals_for_user(self, principals_for_identity, user):
-        result = util.principals_for_user(user)
-
-        principals_for_identity.assert_called_once_with(
-            Any.instance_of(Identity).with_attrs({"user": user})
-        )
-        assert result == principals_for_identity.return_value
-
     @pytest.fixture
     def user(self, factories):
         return factories.User()

--- a/tests/h/security/test_principals.py
+++ b/tests/h/security/test_principals.py
@@ -12,6 +12,12 @@ class TestPrincipalsForIdentity:
     def test_it_with_an_empty_identity(self):
         assert principals_for_identity(Identity()) is None
 
+    def test_it_with_a_user_client_mismatch(self, identity):
+        identity.user.authority = "authority"
+        identity.auth_client.authority = "different_authority"
+
+        assert principals_for_identity(identity) is None
+
     @pytest.mark.parametrize("admin", (True, False))
     @pytest.mark.parametrize("staff", (True, False))
     @pytest.mark.parametrize("with_auth_client", (True, False))

--- a/tests/h/security/test_principals.py
+++ b/tests/h/security/test_principals.py
@@ -32,12 +32,6 @@ class TestPrincipalsForIdentity:
     def test_it_with_an_empty_identity(self):
         assert principals_for_identity(Identity()) is None
 
-    def test_it_with_a_user_client_mismatch(self, identity):
-        identity.user.authority = "authority"
-        identity.auth_client.authority = "different_authority"
-
-        assert principals_for_identity(identity) is None
-
     @pytest.mark.parametrize("admin", (True, False))
     @pytest.mark.parametrize("staff", (True, False))
     @pytest.mark.parametrize("with_auth_client", (True, False))

--- a/tests/h/security/test_principals.py
+++ b/tests/h/security/test_principals.py
@@ -1,0 +1,58 @@
+import pytest
+
+from h.security import Identity
+from h.security.principals import principals_for_identity
+from h.security.role import Role
+
+
+class TestPrincipalsForIdentity:
+    def test_it_with_None(self):
+        assert principals_for_identity(None) is None
+
+    def test_it_with_an_empty_identity(self):
+        assert principals_for_identity(Identity()) is None
+
+    @pytest.mark.parametrize("admin", (True, False))
+    @pytest.mark.parametrize("staff", (True, False))
+    @pytest.mark.parametrize("with_auth_client", (True, False))
+    def test_user_principals(self, identity, admin, staff, with_auth_client):
+        identity.user.admin = admin
+        identity.user.staff = staff
+
+        if not with_auth_client:
+            identity.auth_client = None
+
+        principals = principals_for_identity(identity)
+
+        assert Role.USER in principals
+        assert f"authority:{identity.user.authority}" in principals
+        for group in identity.user.groups:
+            assert f"group:{group.pubid}" in principals
+
+        assert bool(Role.ADMIN in principals) == admin
+        assert bool(Role.STAFF in principals) == staff
+
+    @pytest.mark.parametrize("with_user", (True, False))
+    def test_auth_client_principals(self, identity, with_user):
+        if not with_user:
+            identity.user = None
+
+        principals = principals_for_identity(identity)
+
+        auth_client = identity.auth_client
+        assert f"client:{auth_client.id}@{auth_client.authority}" in principals
+        assert f"client_authority:{auth_client.authority}" in principals
+        assert Role.AUTH_CLIENT in principals
+
+    def test_auth_client_and_user_principals(self, identity):
+        principals = principals_for_identity(identity)
+
+        assert identity.user.userid in principals
+        assert Role.AUTH_CLIENT_FORWARDED_USER in principals
+
+    @pytest.fixture
+    def identity(self, factories):
+        return Identity(
+            user=factories.User(groups=factories.Group.create_batch(2)),
+            auth_client=factories.AuthClient(),
+        )

--- a/tests/h/security/test_principals.py
+++ b/tests/h/security/test_principals.py
@@ -1,8 +1,28 @@
+from unittest.mock import sentinel
+
 import pytest
+from h_matchers import Any
 
 from h.security import Identity
-from h.security.principals import principals_for_identity
+from h.security.principals import principals_for_identity, principals_for_userid
 from h.security.role import Role
+
+
+class TestPrincipalsForUserid:
+    def test_it(self, pyramid_request, user_service, principals_for_identity):
+        result = principals_for_userid(sentinel.userid, pyramid_request)
+
+        user_service.fetch.assert_called_once_with(sentinel.userid)
+        principals_for_identity.assert_called_once_with(
+            Any.instance_of(Identity).with_attrs(
+                {"user": user_service.fetch.return_value}
+            )
+        )
+        assert result == principals_for_identity.return_value
+
+    @pytest.fixture
+    def principals_for_identity(self, patch):
+        return patch("h.security.principals.principals_for_identity")
 
 
 class TestPrincipalsForIdentity:


### PR DESCRIPTION
This PR consolidates all of the principal generation into the security module in a single function. This also introduces an `Identity` object, which is the core of how auth works in Pyramid 2.0
 
My hope is we can start to make the policies more identity centric, and then leave generating out the principals as an after thought, and eventually when we don't rely on principals any more, this can be snipped out.

### What's changed

 * `h.auth.util` methods `principals_for_user()`, `principals_for_auth_client()` and `principals_for_auth_client_user()` are gone
 * They have been replaced with `h.security.principals:principals_for_identity()`
 * A simple identity dataclass which has a user and auth client has been introduced to work with it
 * `h.auth.util:groupfinder()` has been replaced with `h.security.principals:principals_for_userid()`

### Review notes

A lot of the size of this is because code moved. The PRs try to show an incremental way of doing it (including interstitial tests if you care), but it might be worth jumping to the conclusion for for this one.

The tests that have been written are all effectively new. The only logic that really needs careful comparison is the merging of the functions, but it's quite basic stuff.