### PR TITLE
Consolidate principal generation in `principals_for_identity`

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pyramid import interfaces
 from pyramid.authentication import extract_http_basic_credentials
-from pyramid.security import Authenticated, Everyone
+from pyramid.security import Authenticated
 from sqlalchemy.exc import StatementError
 from zope import interface
 
@@ -174,21 +174,7 @@ class IdentityBasedPolicy:
         :param request: Pyramid request to check
         :returns: List of principals
         """
-        effective_principals = [Everyone]
-
-        if identity := self.identity(request):
-            effective_principals.append(Authenticated)
-
-            # This is very suspicious to me. I think we probably want both of
-            # these
-            if identity.auth_client:
-                effective_principals.append(identity.auth_client.id)
-            else:
-                effective_principals.append(identity.user.userid)
-
-            effective_principals.extend(principals_for_identity(identity))
-
-        return effective_principals
+        return principals_for_identity(self.identity(request))
 
     def remember(self, _request, _userid, **_kwargs):  # pylint: disable=no-self-use
         return []

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -575,37 +575,13 @@ class TestIdentityBasedPolicy:
 
         assert getattr(policy, method)(pyramid_request) is None
 
-    @pytest.mark.parametrize("with_auth_client", (True, False))
     def test_effective_principals(
-        self,
-        policy,
-        pyramid_request,
-        identity,
-        principals_for_identity,
-        with_auth_client,
-        factories,
+        self, policy, pyramid_request, identity, principals_for_identity
     ):
-        if with_auth_client:
-            identity.auth_client = factories.AuthClient()
-
-        principals_for_identity.return_value = ["principal"]
-
         principals = policy.effective_principals(pyramid_request)
 
         principals_for_identity.assert_called_once_with(identity)
-        assert principals == [
-            Everyone,
-            Authenticated,
-            # I'm suspicious that this is an either or. I feel like both values
-            # should just be dependant on the presence of the relevant thing
-            identity.auth_client.id if with_auth_client else identity.user.userid,
-            "principal",
-        ]
-
-    def test_effective_principals_with_no_identity(self, policy, pyramid_request):
-        policy.returned_identity = None
-
-        assert policy.effective_principals(pyramid_request) == [Everyone]
+        assert principals == principals_for_identity.return_value
 
     def test_remember_does_nothing(self, policy, pyramid_request):
         assert policy.remember(pyramid_request, "foo") == []


### PR DESCRIPTION
Also simplify some obvious nonsense logic once it's all together. Now this is only called in one place it's much easier to see what's going on.