### PR TITLE
Move the `auth_token` request method to the `AuthTokenService`

### DIFF
--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -6,6 +6,3 @@ from h.auth.util import default_authority
 def includeme(config):  # pragma: no cover
     # Allow retrieval of the authority from the request object.
     config.add_request_method(default_authority, name="default_authority", reify=True)
-
-    # Allow retrieval of the auth token (if present) from the request object.
-    config.add_request_method("h.auth.tokens.auth_token", reify=True)

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -33,30 +33,3 @@ class Token:
             return True
         now = datetime.datetime.utcnow()
         return now < self.expires
-
-
-def auth_token(request):
-    """
-    Fetch the token (if any) associated with a request.
-
-    :param request: the request object
-    :type request: pyramid.request.Request
-
-    :returns: the auth token carried by the request, or None
-    :rtype: h.models.Token or None
-    """
-    try:
-        header = request.headers["Authorization"]
-    except KeyError:
-        return None
-
-    if not header.startswith("Bearer "):
-        return None
-
-    token = str(header[len("Bearer ") :]).strip()
-    # If the token is empty at this point, it is clearly invalid and we
-    # should reject it.
-    if not token:
-        return None
-
-    return token

--- a/h/services/auth_token.py
+++ b/h/services/auth_token.py
@@ -50,6 +50,30 @@ class AuthTokenService:
             self._session.query(models.Token).filter_by(value=token_str).one_or_none()
         )
 
+    @staticmethod
+    def get_bearer_token(request):
+        """
+        Fetch the token (if any) associated with a request.
+
+        :param request: the request object
+        :returns: the auth token carried by the request, or None
+        """
+        try:
+            header = request.headers["Authorization"]
+        except KeyError:
+            return None
+
+        if not header.startswith("Bearer "):
+            return None
+
+        token = str(header[len("Bearer ") :]).strip()
+        # If the token is empty at this point, it is clearly invalid and we
+        # should reject it.
+        if not token:
+            return None
+
+        return token
+
     def _fetch_auth_token(self, token_str):
         token_model = self.fetch(token_str)
         if token_model is not None:

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -236,19 +236,20 @@ class OAuthRevocationController:
 
 @api_config(versions=["v1", "v2"], route_name="api.debug_token", request_method="GET")
 def debug_token(request):
-    if not request.auth_token:
+    svc = request.find_service(name="auth_token")
+
+    bearer_token = svc.get_bearer_token(request)
+    if not bearer_token:
         raise OAuthTokenError(
             "Bearer token is missing in Authorization HTTP header", "missing_token"
         )
 
-    svc = request.find_service(name="auth_token")
-    token = svc.validate(request.auth_token)
-    if token is None:
+    if not svc.validate(bearer_token):
         raise OAuthTokenError(
             "Bearer token does not exist or is expired", "missing_token"
         )
 
-    token = svc.fetch(request.auth_token)
+    token = svc.fetch(bearer_token)
     return _present_debug_token(token)
 
 

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -25,24 +25,3 @@ class TestToken:
         )
 
         assert token.is_valid() == is_valid
-
-
-class TestAuthToken:
-    @pytest.mark.parametrize(
-        "header,expected",
-        (
-            ("Bearer abcdef123", "abcdef123"),
-            (None, None),
-            ("Bearer ", None),
-            ("", None),
-            ("abcdef123", None),
-            ("\x10", None),
-            (".\x00\"Ħ(\x12'𨳂\x05\U000df02a\U00095c2c셀", None),
-            ("\U000f022b\t\x07\x1c0\x04\x06", None),
-        ),
-    )
-    def test_it(self, pyramid_request, header, expected):
-        if header is not None:
-            pyramid_request.headers["Authorization"] = header
-
-        assert tokens.auth_token(pyramid_request) == expected

--- a/tests/h/security/policy/bearer_token_test.py
+++ b/tests/h/security/policy/bearer_token_test.py
@@ -9,34 +9,36 @@ from h.security.policy.bearer_token import TokenPolicy
 @pytest.mark.usefixtures("user_service", "auth_token_service")
 class TestTokenPolicy:
     def test_identity(self, pyramid_request, auth_token_service, user_service):
-        pyramid_request.auth_token = sentinel.auth_token
-
         identity = TokenPolicy().identity(pyramid_request)
 
-        auth_token_service.validate.assert_called_once_with(sentinel.auth_token)
+        auth_token_service.get_bearer_token.assert_called_once_with(pyramid_request)
+        auth_token_service.validate.assert_called_once_with(
+            auth_token_service.get_bearer_token.return_value
+        )
         user_service.fetch.assert_called_once_with(
             auth_token_service.validate.return_value.userid
         )
         assert identity == Identity(user=user_service.fetch.return_value)
 
     def test_identity_for_webservice(self, pyramid_request, auth_token_service):
-        pyramid_request.auth_token = sentinel.decoy
         pyramid_request.path = "/ws"
         pyramid_request.GET["access_token"] = sentinel.access_token
 
         TokenPolicy().identity(pyramid_request)
 
+        auth_token_service.get_bearer_token.assert_not_called()
         auth_token_service.validate.assert_called_once_with(sentinel.access_token)
 
-    def test_identity_returns_None_with_no_token(self, pyramid_request):
-        pyramid_request.auth_token = None
+    def test_identity_returns_None_with_no_token(
+        self, pyramid_request, auth_token_service
+    ):
+        auth_token_service.get_bearer_token.return_value = None
 
         assert TokenPolicy().identity(pyramid_request) is None
 
     def test_identity_returns_None_for_invalid_tokens(
         self, pyramid_request, auth_token_service
     ):
-        pyramid_request.auth_token = sentinel.auth_token
         auth_token_service.validate.return_value = None
 
         assert TokenPolicy().identity(pyramid_request) is None
@@ -44,7 +46,6 @@ class TestTokenPolicy:
     def test_identity_returns_None_for_invalid_users(
         self, pyramid_request, user_service
     ):
-        pyramid_request.auth_token = sentinel.auth_token
         user_service.fetch.return_value = None
 
         assert TokenPolicy().identity(pyramid_request) is None

--- a/tests/h/services/auth_token_test.py
+++ b/tests/h/services/auth_token_test.py
@@ -49,6 +49,25 @@ class TestAuthTokenService:
     def test_fetch_returns_database_model(self, svc, token):
         assert svc.fetch(token.value) == token
 
+    @pytest.mark.parametrize(
+        "header,expected",
+        (
+            ("Bearer abcdef123", "abcdef123"),
+            (None, None),
+            ("Bearer ", None),
+            ("", None),
+            ("abcdef123", None),
+            ("\x10", None),
+            (".\x00\"Ħ(\x12'𨳂\x05\U000df02a\U00095c2c셀", None),
+            ("\U000f022b\t\x07\x1c0\x04\x06", None),
+        ),
+    )
+    def test_get_bearer_token(self, pyramid_request, header, expected):
+        if header is not None:
+            pyramid_request.headers["Authorization"] = header
+
+        assert AuthTokenService.get_bearer_token(pyramid_request) == expected
+
     @pytest.mark.usefixtures("token")
     def test_fetch_returns_none_when_not_found(self, svc):
         assert svc.fetch("bogus") is None


### PR DESCRIPTION
This is part of the effort to remove `h.auth`. This moves some indirect code and objects and puts them closer to the locations that use them.

Based on:

 * https://github.com/hypothesis/h/pull/7048

To see the end effect take a look a the `h/auth` directory in your checked out copy after: 

 * https://github.com/hypothesis/h/pull/7047 

### `auth_token` request method

Previously `h.auth` attached a function `auth_token` to the request object. This is used in:

* The bearer token policy - which passes it to the `auth_token` service
* In `h.views.api.auth:debug_token()` which also passes it to the `auth_token` service

This is now `get_bearer_token()` on the token service.

## In summary

_Note - This summary includes the work in https://github.com/hypothesis/h/pull/7047 as it written before this ticket was split._

Previously:

* You called `request.auth_token`
* This is added in `h.auth` as a request method using a string (which makes it hard to find)
* And is defined in `h.auth.tokens`
* This returns a string of the bearer token
* You get the `token_service`
* You pass this to the `token_service`
* Which instantiates a `h.auth.auth_token.Token` and gives it to you
* Which implements `h.auth.intefaces.IAuthenticationToken`

Now:

 * You get the `token_service`
 * You call `get_bearer_token()` on the service
 * This returns a string of the bearer token
 * You pass this back to the `token_service`
 * Which instantiates a `LongLivedToken` defined next to the service
