### PR TITLE
Use the identity in the Websocket instead of the user id

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -85,6 +85,7 @@ def includeme(config):
     config.include("h.assets")
     config.include("h.auth")
     config.include("h.authz")
+    config.include("h.security")
     config.include("h.db")
     config.include("h.eventqueue")
     config.include("h.form")

--- a/h/security/__init__.py
+++ b/h/security/__init__.py
@@ -4,6 +4,11 @@ from h.security.encryption import (  # noqa:F401
     password_context,
     token_urlsafe,
 )
-from h.security.identity import Identity  # noqa:F401
+from h.security.identity import Identity, get_identity  # noqa:F401
 from h.security.permissions import Permission  # noqa:F401
 from h.security.principals import principals_for_identity  # noqa:F401
+
+
+def includeme(config):  # pragma: no cover
+    # Fake the Pyramid 2.0 identity method on requests until we upgrade
+    config.add_request_method(get_identity, name="identity", reify=True)

--- a/h/security/identity.py
+++ b/h/security/identity.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from pyramid.interfaces import IAuthenticationPolicy
+
 from h.models import AuthClient, User
 
 
@@ -15,3 +17,14 @@ class Identity:
 
     user: User = None
     auth_client: AuthClient = None
+
+
+def get_identity(request):
+    """
+    Get the identity associated with a request.
+
+    This is a Pyramid 2.0 compatibility addition and should be removed when
+    we upgrade. This is used as a request method `identity()` to mirror that
+    added by Pyramid 2.0.
+    """
+    return request.registry.queryUtility(IAuthenticationPolicy).identity(request)

--- a/h/streamer/app.py
+++ b/h/streamer/app.py
@@ -26,6 +26,9 @@ def create_app(_global_config, **settings):
     config.include("pyramid_services")
 
     config.include("h.auth")
+    # Temporary addition to get the `request.identity` method until
+    # Pyramid 2.0 comes along
+    config.include("h.security")
     # Override the default authentication policy.
     config.set_authentication_policy(TokenAuthenticationPolicy())
 

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -85,7 +85,7 @@ def handle_user_event(message, sockets, _request, _session):
     reply = None
 
     for socket in sockets:
-        if socket.authenticated_userid != message["userid"]:
+        if not socket.identity or socket.identity.user.userid != message["userid"]:
             continue
 
         if reply is None:
@@ -134,7 +134,11 @@ def handle_annotation_event(message, sockets, request, session):
             continue
 
         # Only send NIPSA'd annotations to the author
-        if annotator_nipsad and socket.authenticated_userid != annotation.userid:
+        if (
+            annotator_nipsad
+            and socket.identity
+            and socket.identity.user.userid != annotation.userid
+        ):
             continue
 
         # Check whether client is authorized to read this annotation.

--- a/h/streamer/metrics.py
+++ b/h/streamer/metrics.py
@@ -17,9 +17,7 @@ def websocket_metrics(queue):
     See https://docs.newrelic.com/docs/agents/python-agent/supported-features/python-custom-metrics.
     """
     connections_active = len(WebSocket.instances)
-    connections_anonymous = sum(
-        1 for ws in WebSocket.instances if not ws.authenticated_userid
-    )
+    connections_anonymous = sum(1 for ws in WebSocket.instances if not ws.identity)
 
     # Allow us to tell the difference between reporting 0 and not reporting
     yield f"{PREFIX}/Alive", 1

--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -10,9 +10,9 @@ def websocket_view(request):
     # Provide environment which the WebSocket handler can use...
     request.environ.update(
         {
-            "h.ws.authenticated_userid": request.authenticated_userid,
             "h.ws.effective_principals": request.effective_principals,
             "h.ws.streamer_work_queue": streamer.WORK_QUEUE,
+            "h.ws.identity": request.identity,
         }
     )
 

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -44,6 +44,7 @@ class WebSocket(_WebSocket):
     client_id = None
     filter = None
     query = None
+    identity = None
 
     def __init__(self, sock, protocols=None, extensions=None, environ=None):
         super().__init__(
@@ -54,8 +55,8 @@ class WebSocket(_WebSocket):
             heartbeat_freq=30.0,
         )
 
-        self.authenticated_userid = environ["h.ws.authenticated_userid"]
         self.effective_principals = environ["h.ws.effective_principals"]
+        self.identity = environ["h.ws.identity"]
 
         self._work_queue = environ["h.ws.streamer_work_queue"]
 
@@ -180,7 +181,15 @@ MESSAGE_HANDLERS["ping"] = handle_ping_message
 
 def handle_whoami_message(message, session=None):  # pylint: disable=unused-argument
     """Reply to a client requesting information on its auth state."""
-    message.reply({"type": "whoyouare", "userid": message.socket.authenticated_userid})
+
+    message.reply(
+        {
+            "type": "whoyouare",
+            "userid": message.socket.identity.user.userid
+            if message.socket.identity
+            else None,
+        }
+    )
 
 
 MESSAGE_HANDLERS["whoami"] = handle_whoami_message

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -220,6 +220,7 @@ def pyramid_request(db_session, fake_feature, pyramid_settings):
     request.GET = request.params
     request.POST = request.params
     request.user = None
+    request.identity = None
     return request
 
 

--- a/tests/h/security/test_identity.py
+++ b/tests/h/security/test_identity.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+import pytest
+from pyramid.interfaces import IAuthenticationPolicy
+
+from h.security import get_identity
+
+
+class TestGetIdentity:
+    def test_it(self, pyramid_request):
+        identity = get_identity(pyramid_request)
+
+        pyramid_request.registry.queryUtility.assert_called_once_with(
+            IAuthenticationPolicy
+        )
+        policy = pyramid_request.registry.queryUtility.return_value
+        policy.identity.assert_called_once_with(pyramid_request)
+        assert identity == policy.identity.return_value
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        with patch.object(pyramid_request.registry, "queryUtility"):
+            yield pyramid_request

--- a/tests/h/streamer/conftest.py
+++ b/tests/h/streamer/conftest.py
@@ -1,0 +1,16 @@
+from unittest.mock import create_autospec
+
+import pytest
+from pyramid import security
+
+from h.security import Identity
+from h.streamer.websocket import WebSocket
+
+
+@pytest.fixture
+def socket(factories):
+    socket = create_autospec(WebSocket, instance=True)
+    socket.effective_principals = [security.Everyone, "group:__world__"]
+    socket.identity = Identity(user=factories.User())
+
+    return socket

--- a/tests/h/streamer/messages_speed_test.py
+++ b/tests/h/streamer/messages_speed_test.py
@@ -2,6 +2,7 @@ import pytest
 from _datetime import datetime
 from pyramid import security
 
+from h.security import Identity
 from h.streamer.app import create_app
 from h.streamer.contexts import request_context
 from h.streamer.messages import handle_annotation_event
@@ -83,7 +84,7 @@ class TestHandleAnnotationEventSpeed:  # pragma: no cover
         socket = WebSocket(
             sock=None,
             environ={
-                "h.ws.authenticated_userid": "foo",
+                "h.ws.identity": Identity(),
                 "h.ws.effective_principals": [security.Everyone, "group:__world__"],
                 "h.ws.streamer_work_queue": None,
             },

--- a/tests/h/streamer/metrics_test.py
+++ b/tests/h/streamer/metrics_test.py
@@ -5,15 +5,14 @@ from gevent.pool import Pool
 from gevent.queue import Queue
 from h_matchers import Any
 
+from h.security import Identity
 from h.streamer.metrics import websocket_metrics
 from h.streamer.websocket import WebSocket
 
 
 class TestWebsocketMetrics:
     def test_it_records_socket_metrics(self, generate_metrics, sockets):
-        sockets[0].authenticated_userid = "acct:jimsmith@hypothes.is"
-        sockets[1].authenticated_userid = None
-        sockets[2].authenticated_userid = None
+        sockets[0].identity = Identity()
 
         metrics = generate_metrics()
 
@@ -66,7 +65,7 @@ class TestWebsocketMetrics:
     def sockets(self):
         sockets = [create_autospec(WebSocket, instance=True) for _ in range(3)]
         for socket in sockets:
-            socket.authenticated_userid = None
+            socket.identity = None
 
         return sockets
 

--- a/tests/h/streamer/views_test.py
+++ b/tests/h/streamer/views_test.py
@@ -1,14 +1,16 @@
+from h.security import Identity
 from h.streamer import streamer, views
 
 
 def test_websocket_view_adds_auth_state_to_environ(pyramid_config, pyramid_request):
-    pyramid_config.testing_securitypolicy("ragnar", groupids=["foo", "bar"])
+    pyramid_config.testing_securitypolicy("userid", groupids=["foo", "bar"])
+    pyramid_request.identity = Identity()
     pyramid_request.get_response = lambda _: None
 
     views.websocket_view(pyramid_request)
     env = pyramid_request.environ
 
-    assert env["h.ws.authenticated_userid"] == "ragnar"
+    assert env["h.ws.identity"] == pyramid_request.identity
     assert env["h.ws.effective_principals"] == pyramid_request.effective_principals
 
 


### PR DESCRIPTION
This introduces a temporary fake for Pyramid 2.0's `request.identity` function, and swaps out the `authenticated_userid` for an identity object in the websocket.

We're doing this for a few reasons:

 * We need to remove `principals_allowed_by_permission` because it doesn't exist in Pyramid 2.0 and there's no replacement
 * Currently we pass in principals to the websocket which similarly needs to go
 * Our new permissions system is going to be identity based
 * If we can get an identity instead of userids we can do away with both the `authenticated_userid` and the `effective_principals` on the websockets.
