### PR TITLE
Fix the fallback link in the navbar settings to be a call not a string

### DIFF
--- a/h/templates/includes/navbar.html.jinja2
+++ b/h/templates/includes/navbar.html.jinja2
@@ -93,7 +93,7 @@
         <span class="nav-bar-links__item">
         {% call dropdown_menu(nav.settings_menu_items,
                               link_class='nav-bar-links__link',
-                              fallback_link='{{ request.route_url("account") }}',
+                              fallback_link=request.route_url("account"),
                               title='Settings',
                               footer_item=nav.signout_item) %}
             {{ svg_icon('settings') }}


### PR DESCRIPTION
Previously this was the string we intended to evaluate rather than the result. I don't know exactly why this is kicking in for me, but if
it does it shouldn't be broken.

I think this happens when the javascript bundle is broken or missing, and you run this separately (outside of `make dev`) which would re-create the bundle.

You might be able to re-create by blocking Javascript.