### PR TITLE
Up the number of available handles for the Websocket in NGINX

### DIFF
--- a/h/streamer/conf/nginx.conf
+++ b/h/streamer/conf/nginx.conf
@@ -3,13 +3,18 @@ worker_processes auto;
 pid /var/lib/hypothesis/nginx.pid;
 error_log /dev/stderr;
 
-# This file handle limit should ideally by the number of worker
+# This file handle limit should ideally be at least the number of worker
 # connections * 2. But it can't exceed the "hard" limit applied
-# by the OS. Which for the moment is 4096 in our deploys.
-worker_rlimit_nofile 4096;
+# by the OS. See here for the settings applied by our deployments:
+# https://github.com/hypothesis/deployment/blob/master/h-websocket/ebextensions/prod/docker_nofile.config
+worker_rlimit_nofile 8192;
 
 events {
-  worker_connections 4096;
+  # Worker connections can exceed those of the upstream NGINX, but it won't do
+  # us much good as the upstream AWS NGINX will reject connections before they
+  # get to us:
+  # https://github.com/hypothesis/deployment/blob/master/h-websocket/platform/prod/nginx/nginx.conf
+  worker_connections 8192;
 }
 
 http {


### PR DESCRIPTION
This is part of our tweaking process to try and see how much traffic we can handle on a single instance.