### PR TITLE
Separate the `Group.ADMIN` and `AdminPage.GROUPS` permission

### DIFF
--- a/h/security/acl.py
+++ b/h/security/acl.py
@@ -98,19 +98,19 @@ class ACL:
         yield Allow, client_authority_principal, Permission.Group.READ
         yield Allow, client_authority_principal, Permission.Group.MEMBER_READ
         yield Allow, client_authority_principal, Permission.Group.MEMBER_ADD
-        yield Allow, client_authority_principal, Permission.Group.ADMIN
+        yield Allow, client_authority_principal, Permission.Group.EDIT
 
         # Do we need these permissions? Can / do our staff actually need edit
         # permissions to the group? Our admins don't have any other permissions
-        yield Allow, Role.STAFF, Permission.Group.ADMIN
-        yield Allow, Role.ADMIN, Permission.Group.ADMIN
+        yield Allow, Role.STAFF, Permission.Group.EDIT
+        yield Allow, Role.ADMIN, Permission.Group.EDIT
         # We definitely need these permissions so the admin can edit the page
         # in the admin interface
         yield Allow, Role.STAFF, Permission.AdminPage.GROUPS
         yield Allow, Role.ADMIN, Permission.AdminPage.GROUPS
 
         if group.creator:
-            yield Allow, group.creator.userid, Permission.Group.ADMIN
+            yield Allow, group.creator.userid, Permission.Group.EDIT
             yield Allow, group.creator.userid, Permission.Group.MODERATE
             yield Allow, group.creator.userid, Permission.Group.UPSERT
 

--- a/h/security/acl.py
+++ b/h/security/acl.py
@@ -14,6 +14,9 @@ class ACL:
         yield Allow, Role.STAFF, Permission.AdminPage.MAILER
         yield Allow, Role.STAFF, Permission.AdminPage.ORGANIZATIONS
         yield Allow, Role.STAFF, Permission.AdminPage.USERS
+        # Admin staff absolutely *DO NOT* have all permissions. They only have
+        # all permissions in the admin page context. This is just a lazy way
+        # of not enumerating all the separate permissions in that context.
         yield Allow, Role.ADMIN, security.ALL_PERMISSIONS
         yield DENY_ALL
 
@@ -100,12 +103,7 @@ class ACL:
         yield Allow, client_authority_principal, Permission.Group.MEMBER_ADD
         yield Allow, client_authority_principal, Permission.Group.EDIT
 
-        # Do we need these permissions? Can / do our staff actually need edit
-        # permissions to the group? Our admins don't have any other permissions
-        yield Allow, Role.STAFF, Permission.Group.EDIT
-        yield Allow, Role.ADMIN, Permission.Group.EDIT
-        # We definitely need these permissions so the admin can edit the page
-        # in the admin interface
+        # Let admins and staff edit the group in the admin page interface
         yield Allow, Role.STAFF, Permission.AdminPage.GROUPS
         yield Allow, Role.ADMIN, Permission.AdminPage.GROUPS
 

--- a/h/security/acl.py
+++ b/h/security/acl.py
@@ -100,10 +100,14 @@ class ACL:
         yield Allow, client_authority_principal, Permission.Group.MEMBER_ADD
         yield Allow, client_authority_principal, Permission.Group.ADMIN
 
-        # Those with the admin or staff Role should be able to admin/edit any
-        # group
+        # Do we need these permissions? Can / do our staff actually need edit
+        # permissions to the group? Our admins don't have any other permissions
         yield Allow, Role.STAFF, Permission.Group.ADMIN
         yield Allow, Role.ADMIN, Permission.Group.ADMIN
+        # We definitely need these permissions so the admin can edit the page
+        # in the admin interface
+        yield Allow, Role.STAFF, Permission.AdminPage.GROUPS
+        yield Allow, Role.ADMIN, Permission.AdminPage.GROUPS
 
         if group.creator:
             yield Allow, group.creator.userid, Permission.Group.ADMIN

--- a/h/security/permissions.py
+++ b/h/security/permissions.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class Permission:
     class Group(Enum):
-        ADMIN = "group:admin"  # Is this really "EDIT" or a combination?
+        EDIT = "group:edit"
         JOIN = "group:join"
         READ = "group:read"
         WRITE = "group:write"

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -191,7 +191,7 @@ class GroupSearchController(SearchController):
             self.group.creator.userid if self.group.creator else None,
         ]
 
-        if self.request.has_permission(Permission.Group.ADMIN, context=self.context):
+        if self.request.has_permission(Permission.Group.EDIT, context=self.context):
             result["group_edit_url"] = self.request.route_url(
                 "group_edit", pubid=self.group.pubid
             )

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -126,7 +126,7 @@ class GroupCreateViews:  # pylint: disable=too-many-instance-attributes
 
 @view_defaults(
     route_name="admin.groups_edit",
-    permission=Permission.Group.ADMIN,
+    permission=Permission.AdminPage.GROUPS,
     renderer="h:templates/admin/groups_edit.html.jinja2",
 )
 class GroupEditViews:  # pylint: disable=too-many-instance-attributes

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -94,7 +94,7 @@ def read(context, request):
     versions=["v1", "v2"],
     route_name="api.group",
     request_method="PATCH",
-    permission=Permission.Group.ADMIN,
+    permission=Permission.Group.EDIT,
     link_name="group.update",
     description="Update a group",
 )

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -67,7 +67,7 @@ class GroupCreateController:
 @view_defaults(
     route_name="group_edit",
     renderer="h:templates/groups/edit.html.jinja2",
-    permission=Permission.Group.ADMIN,
+    permission=Permission.Group.EDIT,
 )
 class GroupEditController:
     def __init__(self, context, request):

--- a/tests/functional/h/views/admin/test_permissions.py
+++ b/tests/functional/h/views/admin/test_permissions.py
@@ -34,3 +34,43 @@ class TestAdminPermissions:
         res = app.get(url, expect_errors=not accessible)
 
         assert res.status_code == 200 if accessible else 404
+
+    GROUP_PAGES = (
+        ("POST", "/admin/groups/delete/{pubid}", 302),
+        ("GET", "/admin/groups/{pubid}", 200),
+    )
+
+    @pytest.mark.usefixtures("with_logged_in_admin")
+    @pytest.mark.parametrize("method,url_template,success_code", GROUP_PAGES)
+    def test_group_end_points_accessible_by_admin(
+        self, app, group, method, url_template, success_code
+    ):
+        url = url_template.format(pubid=group.pubid)
+
+        app.request(url, method=method, status=success_code)
+
+    @pytest.mark.usefixtures("with_logged_in_staff_member")
+    @pytest.mark.parametrize("method,url_template,success_code", GROUP_PAGES)
+    def test_group_end_points_accessible_by_staff(
+        self, app, group, method, url_template, success_code
+    ):
+        url = url_template.format(pubid=group.pubid)
+
+        app.request(url, method=method, status=success_code)
+
+    @pytest.mark.usefixtures("with_logged_in_user")
+    @pytest.mark.parametrize("method,url_template,_", GROUP_PAGES)
+    def test_group_end_points_not_accessible_by_regular_user(
+        self, app, group, method, url_template, _
+    ):
+        url = url_template.format(pubid=group.pubid)
+
+        app.request(url, method=method, status=404)
+
+    @pytest.fixture
+    def group(self, factories, db_session):
+        # Without an org `views.admin.groups:GroupEditViews._update_appstruct`
+        # fails
+        group = factories.Group(organization=factories.Organization())
+        db_session.commit()
+        return group

--- a/tests/functional/h/views/test_activity.py
+++ b/tests/functional/h/views/test_activity.py
@@ -59,7 +59,7 @@ class TestGroupSearchController:
 
         response = app.get(f"/groups/{open_group.pubid}/{open_group.slug}")
 
-        # Permission.Group.ADMIN
+        # Permission.Group.EDIT
         # The `group_edit_url` should be visible for those with edit
         # permissions
         # OAuth clients, staff and admins can edit a group

--- a/tests/functional/h/views/test_group.py
+++ b/tests/functional/h/views/test_group.py
@@ -38,20 +38,21 @@ class TestGroupEditController:
         app.get(f"/groups/{user_owned_group.pubid}/edit")
 
     @pytest.mark.parametrize(
-        "is_staff,is_admin,expected_status",
+        "is_staff,is_admin",
         (
-            param(True, False, 200, id="staff"),
-            param(False, True, 200, id="admin"),
-            # Regular users can't edit other people's groups
-            param(False, False, 404, id="regular_user"),
+            # Doesn't matter if you are staff or an admin, you can't edit
+            # peoples groups using the user facing form
+            param(True, False, id="staff"),
+            param(False, True, id="admin"),
+            param(False, False, id="regular_user"),
         ),
     )
-    def test_editing_other_peoples_groups(
-        self, app, group, login_user, is_staff, is_admin, expected_status
+    def test_you_cannot_edit_other_peoples_groups(
+        self, app, group, login_user, is_staff, is_admin
     ):
         login_user(staff=is_staff, admin=is_admin)
 
-        app.get(f"/groups/{group.pubid}/edit", status=expected_status)
+        app.get(f"/groups/{group.pubid}/edit", status=404)
 
     @pytest.fixture
     def group(self, factories, db_session):

--- a/tests/h/security/test_acl.py
+++ b/tests/h/security/test_acl.py
@@ -225,9 +225,11 @@ class TestACLForGroup:
 
     def test_staff_user_has_admin_permission_on_any_group(self, group_permits):
         assert group_permits([Role.STAFF], Permission.Group.ADMIN)
+        assert group_permits([Role.STAFF], Permission.AdminPage.GROUPS)
 
     def test_admin_user_has_admin_permission_on_any_group(self, group_permits):
         assert group_permits([Role.ADMIN], Permission.Group.ADMIN)
+        assert group_permits([Role.ADMIN], Permission.AdminPage.GROUPS)
 
     @pytest.mark.parametrize("readable_by", (ReadableBy.members, ReadableBy.world))
     def test_creator_permissions(

--- a/tests/h/security/test_acl.py
+++ b/tests/h/security/test_acl.py
@@ -217,18 +217,18 @@ class TestACLForGroup:
         self, group, group_permits
     ):
         assert group_permits(
-            [f"client_authority:{group.authority}"], Permission.Group.ADMIN
+            [f"client_authority:{group.authority}"], Permission.Group.EDIT
         )
         assert not group_permits(
-            ["client_authority:DIFFERENT_AUTHORITY"], Permission.Group.ADMIN
+            ["client_authority:DIFFERENT_AUTHORITY"], Permission.Group.EDIT
         )
 
     def test_staff_user_has_admin_permission_on_any_group(self, group_permits):
-        assert group_permits([Role.STAFF], Permission.Group.ADMIN)
+        assert group_permits([Role.STAFF], Permission.Group.EDIT)
         assert group_permits([Role.STAFF], Permission.AdminPage.GROUPS)
 
     def test_admin_user_has_admin_permission_on_any_group(self, group_permits):
-        assert group_permits([Role.ADMIN], Permission.Group.ADMIN)
+        assert group_permits([Role.ADMIN], Permission.Group.EDIT)
         assert group_permits([Role.ADMIN], Permission.AdminPage.GROUPS)
 
     @pytest.mark.parametrize("readable_by", (ReadableBy.members, ReadableBy.world))
@@ -237,7 +237,7 @@ class TestACLForGroup:
     ):
         group.readable_by = readable_by
 
-        assert group_permits(group.creator.userid, Permission.Group.ADMIN)
+        assert group_permits(group.creator.userid, Permission.Group.EDIT)
         assert group_permits(group.creator.userid, Permission.Group.UPSERT)
         assert permitted_principals_for(Permission.Group.MODERATE) == {
             group.creator.userid

--- a/tests/h/security/test_acl.py
+++ b/tests/h/security/test_acl.py
@@ -224,11 +224,9 @@ class TestACLForGroup:
         )
 
     def test_staff_user_has_admin_permission_on_any_group(self, group_permits):
-        assert group_permits([Role.STAFF], Permission.Group.EDIT)
         assert group_permits([Role.STAFF], Permission.AdminPage.GROUPS)
 
     def test_admin_user_has_admin_permission_on_any_group(self, group_permits):
-        assert group_permits([Role.ADMIN], Permission.Group.EDIT)
         assert group_permits([Role.ADMIN], Permission.AdminPage.GROUPS)
 
     @pytest.mark.parametrize("readable_by", (ReadableBy.members, ReadableBy.world))

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -282,7 +282,7 @@ class TestGroupSearchController:
         self, controller, test_group, test_user, pyramid_request
     ):
         def fake_has_permission(permission, context=None):
-            return permission != Permission.Group.ADMIN
+            return permission != Permission.Group.EDIT
 
         pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/h/issues/6595

More analysis here:

 * https://github.com/hypothesis/h/pull/6869

This PR sorts out a few permission confusions between `Group.ADMIN` and `AdminPage.GROUPS`

 * `AdminPage.GROUPS` is now the permission required for all admin pages actions (getting and deleting required `Group.ADMIN` before)
 * `Group.ADMIN` is no longer granted to admin and staff (as it was only used for the above I think?)
 * `Group.ADMIN` is called `Group.EDIT` now, as it _doesn't_ grant you any kind of broad permissions as the name implies and is only used for group edit and upsert actions.

### Changes in behavior

 * Previously regular users with `Group.EDIT` could access our admin pages to manipulate their own groups (although that page crashes if you don't have an org)
 * Now regular users can't access admin pages even if they own the group
 * Previously admin and staff could use the public edit and update end-points for any group (but couldn't see then necessarily)
 * Now admin users can't access groups they are not creators of (outside of admin pages)

## Testing notes

 * Login as the `devdata_user`
 * Create a group and get the pubid
 * Visit: http://localhost:5000/admin/groups/<PUB_ID>
    * As the `devdata_user` you should **_now_** see "Page not found"
    * As `devdata_admin` you get a 500 because that page crashes without an org as it doesn't support private pages
 * Visit: http://localhost:5000/groups/<PUB_ID>/edit
   * As the `devdata_user` you should see your own group
   * As the `devdata_admin` you should **_now_** see "Page not found"
* Visit: http://localhost:5000/admin/groups/V3ZoedPa
  * As `devdata_biopub_creator` you should **_now_** see "Page not found"
  * Ad `devdata_admin` you should see the admin edit page
