### PR TITLE
Ensure we don't issue a query per annotation for moderation information

### DIFF
--- a/tests/h/services/annotation_json_presentation_test/service_test.py
+++ b/tests/h/services/annotation_json_presentation_test/service_test.py
@@ -106,7 +106,7 @@ class TestAnnotationJSONPresentationService:
             AnnotationJSONPresenter.return_value.asdict.return_value,
         ]
 
-    @pytest.mark.parametrize("attribute", ("document", "moderation"))
+    @pytest.mark.parametrize("attribute", ("document", "moderation", "group"))
     @pytest.mark.parametrize("with_preload", (True, False))
     def test_present_all_preloading_is_effective(
         self, svc, annotation, db_session, query_counter, attribute, with_preload


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/6769

It's hard to test this directly in the current unit test setting as this is an effect across multiple layers of the app, but calling for annotation permissions uses the `annotation.group` relationship, which causes queries.

### Testing notes

* Hack the DB engine to dump queries:
```diff
--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -66,7 +66,7 @@ def init(engine, base=Base, should_create=False, should_drop=False, authority=No
 
 def make_engine(settings):
     """Construct a sqlalchemy engine from the passed ``settings``."""
-    return sqlalchemy.create_engine(settings["sqlalchemy.url"])
+    return sqlalchemy.create_engine(settings["sqlalchemy.url"], echo=True)
``` 
 * Load all the various services and put lots of annotations on a single page
 * Refresh the page
 * In master you should see lots of group queries
 * In this branch you should see one
