### PR TITLE
Run the functests backwards in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,12 +66,13 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
+          .tox/lint
           .tox/checkformatting
           .tox/tests
           .tox/coverage
         key: ${{ runner.os }}-tox-backend-${{ hashFiles('tox.ini', 'requirements/**', 'setup.py', 'setup.cfg') }}
     - name: Run tox
-      run: tox --parallel auto -e checkformatting,tests,coverage
+      run: tox --parallel auto -e checkformatting,tests,coverage,lint
 
   functests:
     name: Functional tests
@@ -116,7 +117,6 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          .tox/lint
           .tox/functests
         key: ${{ runner.os }}-tox-functests-${{ hashFiles('tox.ini', 'requirements/**', 'setup.py', 'setup.cfg') }}
 
@@ -133,7 +133,9 @@ jobs:
       run: gulp build
 
     - name: Run tox
-      run: tox --parallel auto -e lint,functests
+      # Note we run the func tests backwards here to prove there are no order
+      # dependent tests
+      run: tox -e functests -- tests/functional --reverse
 
   frontend:
     name: Frontend

--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -1,4 +1,5 @@
 pytest
 factory-boy
 webtest
+pytest-reverse
 -r requirements.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -219,6 +219,10 @@ pyrsistent==0.17.3
     #   -r requirements/requirements.txt
     #   jsonschema
 pytest==6.2.5
+    # via
+    #   -r requirements/functests.in
+    #   pytest-reverse
+pytest-reverse==1.3.0
     # via -r requirements/functests.in
 python-dateutil==2.8.2
     # via

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -348,6 +348,9 @@ pytest==6.2.5
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+    #   pytest-reverse
+pytest-reverse==1.3.0
+    # via -r requirements/functests.txt
 python-dateutil==2.8.2
     # via
     #   -r requirements/functests.txt


### PR DESCRIPTION
This introduces `make functests-backwards` which will run the tests in reverse order to help ensure there are no order dependent tests.

For: https://github.com/hypothesis/h/issues/6883

This also makes functests the only thing we run in the functests group. This results in everything taking about the same amount of time, but the func-tests are much faster.

Also it's less confusing because linting failing in a stage called "functests" was always a bit weird.