### PR TITLE
Refactor auth token tests

### DIFF
--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -1,85 +1,48 @@
 import datetime
-from unittest import mock
 
-import jwt
 import pytest
+from pytest import param
 
 from h.auth import tokens
 
 
+def _seconds_from_now(seconds):
+    return datetime.datetime.utcnow() + datetime.timedelta(seconds=seconds)
+
+
 class TestToken:
-    def test_token_with_no_expiry_is_valid(self):
-        token = tokens.Token(mock.Mock(expires=None, userid="acct:foo@example.com"))
-
-        assert token.is_valid()
-
-    def test_token_with_future_expiry_is_valid(self):
+    @pytest.mark.parametrize(
+        "expires,is_valid",
+        (
+            param(None, True, id="no expiry"),
+            param(_seconds_from_now(1800), True, id="future expiry"),
+            param(_seconds_from_now(-1800), False, id="past expiry"),
+        ),
+    )
+    def test_it(self, expires, is_valid, factories):
         token = tokens.Token(
-            mock.Mock(userid="acct:foo@example.com", expires=_seconds_from_now(1800))
+            factories.OAuth2Token(userid="acct:foo@example.com", expires=expires)
         )
 
-        assert token.is_valid()
-
-    def test_token_with_past_expiry_is_not_valid(self):
-        token = tokens.Token(
-            mock.Mock(userid="acct:foo@example.com", expires=_seconds_from_now(-1800))
-        )
-
-        assert not token.is_valid()
-
-
-VALID_TOKEN_EXAMPLES = [
-    # Valid
-    lambda k: jwt.encode({"exp": _seconds_from_now(3600)}, key=k),
-    # Expired, but within leeway
-    lambda k: jwt.encode({"exp": _seconds_from_now(-120)}, key=k),
-]
-
-INVALID_TOKEN_EXAMPLES = [
-    # Expired 1 hour ago
-    lambda k: jwt.encode({"exp": _seconds_from_now(-3600)}, key=k),
-    # Incorrect encoding key
-    lambda k: jwt.encode({"exp": _seconds_from_now(3600)}, key="somethingelse"),
-]
+        assert token.is_valid() == is_valid
 
 
 class TestAuthToken:
-    def test_retrieves_token_for_request(self, pyramid_request):
-        pyramid_request.headers["Authorization"] = "Bearer abcdef123"
-
-        result = tokens.auth_token(pyramid_request)
-
-        assert result == "abcdef123"
-
-    def test_returns_none_when_no_authz_header(self, pyramid_request):
-        result = tokens.auth_token(pyramid_request)
-
-        assert result is None
-
-    def test_returns_none_for_empty_token(self, pyramid_request):
-        pyramid_request.headers["Authorization"] = "Bearer "
-
-        result = tokens.auth_token(pyramid_request)
-
-        assert result is None
-
     @pytest.mark.parametrize(
-        "header",
-        [
-            "",
-            "abcdef123",
-            "\x10",
-            ".\x00\"Ħ(\x12'𨳂\x05\U000df02a\U00095c2c셀",
-            "\U000f022b\t\x07\x1c0\x04\x06",
-        ],
+        "header,expected",
+        (
+            ("Bearer abcdef123", "abcdef123"),
+            (None, None),
+            ("Bearer ", None),
+            ("", None),
+            ("abcdef123", None),
+            ("\x10", None),
+            (".\x00\"Ħ(\x12'𨳂\x05\U000df02a\U00095c2c셀", None),
+            ("\U000f022b\t\x07\x1c0\x04\x06", None),
+        ),
     )
-    def test_returns_none_for_malformed_header(self, header, pyramid_request):
-        pyramid_request.headers["Authorization"] = header
+    def test_it(self, pyramid_request, header, expected):
+        if header is not None:
+            pyramid_request.headers["Authorization"] = header
 
-        result = tokens.auth_token(pyramid_request)
-
-        assert result is None
-
-
-def _seconds_from_now(seconds):
-    return datetime.datetime.utcnow() + datetime.timedelta(seconds=seconds)
+        assert tokens.auth_token(pyramid_request) == expected


### PR DESCRIPTION
This removed a bunch of dead code and also used parameterisation to really cut down on the number of separate test cases (to one for each item).

This is in order to make moving these around easier in some coming refactors without big PRs.