### PR TITLE
Add a permits method to make this a 2.0 compliant policy

### DIFF
--- a/h/auth/policy/_identity_base.py
+++ b/h/auth/policy/_identity_base.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from h.security import Identity, principals_for_identity
+from h.security import Identity, identity_permits, principals_for_identity
 
 
 class IdentityBasedPolicy:
@@ -15,6 +15,16 @@ class IdentityBasedPolicy:
         :param request: Pyramid request to inspect
         """
         return None
+
+    def permits(self, request, context, permission) -> bool:
+        """
+        Get whether a given request has the requested permission on the context.
+
+        :param request: Pyramid request to extract identity from
+        :param context: A context object
+        :param permission: The permission requested
+        """
+        return identity_permits(self.identity(request), context, permission)
 
     def authenticated_userid(self, request):
         """


### PR DESCRIPTION
Fixing a miss merge. Which merged this into the parent PR instead of master. This is already approved in: https://github.com/hypothesis/h/pull/7027, but the parent PR isn't.