### PR TITLE
Factor out the `RemoteUserAuthenticationPolicy` policy from Pyramid 1.x

### DIFF
--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -11,7 +11,6 @@ from h.auth.policy import (
     TokenAuthenticationPolicy,
 )
 from h.auth.util import default_authority
-from h.security import principals_for_userid
 from h.security.encryption import derive_key
 
 # We export this for the websocket to use as it's main policy

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -7,7 +7,7 @@ from h.auth.policy import (
     APIAuthenticationPolicy,
     AuthClientPolicy,
     AuthenticationPolicy,
-    RemoteUserAuthPolicy,
+    RemoteUserAuthenticationPolicy,
     TokenAuthenticationPolicy,
 )
 from h.auth.util import default_authority
@@ -54,7 +54,7 @@ def _get_policy(proxy_auth):  # pragma: no cover
             "being available to ANYONE!"
         )
 
-        fallback_policy = RemoteUserAuthPolicy()
+        fallback_policy = RemoteUserAuthenticationPolicy()
 
     else:
         fallback_policy = pyramid_authsanity.AuthServicePolicy()

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -2,12 +2,12 @@
 import logging
 
 import pyramid_authsanity
-from pyramid.authentication import RemoteUserAuthenticationPolicy
 
 from h.auth.policy import (
     APIAuthenticationPolicy,
     AuthClientPolicy,
     AuthenticationPolicy,
+    RemoteUserAuthPolicy,
     TokenAuthenticationPolicy,
 )
 from h.auth.util import default_authority
@@ -54,9 +54,7 @@ def _get_policy(proxy_auth):  # pragma: no cover
             "being available to ANYONE!"
         )
 
-        fallback_policy = RemoteUserAuthenticationPolicy(
-            environ_key="HTTP_X_FORWARDED_USER", callback=principals_for_userid
-        )
+        fallback_policy = RemoteUserAuthPolicy()
 
     else:
         fallback_policy = pyramid_authsanity.AuthServicePolicy()

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -1,11 +1,14 @@
 from pyramid import interfaces
-from pyramid.authentication import BasicAuthAuthenticationPolicy
+from pyramid.authentication import (
+    BasicAuthAuthenticationPolicy,
+    RemoteUserAuthenticationPolicy,
+)
 from pyramid.security import Authenticated, Everyone
 from zope import interface
 
 from h.auth import util
 from h.exceptions import InvalidUserId
-from h.security import Identity, principals_for_identity
+from h.security import Identity, principals_for_identity, principals_for_userid
 
 #: List of route name-method combinations that should
 #: allow AuthClient authentication
@@ -376,6 +379,14 @@ class TokenAuthenticationPolicy:
     @staticmethod
     def _is_ws_request(request):
         return request.path == "/ws"
+
+
+@interface.implementer(interfaces.IAuthenticationPolicy)
+class RemoteUserAuthPolicy(RemoteUserAuthenticationPolicy):
+    def __init__(self):
+        super().__init__(
+            environ_key="HTTP_X_FORWARDED_USER", callback=principals_for_userid
+        )
 
 
 def _is_api_request(request):

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -382,11 +382,20 @@ class TokenAuthenticationPolicy:
 
 
 @interface.implementer(interfaces.IAuthenticationPolicy)
-class RemoteUserAuthPolicy(RemoteUserAuthenticationPolicy):
+class RemoteUserAuthPolicy(CallbackAuthenticationPolicy):
     def __init__(self):
-        super().__init__(
-            environ_key="HTTP_X_FORWARDED_USER", callback=principals_for_userid
-        )
+        self.environ_key = "HTTP_X_FORWARDED_USER"
+        self.callback = principals_for_userid
+
+    def unauthenticated_userid(self, request):
+        """ The ``REMOTE_USER`` value found within the ``environ``."""
+        return request.environ.get(self.environ_key)
+
+    def remember(self, request, userid, **kw):
+        return []
+
+    def forget(self, request):
+        return []
 
 
 def _is_api_request(request):

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -397,9 +397,11 @@ class RemoteUserAuthenticationPolicy(IdentityBasedPolicy):
         return request.environ.get("HTTP_X_FORWARDED_USER")
 
     def identity(self, request):
-        user = request.find_service(name="user").fetch(
-            self.unauthenticated_userid(request)
-        )
+        user_id = self.unauthenticated_userid(request)
+        if not user_id:
+            return None
+
+        user = request.find_service(name="user").fetch(user_id)
         if user is None:
             return None
 

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -288,7 +288,8 @@ class AuthClientPolicy:
 
 
 class IdentityBasedPolicy:
-    def identity(self, request) -> Optional[Identity]:
+    @classmethod
+    def identity(cls, request) -> Optional[Identity]:
         """
         Get an Identity object for valid credentials.
 
@@ -296,7 +297,6 @@ class IdentityBasedPolicy:
         the request contains valid credentials.
 
         :param request: Pyramid request to inspect
-        :returns: An `Identity` object if the login is authenticated or None
         """
         return None
 

--- a/h/security/__init__.py
+++ b/h/security/__init__.py
@@ -6,7 +6,4 @@ from h.security.encryption import (  # noqa:F401
 )
 from h.security.identity import Identity  # noqa:F401
 from h.security.permissions import Permission  # noqa:F401
-from h.security.principals import (  # noqa:F401
-    principals_for_identity,
-    principals_for_userid,
-)
+from h.security.principals import principals_for_identity  # noqa:F401

--- a/h/security/principals.py
+++ b/h/security/principals.py
@@ -2,20 +2,6 @@ from h.security.identity import Identity
 from h.security.role import Role
 
 
-def principals_for_userid(userid, request):
-    """
-    Return the list of additional principals for a valid userid, or None.
-
-    :param userid: Userid to get principals for
-    :param request: Pyramid request object
-    :returns: A list of principals or None
-    """
-
-    identity = Identity(user=request.find_service(name="user").fetch(userid))
-
-    return principals_for_identity(identity)
-
-
 def principals_for_identity(identity: Identity):
     """
     Get the security principals for a given identity.

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -809,6 +809,11 @@ class TestRemoteUserAuthenticationPolicy:
         user_service.fetch.assert_called_once_with(sentinel.forwarded_user)
         assert identity == Identity(user=user_service.fetch.return_value)
 
+    def test_identity_returns_None_for_no_forwarded_user(self, pyramid_request):
+        pyramid_request.environ["HTTP_X_FORWARDED_USER"] = None
+
+        assert RemoteUserAuthenticationPolicy().identity(pyramid_request) is None
+
     def test_identity_returns_None_for_no_user(self, pyramid_request, user_service):
         pyramid_request.environ["HTTP_X_FORWARDED_USER"] = sentinel.forwarded_user
         user_service.fetch.return_value = None

--- a/tests/h/security/test_principals.py
+++ b/tests/h/security/test_principals.py
@@ -1,28 +1,8 @@
-from unittest.mock import sentinel
-
 import pytest
-from h_matchers import Any
 
 from h.security import Identity
-from h.security.principals import principals_for_identity, principals_for_userid
+from h.security.principals import principals_for_identity
 from h.security.role import Role
-
-
-class TestPrincipalsForUserid:
-    def test_it(self, pyramid_request, user_service, principals_for_identity):
-        result = principals_for_userid(sentinel.userid, pyramid_request)
-
-        user_service.fetch.assert_called_once_with(sentinel.userid)
-        principals_for_identity.assert_called_once_with(
-            Any.instance_of(Identity).with_attrs(
-                {"user": user_service.fetch.return_value}
-            )
-        )
-        assert result == principals_for_identity.return_value
-
-    @pytest.fixture
-    def principals_for_identity(self, patch):
-        return patch("h.security.principals.principals_for_identity")
 
 
 class TestPrincipalsForIdentity:

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ passenv =
     dev: NEW_RELIC_APP_NAME
     dev: NODE_ENV
     dev: KILL_SWITCH_WEBSOCKET
+    dev: PROXY_AUTH
     {tests,functests}: TEST_DATABASE_URL
     {tests,functests}: ELASTICSEARCH_URL
     {tests,functests}: PYTEST_ADDOPTS


### PR DESCRIPTION
We were using a deprecated built in policy called `RemoteUserAuthenticationPolicy`. This PR re-implements it from scratch.

This kicks in if the environment variable `PROXY_AUTH` is truthy, and causes `h` to blindly trust any user id sent in a header `X-Forwarded-User`.

## Testing notes

 * Run `PROXY_AUTH=1 make services dev`
 * Visit http://localhost:5000/admin/
 * You should see "Page not found"
 * Set the header and visit and you should see the page:
  
 ```
 curl --request GET \
  --url http://localhost:5000/admin/ \
  --header 'X_FORWARDED_USER: acct:devdata_admin@localhost'```