### PR TITLE
Merge combining auth policies into one class

### DIFF
--- a/h/auth/policy/__init__.py
+++ b/h/auth/policy/__init__.py
@@ -1,6 +1,2 @@
-# These will become private soon
-from h.auth.policy._basic_http_auth import AuthClientPolicy
-from h.auth.policy._cookie import CookieAuthenticationPolicy
-from h.auth.policy._remote_user import RemoteUserAuthenticationPolicy
 from h.auth.policy.bearer_token import TokenAuthenticationPolicy
-from h.auth.policy.combined import APIAuthenticationPolicy, AuthenticationPolicy
+from h.auth.policy.combined import AuthenticationPolicy

--- a/h/auth/policy/_basic_http_auth.py
+++ b/h/auth/policy/_basic_http_auth.py
@@ -30,7 +30,7 @@ class AuthClientPolicy(IdentityBasedPolicy):
 
     #: List of route name-method combinations that should
     #: allow AuthClient authentication
-    AUTH_CLIENT_API_WHITELIST = [
+    API_WHITELIST = [
         ("api.groups", "POST"),
         ("api.group", "PATCH"),
         ("api.group", "GET"),
@@ -50,7 +50,7 @@ class AuthClientPolicy(IdentityBasedPolicy):
             return (
                 request.matched_route.name,
                 request.method,
-            ) in cls.AUTH_CLIENT_API_WHITELIST
+            ) in cls.API_WHITELIST
         return False
 
     def unauthenticated_userid(self, request):

--- a/h/auth/policy/_basic_http_auth.py
+++ b/h/auth/policy/_basic_http_auth.py
@@ -28,6 +28,31 @@ class AuthClientPolicy(IdentityBasedPolicy):
     from regular users.
     """
 
+    #: List of route name-method combinations that should
+    #: allow AuthClient authentication
+    AUTH_CLIENT_API_WHITELIST = [
+        ("api.groups", "POST"),
+        ("api.group", "PATCH"),
+        ("api.group", "GET"),
+        ("api.group_upsert", "PUT"),
+        ("api.group_member", "POST"),
+        ("api.users", "POST"),
+        ("api.user_read", "GET"),
+        ("api.user", "PATCH"),
+        ("api.bulk", "POST"),
+    ]
+
+    @classmethod
+    def handles(cls, request):
+        """Get whether this policy should accept this request."""
+
+        if request.matched_route:
+            return (
+                request.matched_route.name,
+                request.method,
+            ) in cls.AUTH_CLIENT_API_WHITELIST
+        return False
+
     def unauthenticated_userid(self, request):
         """Return the forwarded userid or the auth_client's id."""
 

--- a/h/auth/policy/combined.py
+++ b/h/auth/policy/combined.py
@@ -15,9 +15,9 @@ class AuthenticationPolicy(IdentityBasedPolicy):
         self._http_basic_auth_policy = AuthClientPolicy()
 
         if proxy_auth:
-            self.ui_policy = RemoteUserAuthenticationPolicy()
+            self._ui_policy = RemoteUserAuthenticationPolicy()
         else:
-            self.ui_policy = CookieAuthenticationPolicy()
+            self._ui_policy = CookieAuthenticationPolicy()
 
     def authenticated_userid(self, request):
         return self._call_sub_policies("authenticated_userid", request)
@@ -36,7 +36,7 @@ class AuthenticationPolicy(IdentityBasedPolicy):
 
     def _call_sub_policies(self, method, request, *args, **kwargs):
         if not self._is_api_request(request):
-            return getattr(self.ui_policy, method)(request, *args, **kwargs)
+            return getattr(self._ui_policy, method)(request, *args, **kwargs)
 
         result = getattr(self._bearer_token_policy, method)(request, *args, **kwargs)
 

--- a/h/auth/policy/combined.py
+++ b/h/auth/policy/combined.py
@@ -1,29 +1,15 @@
 from pyramid import interfaces
-from pyramid.security import Authenticated
 from zope import interface
 
-#: List of route name-method combinations that should
-#: allow AuthClient authentication
 from h.auth.policy._basic_http_auth import AuthClientPolicy
 from h.auth.policy._cookie import CookieAuthenticationPolicy
+from h.auth.policy._identity_base import IdentityBasedPolicy
 from h.auth.policy._remote_user import RemoteUserAuthenticationPolicy
 from h.auth.policy.bearer_token import TokenAuthenticationPolicy
 
-AUTH_CLIENT_API_WHITELIST = [
-    ("api.groups", "POST"),
-    ("api.group", "PATCH"),
-    ("api.group", "GET"),
-    ("api.group_upsert", "PUT"),
-    ("api.group_member", "POST"),
-    ("api.users", "POST"),
-    ("api.user_read", "GET"),
-    ("api.user", "PATCH"),
-    ("api.bulk", "POST"),
-]
-
 
 @interface.implementer(interfaces.IAuthenticationPolicy)
-class AuthenticationPolicy:
+class AuthenticationPolicy(IdentityBasedPolicy):
     def __init__(self, proxy_auth=False):
         self._bearer_token_policy = TokenAuthenticationPolicy()
         self._http_basic_auth_policy = AuthClientPolicy()
@@ -45,47 +31,25 @@ class AuthenticationPolicy:
     def forget(self, request):
         return self._call_sub_policies("forget", request)
 
-    def effective_principals(self, request):
-        if _is_api_request(request):
-            user_principals = self._bearer_token_policy.effective_principals(request)
-            # If authentication via user_policy was not successful
-            if Authenticated not in user_principals and _is_client_request(request):
-                return self._http_basic_auth_policy.effective_principals(request)
-            return user_principals
-        return self.ui_policy.effective_principals(request)
+    def identity(self, request):
+        return self._call_sub_policies("identity", request)
 
     def _call_sub_policies(self, method, request, *args, **kwargs):
-        if _is_api_request(request):
-            result = getattr(self._bearer_token_policy, method)(
+        if not self._is_api_request(request):
+            return getattr(self.ui_policy, method)(request, *args, **kwargs)
+
+        result = getattr(self._bearer_token_policy, method)(request, *args, **kwargs)
+
+        if not result and self._http_basic_auth_policy.handles(request):
+            return getattr(self._http_basic_auth_policy, method)(
                 request, *args, **kwargs
             )
-            if not result and _is_client_request(request):
-                return getattr(self._http_basic_auth_policy, method)(
-                    request, *args, **kwargs
-                )
-            return result
-        return getattr(self.ui_policy, method)(request, *args, **kwargs)
 
+        return result
 
-def _is_api_request(request):
-    return request.path.startswith("/api") and request.path not in [
-        "/api/token",
-        "/api/badge",
-    ]
-
-
-def _is_client_request(request):
-    """
-    Return if this is auth_client_auth authentication valid for the given request.
-
-    Uuthentication should be performed by
-    :py:class:`~h.auth.policy.AuthClientPolicy` only for requests
-    that match the whitelist.
-
-    The whitelist will likely evolve.
-
-    :rtype: bool
-    """
-    if request.matched_route:
-        return (request.matched_route.name, request.method) in AUTH_CLIENT_API_WHITELIST
-    return False
+    @staticmethod
+    def _is_api_request(request):
+        return request.path.startswith("/api") and request.path not in [
+            "/api/token",
+            "/api/badge",
+        ]

--- a/tests/h/auth/policy/_basic_http_auth_test.py
+++ b/tests/h/auth/policy/_basic_http_auth_test.py
@@ -11,6 +11,23 @@ from h.security import Identity
 
 @pytest.mark.usefixtures("user_service")
 class TestAuthClientPolicy:
+    @pytest.mark.parametrize("route_name,method", AuthClientPolicy.API_WHITELIST)
+    def test_handles(self, pyramid_request, route_name, method):
+        pyramid_request.matched_route.name = route_name
+        pyramid_request.method = method
+
+        assert AuthClientPolicy.handles(pyramid_request)
+
+    def test_handles_rejects_unknown_routes(self, pyramid_request):
+        pyramid_request.matched_route.name = "not.recognised"
+
+        assert not AuthClientPolicy.handles(pyramid_request)
+
+    def test_handles_rejects_no_route(self, pyramid_request):
+        pyramid_request.matched_route = None
+
+        assert not AuthClientPolicy.handles(pyramid_request)
+
     def test_identity(self, pyramid_request, auth_client, user_service):
         pyramid_request.headers["X-Forwarded-User"] = sentinel.forwarded_user
 

--- a/tests/h/auth/policy/combined_test.py
+++ b/tests/h/auth/policy/combined_test.py
@@ -1,400 +1,128 @@
-from unittest import mock
+from unittest.mock import patch, sentinel
 
 import pytest
-from pyramid.interfaces import IAuthenticationPolicy
-from pyramid.security import Authenticated, Everyone
 
-from h.auth.policy._basic_http_auth import AuthClientPolicy
-from h.auth.policy.bearer_token import TokenAuthenticationPolicy
-from h.auth.policy.combined import (
-    AUTH_CLIENT_API_WHITELIST,
-    APIAuthenticationPolicy,
-    AuthenticationPolicy,
-)
+from h.auth.policy.combined import AuthenticationPolicy
 
-API_PATHS = ("/api", "/api/foo", "/api/annotations/abc123")
-
-NONAPI_PATHS = ("/login", "/account/settings", "/api/badge", "/api/token")
-
-AUTH_CLIENT_API_BLACKLIST = [
-    ("api.groups", "GET"),
-    ("api.user", "POST"),
-    ("group_create", "POST"),
-    ("api.group_member", "DELETE"),
-]
+# pylint: disable=protected-access
 
 
 class TestAuthenticationPolicy:
+    def test_construction(
+        self, TokenAuthenticationPolicy, AuthClientPolicy, CookieAuthenticationPolicy
+    ):
+        policy = AuthenticationPolicy(proxy_auth=False)
+
+        TokenAuthenticationPolicy.assert_called_once_with()
+        assert policy._bearer_token_policy == TokenAuthenticationPolicy.return_value
+        AuthClientPolicy.assert_called_once_with()
+        assert policy._http_basic_auth_policy == AuthClientPolicy.return_value
+        CookieAuthenticationPolicy.assert_called_once_with()
+        assert policy._ui_policy == CookieAuthenticationPolicy.return_value
+
+    def test_construction_for_proxy_auth(self, RemoteUserAuthenticationPolicy):
+        policy = AuthenticationPolicy(proxy_auth=True)
+
+        RemoteUserAuthenticationPolicy.assert_called_once_with()
+        assert policy._ui_policy == RemoteUserAuthenticationPolicy.return_value
+
+    @pytest.mark.parametrize(
+        "method,args,kwargs",
+        (
+            ("authenticated_userid", [], {}),
+            ("unauthenticated_userid", [], {}),
+            ("remember", [sentinel.userid], {"kwargs": True}),
+            ("forget", [], {}),
+            ("identity", [], {}),
+        ),
+    )
+    def test_most_methods_delegate(self, pyramid_request, method, args, kwargs):
+        policy = AuthenticationPolicy()
+
+        with patch.object(policy, "_call_sub_policies") as _call_sub_policies:
+            auth_method = getattr(policy, method)
+
+            result = auth_method(pyramid_request, *args, **kwargs)
+
+            _call_sub_policies.assert_called_once_with(
+                method, pyramid_request, *args, **kwargs
+            )
+            assert result == _call_sub_policies.return_value
+
+    @pytest.mark.parametrize(
+        "path,is_ui",
+        (
+            ("/most/things/really", True),
+            ("/api/token", True),
+            ("/api/badge", True),
+            ("/api/anything_else", False),
+        ),
+    )
+    def test_calls_are_routed_based_on_api_or_not(self, pyramid_request, path, is_ui):
+        pyramid_request.path = path
+        policy = AuthenticationPolicy()
+
+        # Use `remember()` as an example, we've proven above which methods use
+        # this
+        result = policy.remember(pyramid_request, sentinel.userid, kwarg=True)
+
+        if is_ui:
+            called_policy, uncalled_policy = (
+                policy._ui_policy,
+                policy._bearer_token_policy,
+            )
+        else:
+            called_policy, uncalled_policy = (
+                policy._bearer_token_policy,
+                policy._ui_policy,
+            )
+
+        called_policy.remember.assert_called_once_with(
+            pyramid_request, sentinel.userid, kwarg=True
+        )
+        assert result == called_policy.remember.return_value
+
+        uncalled_policy.remember.assert_not_called()
+
+    @pytest.mark.parametrize("bearer_returns", (True, False))
+    @pytest.mark.parametrize("basic_auth_handles", (True, False))
+    def test_api_calls_are_passed_on(
+        self, pyramid_request, bearer_returns, basic_auth_handles
+    ):
+        # Pick a URL instead of retesting which URLs trigger the API behavior
+        pyramid_request.path = "/api/anything"
+        policy = AuthenticationPolicy()
+        policy._bearer_token_policy.remember.return_value = bearer_returns
+        policy._http_basic_auth_policy.handles.return_value = basic_auth_handles
+
+        result = policy.remember(pyramid_request, sentinel.userid, kwarg=True)
+
+        if not bearer_returns:
+            policy._http_basic_auth_policy.handles.assert_called_once_with(
+                pyramid_request
+            )
+
+        if basic_auth_handles and not bearer_returns:
+            policy._http_basic_auth_policy.remember.assert_called_once_with(
+                pyramid_request, sentinel.userid, kwarg=True
+            )
+            assert result == policy._http_basic_auth_policy.remember.return_value
+        else:
+            policy._http_basic_auth_policy.remember.assert_not_called()
+            assert result == policy._bearer_token_policy.remember.return_value
+
     @pytest.fixture(autouse=True)
-    def policy(self):
-        # pylint:disable=attribute-defined-outside-init
-        self.api_policy = mock.Mock(spec_set=list(IAuthenticationPolicy))
-        self.fallback_policy = mock.Mock(spec_set=list(IAuthenticationPolicy))
-        self.policy = AuthenticationPolicy(
-            api_policy=self.api_policy, fallback_policy=self.fallback_policy
-        )
-
-        self.fallback_policy.remember.return_value = [("Cookie", "auth=foobar")]
-
-    # api_request and nonapi_request are parametrized fixtures, which will
-    # take on each value in the passed `params` sequence in turn. This is a
-    # quick and easy way to generate a named fixture which takes multiple
-    # values and can be used by multiple tests.
-    @pytest.fixture(params=API_PATHS)
-    def api_request(self, request, pyramid_request):
-        pyramid_request.path = request.param
-        return pyramid_request
-
-    @pytest.fixture(params=NONAPI_PATHS)
-    def nonapi_request(self, request, pyramid_request):
-        pyramid_request.path = request.param
-        return pyramid_request
-
-    def test_authenticated_userid_uses_fallback_policy_for_nonapi_paths(
-        self, nonapi_request
-    ):
-        result = self.policy.authenticated_userid(nonapi_request)
-
-        self.fallback_policy.authenticated_userid.assert_called_once_with(
-            nonapi_request
-        )
-        assert result == self.fallback_policy.authenticated_userid.return_value
-
-    def test_authenticated_userid_uses_api_policy_for_api_paths(self, api_request):
-        result = self.policy.authenticated_userid(api_request)
-
-        self.api_policy.authenticated_userid.assert_called_once_with(api_request)
-        assert result == self.api_policy.authenticated_userid.return_value
-
-    def test_unauthenticated_userid_uses_fallback_policy_for_nonapi_paths(
-        self, nonapi_request
-    ):
-        result = self.policy.unauthenticated_userid(nonapi_request)
-
-        self.fallback_policy.unauthenticated_userid.assert_called_once_with(
-            nonapi_request
-        )
-        assert result == self.fallback_policy.unauthenticated_userid.return_value
-
-    def test_unauthenticated_userid_uses_api_policy_for_api_paths(self, api_request):
-        result = self.policy.unauthenticated_userid(api_request)
-
-        self.api_policy.unauthenticated_userid.assert_called_once_with(api_request)
-        assert result == self.api_policy.unauthenticated_userid.return_value
-
-    def test_effective_principals_uses_fallback_policy_for_nonapi_paths(
-        self, nonapi_request
-    ):
-        result = self.policy.effective_principals(nonapi_request)
-
-        self.fallback_policy.effective_principals.assert_called_once_with(
-            nonapi_request
-        )
-        assert result == self.fallback_policy.effective_principals.return_value
-
-    def test_effective_principals_uses_api_policy_for_api_paths(self, api_request):
-        result = self.policy.effective_principals(api_request)
-
-        self.api_policy.effective_principals.assert_called_once_with(api_request)
-        assert result == self.api_policy.effective_principals.return_value
-
-    def test_remember_uses_fallback_policy_for_nonapi_paths(self, nonapi_request):
-        result = self.policy.remember(nonapi_request, "foo", bar="baz")
-
-        self.fallback_policy.remember.assert_called_once_with(
-            nonapi_request, "foo", bar="baz"
-        )
-        assert result == self.fallback_policy.remember.return_value
-
-    def test_remember_uses_api_policy_for_api_paths(self, api_request):
-        result = self.policy.remember(api_request, "foo", bar="baz")
-
-        self.api_policy.remember.assert_called_once_with(api_request, "foo", bar="baz")
-        assert result == self.api_policy.remember.return_value
-
-    def test_forget_uses_fallback_policy_for_nonapi_paths(self, nonapi_request):
-        result = self.policy.forget(nonapi_request)
-
-        self.fallback_policy.forget.assert_called_once_with(nonapi_request)
-        assert result == self.fallback_policy.forget.return_value
-
-    def test_forget_uses_api_policy_for_api_paths(self, api_request):
-        result = self.policy.forget(api_request)
-
-        self.api_policy.forget.assert_called_once_with(api_request)
-        assert result == self.api_policy.forget.return_value
-
-
-class TestAPIAuthenticationPolicy:
-    def test_authenticated_userid_proxies_to_user_policy_first(
-        self, pyramid_request, api_policy, user_policy, client_policy
-    ):
-        userid = api_policy.authenticated_userid(pyramid_request)
-
-        user_policy.authenticated_userid.assert_called_once_with(pyramid_request)
-        assert not client_policy.authenticated_userid.call_count
-        assert userid == user_policy.authenticated_userid.return_value
-
-    @pytest.mark.parametrize("route_name,route_method", AUTH_CLIENT_API_WHITELIST)
-    def test_authenticated_userid_proxies_to_client_policy_if_user_fails(
-        self,
-        pyramid_request,
-        api_policy,
-        user_policy,
-        client_policy,
-        route_name,
-        route_method,
-    ):
-        pyramid_request.method = route_method
-        pyramid_request.matched_route.name = route_name
-        user_policy.authenticated_userid.return_value = None
-
-        userid = api_policy.authenticated_userid(pyramid_request)
-
-        user_policy.authenticated_userid.assert_called_once_with(pyramid_request)
-        client_policy.authenticated_userid.assert_called_once_with(pyramid_request)
-        assert userid == client_policy.authenticated_userid.return_value
-
-    @pytest.mark.parametrize("route_name,route_method", AUTH_CLIENT_API_BLACKLIST)
-    def test_authenticated_userid_does_not_proxy_to_client_policy_if_path_mismatch(
-        self,
-        pyramid_request,
-        api_policy,
-        user_policy,
-        client_policy,
-        route_name,
-        route_method,
-    ):
-        pyramid_request.method = route_method
-        pyramid_request.matched_route.name = route_name
-        user_policy.authenticated_userid.return_value = None
-
-        userid = api_policy.authenticated_userid(pyramid_request)
-
-        user_policy.authenticated_userid.assert_called_once_with(pyramid_request)
-        assert not client_policy.authenticated_userid.call_count
-        assert userid == user_policy.authenticated_userid.return_value
-
-    @pytest.mark.parametrize("route_name,route_method", AUTH_CLIENT_API_WHITELIST)
-    def test_unauthenticated_userid_proxies_to_user_policy_first(
-        self,
-        pyramid_request,
-        api_policy,
-        user_policy,
-        client_policy,
-        route_name,
-        route_method,
-    ):
-        pyramid_request.method = route_method
-        pyramid_request.matched_route.name = route_name
-        userid = api_policy.unauthenticated_userid(pyramid_request)
-
-        user_policy.unauthenticated_userid.assert_called_once_with(pyramid_request)
-        assert not client_policy.unauthenticated_userid.call_count
-        assert userid == user_policy.unauthenticated_userid.return_value
-
-    def test_unauthenticated_userid_proxies_to_client_policy_if_user_fails(
-        self, pyramid_request, api_policy, user_policy, client_policy
-    ):
-        user_policy.unauthenticated_userid.return_value = None
-
-        userid = api_policy.unauthenticated_userid(pyramid_request)
-
-        user_policy.unauthenticated_userid.assert_called_once_with(pyramid_request)
-        client_policy.unauthenticated_userid.assert_called_once_with(pyramid_request)
-        assert userid == client_policy.unauthenticated_userid.return_value
-
-    @pytest.mark.parametrize("route_name,route_method", AUTH_CLIENT_API_BLACKLIST)
-    def test_unauthenticated_userid_does_not_proxy_to_client_policy_if_path_mismatch(
-        self,
-        pyramid_request,
-        api_policy,
-        user_policy,
-        client_policy,
-        route_name,
-        route_method,
-    ):
-        pyramid_request.method = route_method
-        pyramid_request.matched_route.name = route_name
-        user_policy.unauthenticated_userid.return_value = None
-
-        userid = api_policy.unauthenticated_userid(pyramid_request)
-
-        user_policy.unauthenticated_userid.assert_called_once_with(pyramid_request)
-        assert not client_policy.unauthenticated_userid.call_count
-        assert userid == user_policy.unauthenticated_userid.return_value
-
-    def test_effective_principals_proxies_to_user_policy_first(
-        self, pyramid_request, api_policy, user_policy, client_policy
-    ):
-        user_policy.effective_principals.return_value = [Everyone, Authenticated]
-
-        principals = api_policy.effective_principals(pyramid_request)
-
-        user_policy.effective_principals.assert_called_once_with(pyramid_request)
-        assert not client_policy.effective_principals.call_count
-        assert principals == user_policy.effective_principals.return_value
-
-    @pytest.mark.parametrize("route_name,route_method", AUTH_CLIENT_API_WHITELIST)
-    def test_effective_principals_proxies_to_client_if_auth_principal_missing(
-        self,
-        pyramid_request,
-        api_policy,
-        user_policy,
-        client_policy,
-        route_name,
-        route_method,
-    ):
-        pyramid_request.method = route_method
-        pyramid_request.matched_route.name = route_name
-        user_policy.effective_principals.return_value = [Everyone]
-
-        principals = api_policy.effective_principals(pyramid_request)
-
-        user_policy.effective_principals.assert_called_once_with(pyramid_request)
-        client_policy.effective_principals.assert_called_once_with(pyramid_request)
-        assert principals == client_policy.effective_principals.return_value
-
-    @pytest.mark.parametrize("route_name,route_method", AUTH_CLIENT_API_BLACKLIST)
-    def test_effective_principals_does_not_proxy_to_client_if_path_mismatch(
-        self,
-        pyramid_request,
-        api_policy,
-        user_policy,
-        client_policy,
-        route_name,
-        route_method,
-    ):
-        pyramid_request.method = route_method
-        pyramid_request.matched_route.name = route_name
-        user_policy.effective_principals.return_value = [Everyone]
-
-        principals = api_policy.effective_principals(pyramid_request)
-
-        user_policy.effective_principals.assert_called_once_with(pyramid_request)
-        assert not client_policy.effective_principals.call_count
-        assert principals == user_policy.effective_principals.return_value
-
-    @pytest.mark.parametrize("route_name,route_method", AUTH_CLIENT_API_WHITELIST)
-    def test_remember_proxies_to_user_policy_first(
-        self, pyramid_request, api_policy, user_policy, route_name, route_method
-    ):
-        pyramid_request.method = route_method
-        pyramid_request.matched_route.name = route_name
-        remembered = api_policy.remember(pyramid_request, "acct:foo@bar.com")
-
-        user_policy.remember.assert_called_once_with(
-            pyramid_request, "acct:foo@bar.com"
-        )
-        assert remembered == user_policy.remember.return_value
-
-    def test_remember_proxies_to_client_policy_second(
-        self, pyramid_request, api_policy, user_policy, client_policy
-    ):
-        user_policy.remember.return_value = []
-
-        remembered = api_policy.remember(pyramid_request, "acct:foo@bar.com")
-
-        user_policy.remember.assert_called_once_with(
-            pyramid_request, "acct:foo@bar.com"
-        )
-        client_policy.remember.assert_called_once_with(
-            pyramid_request, "acct:foo@bar.com"
-        )
-        assert remembered == client_policy.remember.return_value
-
-    @pytest.mark.parametrize("route_name,route_method", AUTH_CLIENT_API_BLACKLIST)
-    def test_remember_does_not_proxy_to_client_if_path_mismatch(
-        self,
-        pyramid_request,
-        api_policy,
-        user_policy,
-        client_policy,
-        route_name,
-        route_method,
-    ):
-        pyramid_request.method = route_method
-        pyramid_request.matched_route.name = route_name
-        user_policy.remember.return_value = []
-
-        remembered = api_policy.remember(pyramid_request, "acct:foo@bar.com")
-
-        user_policy.remember.assert_called_once_with(
-            pyramid_request, "acct:foo@bar.com"
-        )
-        assert not client_policy.remember.call_count
-        assert remembered == user_policy.remember.return_value
-
-    @pytest.mark.parametrize("route_name,route_method", AUTH_CLIENT_API_WHITELIST)
-    def test_forget_proxies_to_user_policy_first(
-        self, pyramid_request, api_policy, user_policy, route_name, route_method
-    ):
-        pyramid_request.method = route_method
-        pyramid_request.matched_route.name = route_name
-        forgot = api_policy.forget(pyramid_request)
-
-        user_policy.forget.assert_called_once_with(pyramid_request)
-        assert forgot == user_policy.forget.return_value
-
-    def test_forget_proxies_to_client_policy_second(
-        self, pyramid_request, api_policy, user_policy, client_policy
-    ):
-        user_policy.forget.return_value = []
-
-        forgot = api_policy.forget(pyramid_request)
-
-        user_policy.forget.assert_called_once_with(pyramid_request)
-        client_policy.forget.assert_called_once_with(pyramid_request)
-        assert forgot == client_policy.forget.return_value
-
-    @pytest.mark.parametrize("route_name,route_method", AUTH_CLIENT_API_BLACKLIST)
-    def test_forget_does_not_proxy_to_client_if_path_mismatch(
-        self,
-        pyramid_request,
-        api_policy,
-        user_policy,
-        client_policy,
-        route_name,
-        route_method,
-    ):
-        pyramid_request.method = route_method
-        pyramid_request.matched_route.name = route_name
-        user_policy.forget.return_value = []
-
-        forgot = api_policy.forget(pyramid_request)
-
-        user_policy.forget.assert_called_once_with(pyramid_request)
-        assert not client_policy.forget.call_count
-        assert forgot == user_policy.forget.return_value
-
-    def test_forget_does_not_proxy_with_no_matched_route(
-        self, pyramid_request, api_policy, user_policy, client_policy
-    ):
-        pyramid_request.matched_route = None
-        user_policy.forget.return_value = []
-
-        forgot = api_policy.forget(pyramid_request)
-        assert not client_policy.forget.call_count
-        assert forgot == user_policy.forget.return_value
-
-    @pytest.fixture
-    def client_policy(self):
-        return mock.create_autospec(AuthClientPolicy, instance=True, spec_set=True)
-
-    @pytest.fixture
-    def user_policy(self):
-        return mock.create_autospec(
-            TokenAuthenticationPolicy, instance=True, spec_set=True
-        )
-
-    @pytest.fixture
-    def api_policy(self, client_policy, user_policy):
-        return APIAuthenticationPolicy(
-            user_policy=user_policy, client_policy=client_policy
-        )
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.matched_route.name = "api.groups"
-        pyramid_request.method = "POST"
-        return pyramid_request
+    def TokenAuthenticationPolicy(self, patch):
+        return patch("h.auth.policy.combined.TokenAuthenticationPolicy")
+
+    @pytest.fixture(autouse=True)
+    def AuthClientPolicy(self, patch):
+        return patch("h.auth.policy.combined.AuthClientPolicy")
+
+    @pytest.fixture(autouse=True)
+    def RemoteUserAuthenticationPolicy(self, patch):
+        return patch("h.auth.policy.combined.RemoteUserAuthenticationPolicy")
+
+    @pytest.fixture(autouse=True)
+    def CookieAuthenticationPolicy(self, patch):
+        return patch("h.auth.policy.combined.CookieAuthenticationPolicy")


### PR DESCRIPTION
This PR takes the `APIAuthenticationPolicy` and `AuthenticationPolicy` and merges them into one policy and makes that policy an `IdentityBasedPolicy` like all the others.

We don't make that much use of `IdentityBasedPolicy` in this state (it only provides `effective_principals` for us), but it means we'll gain the `permits` function needed by Pyramid 2.0 along with all the other policies when required.