### PR TITLE
Fix pylint unused-argument on the test code

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -33,8 +33,6 @@ disable=bad-continuation,
         duplicate-code,
 
         # Ignored during pep8 -> pylint transition
-        unused-argument,
-        too-many-arguments,
         super-init-not-called,
         fixme,
 

--- a/h/auth/cookie_authentication_policy.py
+++ b/h/auth/cookie_authentication_policy.py
@@ -18,7 +18,7 @@ class CookieAuthenticationPolicy(IdentityBasedPolicy):
 
         return Identity(user=user)
 
-    def remember(self, request, userid, **kw):
+    def remember(self, request, userid, **kw):  # pylint:disable=unused-argument
         """Get a list of headers which will remember the user in a cookie."""
 
         self._add_vary_by_cookie(request)
@@ -52,7 +52,7 @@ class CookieAuthenticationPolicy(IdentityBasedPolicy):
     @staticmethod
     @lru_cache  # Ensure we only add this once per request
     def _add_vary_by_cookie(request):
-        def vary_add(request, response):
+        def vary_add(request, response):  # pylint:disable=unused-argument
             vary = set(response.vary if response.vary is not None else [])
             vary.add("Cookie")
             response.vary = list(vary)

--- a/h/services/oauth_provider.py
+++ b/h/services/oauth_provider.py
@@ -127,7 +127,7 @@ class OAuthProviderService(AuthorizationEndpoint, RevocationEndpoint, TokenEndpo
             raise InvalidRefreshTokenError()
 
     @staticmethod
-    def generate_access_token(oauth_request):
+    def generate_access_token(oauth_request):  # pylint: disable=unused-argument
         return ACCESS_TOKEN_PREFIX + token_urlsafe()
 
     @staticmethod

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -119,7 +119,7 @@ def handle_message(message, session=None):
     handler(message, session=session)
 
 
-def handle_client_id_message(message, session=None):
+def handle_client_id_message(message, session=None):  # pylint: disable=unused-argument
     """Answer to a client telling us its client ID."""
     if "value" not in message.payload:
         message.reply(
@@ -136,7 +136,7 @@ def handle_client_id_message(message, session=None):
 MESSAGE_HANDLERS["client_id"] = handle_client_id_message
 
 
-def handle_filter_message(message, session=None):
+def handle_filter_message(message, session=None):  # pylint: disable=unused-argument
     """Answer to a client updating its streamer filter."""
     if "filter" not in message.payload:
         message.reply(
@@ -170,7 +170,7 @@ def handle_filter_message(message, session=None):
 MESSAGE_HANDLERS["filter"] = handle_filter_message
 
 
-def handle_ping_message(message, session=None):
+def handle_ping_message(message, session=None):  # pylint: disable=unused-argument
     """Reply to a client requesting a pong."""
     message.reply({"type": "pong"})
 
@@ -178,7 +178,7 @@ def handle_ping_message(message, session=None):
 MESSAGE_HANDLERS["ping"] = handle_ping_message
 
 
-def handle_whoami_message(message, session=None):
+def handle_whoami_message(message, session=None):  # pylint: disable=unused-argument
     """Reply to a client requesting information on its auth state."""
     message.reply({"type": "whoyouare", "userid": message.socket.authenticated_userid})
 
@@ -186,7 +186,7 @@ def handle_whoami_message(message, session=None):
 MESSAGE_HANDLERS["whoami"] = handle_whoami_message
 
 
-def handle_unknown_message(message, session=None):
+def handle_unknown_message(message, session=None):  # pylint: disable=unused-argument
     """Handle the message type being missing or not recognised."""
     type_ = json.dumps(message.payload.get("type"))
     message.reply(

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -62,7 +62,6 @@ disable=
     duplicate-code,
 
     # Ignored during pep8 -> pylint transition
-    unused-argument,
     fixme,
     no-member, #  Intermittent failures with the same input
 

--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -55,7 +55,9 @@ class Annotation(ModelFactory):
         ]
 
     @factory.post_generation
-    def make_metadata(self, create, extracted, **kwargs):
+    def make_metadata(  # pylint:disable=unused-argument
+        self, create, extracted, **kwargs
+    ):
         """Create associated document metadata for the annotation."""
         # The metadata objects are going to be added to the db, so if we're not
         # using the create strategy then simply don't make any.
@@ -118,7 +120,7 @@ class Annotation(ModelFactory):
         )
 
     @factory.post_generation
-    def make_id(self, create, extracted, **kwargs):
+    def make_id(self, create, extracted, **kwargs):  # pylint:disable=unused-argument
         """Add a randomly ID if the annotation doesn't have one yet."""
         # If using the create strategy don't generate an id.
         # models.Annotation.id's server_default function will generate one
@@ -136,7 +138,7 @@ class Annotation(ModelFactory):
         )
 
     @factory.post_generation
-    def timestamps(self, create, extracted, **kwargs):
+    def timestamps(self, create, extracted, **kwargs):  # pylint:disable=unused-argument
         # If using the create strategy let sqlalchemy set the created and
         # updated times when saving to the DB.
         if create:

--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -23,7 +23,9 @@ class Group(ModelFactory):
     enforce_scope = True
 
     @factory.post_generation
-    def scopes(self, create, scopes=0, **kwargs):  # pylint: disable=method-hidden
+    def scopes(  # pylint: disable=method-hidden,unused-argument
+        self, create, scopes=0, **kwargs
+    ):
         if isinstance(scopes, int):
             scopes = [GroupScope(group=self) for _ in range(0, scopes)]
 

--- a/tests/functional/api/test_moderation.py
+++ b/tests/functional/api/test_moderation.py
@@ -129,7 +129,7 @@ def world_annotation(user, db_session, factories):
 
 
 @pytest.fixture
-def group_annotation(user, group, db_session, factories):
+def group_annotation(group, db_session, factories):
     ann = factories.Annotation(
         userid="acct:someone@example.com", groupid=group.pubid, shared=True
     )
@@ -138,7 +138,7 @@ def group_annotation(user, group, db_session, factories):
 
 
 @pytest.fixture
-def private_group_annotation(user, group, db_session, factories):
+def private_group_annotation(group, db_session, factories):
     ann = factories.Annotation(
         userid="acct:someone@example.com", groupid=group.pubid, shared=False
     )

--- a/tests/functional/api/test_profile.py
+++ b/tests/functional/api/test_profile.py
@@ -27,7 +27,7 @@ class TestGetProfile:
         assert res.json["userid"] == user.userid
 
     def test_it_returns_profile_for_third_party_authd_user(
-        self, app, open_group, third_party_user_with_token
+        self, app, third_party_user_with_token
     ):
         """Fetch a profile for a third-party account."""
 
@@ -135,7 +135,7 @@ class TestPatchProfile:
 
 
 @pytest.fixture
-def groups(db_session, factories):
+def groups(factories):
     groups = [
         factories.Group(),
         factories.Group(),

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -28,7 +28,7 @@ TEST_SETTINGS = {
 
 
 @pytest.fixture(scope="session")
-def app(pyramid_app, db_engine):
+def app(pyramid_app):
     return TestApp(pyramid_app)
 
 
@@ -93,5 +93,5 @@ def pyramid_app():
 # Always unconditionally wipe the Elasticsearch index after every functional
 # test.
 @pytest.fixture(autouse=True)
-def always_delete_all_elasticsearch_documents(es_client):
+def always_delete_all_elasticsearch_documents():
     pass

--- a/tests/functional/fixtures/authentication.py
+++ b/tests/functional/fixtures/authentication.py
@@ -37,10 +37,10 @@ def with_logged_in_user(login_user):
 
 
 @pytest.fixture
-def with_logged_in_staff_member(login_user, user):
+def with_logged_in_staff_member(login_user):
     login_user(staff=True)
 
 
 @pytest.fixture
-def with_logged_in_admin(login_user, user):
+def with_logged_in_admin(login_user):
     login_user(admin=True)

--- a/tests/functional/test_moderation.py
+++ b/tests/functional/test_moderation.py
@@ -3,7 +3,7 @@ import pytest
 
 class TestModeration:
     def test_moderator_flag_listing(
-        self, app, group, flagged_annotation, moderator_with_token
+        self, app, flagged_annotation, moderator_with_token
     ):
         _, token = moderator_with_token
 

--- a/tests/functional/test_oauth.py
+++ b/tests/functional/test_oauth.py
@@ -18,12 +18,10 @@ class TestOAuth:
 
         self.assert_is_authorized(app, userid, access_token)
 
-    def test_request_fails_if_access_token_wrong(self, app, authclient, userid):
+    def test_request_fails_if_access_token_wrong(self, app):
         self.assert_is_not_authorised(app, access_token="wrong")
 
-    def test_request_fails_if_access_token_expired(
-        self, app, authclient, db_session, factories, userid
-    ):
+    def test_request_fails_if_access_token_expired(self, app, db_session, factories):
         token = factories.DeveloperToken(
             expires=datetime.datetime.utcnow() - datetime.timedelta(hours=1)
         )
@@ -52,9 +50,7 @@ class TestOAuth:
         # Test that the old access token still works, too.
         self.assert_is_authorized(app, userid, old_access_token)
 
-    def test_refresh_token_request_fails_if_refresh_token_wrong(
-        self, app, authclient, userid
-    ):
+    def test_refresh_token_request_fails_if_refresh_token_wrong(self, app):
         app.post(
             "/api/token",
             {"grant_type": "refresh_token", "refresh_token": "wrong"},
@@ -62,7 +58,7 @@ class TestOAuth:
         )
 
     def test_refresh_token_request_fails_if_token_expired(
-        self, app, authclient, db_session, factories, userid
+        self, app, db_session, factories
     ):
         token = factories.DeveloperToken(
             expires=datetime.datetime.utcnow() - datetime.timedelta(hours=1)

--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -17,9 +17,7 @@ class TestGetUser:
 
         user_service.fetch.assert_called_once_with("userid")
 
-    def test_does_not_invalidate_session_if_not_authenticated(
-        self, pyramid_config, pyramid_request
-    ):
+    def test_does_not_invalidate_session_if_not_authenticated(self, pyramid_request):
         """
         If authenticated_userid is None it shouldn't invalidate the session.
 

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -44,21 +44,19 @@ class TestDocumentBucket:
         bucket = bucketing.DocumentBucket(document)
         assert bucket.title == "The Document Title"
 
-    def test_init_uses_the_document_web_uri(self, db_session, document):
+    def test_init_uses_the_document_web_uri(self, document):
         document.web_uri = "http://example.com"
 
         bucket = bucketing.DocumentBucket(document)
         assert bucket.uri == "http://example.com"
 
-    def test_init_sets_None_uri_when_no_http_or_https_can_be_found(
-        self, db_session, document
-    ):
+    def test_init_sets_None_uri_when_no_http_or_https_can_be_found(self, document):
         document.web_uri = None
 
         bucket = bucketing.DocumentBucket(document)
         assert bucket.uri is None
 
-    def test_init_sets_the_domain_from_the_extracted_uri(self, db_session, document):
+    def test_init_sets_the_domain_from_the_extracted_uri(self, document):
         document.web_uri = "https://www.example.com/foobar.html"
 
         bucket = bucketing.DocumentBucket(document)
@@ -76,7 +74,7 @@ class TestDocumentBucket:
         bucket = bucketing.DocumentBucket(document)
         assert bucket.domain == "Local file"
 
-    def test_annotations_count_returns_count_of_annotations(self, db_session, document):
+    def test_annotations_count_returns_count_of_annotations(self, document):
         bucket = bucketing.DocumentBucket(document)
 
         for _ in range(7):

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -239,7 +239,7 @@ class TestExecute:
         search.append_aggregation.assert_called_with(TagsAggregation.return_value)
 
     def test_it_does_not_add_a_users_aggregation(
-        self, pyramid_request, search, UsersAggregation
+        self, pyramid_request, UsersAggregation
     ):
         """On non-group pages there's no users aggregations."""
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
@@ -365,7 +365,7 @@ class TestExecute:
         )
 
     def test_it_buckets_the_annotations(
-        self, fetch_annotations, bucketing, pyramid_request, search
+        self, fetch_annotations, bucketing, pyramid_request
     ):
         result = execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
@@ -396,9 +396,7 @@ class TestExecute:
             else:
                 assert False
 
-    def test_it_returns_each_annotations_group(
-        self, _fetch_groups, annotations, group_pubids, pyramid_request
-    ):
+    def test_it_returns_each_annotations_group(self, _fetch_groups, pyramid_request):
         result = execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
         presented_annotations = []
@@ -413,9 +411,7 @@ class TestExecute:
             else:
                 assert False
 
-    def test_it_returns_each_annotations_incontext_link(
-        self, annotations, links, pyramid_request
-    ):
+    def test_it_returns_each_annotations_incontext_link(self, links, pyramid_request):
         def incontext_link(request, annotation):
             assert (
                 request == pyramid_request
@@ -439,9 +435,7 @@ class TestExecute:
                 )
             )
 
-    def test_it_returns_each_annotations_html_link(
-        self, annotations, links, pyramid_request
-    ):
+    def test_it_returns_each_annotations_html_link(self, links, pyramid_request):
         def html_link(request, annotation):
             assert (
                 request == pyramid_request

--- a/tests/h/cli/commands/authclient_test.py
+++ b/tests/h/cli/commands/authclient_test.py
@@ -66,6 +66,6 @@ class TestAddCommand:
 
 
 @pytest.fixture
-def cliconfig(pyramid_config, pyramid_request):
+def cliconfig(pyramid_request):
     pyramid_request.tm = mock.Mock()
     return {"bootstrap": mock.Mock(return_value=pyramid_request)}

--- a/tests/h/cli/commands/user_test.py
+++ b/tests/h/cli/commands/user_test.py
@@ -309,7 +309,7 @@ def delete_user_service(pyramid_request, annotation_delete_service):
 
 
 @pytest.fixture
-def annotation_delete_service(pyramid_config):
+def annotation_delete_service(pyramid_config):  # pylint:disable=unused-argument
     service = mock.create_autospec(
         AnnotationDeleteService, spec_set=True, instance=True
     )
@@ -327,6 +327,6 @@ def pyramid_config(
 
 
 @pytest.fixture
-def cliconfig(pyramid_config, pyramid_request):
+def cliconfig(pyramid_config, pyramid_request):  # pylint:disable=unused-argument
     pyramid_request.tm = mock.Mock()
     return {"bootstrap": mock.Mock(return_value=pyramid_request)}

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -96,8 +96,6 @@ class TestGenerate:
         self,
         notification,
         pyramid_request,
-        html_renderer,
-        text_renderer,
         parent_user,
         reply_user,
     ):
@@ -141,7 +139,7 @@ class TestGenerate:
         assert text == "Text output"
 
     def test_returns_subject_with_reply_display_name(
-        self, notification, pyramid_request, reply_user
+        self, notification, pyramid_request
     ):
         _, subject, _, _ = generate(pyramid_request, notification)
 

--- a/tests/h/eventqueue_test.py
+++ b/tests/h/eventqueue_test.py
@@ -13,7 +13,7 @@ class DummyEvent:
 
 @pytest.mark.usefixtures("pyramid_config")
 class TestEventQueue:
-    def test_init_adds_response_callback(self, pyramid_request):
+    def test_init_adds_response_callback(self):
         request = mock.Mock()
         queue = eventqueue.EventQueue(request)
 

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -54,7 +54,7 @@ def test_feed_contains_entries(_feed_entry_from_annotation, factories):
         "feed entry for annotation 3",
     ]
 
-    def pop(*args, **kwargs):
+    def pop(*args, **kwargs):  # pylint:disable=unused-argument
         return entries.pop(0)
 
     _feed_entry_from_annotation.side_effect = pop
@@ -97,12 +97,11 @@ def test_entry_id(util, factories):
     """The ids of feed entries should come from tag_uri_for_annotation()."""
     annotation = factories.Annotation()
 
-    def annotation_url(ann):
-        return "annotation url"
+    feed = atom.feed_from_annotations(
+        [annotation], "atom_url", lambda _: "annotation url"
+    )
 
-    feed = atom.feed_from_annotations([annotation], "atom_url", annotation_url)
-
-    util.tag_uri_for_annotation.assert_called_once_with(annotation, annotation_url)
+    util.tag_uri_for_annotation.assert_called_once()
     assert feed["entries"][0]["id"] == util.tag_uri_for_annotation.return_value
 
 
@@ -111,7 +110,7 @@ def test_entry_author(factories):
     annotation = factories.Annotation(userid="acct:nobu@hypothes.is")
 
     feed = atom.feed_from_annotations(
-        [annotation], "atom_url", lambda annotation: "annotation url"
+        [annotation], "atom_url", lambda _: "annotation url"
     )
 
     assert feed["entries"][0]["author"]["name"] == "nobu"
@@ -126,7 +125,7 @@ def test_entry_title(factories):
         annotation = factories.Annotation()
 
         feed = atom.feed_from_annotations(
-            [annotation], "atom_url", lambda annotation: "annotation url"
+            [annotation], "atom_url", lambda _: "annotation url"
         )
 
         mock_title.assert_called_once_with()

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -86,7 +86,7 @@ class TestCreateForm:
             renderer=Any.instance_of(form.Jinja2Renderer),
         )
 
-    def test_adds_feature_client_to_system_context(self, Form, patch, pyramid_request):
+    def test_adds_feature_client_to_system_context(self, patch, pyramid_request):
         Jinja2Renderer = patch("h.form.Jinja2Renderer")
 
         form.create_form(pyramid_request, mock.sentinel.schema)
@@ -95,7 +95,7 @@ class TestCreateForm:
             mock.sentinel.jinja2_env, {"feature": pyramid_request.feature}
         )
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def Form(self, patch):
         return patch("deform.Form")
 

--- a/tests/h/models/document/_document_test.py
+++ b/tests/h/models/document/_document_test.py
@@ -320,7 +320,7 @@ class TestUpdateDocumentMetadata:
         first.assert_called_once_with()
         assert result == first.return_value
 
-    def test_it_updates_document_updated(self, Document, merge_documents, caller):
+    def test_it_updates_document_updated(self, Document, caller):
         caller(updated=sentinel.updated)
 
         document = Document.find_or_create_by_uris.return_value.first.return_value
@@ -399,7 +399,7 @@ class TestUpdateDocumentMetadata:
         ]
 
     @pytest.fixture
-    def caller(self, db_session):
+    def caller(self):
         return functools.partial(
             update_document_metadata,
             session=sentinel.db_session,

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -22,7 +22,7 @@ class TestGroupScope:
         factories.GroupScope(scope="http://localhost:5000")
         db_session.flush()
 
-    def test_it_raises_if_scope_has_no_origin(self, db_session, factories):
+    def test_it_raises_if_scope_has_no_origin(self, factories):
         with pytest.raises(ValueError, match="Invalid URL"):
             factories.GroupScope(scope="diplodocus : 123")
 
@@ -47,9 +47,7 @@ class TestGroupScope:
 
         assert group_scope.group == group
 
-    def test_you_can_get_a_groups_scopes_by_the_scopes_property(
-        self, factories, matchers
-    ):
+    def test_you_can_get_a_groups_scopes_by_the_scopes_property(self, factories):
         group = factories.OpenGroup()
         scopes = [
             factories.GroupScope(group=group),

--- a/tests/h/models/organization_test.py
+++ b/tests/h/models/organization_test.py
@@ -38,7 +38,7 @@ def test_none_logo_is_valid():
     assert org.logo is None
 
 
-def test_repr(db_session, factories):
+def test_repr():
     organization = models.Organization(
         name="My Organization", authority="example.com", pubid="test_pubid"
     )

--- a/tests/h/models/user_identity_test.py
+++ b/tests/h/models/user_identity_test.py
@@ -5,9 +5,7 @@ from h import models
 
 
 class TestUserIdentity:
-    def test_you_can_save_and_then_retrieve_field_values(
-        self, db_session, matchers, user
-    ):
+    def test_you_can_save_and_then_retrieve_field_values(self, db_session, user):
         user_identity_1 = models.UserIdentity(
             provider="provider_1", provider_unique_id="1", user=user
         )

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -267,7 +267,8 @@ class TestUserGetByEmail:
         actual = models.User.get_by_email(db_session, user.email, user.authority)
         assert actual == user
 
-    def test_it_filters_by_email(self, db_session, users):
+    @pytest.mark.usefixtures("users")
+    def test_it_filters_by_email(self, db_session):
         authority = "example.com"
         email = "bogus@msn.com"
 

--- a/tests/h/notification/reply_test.py
+++ b/tests/h/notification/reply_test.py
@@ -121,7 +121,7 @@ class TestGetNotification:
         assert result is None
 
     def test_returns_none_when_subscription_absent(
-        self, db_session, parent, pyramid_request, reply
+        self, db_session, pyramid_request, reply
     ):
         db_session.query(Subscriptions).delete()
 

--- a/tests/h/oauth/jwt_grant_test.py
+++ b/tests/h/oauth/jwt_grant_test.py
@@ -38,9 +38,7 @@ class TestJWTAuthorizationGrantCreateTokenResponse:
             oauth_request, refresh_token=True
         )
 
-    def test_saves_token(
-        self, grant, oauth_request, token_handler, db_session, request_validator
-    ):
+    def test_saves_token(self, grant, oauth_request, token_handler, request_validator):
         token = token_handler.create_token.return_value
 
         grant.create_token_response(oauth_request, token_handler)

--- a/tests/h/panels/navbar_test.py
+++ b/tests/h/panels/navbar_test.py
@@ -30,7 +30,7 @@ class TestNavbar:
             for g in user.groups
         ]
 
-    def test_includes_groups_suggestions_when_logged_in(self, req, user, open_group):
+    def test_includes_groups_suggestions_when_logged_in(self, req, user):
         req.user = user
         result = navbar({}, req)
         assert result["groups_suggestions"] == [

--- a/tests/h/presenters/annotation_html_test.py
+++ b/tests/h/presenters/annotation_html_test.py
@@ -51,7 +51,7 @@ class TestAnnotationHTMLPresenter:
             ("title", "title"),
         ),
     )
-    def test_document_proxies(self, annotation, presenter, method, proxied_method):
+    def test_document_proxies(self, presenter, method, proxied_method):
         # Note that the "document" here is actually a `DocumentHTMLPresenter`
         assert getattr(presenter, method) == getattr(presenter.document, proxied_method)
 

--- a/tests/h/presenters/annotation_searchindex_test.py
+++ b/tests/h/presenters/annotation_searchindex_test.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.usefixtures("moderation_service")
 
 @pytest.mark.usefixtures("nipsa_service")
 class TestAnnotationSearchIndexPresenter:
-    def test_asdict(self, DocumentSearchIndexPresenter, pyramid_request, factories):
+    def test_asdict(self, DocumentSearchIndexPresenter, pyramid_request):
         annotation = mock.MagicMock(
             id="xyz123",
             created=datetime.datetime(2016, 2, 24, 18, 3, 25, 768),

--- a/tests/h/schemas/annotation_test.py
+++ b/tests/h/schemas/annotation_test.py
@@ -293,7 +293,9 @@ class TestCreateUpdateAnnotationSchema:
             "sub_dict": {"key": "original_value"},
         }
 
-        def document_uris_from_data(document, claimant):
+        def document_uris_from_data(
+            document, claimant  # pylint:disable=unused-argument
+        ):
             document["new_key"] = "new_value"
             document["top_level_key"] = "new_value"
             document["sub_dict"]["key"] = "new_value"

--- a/tests/h/schemas/forms/accounts/login_test.py
+++ b/tests/h/schemas/forms/accounts/login_test.py
@@ -46,7 +46,7 @@ class TestLoginSchema:
 
         assert result["user"] is user
 
-    def test_invalid_with_bad_csrf(self, pyramid_request, user_service):
+    def test_invalid_with_bad_csrf(self, pyramid_request):
         schema = LoginSchema().bind(request=pyramid_request)
 
         with pytest.raises(BadCSRFToken):

--- a/tests/h/schemas/forms/accounts/reset_password_test.py
+++ b/tests/h/schemas/forms/accounts/reset_password_test.py
@@ -83,9 +83,7 @@ class TestResetPasswordSchemaDeserialize:
         )
         assert appstruct["user"] == user
 
-    def test_it_is_invalid_if_user_has_already_reset_their_password(
-        self, schema, serializer, user
-    ):
+    def test_it_is_invalid_if_user_has_already_reset_their_password(self, schema, user):
         # This situation triggers if the users password has been used since
         # the token was issued. Note our DB dates are not timezone aware.
         user.password_updated = datetime.now() + timedelta(days=1)
@@ -101,7 +99,9 @@ class TestResetPasswordSchemaDeserialize:
         return ResetPasswordSchema().bind(request=pyramid_csrf_request)
 
     @pytest.fixture(autouse=True)
-    def serializer(self, pyramid_csrf_request, pyramid_config):
+    def serializer(
+        self, pyramid_csrf_request, pyramid_config
+    ):  # pylint:disable=unused-argument
         # We must be after `pyramid_config` in the queue, as it replaces the
         # registry object with another one which undoes our changes here
 

--- a/tests/h/schemas/forms/admin/group_test.py
+++ b/tests/h/schemas/forms/admin/group_test.py
@@ -171,7 +171,7 @@ class TestAdminGroupSchema:
 
 
 @pytest.fixture
-def group_data(factories, org):
+def group_data(org):
     """
     Return a serialized representation of the "Create Group" form.
 
@@ -192,7 +192,7 @@ def group_data(factories, org):
 
 @pytest.fixture
 def user_service(user_service, factories):
-    def fetch(username, authority):
+    def fetch(username, authority):  # pylint: disable=unused-argument
         if "invalid" in username:
             return False
 

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -46,7 +46,9 @@ def index_annotations(es_client, search_index):
 
 
 @pytest.fixture
-def search_index(es_client, pyramid_request, moderation_service):
+def search_index(  # pylint:disable=unused-argument
+    es_client, pyramid_request, moderation_service
+):
     return SearchIndexService(
         pyramid_request,
         es_client,

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -84,7 +84,7 @@ class TestBatchIndexer:
         assert num_index_records == num_annotations // window_size
 
     def test_it_correctly_indexes_fields_for_bulk_actions(
-        self, batch_indexer, es_client, factories, get_indexed_ann
+        self, batch_indexer, factories, get_indexed_ann
     ):
         annotations = factories.Annotation.create_batch(2, groupid="group_a")
 
@@ -141,7 +141,9 @@ class TestBatchIndexer:
 
 
 @pytest.fixture
-def batch_indexer(db_session, es_client, pyramid_request, moderation_service):
+def batch_indexer(  # pylint:disable=unused-argument
+    db_session, es_client, pyramid_request, moderation_service
+):
     return BatchIndexer(db_session, es_client, pyramid_request)
 
 

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -53,7 +53,7 @@ class TestLimiter:
             ("9801", OFFSET_MAX),
         ],
     )
-    def test_offset(self, es_dsl_search, pyramid_request, offset, from_):
+    def test_offset(self, es_dsl_search, offset, from_):
         limiter = query.Limiter()
 
         params = webob.multidict.MultiDict({"offset": offset})
@@ -76,9 +76,7 @@ class TestLimiter:
             (1.5, 1),
         ],
     )
-    def test_limit_output_within_bounds(
-        self, es_dsl_search, pyramid_request, limit, expected
-    ):
+    def test_limit_output_within_bounds(self, es_dsl_search, limit, expected):
         """Given any string input, output should be in the allowed range."""
         limiter = query.Limiter()
 
@@ -89,7 +87,7 @@ class TestLimiter:
         assert isinstance(q["size"], int)
         assert q["size"] == expected
 
-    def test_limit_set_to_default_when_missing(self, es_dsl_search, pyramid_request):
+    def test_limit_set_to_default_when_missing(self, es_dsl_search):
         limiter = query.Limiter()
 
         q = limiter(es_dsl_search, webob.multidict.MultiDict({})).to_dict()
@@ -180,9 +178,7 @@ class TestSorter:
         actual_order = [ann_ids.index(id_) for id_ in result.annotation_ids]
         assert actual_order == expected_order
 
-    def test_incomplete_date_defaults_to_min_datetime_values(
-        self, es_dsl_search, pyramid_request
-    ):
+    def test_incomplete_date_defaults_to_min_datetime_values(self, es_dsl_search):
         sorter = query.Sorter()
 
         params = {"search_after": "2018"}
@@ -652,9 +648,7 @@ class TestUriCombinedWildcardFilter:
 
 
 class TestDeletedFilter:
-    def test_excludes_deleted_annotations(
-        self, search, es_client, Annotation, search_index
-    ):
+    def test_excludes_deleted_annotations(self, search, Annotation, search_index):
         deleted_ids = [Annotation(deleted=True).id]
         not_deleted_ids = [Annotation(deleted=False).id]
 
@@ -688,16 +682,8 @@ class TestHiddenFilter:
         else:
             assert result.annotation_ids == [annotation.id]
 
-    @pytest.mark.usefixtures("as_banned_user")
-    def test_visibility_annotations_to_self(
-        self,
-        pyramid_request,
-        search,
-        banned_user,
-        make_annotation,
-        is_nipsaed,
-        is_hidden,
-    ):
+    @pytest.mark.usefixtures("as_banned_user", "is_nipsaed", "is_hidden")
+    def test_visibility_annotations_to_self(self, search, banned_user, make_annotation):
         annotation = make_annotation(banned_user)
 
         result = search.run({})
@@ -746,7 +732,7 @@ class TestHiddenFilter:
         return search
 
     @pytest.fixture
-    def user(self, factories, pyramid_request):
+    def user(self, factories):
         return factories.User(username="notbanned")
 
     @pytest.fixture
@@ -1026,7 +1012,7 @@ class TestUsersAggregation:
 
 
 @pytest.fixture
-def search(pyramid_request, group_service):
+def search(pyramid_request, group_service):  # pylint:disable=unused-argument
     search = Search(pyramid_request)
     # Remove all default modifiers and aggregators except Sorter.
     search.clear()

--- a/tests/h/security/test_acl.py
+++ b/tests/h/security/test_acl.py
@@ -223,10 +223,10 @@ class TestACLForGroup:
             ["client_authority:DIFFERENT_AUTHORITY"], Permission.Group.ADMIN
         )
 
-    def test_staff_user_has_admin_permission_on_any_group(self, group, group_permits):
+    def test_staff_user_has_admin_permission_on_any_group(self, group_permits):
         assert group_permits([Role.STAFF], Permission.Group.ADMIN)
 
-    def test_admin_user_has_admin_permission_on_any_group(self, group, group_permits):
+    def test_admin_user_has_admin_permission_on_any_group(self, group_permits):
         assert group_permits([Role.ADMIN], Permission.Group.ADMIN)
 
     @pytest.mark.parametrize("readable_by", (ReadableBy.members, ReadableBy.world))
@@ -249,7 +249,7 @@ class TestACLForGroup:
         assert not permitted_principals_for(Permission.Group.MODERATE)
         assert not permitted_principals_for(Permission.Group.UPSERT)
 
-    def test_fallback_is_deny_all(self, group, group_permits):
+    def test_fallback_is_deny_all(self, group_permits):
         assert not group_permits([security.Everyone], "non_existant_permission")
 
     @pytest.fixture
@@ -340,7 +340,7 @@ class TestACLForAnnotation:
         for_group.assert_called_with(group)
 
     def test_it_mirrors_group_permissions_for_shared_deleted_annotations(
-        self, annotation, group, for_group, anno_permits
+        self, annotation, for_group, anno_permits
     ):
         annotation.shared = True
         annotation.deleted = True
@@ -348,7 +348,7 @@ class TestACLForAnnotation:
 
         anno_permits(["principal"], Permission.Annotation.READ_REALTIME_UPDATES)
 
-    def test_it_with_a_shared_annotation_with_no_group(self, annotation, anno_permits):
+    def test_it_with_a_shared_annotation_with_no_group(self, annotation):
         annotation.shared = True
         annotation.group = None
 

--- a/tests/h/services/annotation_delete_test.py
+++ b/tests/h/services/annotation_delete_test.py
@@ -7,25 +7,19 @@ from h.services.annotation_delete import annotation_delete_service_factory
 
 
 class TestAnnotationDeleteService:
-    def test_it_marks_the_annotation_as_deleted(
-        self, svc, pyramid_request, factories, annotation
-    ):
+    def test_it_marks_the_annotation_as_deleted(self, svc, annotation):
         ann = annotation()
         svc.delete(ann)
 
         assert ann.deleted
 
-    def test_it_updates_the_updated_field(
-        self, svc, pyramid_request, factories, annotation, datetime
-    ):
+    def test_it_updates_the_updated_field(self, svc, annotation, datetime):
         ann = annotation()
         svc.delete(ann)
 
         assert ann.updated == datetime.utcnow.return_value
 
-    def test_it_publishes_a_delete_event(
-        self, svc, pyramid_request, factories, annotation
-    ):
+    def test_it_publishes_a_delete_event(self, svc, pyramid_request, annotation):
         ann = annotation()
         svc.delete(ann)
 
@@ -37,9 +31,7 @@ class TestAnnotationDeleteService:
             expected_event.action,
         ) == (actual_event.request, actual_event.annotation_id, actual_event.action)
 
-    def test_it_deletes_all_annotations(
-        self, svc, pyramid_request, factories, annotation
-    ):
+    def test_it_deletes_all_annotations(self, svc, annotation):
         svc.delete = mock.create_autospec(svc.delete, spec_set=True)
 
         anns = [annotation(), annotation()]

--- a/tests/h/services/annotation_json_presentation_test/service_test.py
+++ b/tests/h/services/annotation_json_presentation_test/service_test.py
@@ -86,7 +86,6 @@ class TestAnnotationJSONPresentationService:
         self,
         svc,
         user,
-        factories,
         annotation,
         AnnotationJSONPresenter,
         flag_service,

--- a/tests/h/services/bulk_executor/_actions_test.py
+++ b/tests/h/services/bulk_executor/_actions_test.py
@@ -319,7 +319,7 @@ class TestBulkGroupMembershipCreate:
         assert memberships == expected_memberships
 
     @pytest.fixture
-    def commands(self, db_session, user, groups):
+    def commands(self, user, groups):
         return [group_membership_create(user.id, group.id) for group in groups]
 
     @pytest.fixture

--- a/tests/h/services/bulk_executor/_executor_test.py
+++ b/tests/h/services/bulk_executor/_executor_test.py
@@ -103,9 +103,7 @@ class TestDBExecutor:
 
         assert executor.effective_user_id == user.id
 
-    def test_configure_raises_if_the_effective_user_does_not_exist(
-        self, executor, user
-    ):
+    def test_configure_raises_if_the_effective_user_does_not_exist(self, executor):
         with pytest.raises(InvalidDeclarationError):
             executor.configure(
                 Configuration.create(

--- a/tests/h/services/delete_group_test.py
+++ b/tests/h/services/delete_group_test.py
@@ -12,7 +12,7 @@ from h.services.delete_group import (
 
 @pytest.mark.usefixtures("annotation_delete_service")
 class TestDeleteGroupService:
-    def test_it_does_not_delete_public_group(self, svc, db_session, factories):
+    def test_it_does_not_delete_public_group(self, svc, factories):
         group = factories.Group()
         group.pubid = "__world__"
 
@@ -26,9 +26,7 @@ class TestDeleteGroupService:
 
         assert group in db_session.deleted
 
-    def test_it_deletes_annotations(
-        self, svc, factories, pyramid_request, annotation_delete_service
-    ):
+    def test_it_deletes_annotations(self, svc, factories, annotation_delete_service):
         group = factories.Group()
         annotations = [
             factories.Annotation(groupid=group.pubid).id,

--- a/tests/h/services/delete_user_test.py
+++ b/tests/h/services/delete_user_test.py
@@ -18,7 +18,7 @@ class TestDeleteUserService:
         assert user.groups == []
 
     def test_delete_deletes_annotations(
-        self, factories, pyramid_request, svc, annotation_delete_service
+        self, factories, svc, annotation_delete_service
     ):
         user = factories.User(username="bob")
         anns = [
@@ -32,7 +32,7 @@ class TestDeleteUserService:
             [mock.call(anns[0]), mock.call(anns[1])], any_order=True
         )
 
-    def test_delete_deletes_user(self, db_session, factories, pyramid_request, svc):
+    def test_delete_deletes_user(self, db_session, factories, svc):
         user = factories.User()
 
         svc.delete(user)

--- a/tests/h/services/developer_token_test.py
+++ b/tests/h/services/developer_token_test.py
@@ -53,7 +53,7 @@ class TestDeveloperTokenService:
         return factories.DeveloperToken(userid=userid)
 
     @pytest.fixture
-    def userid(self, factories):
+    def userid(self):
         return "acct:john@doe.org"
 
 

--- a/tests/h/services/document_test.py
+++ b/tests/h/services/document_test.py
@@ -15,15 +15,13 @@ class TestFetchByGroupid:
         )
 
     def test_it_does_not_return_documents_annotated_in_other_groups(
-        self, groups, annotations, other_annotations, svc
+        self, groups, other_annotations, svc
     ):
         docs = svc.fetch_by_groupid(groupid=groups["target_group"].pubid)
         for other_anno in other_annotations:
             assert other_anno.document not in docs
 
-    def test_it_returns_each_document_only_once(
-        self, svc, groups, annotations, db_session
-    ):
+    def test_it_returns_each_document_only_once(self, svc, groups, annotations):
         # This will make both annotations point to the same document
         annotations[1].document = annotations[0].document
         annotations[2].document = annotations[0].document
@@ -33,7 +31,7 @@ class TestFetchByGroupid:
         assert docs == [annotations[0].document]
 
     def test_it_returns_only_documents_with_shared_annotations_when_no_user(
-        self, annotations, groups, svc, db_session
+        self, annotations, groups, svc
     ):
         annotations[1].shared = False
         annotations[2].shared = False
@@ -43,7 +41,7 @@ class TestFetchByGroupid:
         assert docs == [annotations[0].document]
 
     def test_it_returns_only_documents_with_visible_annotations_for_user(
-        self, svc, annotations, groups, target_user, other_user, db_session
+        self, svc, annotations, groups, target_user, other_user
     ):
         # This makes an "only me" annotation, associated with our target user
         annotations[1].shared = False
@@ -67,7 +65,7 @@ class TestFetchByGroupid:
         )
 
     def test_it_returns_documents_ordered_by_last_activity_desc(
-        self, svc, annotations, groups, factories, db_session
+        self, svc, annotations, groups, factories
     ):
         # Update the document associated with ``annotations[1]``...
         annotations[1].document.title = "Bleep bloop"

--- a/tests/h/services/group_create_test.py
+++ b/tests/h/services/group_create_test.py
@@ -230,7 +230,7 @@ class TestCreateOpenGroup:
             == Any.list.containing([GroupScopeWithOrigin(h) for h in origins]).only()
         )
 
-    def test_it_always_creates_new_scopes(self, db_session, factories, svc, creator):
+    def test_it_always_creates_new_scopes(self, factories, svc, creator):
         # It always creates a new scope, even if a scope with the given origin
         # already exists (this is because a single scope can only belong to
         # one group, so the existing scope can't be reused with the new group).
@@ -378,7 +378,7 @@ class TestCreateRestrictedGroup:
         )
 
     def test_it_with_mismatched_authorities_raises_value_error(
-        self, db_session, svc, origins, creator, factories
+        self, svc, origins, creator, factories
     ):
         org = factories.Organization(name="My organization", authority="bar.com")
         with pytest.raises(ValueError):
@@ -390,7 +390,7 @@ class TestCreateRestrictedGroup:
                 organization=org,
             )
 
-    def test_it_always_creates_new_scopes(self, db_session, factories, svc, creator):
+    def test_it_always_creates_new_scopes(self, factories, svc, creator):
         # It always creates a new scope, even if a scope with the given origin
         # already exists (this is because a single scope can only belong to
         # one group, so the existing scope can't be reused with the new group).
@@ -443,7 +443,7 @@ class TestGroupCreateFactory:
 
 
 @pytest.fixture
-def usr_svc(pyramid_request, db_session):
+def usr_svc(db_session):
     def fetch(userid):
         # One doesn't want to couple to the user fetching service but
         # we do want to be able to fetch user models for internal

--- a/tests/h/services/group_links_test.py
+++ b/tests/h/services/group_links_test.py
@@ -14,7 +14,7 @@ class TestGroupLinks:
         assert "html" in links
 
     def test_it_returns_no_activity_link_for_non_default_authority_group(
-        self, pyramid_request, factories, svc
+        self, factories, svc
     ):
         group = factories.OpenGroup(authority="foo.com")
         links = svc.get_all(group)
@@ -42,7 +42,7 @@ def routes(pyramid_config):
 
 
 @pytest.fixture
-def svc(pyramid_request, db_session):
+def svc(pyramid_request):
     return GroupLinksService(
         default_authority=pyramid_request.default_authority,
         route_url=pyramid_request.route_url,

--- a/tests/h/services/group_list_test.py
+++ b/tests/h/services/group_list_test.py
@@ -26,7 +26,7 @@ class TestListGroupsSessionGroups:
 
 
 class TestAssociatedGroups:
-    def test_it_does_not_return_world_group(self, svc, sample_groups, user):
+    def test_it_does_not_return_world_group(self, svc, user):
         groups = svc.associated_groups(user)
 
         assert "__world__" not in [group.pubid for group in groups]
@@ -70,7 +70,7 @@ class TestAssociatedGroups:
 
         assert private_group not in groups
 
-    def test_it_returns_empty_list_if_user_is_None(self, svc, sample_groups):
+    def test_it_returns_empty_list_if_user_is_None(self, svc):
         groups = svc.associated_groups(user=None)
 
         assert groups == []
@@ -90,7 +90,7 @@ class TestAssociatedGroups:
 
 
 class TestListGroupsRequestGroups:
-    def test_it_returns_world_group(self, svc, default_authority, sample_groups):
+    def test_it_returns_world_group(self, svc, default_authority):
         groups = svc.request_groups(authority=default_authority)
 
         assert "__world__" in [group.pubid for group in groups]
@@ -107,7 +107,7 @@ class TestListGroupsRequestGroups:
         assert "__world__" not in [group.pubid for group in groups]
 
     def test_it_returns_scoped_groups_for_authority_and_document_uri(
-        self, svc, group_scope_service, default_authority, document_uri, sample_groups
+        self, svc, default_authority, document_uri, sample_groups
     ):
         groups = svc.request_groups(
             authority=default_authority, document_uri=document_uri
@@ -215,7 +215,7 @@ class TestScopedGroups:
         group_scope_service.fetch_by_scope.assert_called_once_with(document_uri)
 
     def test_it_returns_empty_list_if_no_matching_scopes(
-        self, svc, default_authority, document_uri, sample_groups, group_scope_service
+        self, svc, default_authority, document_uri, group_scope_service
     ):
         group_scope_service.fetch_by_scope.return_value = []
 
@@ -275,13 +275,14 @@ class TestWorldGroup:
         assert w_group is None
 
 
+@pytest.mark.usefixtures("group_scope_service")
 class TestGroupListFactory:
-    def test_group_list_factory(self, pyramid_request, group_scope_service):
+    def test_group_list_factory(self, pyramid_request):
         svc = group_list_factory(None, pyramid_request)
 
         assert isinstance(svc, GroupListService)
 
-    def test_uses_request_default_authority(self, pyramid_request, group_scope_service):
+    def test_uses_request_default_authority(self, pyramid_request):
         pyramid_request.default_authority = "bar.com"
 
         svc = group_list_factory(None, pyramid_request)

--- a/tests/h/services/group_members_test.py
+++ b/tests/h/services/group_members_test.py
@@ -197,7 +197,7 @@ class TestFactory:
 
 
 @pytest.fixture
-def usr_group_members_service(pyramid_request, db_session):
+def usr_group_members_service(db_session):
     def fetch(userid):
         # One doesn't want to couple to the user fetching service but
         # we do want to be able to fetch user models for internal

--- a/tests/h/services/group_scope_test.py
+++ b/tests/h/services/group_scope_test.py
@@ -24,7 +24,8 @@ class TestFetchByScope:
         assert scope_util.url_in_scope.call_count == len(sample_scopes)
         assert scopes == []
 
-    def test_it_returns_list_of_matching_scopes(self, svc, document_uri, sample_scopes):
+    @pytest.mark.usefixtures("sample_scopes")
+    def test_it_returns_list_of_matching_scopes(self, svc, document_uri):
         results = svc.fetch_by_scope(document_uri)
 
         matching_scope_scopes = [scope.scope for scope in results]

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -197,7 +197,7 @@ class TestGroupsFactory:
 
 
 @pytest.fixture
-def usr_svc(pyramid_request, db_session):
+def usr_svc(db_session):
     def fetch(userid):
         # One doesn't want to couple to the user fetching service but
         # we do want to be able to fetch user models for internal

--- a/tests/h/services/group_update_test.py
+++ b/tests/h/services/group_update_test.py
@@ -25,7 +25,7 @@ class TestGroupUpdate:
 
         assert updated_group == group
 
-    def test_it_accepts_scope_relations(self, factories, svc, db_session):
+    def test_it_accepts_scope_relations(self, factories, svc):
         group = factories.Group()
         scopes = [factories.GroupScope(), factories.GroupScope()]
         data = {"name": "whatnot", "scopes": scopes}
@@ -34,7 +34,7 @@ class TestGroupUpdate:
 
         assert updated_group.scopes == scopes
 
-    def test_it_replaces_scope_relations(self, factories, svc, db_session):
+    def test_it_replaces_scope_relations(self, factories, svc):
         group = factories.Group(scopes=[factories.GroupScope()])
         updated_scopes = [factories.GroupScope(), factories.GroupScope()]
         data = {"name": "whatnot", "scopes": updated_scopes}
@@ -54,7 +54,7 @@ class TestGroupUpdate:
         assert updated_group.some_random_field == "whatever"
 
     def test_it_raises_ValidationError_if_name_fails_model_validation(
-        self, factories, svc, db_session
+        self, factories, svc
     ):
         group = factories.Group()
 
@@ -62,7 +62,7 @@ class TestGroupUpdate:
             svc.update(group, name="ye")
 
     def test_it_raises_ValidationError_if_authority_provided_id_fails_model_validation(
-        self, factories, svc, db_session
+        self, factories, svc
     ):
         group = factories.Group()
 
@@ -73,7 +73,7 @@ class TestGroupUpdate:
             svc.update(group, authority_provided_id="%%^&#*")
 
     def test_it_raises_ConflictError_on_provided_id_uniqueness_violation(
-        self, factories, svc, db_session
+        self, factories, svc
     ):
         factories.Group(authority_provided_id="foo", authority="foo.com")
         group2 = factories.Group(authority_provided_id="bar", authority="foo.com")

--- a/tests/h/services/list_organizations_test.py
+++ b/tests/h/services/list_organizations_test.py
@@ -9,9 +9,7 @@ from h.services.list_organizations import (
 class TestListOrganizations:
     ALT_AUTHORITY = "bar.com"
 
-    def test_returns_all_organizations_if_no_authority_specified(
-        self, svc, organizations, alt_organizations
-    ):
+    def test_returns_all_organizations_if_no_authority_specified(self, svc):
         results = svc.organizations()
 
         names = [org.name for org in results]
@@ -19,9 +17,7 @@ class TestListOrganizations:
         # The "Hypothesis" here is from the default org added by DB init
         assert names == ["Hypothesis", "alt_org_1", "alt_org_2", "org_1", "org_2"]
 
-    def test_returns_organizations_for_the_authority_specified(
-        self, svc, alt_organizations
-    ):
+    def test_returns_organizations_for_the_authority_specified(self, svc):
         results = svc.organizations(authority=self.ALT_AUTHORITY)
 
         names = [org.name for org in results]

--- a/tests/h/services/nipsa_test.py
+++ b/tests/h/services/nipsa_test.py
@@ -10,7 +10,7 @@ class TestNipsaService:
             "acct:flagged_user_2@example.com",
         }
 
-    def test_is_flagged_returns_true_for_flagged_users(self, svc, users):
+    def test_is_flagged_returns_true_for_flagged_users(self, svc):
         assert svc.is_flagged("acct:flagged_user@example.com")
 
     def test_is_flagged_returns_false_for_unflagged_users(self, svc):

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -36,7 +36,7 @@ class TestAuthenticateClient:
         assert oauth_request.client.authclient == client
 
     def test_returns_False_for_missing_client_id_request_param(
-        self, svc, client, oauth_request
+        self, svc, oauth_request
     ):
         assert not svc.authenticate_client(oauth_request)
 
@@ -93,7 +93,7 @@ class TestClientAuthenticationRequired:
         assert not svc.client_authentication_required(oauth_request)
 
     def test_returns_False_for_refresh_token_with_jwt_client(
-        self, svc, oauth_request, factories, client
+        self, svc, oauth_request, client
     ):
         oauth_request.client_id = client.id
         oauth_request.grant_type = "refresh_token"
@@ -181,7 +181,7 @@ class TestFindClient:
     def test_returns_none_for_invalid_client_id(self, svc):
         assert svc.find_client("bogus") is None
 
-    def test_returns_none_when_not_found(self, svc, client):
+    def test_returns_none_when_not_found(self, svc):
         id_ = str(uuid.uuid1())
         assert svc.find_client(id_) is None
 
@@ -275,7 +275,7 @@ class TestFindToken:
 
         assert token.value == token.value
 
-    def test_it_returns_None_when_token_is_missing(self, svc, token):
+    def test_it_returns_None_when_token_is_missing(self, svc):
         result = svc.find_token("missing-value")
 
         assert result is None
@@ -645,7 +645,7 @@ class TestValidateRefreshToken:
     def test_sets_user_when_token_valid(
         self, svc, client, oauth_request, token, user_service
     ):
-        def fake_fetch(userid, authority=None):
+        def fake_fetch(userid, authority=None):  # pylint:disable=unused-argument
             if userid == token.userid:
                 return mock.Mock(userid=userid)
             return None

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -65,7 +65,7 @@ class TestRenameUserService:
         )
         assert not count
 
-    def test_rename_updates_tokens(self, service, user, db_session, factories):
+    def test_rename_updates_tokens(self, service, user, db_session):
         token = models.Token(userid=user.userid, value="foo")
         db_session.add(token)
 
@@ -76,17 +76,16 @@ class TestRenameUserService:
         )
         assert updated_token.userid == user.userid
 
+    @pytest.mark.usefixtures("annotations")
     def test_rename_changes_the_users_annotations_userid(
-        self, service, user, annotations, db_session
+        self, service, user, db_session
     ):
         service.rename(user, "panda")
 
         userids = [ann.userid for ann in db_session.query(models.Annotation)]
         assert {user.userid} == set(userids)
 
-    def test_rename_reindexes_the_users_annotations(
-        self, service, user, annotations, search_index
-    ):
+    def test_rename_reindexes_the_users_annotations(self, service, user, search_index):
         original_userid = user.userid
 
         service.rename(user, "panda")
@@ -112,7 +111,7 @@ class TestRenameUserService:
         return user
 
     @pytest.fixture
-    def annotations(self, user, factories, db_session, pyramid_request):
+    def annotations(self, user, factories, db_session):
         anns = []
         for _ in range(8):
             anns.append(factories.Annotation(userid=user.userid))

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -394,7 +394,7 @@ class TestSync:
     @pytest.fixture
     def search_index(
         self, es_client, pyramid_request, moderation_service, nipsa_service
-    ):
+    ):  # pylint:disable=unused-argument
         return SearchIndexService(
             pyramid_request,
             es_client,

--- a/tests/h/services/settings_test.py
+++ b/tests/h/services/settings_test.py
@@ -40,7 +40,7 @@ class TestSettingsService:
 
         assert db_session.query(Setting).get(setting.key) is None
 
-    def test_delete_is_noop_when_setting_missing(self, db_session, svc, factories):
+    def test_delete_is_noop_when_setting_missing(self, svc, factories):
         # create a random setting
         factories.Setting()
 

--- a/tests/h/services/user_signup_test.py
+++ b/tests/h/services/user_signup_test.py
@@ -76,7 +76,7 @@ class TestUserSignupService:
 
         assert len(user.identities) == 2
 
-    def test_signup_raises_with_invalid_identities(self, svc, db_session):
+    def test_signup_raises_with_invalid_identities(self, svc):
         dupe_identity = {"provider": "a", "provider_unique_id": 1}
         with pytest.raises(
             IntegrityError, match="violates unique constraint.*identity"
@@ -126,7 +126,7 @@ class TestUserSignupService:
         assert sub.active
 
     def test_signup_logs_conflict_error_when_account_with_email_already_exists(
-        self, svc, db_session, patch
+        self, svc, patch
     ):
         log = patch("h.services.user_signup.log")
 
@@ -153,7 +153,7 @@ class TestUserSignupService:
         ],
     )
     def test_signup_raises_conflict_error_when_account_already_exists(
-        self, svc, db_session, username, email
+        self, svc, username, email
     ):
         # This happens when two or more identical
         # concurrent signup requests race each other to the db.
@@ -230,7 +230,7 @@ class TestUserSignupServiceFactory:
 def user_password_service(pyramid_config):
     service = mock.Mock(spec_set=UserPasswordService())
 
-    def password_setter(user, password):
+    def password_setter(user, password):  # pylint:disable=unused-argument
         user.password = "fakehash"
 
     service.update_password.side_effect = password_setter

--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -51,7 +51,7 @@ class TestUserService:
         assert svc.fetch_by_identity("provider_a", "123") is freddo
         assert svc.fetch_by_identity("provider_b", "456") is freddo
 
-    def test_fetch_by_identity_returns_none_if_no_match(self, svc, users):
+    def test_fetch_by_identity_returns_none_if_no_match(self, svc):
         assert svc.fetch_by_identity("nonsense", "abc") is None
 
     def test_fetch_for_login_by_username(self, svc, users):
@@ -73,7 +73,7 @@ class TestUserService:
         with pytest.raises(UserNotActivated):
             svc.fetch_for_login("mirthe")
 
-    def test_fetch_for_login_by_email_not_activated(self, svc, users):
+    def test_fetch_for_login_by_email_not_activated(self, svc):
         with pytest.raises(UserNotActivated):
             svc.fetch_for_login("mirthe@deboer.com")
 
@@ -111,7 +111,7 @@ class TestUserService:
 
         # We need to capture the inline `clear_cache` function so we can
         # call it manually later
-        def on_transaction_end_decorator(session):
+        def on_transaction_end_decorator(session):  # pylint:disable=unused-argument
             def on_transaction_end(func):
                 funcs["clear_cache"] = func
 

--- a/tests/h/services/user_unique_test.py
+++ b/tests/h/services/user_unique_test.py
@@ -40,9 +40,7 @@ class TestUserUniqueEnsureUnique:
     def test_it_allows_duplicate_username_at_different_authority(self, svc, user):
         svc.ensure_unique({"username": user.username}, authority="foo.com")
 
-    def test_it_raises_if_identities_uniqueness_violated(
-        self, svc, user, pyramid_request
-    ):
+    def test_it_raises_if_identities_uniqueness_violated(self, svc, pyramid_request):
         dupe_identity = {"provider": "provider_a", "provider_unique_id": "123"}
 
         with pytest.raises(
@@ -55,7 +53,7 @@ class TestUserUniqueEnsureUnique:
             )
 
     def test_it_raises_if_identities_uniqueness_violated_at_different_authority(
-        self, svc, user
+        self, svc
     ):
         # note that this is different from email and username behavior
         dupe_identity = {"provider": "provider_a", "provider_unique_id": "123"}
@@ -108,14 +106,14 @@ class TestUserUniqueEnsureUnique:
         )
 
     def test_it_does_not_fetch_by_username_if_not_present(
-        self, svc, user_model, db_session, pyramid_request
+        self, svc, user_model, pyramid_request
     ):
         svc.ensure_unique({"email": "foo@bar.com"}, pyramid_request.default_authority)
 
         user_model.get_by_username.assert_not_called()
 
     def test_it_does_not_fetch_by_email_if_not_present(
-        self, svc, user_model, db_session, pyramid_request
+        self, svc, user_model, pyramid_request
     ):
         svc.ensure_unique({"username": "doodle"}, pyramid_request.default_authority)
 

--- a/tests/h/services/user_update_test.py
+++ b/tests/h/services/user_update_test.py
@@ -36,7 +36,7 @@ class TestUserUpdate:
         assert updated_user.some_random_field == "whatever"
 
     def test_it_raises_ValidationError_if_authority_present_in_kwargs(
-        self, factories, svc, db_session
+        self, factories, svc
     ):
         user = factories.User()
 
@@ -46,7 +46,7 @@ class TestUserUpdate:
             svc.update(user, authority="something.com")
 
     def test_it_raises_ValidationError_if_email_fails_model_validation(
-        self, factories, svc, db_session
+        self, factories, svc
     ):
         user = factories.User()
 
@@ -56,7 +56,7 @@ class TestUserUpdate:
             svc.update(user, email="o" * 150)
 
     def test_it_raises_ValidationError_if_username_fails_model_validation(
-        self, factories, svc, db_session
+        self, factories, svc
     ):
         user = factories.User()
 
@@ -65,7 +65,7 @@ class TestUserUpdate:
         ):
             svc.update(user, username="lo")
 
-    def test_it_will_not_raise_on_malformed_email(self, factories, svc, db_session):
+    def test_it_will_not_raise_on_malformed_email(self, factories, svc):
         user = factories.User()
 
         # It's up to callers to validate email at this point
@@ -74,7 +74,7 @@ class TestUserUpdate:
         assert updated_user.email == "fingers"
 
     def test_it_raises_ConflictError_on_username_authority_uniqueness_violation(
-        self, factories, svc, db_session
+        self, factories, svc
     ):
         factories.User(username="user1", authority="baz.com")
         user2 = factories.User(username="user2", authority="baz.com")

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -194,7 +194,7 @@ class TestProfile:
 
         assert profile["authority"] == third_party_domain
 
-    def test_user_info_authenticated(self, authenticated_request, patch):
+    def test_user_info_authenticated(self, authenticated_request):
         profile = session.profile(authenticated_request)
         user_info = profile["user_info"]
         assert user_info["display_name"] == authenticated_request.user.display_name

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -192,7 +192,7 @@ class TestCreateAnnotation:
         assert annotation.group == parent_annotation.group
 
     def test_it_raises_if_parent_annotation_does_not_exist(
-        self, pyramid_request, annotation_data, other_group
+        self, pyramid_request, annotation_data
     ):
         annotation_data["references"] = ["MISSING_ID"]
 
@@ -355,13 +355,13 @@ class TestUpdateAnnotation:
 
 
 class TestValidateGroupScope:
-    def test_it_allows_matching_scopes(self, pyramid_request, scoped_group):
+    def test_it_allows_matching_scopes(self, scoped_group):
         storage._validate_group_scope(  # pylint:disable=protected-access
             scoped_group, "http://inscope.example.com"
         )
 
     def test_it_allows_mismatching_scopes_if_a_group_has_no_scopes(
-        self, pyramid_request, scoped_group, url_in_scope
+        self, scoped_group, url_in_scope
     ):
         scoped_group.scopes = []
 
@@ -372,7 +372,7 @@ class TestValidateGroupScope:
         url_in_scope.assert_not_called()
 
     def test_it_allows_mismatching_scopes_if_enforce_is_False(
-        self, pyramid_request, scoped_group, url_in_scope
+        self, scoped_group, url_in_scope
     ):
         scoped_group.enforce_scope = False
 
@@ -382,9 +382,7 @@ class TestValidateGroupScope:
 
         url_in_scope.assert_not_called()
 
-    def test_it_catches_mismatching_scopes(
-        self, pyramid_request, scoped_group, url_in_scope
-    ):
+    def test_it_catches_mismatching_scopes(self, scoped_group, url_in_scope):
         url_in_scope.return_value = False
 
         with pytest.raises(ValidationError):
@@ -405,7 +403,7 @@ class TestValidateGroupScope:
 
 
 @pytest.fixture
-def group(factories, db_session):
+def group(factories):
     # Set an authority_provided_id so our group_id is not None
     return factories.OpenGroup(authority_provided_id="group_auth_id")
 

--- a/tests/h/streamer/app_test.py
+++ b/tests/h/streamer/app_test.py
@@ -8,7 +8,8 @@ from h.streamer.app import create_app
 
 
 class TestIncludeMe:
-    def test_it_configures_pyramid_sentry_plugin(self, configure, config):
+    @pytest.mark.usefixtures("configure")
+    def test_it_configures_pyramid_sentry_plugin(self, config):
         create_app(None)
 
         config.add_settings.assert_any_call(
@@ -18,8 +19,8 @@ class TestIncludeMe:
             }
         )
 
-    @pytest.mark.usefixtures("with_kill_switch_on")
-    def test_it_respects_the_kill_switch(self, configure, config):
+    @pytest.mark.usefixtures("with_kill_switch_on", "configure")
+    def test_it_respects_the_kill_switch(self, config):
         create_app(None)
 
         config.add_settings.assert_not_called()

--- a/tests/h/streamer/streamer_test.py
+++ b/tests/h/streamer/streamer_test.py
@@ -48,7 +48,7 @@ class TestProcessWorkQueue:
         assert context_manager.__exit__.call_count == len(messages)
 
     @pytest.fixture
-    def process_work_queue(self, session, registry, message):
+    def process_work_queue(self, registry, message):
         def process_work_queue(queue=None):
             return streamer.process_work_queue(registry, queue or [message])
 

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -119,7 +119,7 @@ class TestWebSocket:
         assert queue.empty()
 
     def test_invalid_incoming_message_closes_connection(
-        self, client, queue, fake_socket_close
+        self, client, fake_socket_close
     ):
         """Invalid messages should cause termination of the connection."""
         message = FakeMessage('{"foo":missingquotes}')

--- a/tests/h/traversal/annotation_test.py
+++ b/tests/h/traversal/annotation_test.py
@@ -18,7 +18,6 @@ class TestAnnotationRoot:
         pyramid_request,
         AnnotationContext,
         storage,
-        links_service,
     ):
         context = root[sentinel.annotation_id]
 

--- a/tests/h/traversal/user_test.py
+++ b/tests/h/traversal/user_test.py
@@ -64,7 +64,7 @@ class TestUserRoot:
 class TestUserByNameRoot:
     @pytest.mark.parametrize("returned_authority", (None, sentinel.client_authority))
     def test_it_fetches_the_requested_user(
-        self, pyramid_request, root, user_service, client_authority, returned_authority
+        self, pyramid_request, root, client_authority, returned_authority
     ):
         client_authority.return_value = returned_authority
 
@@ -92,7 +92,7 @@ class TestUserByNameRoot:
 
 @pytest.mark.usefixtures("user_service")
 class TestUserByIDRoot:
-    def test_it_fetches_the_requested_user(self, root, user_service):
+    def test_it_fetches_the_requested_user(self, root):
         context = root[sentinel.userid]
 
         root.get_user_context.assert_called_once_with(sentinel.userid, authority=None)

--- a/tests/h/tweens_test.py
+++ b/tests/h/tweens_test.py
@@ -38,7 +38,7 @@ class TestRedirectTween:
 
         assert response.status_code == 200
 
-    def test_it_redirects_for_redirected_routes(self, pyramid_request, pyramid_config):
+    def test_it_redirects_for_redirected_routes(self, pyramid_request):
         redirects = [
             Redirect(src="/foo", dst="http://bar", internal=False, prefix=False)
         ]

--- a/tests/h/util/db_test.py
+++ b/tests/h/util/db_test.py
@@ -12,7 +12,7 @@ class TestLRUCacheInTransaction:
         # cleared when the transaction ends.
 
         @lru_cache_in_transaction(db_session)
-        def random_float(*args, **kwargs):
+        def random_float(*args, **kwargs):  # pylint:disable=unused-argument
             return random.random()
 
         a = random_float("a")
@@ -35,7 +35,7 @@ class TestLRUCacheInTransaction:
         """The cache should not be cleared when a nested transaction ends."""
 
         @lru_cache_in_transaction(db_session)
-        def random_float(*args, **kwargs):
+        def random_float(*args, **kwargs):  # pylint:disable=unused-argument
             return random.random()
 
         a = random_float("a")

--- a/tests/h/util/session_tracker_test.py
+++ b/tests/h/util/session_tracker_test.py
@@ -14,8 +14,9 @@ def generate_ann_id():
 
 
 class TestTracker:
+    @pytest.mark.usefixtures("session")
     def test_uncommitted_changes_returns_unflushed_changes(
-        self, tracker, session, expected_changes
+        self, tracker, expected_changes
     ):
         added_entry, changed_entry, deleted_entry = expected_changes
 

--- a/tests/h/util/test_logging_filters.py
+++ b/tests/h/util/test_logging_filters.py
@@ -11,7 +11,7 @@ class TestExceptionFilter:
         with pytest.raises(ValueError):
             ExceptionFilter((("ReadTimeoutError", "WARNI"),))
 
-    def test_specify_level_as_int(self, logger):
+    def test_specify_level_as_int(self):
         ExceptionFilter((("ReadTimeoutError", logging.WARNING),))
 
     def test_does_not_log_specified_exceptions(self, logger, read_timeout_exception):

--- a/tests/h/views/account_signup_test.py
+++ b/tests/h/views/account_signup_test.py
@@ -55,16 +55,14 @@ class TestSignupController:
 
         assert not user_signup_service.signup.called
 
-    def test_post_displays_heading_and_message_on_success(
-        self, controller, pyramid_request
-    ):
+    def test_post_displays_heading_and_message_on_success(self, controller):
         result = controller.post()
 
         assert result["heading"] == "Account registration successful"
         assert "message" not in result
 
     def test_post_displays_heading_and_message_on_conflict_error(
-        self, controller, pyramid_request, user_signup_service
+        self, controller, user_signup_service
     ):
         user_signup_service.signup.side_effect = ConflictError(
             "The account bob@example.com is already registered."

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -255,7 +255,6 @@ class TestForgotPasswordController:
     def test_post_generates_mail(
         self,
         reset_password_email,
-        activation_model,
         factories,
         form_validating_to,
         pyramid_request,
@@ -271,7 +270,6 @@ class TestForgotPasswordController:
 
     def test_post_sends_mail(
         self,
-        reset_password_email,
         factories,
         form_validating_to,
         mailer,
@@ -335,7 +333,7 @@ class TestResetController:
         assert not result["has_code"]
 
     def test_get_with_prefilled_code_returns_rendered_form(
-        self, pyramid_request, ResetCode, form_validating_to
+        self, pyramid_request, form_validating_to
     ):
         pyramid_request.matchdict["code"] = "whatnot"
         controller = views.ResetController(pyramid_request)
@@ -411,7 +409,7 @@ class TestResetController:
         pyramid_config.add_route("account_reset", "/reset")
         pyramid_config.add_route("account_reset_with_code", "/reset-with-code")
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def ResetCode(self, patch):
         return patch("h.views.accounts.ResetCode")
 

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -20,7 +20,7 @@ class FakeForm:
 
 @pytest.mark.usefixtures("group_service")
 class TestIndex:
-    def test_it_paginates_results(self, pyramid_request, routes, paginate):
+    def test_it_paginates_results(self, pyramid_request, paginate):
         groups.groups_index(None, pyramid_request)
 
         paginate.assert_called_once_with(pyramid_request, Any(), Any())
@@ -61,11 +61,7 @@ class TestGroupCreateView:
         list_organizations_service.organizations.assert_called_with()
 
     def test_init_binds_schema_with_organizations(
-        self,
-        pyramid_request,
-        organization,
-        AdminGroupSchema,
-        list_organizations_service,
+        self, pyramid_request, organization, AdminGroupSchema
     ):
         GroupCreateViews(pyramid_request)
 
@@ -88,9 +84,11 @@ class TestGroupCreateView:
         )
 
     def test_post_redirects_to_list_view_on_success(
-        self, pyramid_request, matchers, routes, handle_form_submission, base_appstruct
+        self, pyramid_request, matchers, handle_form_submission, base_appstruct
     ):
-        def call_on_success(request, form, on_success, on_failure):
+        def call_on_success(  # pylint:disable=unused-argument
+            request, form, on_success, on_failure
+        ):
             return on_success(base_appstruct)
 
         handle_form_submission.side_effect = call_on_success
@@ -110,7 +108,9 @@ class TestGroupCreateView:
         user_service,
         base_appstruct,
     ):
-        def call_on_success(request, form, on_success, on_failure):
+        def call_on_success(  # pylint:disable=unused-argument
+            request, form, on_success, on_failure
+        ):
             base_appstruct["group_type"] = "open"
             return on_success(base_appstruct)
 
@@ -137,7 +137,9 @@ class TestGroupCreateView:
         user_service,
         base_appstruct,
     ):
-        def call_on_success(request, form, on_success, on_failure):
+        def call_on_success(  # pylint:disable=unused-argument
+            request, form, on_success, on_failure
+        ):
             base_appstruct["group_type"] = "restricted"
             return on_success(base_appstruct)
 
@@ -168,7 +170,9 @@ class TestGroupCreateView:
         user = factories.User()
         user_service.fetch.return_value = user
 
-        def call_on_success(request, form, on_success, on_failure):
+        def call_on_success(  # pylint:disable=unused-argument
+            request, form, on_success, on_failure
+        ):
             base_appstruct["members"] = ["someusername"]
             return on_success(base_appstruct)
 
@@ -278,7 +282,9 @@ class TestGroupEditViews:
 
         list_organizations_service.organizations.return_value.append(updated_org)
 
-        def call_on_success(request, form, on_success, on_failure):
+        def call_on_success(  # pylint:disable=unused-argument
+            request, form, on_success, on_failure
+        ):
             return on_success(
                 {
                     "creator": fetched_user.username,
@@ -315,7 +321,6 @@ class TestGroupEditViews:
         self,
         factories,
         pyramid_request,
-        group_create_service,
         user_service,
         group_members_service,
         handle_form_submission,
@@ -329,7 +334,9 @@ class TestGroupEditViews:
         fetched_user = factories.User()
         user_service.fetch.return_value = fetched_user
 
-        def call_on_success(request, form, on_success, on_failure):
+        def call_on_success(  # pylint:disable=unused-argument
+            request, form, on_success, on_failure
+        ):
             return on_success(
                 {
                     "authority": pyramid_request.default_authority,
@@ -353,9 +360,7 @@ class TestGroupEditViews:
             group, [fetched_user.userid, fetched_user.userid]
         )
 
-    def test_delete_deletes_group(
-        self, group, delete_group_service, pyramid_request, routes
-    ):
+    def test_delete_deletes_group(self, group, delete_group_service, pyramid_request):
         view = GroupEditViews(GroupContext(group), pyramid_request)
 
         view.delete()

--- a/tests/h/views/admin/mailer_test.py
+++ b/tests/h/views/admin/mailer_test.py
@@ -31,7 +31,7 @@ class TestMailerTest:
         assert isinstance(result, HTTPSeeOther)
         assert result.location == "/adm/mailer"
 
-    def test_sends_mail(self, mailer, pyramid_request, testmail):
+    def test_sends_mail(self, mailer, pyramid_request):
         pyramid_request.params["recipient"] = "meerkat@example.com"
 
         mailer_test(pyramid_request)
@@ -40,7 +40,7 @@ class TestMailerTest:
             ["meerkat@example.com"], "TEST", "text", "html"
         )
 
-    def test_redirects(self, mailer, pyramid_request, testmail):
+    def test_redirects(self, pyramid_request):
         pyramid_request.params["recipient"] = "meerkat@example.com"
 
         result = mailer_test(pyramid_request)

--- a/tests/h/views/admin/nipsa_test.py
+++ b/tests/h/views/admin/nipsa_test.py
@@ -33,7 +33,7 @@ class TestNipsaAddRemove:
         assert users["carl"] in nipsa_service.flagged
 
     @pytest.mark.parametrize("user", ["", "donkeys"])
-    def test_add_raises_when_user_not_found(self, user, nipsa_service, pyramid_request):
+    def test_add_raises_when_user_not_found(self, user, pyramid_request):
         pyramid_request.params = {"add": user, "authority": "example.com"}
 
         with pytest.raises(UserNotFoundError):
@@ -55,9 +55,7 @@ class TestNipsaAddRemove:
         assert users["kiki"] not in nipsa_service.flagged
 
     @pytest.mark.parametrize("user", ["", "donkeys", "\x00"])
-    def test_remove_raises_when_user_not_found(
-        self, user, nipsa_service, pyramid_request
-    ):
+    def test_remove_raises_when_user_not_found(self, user, pyramid_request):
         pyramid_request.params = {"remove": user}
 
         with pytest.raises(UserNotFoundError):

--- a/tests/h/views/admin/oauthclients_test.py
+++ b/tests/h/views/admin/oauthclients_test.py
@@ -33,7 +33,7 @@ class FakeForm:
         return self.appstruct
 
 
-def test_index_lists_authclients_sorted_by_name(pyramid_request, routes):
+def test_index_lists_authclients_sorted_by_name(pyramid_request):
     clients = [
         AuthClient(authority="foo.org", name="foo"),
         AuthClient(authority="foo.org", name="bar"),
@@ -216,7 +216,7 @@ class TestAuthClientEditController:
 
         pyramid_request.db.delete.assert_called_with(auth_client)
 
-    def test_delete_redirects_to_index(self, auth_client, matchers, pyramid_request):
+    def test_delete_redirects_to_index(self, matchers, pyramid_request):
         pyramid_request.db.delete = create_autospec(
             pyramid_request.db.delete, return_value=None
         )

--- a/tests/h/views/admin/search_test.py
+++ b/tests/h/views/admin/search_test.py
@@ -47,9 +47,7 @@ class TestSearchAdminViews:
             f"Began reindexing annotations by {user.userid}"
         ]
 
-    def test_reindex_user_errors_if_user_not_found(
-        self, views, pyramid_request, search_index
-    ):
+    def test_reindex_user_errors_if_user_not_found(self, views, pyramid_request):
         pyramid_request.params = {"username": "johnsmith"}
 
         with pytest.raises(NotFoundError, match="User johnsmith not found"):
@@ -75,7 +73,7 @@ class TestSearchAdminViews:
         ]
 
     def test_reindex_group_errors_if_group_not_found(
-        self, views, pyramid_request, search_index, group_service
+        self, views, pyramid_request, group_service
     ):
         pyramid_request.params = {"groupid": "def456"}
         group_service.fetch_by_pubid.return_value = None

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -107,7 +107,7 @@ def test_users_index_no_user_found(models, pyramid_request):
 
 
 @users_index_fixtures
-def test_users_index_user_found(models, pyramid_request, db_session, factories):
+def test_users_index_user_found(models, pyramid_request, factories):
     pyramid_request.params = {"username": "bob", "authority": "foo.org"}
     user = factories.User.build(username="bob", authority="foo.org")
     models.User.get_by_username.return_value = user

--- a/tests/h/views/api/auth_test.py
+++ b/tests/h/views/api/auth_test.py
@@ -95,8 +95,9 @@ class TestOAuthAuthorizeController:
             scopes=DEFAULT_SCOPES,
         )
 
+    @pytest.mark.usefixtures("authenticated_user")
     def test_get_returns_redirect_immediately_for_trusted_clients(
-        self, controller, auth_client, authenticated_user, pyramid_request
+        self, controller, auth_client
     ):
         auth_client.trusted = True
 
@@ -183,7 +184,7 @@ class TestOAuthAuthorizeController:
 
         assert response.location == expected
 
-    def test_post_web_message_returns_expected_context(self, controller, auth_client):
+    def test_post_web_message_returns_expected_context(self, controller):
         response = controller.post_web_message()
 
         assert response == {

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -134,7 +134,7 @@ class TestCreateGroup:
         )
 
     def test_it_raises_HTTPConflict_on_duplicate(
-        self, pyramid_request, CreateGroupAPISchema, group_service, factories
+        self, pyramid_request, group_service, factories
     ):
         # Return a different pre-existing group when we search by id
         group_service.fetch.return_value = factories.Group(
@@ -200,7 +200,7 @@ class TestUpdateGroup:
         )
 
     def test_it_raises_HTTPConflict_on_duplicate(
-        self, pyramid_request, UpdateGroupAPISchema, context, group_service, factories
+        self, pyramid_request, context, group_service, factories
     ):
         # Return a different pre-existing group when we search by id
         group_service.fetch.return_value = factories.Group(
@@ -211,7 +211,7 @@ class TestUpdateGroup:
             views.update(context, pyramid_request)
 
     def test_it_does_not_raise_HTTPConflict_if_duplicate_is_same_group(
-        self, pyramid_request, UpdateGroupAPISchema, context, group_service
+        self, pyramid_request, context, group_service
     ):
         group_service.fetch.return_value = context.group
 

--- a/tests/h/views/api/helpers/angular_test.py
+++ b/tests/h/views/api/helpers/angular_test.py
@@ -3,7 +3,7 @@ from h.views.api.helpers.angular import AngularRouteTemplater
 
 class TestAngularRouteTemplater:
     def test_static_route(self):
-        def route_url(route_name, **kwargs):
+        def route_url(route_name, **kwargs):  # pylint:disable=unused-argument
             return "/" + route_name
 
         templater = AngularRouteTemplater(route_url, params=[])

--- a/tests/h/views/api/helpers/cors_test.py
+++ b/tests/h/views/api/helpers/cors_test.py
@@ -229,7 +229,7 @@ class TestAddPreflightView:
 
 
 # A tiny WSGI application used for testing the middleware
-def wsgi_testapp(environ, start_response):
+def wsgi_testapp(environ, start_response):  # pylint:disable=unused-argument
     start_response("200 OK", [("Content-Type", "text/plain")])
     return ["OK"]
 

--- a/tests/h/views/api/helpers/links_test.py
+++ b/tests/h/views/api/helpers/links_test.py
@@ -88,7 +88,7 @@ class TestRegisterLink:
 #     return mock.create_autospec(AngularRouteTemplater, spec_set=True, instance=True)
 
 
-def _service_link(name="api.example_service"):
+def _service_link(name="api.example_service"):  # pylint:disable=unused-argument
     return links.ServiceLink(
         name="name",
         route_name="api.example_service",

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -118,7 +118,7 @@ class TestCreate:
 
         assert "nope" in str(exc.value)
 
-    def test_raises_for_invalid_json_body(self, pyramid_request, patch):
+    def test_raises_for_invalid_json_body(self, pyramid_request):
         type(pyramid_request).json_body = mock.PropertyMock(side_effect=ValueError())
 
         with pytest.raises(PayloadError):
@@ -184,7 +184,7 @@ class TestUpdate:
         assert result == TrustedUserJSONPresenter.return_value.asdict()
 
     def test_raises_when_schema_validation_fails(
-        self, context, pyramid_request, valid_payload, UpdateUserAPISchema
+        self, context, pyramid_request, UpdateUserAPISchema
     ):
         UpdateUserAPISchema.return_value.validate.side_effect = ValidationError(
             "validation failed"
@@ -193,7 +193,7 @@ class TestUpdate:
         with pytest.raises(ValidationError):
             update(context, pyramid_request)
 
-    def test_raises_for_invalid_json_body(self, context, pyramid_request, patch):
+    def test_raises_for_invalid_json_body(self, context, pyramid_request):
         type(pyramid_request).json_body = mock.PropertyMock(side_effect=ValueError())
 
         with pytest.raises(PayloadError):
@@ -231,7 +231,7 @@ def auth_client(factories):
 
 
 @pytest.fixture
-def user_signup_service(db_session, pyramid_config, user):
+def user_signup_service(pyramid_config, user):
     service = mock.Mock(
         spec_set=UserSignupService(
             default_authority="example.com",

--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -77,9 +77,7 @@ class TestBadge:
         search_run.assert_not_called()
         assert result == {"total": 0}
 
-    def test_it_sets_cache_headers_if_blocked(
-        self, badge_request, Blocklist, pyramid_request
-    ):
+    def test_it_sets_cache_headers_if_blocked(self, badge_request, pyramid_request):
         badge_request("http://example.com", annotated=True, blocked=True)
 
         cache_control = pyramid_request.response.cache_control

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -38,7 +38,9 @@ class TestGroupCreateController:
 
         # If the form submission is valid then handle_form_submission() should
         # call on_success() with the appstruct.
-        def call_on_success(request, form, on_success, on_failure):
+        def call_on_success(  # pylint: disable=unused-argument
+            request, form, on_success, on_failure
+        ):
             on_success({"name": "my_new_group", "description": "foobar"})
 
         handle_form_submission.side_effect = call_on_success
@@ -62,7 +64,9 @@ class TestGroupCreateController:
 
         # If the form submission is valid then handle_form_submission() should
         # return the redirect that on_success() returns.
-        def return_on_success(request, form, on_success, on_failure):
+        def return_on_success(  # pylint: disable=unused-argument
+            request, form, on_success, on_failure
+        ):
             return on_success({"name": "my_new_group"})
 
         handle_form_submission.side_effect = return_on_success
@@ -76,7 +80,9 @@ class TestGroupCreateController:
     ):
         # If the form submission is invalid then handle_form_submission() should
         # call on_failure().
-        def call_on_failure(request, form, on_success, on_failure):
+        def call_on_failure(  # pylint: disable=unused-argument
+            request, form, on_success, on_failure
+        ):
             on_failure()
 
         handle_form_submission.side_effect = call_on_failure
@@ -90,7 +96,9 @@ class TestGroupCreateController:
     ):
         # If the form submission is invalid then handle_form_submission() should
         # return the template data that on_failure() returns.
-        def return_on_failure(request, form, on_success, on_failure):
+        def return_on_failure(  # pylint: disable=unused-argument
+            request, form, on_success, on_failure
+        ):
             return on_failure()
 
         handle_form_submission.side_effect = return_on_failure

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -7,7 +7,7 @@ from h.traversal import AnnotationContext
 from h.views import main
 
 
-def _fake_sidebar_app(request, extra):
+def _fake_sidebar_app(request, extra):  # pylint:disable=unused-argument
     return extra
 
 
@@ -67,7 +67,7 @@ class TestStreamUserRedirect:
         assert exc.value.location == "http://example.com/search?q=tag%3A%22foo+bar%22"
 
     def test_it_redirects_to_activity_page_if_q_length_great_than_2(
-        self, sidebar_app, pyramid_request
+        self, pyramid_request
     ):
         pyramid_request.params["q"] = "tag:foo:bar"
         pyramid_request.matchdict["tag"] = "foo:bar"


### PR DESCRIPTION
Enabling rules that were disabled in `pylintrc`, fixing some of them and also many disable inlines.