### PR TITLE
Double the capacity of the websocket to 16384 connections

### DIFF
--- a/h/streamer/conf/nginx.conf
+++ b/h/streamer/conf/nginx.conf
@@ -7,14 +7,14 @@ error_log /dev/stderr;
 # connections * 2. But it can't exceed the "hard" limit applied
 # by the OS. See here for the settings applied by our deployments:
 # https://github.com/hypothesis/deployment/blob/master/h-websocket/ebextensions/prod/docker_nofile.config
-worker_rlimit_nofile 16384;
+worker_rlimit_nofile 32768;
 
 events {
   # Worker connections can exceed those of the upstream NGINX, but it won't do
   # us much good as the upstream AWS NGINX will reject connections before they
   # get to us:
   # https://github.com/hypothesis/deployment/blob/master/h-websocket/platform/prod/nginx/nginx.conf
-  worker_connections 16384;
+  worker_connections 32768;
 }
 
 http {

--- a/h/streamer/conf/websocket-dev.ini
+++ b/h/streamer/conf/websocket-dev.ini
@@ -18,6 +18,7 @@ worker_class: h.streamer.Worker
 graceful_timeout: 0
 proc_name: websocket
 # This is very low so you can see what happens when we run out
+workers: 2
 worker_connections: 8
 
 [loggers]

--- a/h/streamer/conf/websocket.ini
+++ b/h/streamer/conf/websocket.ini
@@ -7,6 +7,7 @@ bind: unix:/tmp/gunicorn-websocket.sock
 worker_class: h.streamer.Worker
 graceful_timeout: 0
 proc_name: websocket
+workers: 2
 worker_connections: 8192
 
 [loggers]


### PR DESCRIPTION
For: https://github.com/hypothesis/deployment/pull/378

This takes a different approach to increasing single machine capacity to before. Previously we were upping the number of connections per worker. In this case I'd like to increase the number of workers for a few reasons:

 * These should execute in parallel on the machine
 * This could mean a lower overall response time
 * This is as people at the end of the queue will be at the end of two shorter queues (hopefully)
 * Also more efficient use of the CPU
 * This might cause greater CPU load, as some of the work which had to be done once is now done twice
 * Most of the work however is per socket, and this will be spread evenly
 
I'm not sure what effect this will have on reporting. This might appear as 2 websockets to us?
 
The docs I've seen says you can typically run CPU cores * 2 + 1 for workers. On a 2 core machine this would mean 5, but we are also running a lot of other processes like NGINX and supervisord which will need some space. So we could probably add one more, and then look at removing NGINX.