### PR TITLE
Make `client_authority()` identity based

### DIFF
--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -1,6 +1,3 @@
-import re
-
-
 def default_authority(request):
     """
     Return the value of the h.authority config settings.
@@ -14,17 +11,10 @@ def client_authority(request):
     """
     Return the authority associated with an authenticated auth_client or None.
 
-    Once a request with an auth_client is authenticated, a principal is set
-    indicating the auth_client's verified authority
-
-    see :func:`~h.auth.util.principals_for_auth_client` for more details on
-    principals applied when auth_clients are authenticated
-
     :rtype: str or None
     """
-    for principal in request.effective_principals:
-        match = re.match(r"^client_authority:(.+)$", principal)
-        if match and match.group(1):
-            return match.group(1)
+    # This function is kind of dumb and should be removed...
+    if request.identity and request.identity.auth_client:
+        return request.identity.auth_client.authority
 
     return None

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -13,7 +13,6 @@ def client_authority(request):
 
     :rtype: str or None
     """
-    # This function is kind of dumb and should be removed...
     if request.identity and request.identity.auth_client:
         return request.identity.auth_client.authority
 

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -19,8 +19,6 @@ class TestClientAuthority:
         assert result == identity.auth_client.authority
 
     def set_identity(self, pyramid_request, pyramid_config, identity):
-        # This should be simplified after the 2.0 upgrade as the other code
-        # path will not be required
         try:
             # Pyramid 2.0
             pyramid_config.testing_securitypolicy(identity=identity)


### PR DESCRIPTION
Currently the `client_authority` method uses `effective_principals` which won't exist in Pyramid 2.0. This uses the identity instead, and also sort of shows the function is quite dumb when it comes down to it.

This will hopefully be cleaned up quite soon.