### PR TITLE
Factor out the `CallbackAuthenticationPolicy` in the token policy

### DIFF
--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -14,12 +14,10 @@ from h.auth.util import default_authority
 from h.security import principals_for_userid
 from h.security.encryption import derive_key
 
-__all__ = ("TOKEN_POLICY",)
+# We export this for the websocket to use as it's main policy
+__all__ = ("TokenAuthenticationPolicy",)
 
 log = logging.getLogger(__name__)
-
-# We export this for the websocket to use as it's main policy
-TOKEN_POLICY = TokenAuthenticationPolicy(callback=principals_for_userid)
 
 
 def includeme(config):  # pragma: no cover
@@ -65,7 +63,7 @@ def _get_policy(proxy_auth):  # pragma: no cover
 
     return AuthenticationPolicy(
         api_policy=APIAuthenticationPolicy(
-            user_policy=TOKEN_POLICY, client_policy=AuthClientPolicy()
+            user_policy=TokenAuthenticationPolicy(), client_policy=AuthClientPolicy()
         ),
         fallback_policy=fallback_policy,
     )

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -8,7 +8,7 @@ from zope import interface
 
 from h.auth import util
 from h.exceptions import InvalidUserId
-from h.security import Identity, principals_for_identity
+from h.security import Identity, principals_for_identity, principals_for_userid
 
 #: List of route name-method combinations that should
 #: allow AuthClient authentication
@@ -305,9 +305,8 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
     additional principals for the authenticated user.
     """
 
-    def __init__(self, callback=None, debug=False):
-        self.callback = callback
-        self.debug = debug
+    def __init__(self):
+        self.callback = principals_for_userid
 
     def remember(self, _request, _userid, **_kwargs):  # pylint: disable=no-self-use
         """Not implemented for token auth policy."""

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -320,11 +320,20 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
         """
         Return the userid implied by the token in the passed request, if any.
 
-        :param request: a request object
-        :type request: pyramid.request.Request
+        :param request: Pyramid request to inspect
+        :return: The userid authenticated for the passed request or None
+        """
 
-        :returns: the userid authenticated for the passed request or None
-        :rtype: unicode or None
+        # We actually just do the same thing for unauthenticated user ids,
+        # which is to say they have to be valid.
+        return self.authenticated_userid(request)
+
+    def authenticated_userid(self, request):
+        """
+        Return the userid implied by the token in the passed request, if any.
+
+        :param request: Pyramid request to inspect
+        :return: The userid authenticated for the passed request or None
         """
         if identity := self.identity(request):
             return identity.user.userid

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -328,7 +328,7 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
         :rtype: unicode or None
         """
         token_str = None
-        if _is_ws_request(request):
+        if self._is_ws_request(request):
             token_str = request.GET.get("access_token", None)
         if token_str is None:
             token_str = getattr(request, "auth_token", None)
@@ -336,12 +336,15 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
         if token_str is None:
             return None
 
-        svc = request.find_service(name="auth_token")
-        token = svc.validate(token_str)
+        token = request.find_service(name="auth_token").validate(token_str)
         if token is None:
             return None
 
         return token.userid
+
+    @staticmethod
+    def _is_ws_request(request):
+        return request.path == "/ws"
 
 
 def _is_api_request(request):
@@ -366,7 +369,3 @@ def _is_client_request(request):
     if request.matched_route:
         return (request.matched_route.name, request.method) in AUTH_CLIENT_API_WHITELIST
     return False
-
-
-def _is_ws_request(request):
-    return request.path == "/ws"

--- a/h/streamer/app.py
+++ b/h/streamer/app.py
@@ -2,6 +2,7 @@ import os
 
 import pyramid
 
+from h.auth import TokenAuthenticationPolicy
 from h.config import configure
 from h.sentry_filters import SENTRY_FILTERS
 from h.streamer.worker import log
@@ -26,7 +27,7 @@ def create_app(_global_config, **settings):
 
     config.include("h.auth")
     # Override the default authentication policy.
-    config.set_authentication_policy("h.auth.TOKEN_POLICY")
+    config.set_authentication_policy(TokenAuthenticationPolicy())
 
     config.include("h.authz")
     config.include("h.db")

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -4,6 +4,7 @@ import pytest
 
 from h.services.annotation_delete import AnnotationDeleteService
 from h.services.annotation_moderation import AnnotationModerationService
+from h.services.auth_token import AuthTokenService
 from h.services.delete_group import DeleteGroupService
 from h.services.flag import FlagService
 from h.services.group import GroupService
@@ -22,6 +23,7 @@ from h.services.search_index._queue import Queue
 __all__ = (
     "mock_service",
     "annotation_delete_service",
+    "auth_token_service",
     "delete_group_service",
     "links_service",
     "list_organizations_service",
@@ -58,6 +60,11 @@ def mock_service(pyramid_config):
 @pytest.fixture
 def annotation_delete_service(mock_service):
     return mock_service(AnnotationDeleteService, name="annotation_delete")
+
+
+@pytest.fixture
+def auth_token_service(mock_service):
+    return mock_service(AuthTokenService, name="auth_token")
 
 
 @pytest.fixture

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -700,7 +700,6 @@ class TestTokenAuthenticationPolicy:
     def test_unauthenticated_userid_returns_None_for_invalid_token(
         self, pyramid_request, auth_token_service
     ):
-
         auth_token_service.validate.return_value = None
 
         assert (
@@ -711,10 +710,9 @@ class TestTokenAuthenticationPolicy:
         self, pyramid_request, auth_token_service, principals_for_userid
     ):
         principals_for_userid.return_value = ["principal"]
-        policy = TokenAuthenticationPolicy(callback=principals_for_userid)
-        pyramid_request.auth_token = "valid123"
+        pyramid_request.auth_token = sentinel.auth_token
 
-        result = policy.authenticated_userid(pyramid_request)
+        result = TokenAuthenticationPolicy().authenticated_userid(pyramid_request)
 
         userid = auth_token_service.validate.return_value.userid
         principals_for_userid.assert_called_once_with(userid, pyramid_request)
@@ -724,9 +722,8 @@ class TestTokenAuthenticationPolicy:
         self, pyramid_request, principals_for_userid
     ):
         principals_for_userid.return_value = None
-        policy = TokenAuthenticationPolicy(callback=principals_for_userid)
 
-        result = policy.authenticated_userid(pyramid_request)
+        result = TokenAuthenticationPolicy().authenticated_userid(pyramid_request)
 
         assert result is None
 
@@ -734,10 +731,9 @@ class TestTokenAuthenticationPolicy:
         self, pyramid_request, auth_token_service, principals_for_userid
     ):
         principals_for_userid.return_value = ["principal"]
-        policy = TokenAuthenticationPolicy(callback=principals_for_userid)
-        pyramid_request.auth_token = "valid123"
+        pyramid_request.auth_token = sentinel.auth_token
 
-        result = policy.effective_principals(pyramid_request)
+        result = TokenAuthenticationPolicy().effective_principals(pyramid_request)
 
         assert result == [
             Everyone,
@@ -746,6 +742,6 @@ class TestTokenAuthenticationPolicy:
             "principal",
         ]
 
-    @pytest.fixture
-    def principals_for_userid(self):
-        return create_autospec(principals_for_userid)
+    @pytest.fixture(autouse=True)
+    def principals_for_userid(self, patch):
+        return patch("h.auth.policy.principals_for_userid")

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -732,9 +732,7 @@ class TestTokenAuthenticationPolicy:
 
         result = TokenAuthenticationPolicy().authenticated_userid(pyramid_request)
 
-        userid = user_service.fetch.return_value.userid
-        principals_for_userid.assert_called_once_with(userid, pyramid_request)
-        assert result is userid
+        assert result is user_service.fetch.return_value.userid
 
     def test_authenticated_userid_returns_None_with_no_user(
         self, pyramid_request, principals_for_userid


### PR DESCRIPTION
This removes the deprecated `CallbackAuthenticationPolicy` from our `TokenAuthenticationPolicy` which is now based around an `identity` method as required in Pyramid 2.0.

This isn't all the way there, but it's on the way.