### PR TITLE
Fix admin pages for staff members

### DIFF
--- a/h/jinja_extensions/__init__.py
+++ b/h/jinja_extensions/__init__.py
@@ -3,6 +3,7 @@ from urllib.parse import unquote
 from h.jinja_extensions import filters
 from h.jinja_extensions.back_link_label import back_link_label
 from h.jinja_extensions.navbar_data import navbar_data
+from h.jinja_extensions.navbar_data_admin import navbar_data_admin
 from h.jinja_extensions.svg_icon import svg_icon
 
 
@@ -19,6 +20,7 @@ def setup_jinja2_env(environment):
     environment.globals["svg_icon"] = svg_icon
     environment.globals["back_link_label"] = back_link_label
     environment.globals["navbar_data"] = navbar_data
+    environment.globals["navbar_data_admin"] = navbar_data_admin
 
 
 def includeme(config):  # pragma: no cover

--- a/h/jinja_extensions/navbar_data_admin.py
+++ b/h/jinja_extensions/navbar_data_admin.py
@@ -1,0 +1,116 @@
+from copy import deepcopy
+
+from h.security import Permission
+from h.traversal import Root
+
+
+def navbar_data_admin(request):
+    """
+    Get the navigation bar displayed at the top of the admin page.
+
+    This is used in `templates/layouts/admin.html.jinja2`
+    """
+
+    # The ACL based system only has the admin page ACLs attached to various
+    # contexts. On some of the admin pages we will have a GroupContext instead.
+    # We could fix that but it won't matter soon, so we'll create a context
+    # with the right ACL for now to determine which pages the user can see.
+    context = Root(request)
+
+    for tab in deepcopy(_ADMIN_MENU):
+        if not request.has_permission(tab.pop("permission"), context=context):
+            continue
+
+        if route := tab.get("route"):
+            tab["url"] = request.route_url(route)
+
+        if children := tab.get("children"):
+            for child in children:
+                child["url"] = request.route_url(child["route"])
+
+        yield tab
+
+
+_ADMIN_MENU = [
+    {
+        "id": "index",
+        "permission": Permission.AdminPage.INDEX,
+        "title": "Home",
+        "route": "admin.index",
+    },
+    {
+        "id": "admins",
+        "permission": Permission.AdminPage.ADMINS,
+        "title": "Administrators",
+        "route": "admin.admins",
+    },
+    {
+        "id": "badge",
+        "permission": Permission.AdminPage.BADGE,
+        "title": "Badge",
+        "route": "admin.badge",
+    },
+    {
+        "id": "features",
+        "permission": Permission.AdminPage.FEATURES,
+        "title": "Feature flags",
+        "children": [
+            {"route": "admin.features", "title": "Manage feature flags"},
+            {"route": "admin.cohorts", "title": "Manage feature cohorts"},
+        ],
+    },
+    {
+        "id": "groups",
+        "permission": Permission.AdminPage.GROUPS,
+        "title": "Groups",
+        "children": [
+            {"route": "admin.groups", "title": "List Groups"},
+            {"route": "admin.groups_create", "title": "Create a Group"},
+        ],
+    },
+    {
+        "id": "mailer",
+        "permission": Permission.AdminPage.MAILER,
+        "title": "Mailer",
+        "route": "admin.mailer",
+    },
+    {
+        "id": "nipsa",
+        "permission": Permission.AdminPage.NIPSA,
+        "title": "NIPSA",
+        "route": "admin.nipsa",
+    },
+    {
+        "id": "oauth",
+        "permission": Permission.AdminPage.OAUTH_CLIENTS,
+        "title": "OAuth clients",
+        "route": "admin.oauthclients",
+    },
+    {
+        "id": "organizations",
+        "permission": Permission.AdminPage.ORGANIZATIONS,
+        "title": "Organizations",
+        "children": [
+            {"route": "admin.organizations", "title": "List organizations"},
+            {"route": "admin.organizations_create", "title": "Create an organization"},
+        ],
+    },
+    {
+        "id": "staff",
+        "permission": Permission.AdminPage.STAFF,
+        "title": "Staff",
+        "route": "admin.staff",
+    },
+    {
+        "id": "users",
+        "permission": Permission.AdminPage.USERS,
+        "title": "Users",
+        "route": "admin.users",
+    },
+    {
+        "id": "search",
+        "permission": Permission.AdminPage.SEARCH,
+        "title": "Search",
+        "route": "admin.search",
+    },
+]

--- a/h/templates/layouts/admin.html.jinja2
+++ b/h/templates/layouts/admin.html.jinja2
@@ -4,19 +4,19 @@
     ('admins', 'admin.admins', 'Administrators', []),
     ('badge', 'admin.badge', 'Badge', []),
     ('features', 'admin.features', 'Feature flags', [
-      ('features', 'admin.features', 'Manage feature flags'),
-      ('cohorts', 'admin.cohorts', 'Manage feature cohorts'),
+      ('admin.features', 'Manage feature flags'),
+      ('admin.cohorts', 'Manage feature cohorts'),
     ]),
     ('groups', 'admin.groups', 'Groups', [
-      ('groups', 'admin.groups', 'List Groups'),
-      ('groups_create', 'admin.groups_create', 'Create a Group'),
+      ('admin.groups', 'List Groups'),
+      ('admin.groups_create', 'Create a Group'),
     ]),
     ('mailer', 'admin.mailer', 'Mailer', []),
     ('nipsa', 'admin.nipsa', 'NIPSA', []),
     ('oauth', 'admin.oauthclients', 'OAuth clients', []),
     ('organizations', 'admin.organizations', 'Organizations', [
-      ('organizations', 'admin.organizations', 'List organizations'),
-      ('organizations_create', 'admin.organizations_create', 'Create an organization'),
+      ('admin.organizations', 'List organizations'),
+      ('admin.organizations_create', 'Create an organization'),
     ]),
     ('staff', 'admin.staff', 'Staff', []),
     ('users', 'admin.users', 'Users', []),
@@ -47,6 +47,7 @@
 
     {% include 'h:templates/includes/settings.html.jinja2' %}
   </head>
+
   <body>
     <nav class="admin-navbar">
       <div class="admin-navbar__container">
@@ -67,7 +68,7 @@
                     <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
-                      {% for id, url, title in children %}
+                      {% for url, title in children %}
                         <li><a href="{{ request.route_url(url) }}">{{ title }}</a></li>
                       {% endfor %}
                     </ul>

--- a/h/templates/layouts/admin.html.jinja2
+++ b/h/templates/layouts/admin.html.jinja2
@@ -61,7 +61,7 @@
                   <a class="admin-navbar__tab-link" href="{{ request.route_url(permission) }}">{{ title }}</a>
                 </li>
               {% else %}
-                <li class="admin-navbar__tab-item dropdown{% if id in page_id %} active{% endif %}">
+                <li class="admin-navbar__tab-item dropdown{% if id in page_id %} is-active{% endif %}">
                     <a href="#" class="admin-navbar__tab-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                     {{ title }}
                     <span class="caret"></span>

--- a/h/templates/layouts/admin.html.jinja2
+++ b/h/templates/layouts/admin.html.jinja2
@@ -1,30 +1,25 @@
-{%- set nav_pages = [
-    ('index', 'admin.index', 'Home', []),
-
-    ('admins', 'admin.admins', 'Administrators', []),
-    ('badge', 'admin.badge', 'Badge', []),
-    ('features', 'admin.features', 'Feature flags', [
-      ('admin.features', 'Manage feature flags'),
-      ('admin.cohorts', 'Manage feature cohorts'),
-    ]),
-    ('groups', 'admin.groups', 'Groups', [
-      ('admin.groups', 'List Groups'),
-      ('admin.groups_create', 'Create a Group'),
-    ]),
-    ('mailer', 'admin.mailer', 'Mailer', []),
-    ('nipsa', 'admin.nipsa', 'NIPSA', []),
-    ('oauth', 'admin.oauthclients', 'OAuth clients', []),
-    ('organizations', 'admin.organizations', 'Organizations', [
-      ('admin.organizations', 'List organizations'),
-      ('admin.organizations_create', 'Create an organization'),
-    ]),
-    ('staff', 'admin.staff', 'Staff', []),
-    ('users', 'admin.users', 'Users', []),
-    ('search', 'admin.search', 'Search', []),
-] -%}
-
 {%- set page_id = page_id|default('home') -%}
 {%- set page_title = page_title|default('Administration pages') -%}
+
+{% macro menu_tab(tab) %}
+  {% if tab.children %}
+    <li class="admin-navbar__tab-item dropdown{% if tab.id in page_id %} is-active{% endif %}">
+      <a href="#" class="admin-navbar__tab-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+      {{ tab.title }}
+      <span class="caret"></span>
+      </a>
+      <ul class="dropdown-menu">
+        {% for child in tab.children %}
+          <li><a href="{{ child.url }}">{{ child.title }}</a></li>
+        {% endfor %}
+      </ul>
+    </li>
+  {% else %}
+    <li class="admin-navbar__tab-item{% if tab.id == page_id %} is-active{% endif %}">
+      <a class="admin-navbar__tab-link" href="{{ tab.url }}">{{ tab.title }}</a>
+    </li>
+  {% endif %}
+{% endmacro %}
 
 <!DOCTYPE html>
 <html>
@@ -37,12 +32,12 @@
       Hypothesis: {{ page_title }}
     </title>
 
-  {% for url in asset_urls("admin_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
+    {% for url in asset_urls("admin_css") %}
+      <link rel="stylesheet" href="{{ url }}">
+    {% endfor %}
 
     {% for url in asset_urls("header_js") %}
-    <script src="{{ url }}"></script>
+      <script src="{{ url }}"></script>
     {% endfor %}
 
     {% include 'h:templates/includes/settings.html.jinja2' %}
@@ -55,26 +50,8 @@
           {{ svg_icon('logo', 'admin-navbar__logo') }}
         </a>
         <ul class="admin-navbar__tab-list">
-          {% for id, permission, title, children in nav_pages %}
-            {% if request.has_permission(permission) %}
-              {% if not children %}
-                <li class="admin-navbar__tab-item{% if id == page_id %} is-active{% endif %}">
-                  <a class="admin-navbar__tab-link" href="{{ request.route_url(permission) }}">{{ title }}</a>
-                </li>
-              {% else %}
-                <li class="admin-navbar__tab-item dropdown{% if id in page_id %} is-active{% endif %}">
-                    <a href="#" class="admin-navbar__tab-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                    {{ title }}
-                    <span class="caret"></span>
-                    </a>
-                    <ul class="dropdown-menu">
-                      {% for url, title in children %}
-                        <li><a href="{{ request.route_url(url) }}">{{ title }}</a></li>
-                      {% endfor %}
-                    </ul>
-                </li>
-              {% endif %}
-            {% endif %}
+          {% for tab in navbar_data_admin(request) %}
+            {{ menu_tab(tab) }}
           {% endfor %}
         </ul>
       </div>
@@ -91,7 +68,7 @@
     </div>
 
     {% for url in asset_urls("admin_js") %}
-    <script src="{{ url }}"></script>
+      <script src="{{ url }}"></script>
     {% endfor %}
     {% block scripts %}{% endblock %}
   </body>

--- a/h/views/admin/index.py
+++ b/h/views/admin/index.py
@@ -12,7 +12,7 @@ from h.security import Permission
     renderer="h:templates/admin/index.html.jinja2",
     permission=Permission.AdminPage.INDEX,
 )
-def index(_):
+def index(_request):
     return {
         "release_info": {
             "hostname": platform.node(),

--- a/tests/h/jinja2_extensions/navbar_data_admin_test.py
+++ b/tests/h/jinja2_extensions/navbar_data_admin_test.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+import pytest
+
+from h.jinja_extensions import navbar_data_admin
+
+STAFF_TABS = ["index", "groups", "mailer", "organizations", "users"]
+
+
+class TestNavbarDataAdmin:
+    @pytest.mark.parametrize("permissive", (True, False))
+    def test_it(self, pyramid_config, pyramid_request, permissive):
+        pyramid_config.testing_securitypolicy(permissive=permissive)
+
+        tabs = list(navbar_data_admin(pyramid_request))
+
+        if not permissive:
+            assert not tabs
+            return
+
+        assert tabs
+
+        for tab in tabs:
+            assert tab["id"]
+            assert tab["title"]
+            assert not tab.get("permission")
+
+            if route := tab.get("route"):
+                assert tab["url"] == f"route:{route}"
+
+            if children := tab.get("children"):
+                for child in children:
+                    assert child["title"]
+                    assert child["url"] == f"route:{child['route']}"
+
+    @pytest.fixture(autouse=True)
+    def pyramid_request(self, pyramid_request):
+        with patch.object(pyramid_request, "route_url") as route_url:
+            route_url.side_effect = lambda route: f"route:{route}"
+            yield pyramid_request


### PR DESCRIPTION
It turns out there is a ton of permissions access hidden away in the templates for the admin page menus. These weren't working at all, but as admins have blanket access nothing appears wrong.

Staff users however would see a blank bar. It turns out we don't actually have any staff users, but it seems wrong to leave it broken. It's also breaking the func tests in future releases.

This PR:

 * [bug] Fixes a small highlighting issue where groups didn't highlight correctly
 * [bug] Fixes staff members not being able to see any items
 * [bug] Fixes staff members not being able to see group and org creation elements
 * Creates a Jinja extension to provide the data required for the nav bar in Python
 * Uses the correct permissions to decide who should see what

### Testing notes

Highlighting

 * Run `make services dev`
 * Visit http://localhost:5000
 * Login as `devdata_admin`
 * Visit: http://localhost:5000/admin
 * Click through each item in the menu and sub-menus, the relevant tab should highlight 
 
Staff issue:

 * Login as `devdata_staff`
 * Visit: http://localhost:5000/admin
 * You should see a more limited selection of items
 * This should now include group and org create
 * Visit a page for editing a group (this is a special case) everything should look normal