### PR TITLE
Add a status end-point to the websocket

### DIFF
--- a/h/streamer/app.py
+++ b/h/streamer/app.py
@@ -47,6 +47,10 @@ def create_app(_global_config, **settings):
     config.add_route("annotation", "/a/{id}", static=True)
     config.add_route("api.annotation", "/api/annotations/{id}", static=True)
 
+    # Health check
+    config.scan("h.views.status")
+    config.add_route("status", "/_status")
+
     config.scan("h.streamer.views")
     config.scan("h.streamer.streamer")
     config.add_tween(

--- a/h/streamer/conf/nginx.conf
+++ b/h/streamer/conf/nginx.conf
@@ -34,7 +34,7 @@ http {
     server_name _;
     server_tokens off;
 
-    location /ws {
+    location / {
       proxy_pass http://websocket;
       proxy_http_version 1.1;
       proxy_redirect off;


### PR DESCRIPTION
This adds a status end-point to tell if the WS is actually running when running in it's own dedicated docker container for: 

 * https://github.com/hypothesis/playbook/issues/703

## Testing notes

#### Testing the change

This is a bit confusing because of the way this is built. But the docker image is always built from the checked in copy, so if you are planning to test changes to the code, you need to commit it.

 * `make docker-ws`
 * `make run-docker-ws`
 * http://localhost:5000/ws - You should see an error about handshakes (proving this is the websocket)
 * `make services`
 * http://localhost:5000/_status - You should see a status message ok
 * `docker stop h_postgres_1`
 * http://localhost:5000/_status - You should see a 500 error (existing behavior)
 
#### Showing the existing behavior works

 * Stop the container from above
 * `make dev`
 * Start the client, Via
 * Visit a webpage (start ViaHTML too) or PDF in Via: http://0.0.0.0:9082/
 * Log in
 * Open the page in a new tab as well
 * Annotate in one tab
 * The annotation notification red icon should appear in the other