### PR TITLE
Add per request caching of identity to the security policies

### DIFF
--- a/h/security/policy/bearer_token.py
+++ b/h/security/policy/bearer_token.py
@@ -1,4 +1,5 @@
 from pyramid.interfaces import ISecurityPolicy
+from pyramid.request import RequestLocalCache
 from zope.interface import implementer
 
 from h.security import Identity
@@ -15,6 +16,9 @@ class TokenPolicy(IdentityBasedPolicy):
     Websocket requests with the GET parameter `access_token`.
     """
 
+    def __init__(self):
+        self._identity_cache = RequestLocalCache(self._load_identity)
+
     def identity(self, request):
         """
         Get an Identity object for valid credentials.
@@ -25,6 +29,10 @@ class TokenPolicy(IdentityBasedPolicy):
         :param request: Pyramid request to inspect
         :returns: An `Identity` object if the login is authenticated or None
         """
+
+        return self._identity_cache.get_or_create(request)
+
+    def _load_identity(self, request):
         token_svc = request.find_service(name="auth_token")
         token_str = None
 

--- a/tests/h/security/policy/bearer_token_test.py
+++ b/tests/h/security/policy/bearer_token_test.py
@@ -20,6 +20,14 @@ class TestTokenPolicy:
         )
         assert identity == Identity(user=user_service.fetch.return_value)
 
+    def test_identity_caches(self, pyramid_request, auth_token_service):
+        policy = TokenPolicy()
+
+        policy.identity(pyramid_request)
+        policy.identity(pyramid_request)
+
+        auth_token_service.get_bearer_token.assert_called_once()
+
     def test_identity_for_webservice(self, pyramid_request, auth_token_service):
         pyramid_request.path = "/ws"
         pyramid_request.GET["access_token"] = sentinel.access_token

--- a/tests/h/security/policy/combined_test.py
+++ b/tests/h/security/policy/combined_test.py
@@ -45,6 +45,26 @@ class TestSecurityPolicy:
             )
             assert result == _call_sub_policies.return_value
 
+    def test_identity_caches(self, pyramid_request, CookiePolicy):
+        policy = SecurityPolicy()
+
+        policy.identity(pyramid_request)
+        policy.identity(pyramid_request)
+
+        CookiePolicy.return_value.identity.assert_called_once()
+
+    @pytest.mark.parametrize("method,args", (("remember", ["userid"]), ("forget", [])))
+    def test_remember_and_forget_reset_cache(
+        self, pyramid_request, CookiePolicy, method, args
+    ):
+        policy = SecurityPolicy()
+
+        policy.identity(pyramid_request)
+        getattr(policy, method)(pyramid_request, *args)
+        policy.identity(pyramid_request)
+
+        assert CookiePolicy.return_value.identity.call_count == 2
+
     @pytest.mark.parametrize(
         "path,is_ui",
         (


### PR DESCRIPTION
This adds caching to our security policies so we only attempt to get the identity once per request. This has the potential to save us time on repeated permissions requests for example.

In this PR:

 * The `SecurityPolicy` and `TokenSecurity` have caching added to the identity functions
 * This is because they are the only externally called policies
 * Care also has to be taken to clear the cache when "forgetting" or less intuitively when "remembering"
 * We have to clear when we "remember" a user so we don't cache the fact they are logged out