### PR TITLE
Add a `permits()` method for Pyramid 2.0 security policy compliance

### DIFF
--- a/h/auth/policy/_identity_base.py
+++ b/h/auth/policy/_identity_base.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from h.security import Identity, principals_for_identity
+from h.security import Identity, identity_permits, principals_for_identity
 
 
 class IdentityBasedPolicy:
@@ -15,6 +15,16 @@ class IdentityBasedPolicy:
         :param request: Pyramid request to inspect
         """
         return None
+
+    def permits(self, request, context, permission) -> bool:
+        """
+        Get whether a given request has the requested permission on the context.
+
+        :param request: Pyramid request to extract identity from
+        :param context: A context object
+        :param permission: The permission requested
+        """
+        return identity_permits(self.identity(request), context, permission)
 
     def authenticated_userid(self, request):
         """


### PR DESCRIPTION
This adds a `permits` method as required by Pyramid 2.0. This means that this object is now compatible with the interfaces of both the 1.0 auth policy and 2.0 security policy.

We can't really show this works yet, as nothing calls it, but we also can't move to Pyramid 2.0 without having done this.