### PR TITLE
Strip Google Drive `resourcekey` parameter when normalizing URIs

### DIFF
--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -99,6 +99,11 @@ BLACKLISTED_QUERY_PARAMS = [
         #    https://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html
         #
         r"(?i)^x-amz-security-token$",
+        #
+        # Google Drive resource key. Reference:
+        #
+        #    https://support.google.com/a/answer/10685032
+        r"^resourcekey$",
     )
 ]
 

--- a/tests/h/util/uri_test.py
+++ b/tests/h/util/uri_test.py
@@ -265,6 +265,10 @@ class TestURINormalise:
                 "http://example.com?a=1&X-Amz-Security-Token=abcde",
                 "httpx://example.com?a=1",
             ),
+            (
+                "https://drive.google.com/uc?id=foobar&export=download&resourcekey=abc",
+                "httpx://drive.google.com/uc?export=download&id=foobar",
+            ),
             # but don't be over-eager and remove close matches
             (
                 "http://example.com?gclid_foo=abcde",


### PR DESCRIPTION
The `resourcekey` query param was added to a small proportion of non-native
(eg. PDF) download and share URLs in Google Drive. It is only a
security key and does not affect which file the URL refers to.

In general adding new parameters to the query parameter blocklist used
by URI normalization is problematic (see https://github.com/hypothesis/h/issues/6552).
However this parameter was added only quite recently and almost all
affected URIs are PDFs, so the fingerprint will connect any existing
annotations made on URIs with/without the `resourcekey` parameter.