### PR TITLE
Don't attempt to read from /var/www it just causes confusing error messages

### DIFF
--- a/h/streamer/conf/nginx.conf
+++ b/h/streamer/conf/nginx.conf
@@ -34,8 +34,6 @@ http {
     server_name _;
     server_tokens off;
 
-    root /var/www;
-
     location /ws {
       proxy_pass http://websocket;
       proxy_http_version 1.1;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/playbook/issues/703

When we can't find things we end up checking the disk for them which
doesn't work and causes confusing file not found messages. Which people think
means a file is missing (reasonably) whereas it's just bad config.