### PR TITLE
POC: Example functest code for the websocket

### DIFF
--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -2,4 +2,6 @@ pytest
 factory-boy
 webtest
 pytest-reverse
+requests
+wsgiproxy2
 -r requirements.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -30,6 +30,7 @@ celery==5.1.2
 certifi==2021.5.30
     # via
     #   -r requirements/requirements.txt
+    #   requests
     #   sentry-sdk
 cffi==1.14.6
     # via
@@ -39,6 +40,8 @@ chameleon==3.8.1
     # via
     #   -r requirements/requirements.txt
     #   deform
+charset-normalizer==2.0.5
+    # via requests
 click==7.1.2
     # via
     #   -r requirements/requirements.txt
@@ -95,6 +98,8 @@ hupper==1.10.2
     # via
     #   -r requirements/requirements.txt
     #   pyramid
+idna==3.2
+    # via requests
 importlib-resources==5.2.2
     # via
     #   -r requirements/requirements.txt
@@ -236,6 +241,8 @@ repoze.sendmail==4.3
     # via
     #   -r requirements/requirements.txt
     #   pyramid-mailer
+requests==2.26.0
+    # via -r requirements/functests.in
 sentry-sdk==0.17.6
     # via
     #   -r requirements/requirements.txt
@@ -283,6 +290,7 @@ urllib3==1.26.5
     # via
     #   -r requirements/requirements.txt
     #   elasticsearch
+    #   requests
     #   sentry-sdk
 venusian==3.0.0
     # via
@@ -309,6 +317,7 @@ webob==1.8.7
     #   -r requirements/requirements.txt
     #   pyramid
     #   webtest
+    #   wsgiproxy2
 webtest==3.0.0
     # via -r requirements/functests.in
 wired==0.2.2
@@ -319,6 +328,8 @@ ws4py==0.5.1
     # via -r requirements/requirements.txt
 wsaccel==0.6.3
     # via -r requirements/requirements.txt
+wsgiproxy2==0.5.1
+    # via -r requirements/functests.in
 zipp==3.4.1
     # via
     #   -r requirements/requirements.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -47,6 +47,7 @@ certifi==2021.5.30
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+    #   requests
     #   sentry-sdk
 cffi==1.14.6
     # via
@@ -58,6 +59,10 @@ chameleon==3.8.1
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   deform
+charset-normalizer==2.0.5
+    # via
+    #   -r requirements/functests.txt
+    #   requests
 click==7.1.2
     # via
     #   -r requirements/functests.txt
@@ -147,6 +152,10 @@ hupper==1.10.2
     #   pyramid
 hypothesis==6.23.0
     # via -r requirements/tests.txt
+idna==3.2
+    # via
+    #   -r requirements/functests.txt
+    #   requests
 importlib-resources==5.2.2
     # via
     #   -r requirements/functests.txt
@@ -366,6 +375,8 @@ repoze.sendmail==4.3
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pyramid-mailer
+requests==2.26.0
+    # via -r requirements/functests.txt
 sentry-sdk==0.17.6
     # via
     #   -r requirements/functests.txt
@@ -434,6 +445,7 @@ urllib3==1.26.5
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   elasticsearch
+    #   requests
     #   sentry-sdk
 venusian==3.0.0
     # via
@@ -467,6 +479,7 @@ webob==1.8.7
     #   -r requirements/tests.txt
     #   pyramid
     #   webtest
+    #   wsgiproxy2
 webtest==3.0.0
     # via -r requirements/functests.txt
 wired==0.2.2
@@ -484,6 +497,8 @@ wsaccel==0.6.3
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+wsgiproxy2==0.5.1
+    # via -r requirements/functests.txt
 zipp==3.4.1
     # via
     #   -r requirements/functests.txt

--- a/tests/functional/test_streamer.py
+++ b/tests/functional/test_streamer.py
@@ -1,0 +1,196 @@
+from gevent.monkey import MonkeyPatchWarning, patch_all
+
+# We want to patch as early as possible, which totally ruins the import order
+try:
+    patch_all()
+except MonkeyPatchWarning:
+    pass
+
+import json  # pylint: disable=wrong-import-position,wrong-import-order
+from collections import (  # pylint: disable=wrong-import-position,wrong-import-order
+    defaultdict,
+)
+from json import (  # pylint: disable=wrong-import-position,wrong-import-order
+    JSONDecodeError,
+)
+
+import gevent  # pylint: disable=wrong-import-position
+import pytest  # pylint: disable=wrong-import-position
+from h_matchers import Any  # pylint: disable=wrong-import-position
+from ws4py.client.geventclient import (  # pylint: disable=wrong-import-position
+    WebSocketClient,
+)
+
+
+class Client(WebSocketClient):
+    def __init__(self, url, message_queue):
+        super().__init__(
+            url=url,
+            protocols=["http-only", "chat"],
+        )
+        self.connect()
+
+        self.message_queue = message_queue
+        self.threads = []
+
+    def expect_messages(self, client_id, num=1):
+        def _capture_incoming():
+            messages_received = 0
+
+            while True:
+                message = self.receive()
+                if message is not None:
+                    try:
+                        data = json.loads(message.data)
+                    except JSONDecodeError:
+                        data = message.data
+
+                    self.message_queue[client_id].append(data)
+
+                    messages_received += 1
+                    if messages_received == num:
+                        self.close()
+                        break
+                else:
+                    print("Disconnect")
+                    break
+
+                gevent.sleep()
+
+        self.threads.append(gevent.spawn(_capture_incoming))
+
+    def login(self, client_id):
+        for message in [
+            {
+                "filter": {
+                    "match_policy": "include_any",
+                    "clauses": [
+                        {
+                            "field": "/uri",
+                            "operator": "one_of",
+                            "value": ["https://example.com/"],
+                            "case_sensitive": False,
+                        }
+                    ],
+                    "actions": {"create": True, "update": True, "delete": True},
+                }
+            },
+            {"messageType": "client_id", "value": client_id},
+            {"type": "whoami", "id": 1},
+        ]:
+            self.send(json.dumps(message))
+
+    def wait_on_client(self):
+        self.wait_for([self])
+
+    @classmethod
+    def wait_for(cls, clients, timeout=1):
+        try:
+            threads = []
+            for client in clients:
+                threads.extend(client.threads)
+
+            gevent.joinall(threads, timeout=timeout)
+
+        finally:
+            for client in clients:
+                client.close()
+
+
+@pytest.mark.usefixtures("ws_app")
+class TestWebSocket:
+    def test_missing_pages(self, ws_app):
+        response = ws_app.get("/not_a_path", status=404)
+
+        assert response.json == {
+            "ok": False,
+            "error": "not_found",
+            "reason": "These are not the droids you are looking for.",
+        }
+
+    def test_we_can_connect(self, client, messages, user):
+        client.expect_messages(client_id="user_client", num=1)
+        client.login("user_client")
+
+        client.wait_on_client()
+
+        assert messages == {
+            "user_client": [
+                {"ok": True, "reply_to": 1, "type": "whoyouare", "userid": user.userid}
+            ]
+        }
+
+    def test_we_can_pass_messages(
+        self, app, client, auth_token, anonymous_client, messages
+    ):
+        client.expect_messages(client_id="user_client", num=2)
+        client.login("user_client")
+        anonymous_client.expect_messages(client_id="anon_client", num=2)
+        anonymous_client.login("anon_client")
+
+        # Create a public annotation the anonymous user can see
+        app.post_json(
+            "/api/annotations",
+            {
+                "group": "__world__",
+                "permissions": {"read": ["group:__world__"]},
+                "text": "My annotation",
+                "uri": "http://example.com",
+            },
+            headers={"Authorization": f"Bearer {auth_token.value}"},
+            status=200,
+        )
+
+        Client.wait_for([client, anonymous_client])
+
+        assert messages["user_client"] == [
+            Any.dict.containing({"type": "whoyouare"}),
+            Any.dict.containing({"type": "annotation-notification"}),
+        ]
+
+        assert messages["anon_client"] == [
+            Any.dict.containing({"type": "whoyouare"}),
+            Any.dict.containing({"type": "annotation-notification"}),
+        ]
+
+    @pytest.fixture
+    def user(self, factories, db_session):
+        user = factories.User()
+        db_session.commit()
+        return user
+
+    @pytest.fixture
+    def auth_token(self, user, factories, db_session):
+        auth_token = factories.OAuth2Token(userid=user.userid)
+        db_session.commit()
+        return auth_token
+
+    @pytest.fixture
+    def messages(self):
+        return defaultdict(list)
+
+    @pytest.fixture
+    def client(self, auth_token, messages):
+        client = None
+        try:
+            client = Client(
+                url=f"ws://localhost:5001/ws?access_token={auth_token.value}",
+                message_queue=messages,
+            )
+            yield client
+        finally:
+            if client:
+                client.wait_on_client()
+
+    @pytest.fixture
+    def anonymous_client(self, messages):
+        client = None
+        try:
+            client = Client(
+                url="ws://localhost:5001/ws",
+                message_queue=messages,
+            )
+            yield client
+        finally:
+            if client:
+                client.wait_on_client()


### PR DESCRIPTION
Currently the websocket has no functional test coverage, because it's an absolute pain to test. This PR shows what it might take to test it.

I can't tell you the number of blind alley ways I went down before I came up with this...

### How this works

How the websocket app fixture works:

* We run the same code `pserve` does to start the server
* We do this in a `multiprocessing` thread so it's non-blocking
* We then poll the service to see when it's up and ready to accept connection
* As a fixture we yield and when control comes back to us we kill the thread

How the websocket tests work:

 * We start `gevent` co-operative scheduling to connect to the websocket for real
 * These connections "expect" a number of incoming messages and shut down when they get that many
 * As it's co-operative scheduling rather than threading we don't have any race conditions etc, and can simply push the messages onto a list
 * We do a similar yield-kill as above regardless so it terminates even if it doesn't shut down

### Some things that don't work

 * You can't use `TestApp` as it fakes out making connections, so we can't make a real websocket connection to it
 * You can't use `SimpleServer` with `gevent` as it's blocking
 * You _must_ have `gunicorn` in the mix, otherwise the websocket doesn't seem to work (we rely on something about the workers which are `gunicorn` specific etc).
 * You _can_ use `subprocess`, but you have to use `Popen` otherwise it's blocking
 * If you use `subprocess.Popen` it's a devil to kill the process once it's started without leaving zombies
 * Same for `subprocess.check_call` with `multiprocessing`
 * If the fixture for the websocket app has `session` terrible things happen. I don't know why.

### Some things I'm not sure about

 * I'm not sure we need to use `gevent`. It might be possible to do this in serial. Although it might end-up blocking itself I think
 * I'm not sure about `gevent.monkey_patch` - We need it for `gevent` to work, and it doesn't _seem_ to cause any problems, but it does modify loads of libraries and methods
 * Connecting to the websocket takes a lot of code for a test. Not sure there's a way around this, it's just complicated