### PR TITLE
Get to 100% coverage for `h.auth.policy`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,5 +12,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 97.20
+fail_under = 97.28
 skip_covered = True

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -697,6 +697,7 @@ class TestTokenAuthenticationPolicy:
     def test_identity_returns_None_for_invalid_tokens(
         self, pyramid_request, auth_token_service
     ):
+        pyramid_request.auth_token = sentinel.auth_token
         auth_token_service.validate.return_value = None
 
         assert TokenAuthenticationPolicy().identity(pyramid_request) is None
@@ -704,6 +705,7 @@ class TestTokenAuthenticationPolicy:
     def test_identity_returns_None_for_invalid_users(
         self, pyramid_request, user_service
     ):
+        pyramid_request.auth_token = sentinel.auth_token
         user_service.fetch.return_value = None
 
         assert TokenAuthenticationPolicy().identity(pyramid_request) is None
@@ -750,6 +752,13 @@ class TestTokenAuthenticationPolicy:
             user_service.fetch.return_value.userid,
             "principal",
         ]
+
+    def test_effective_principals_with_no_identity(self, pyramid_request):
+        pyramid_request.auth_token = None
+
+        result = TokenAuthenticationPolicy().effective_principals(pyramid_request)
+
+        assert result == [Everyone]
 
     @pytest.fixture(autouse=True)
     def principals_for_identity(self, patch):

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -372,6 +372,16 @@ class TestAPIAuthenticationPolicy:
         assert not client_policy.forget.call_count
         assert forgot == user_policy.forget.return_value
 
+    def test_forget_does_not_proxy_with_no_matched_route(
+        self, pyramid_request, api_policy, user_policy, client_policy
+    ):
+        pyramid_request.matched_route = None
+        user_policy.forget.return_value = []
+
+        forgot = api_policy.forget(pyramid_request)
+        assert not client_policy.forget.call_count
+        assert forgot == user_policy.forget.return_value
+
     @pytest.fixture
     def client_policy(self):
         return mock.create_autospec(AuthClientPolicy, instance=True, spec_set=True)


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/6595

This is a bump to fix some faulty tests and get us to 100% so we don't have to think about whether we've changed the coverage in this file any more.