### PR TITLE
Don't use any other cached env from previous runs on GHA

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,9 +69,7 @@ jobs:
           .tox/checkformatting
           .tox/tests
           .tox/coverage
-        key: ${{ runner.os }}-tox-backend-${{ hashFiles('tox.ini', 'requirements*', 'setup.py', 'setup.cfg') }}
-        restore-keys: |
-          ${{ runner.os }}-tox-backend-
+        key: ${{ runner.os }}-tox-backend-${{ hashFiles('tox.ini', 'requirements/**', 'setup.py', 'setup.cfg') }}
     - name: Run tox
       run: tox --parallel auto -e checkformatting,tests,coverage
 
@@ -120,9 +118,7 @@ jobs:
         path: |
           .tox/lint
           .tox/functests
-        key: ${{ runner.os }}-tox-functests-${{ hashFiles('tox.ini', 'requirements*', 'setup.py', 'setup.cfg') }}
-        restore-keys: |
-          ${{ runner.os }}-tox-functests-
+        key: ${{ runner.os }}-tox-functests-${{ hashFiles('tox.ini', 'requirements/**', 'setup.py', 'setup.cfg') }}
 
     - name: Cache the node_modules dir
       uses: actions/cache@v2


### PR DESCRIPTION
As far as I can tell we used a key like: `Linux-tox-functests-HASHXXXXXXX` but because of the `restore keys {{ runner.os }}-tox-backend-` we were happy to just use any previous cached directory as long as the keys matched up to `Linux-tox-functests-`.

I think the rationale here is that instead of starting with a fresh install you use any older version and tox would install the new dependencies on top but that doesn't seem to work as expected.