### PR TITLE
Simplified admin page permissions

### DIFF
--- a/h/jinja_extensions/navbar_data_admin.py
+++ b/h/jinja_extensions/navbar_data_admin.py
@@ -27,25 +27,25 @@ def navbar_data_admin(request):
 _ADMIN_MENU = [
     {
         "id": "index",
-        "permission": Permission.AdminPage.INDEX,
+        "permission": Permission.AdminPage.LOW_RISK,
         "title": "Home",
         "route": "admin.index",
     },
     {
         "id": "admins",
-        "permission": Permission.AdminPage.ADMINS,
+        "permission": Permission.AdminPage.HIGH_RISK,
         "title": "Administrators",
         "route": "admin.admins",
     },
     {
         "id": "badge",
-        "permission": Permission.AdminPage.BADGE,
+        "permission": Permission.AdminPage.HIGH_RISK,
         "title": "Badge",
         "route": "admin.badge",
     },
     {
         "id": "features",
-        "permission": Permission.AdminPage.FEATURES,
+        "permission": Permission.AdminPage.HIGH_RISK,
         "title": "Feature flags",
         "children": [
             {"route": "admin.features", "title": "Manage feature flags"},
@@ -54,7 +54,7 @@ _ADMIN_MENU = [
     },
     {
         "id": "groups",
-        "permission": Permission.AdminPage.GROUPS,
+        "permission": Permission.AdminPage.LOW_RISK,
         "title": "Groups",
         "children": [
             {"route": "admin.groups", "title": "List Groups"},
@@ -63,25 +63,25 @@ _ADMIN_MENU = [
     },
     {
         "id": "mailer",
-        "permission": Permission.AdminPage.MAILER,
+        "permission": Permission.AdminPage.LOW_RISK,
         "title": "Mailer",
         "route": "admin.mailer",
     },
     {
         "id": "nipsa",
-        "permission": Permission.AdminPage.NIPSA,
+        "permission": Permission.AdminPage.HIGH_RISK,
         "title": "NIPSA",
         "route": "admin.nipsa",
     },
     {
         "id": "oauth",
-        "permission": Permission.AdminPage.OAUTH_CLIENTS,
+        "permission": Permission.AdminPage.HIGH_RISK,
         "title": "OAuth clients",
         "route": "admin.oauthclients",
     },
     {
         "id": "organizations",
-        "permission": Permission.AdminPage.ORGANIZATIONS,
+        "permission": Permission.AdminPage.LOW_RISK,
         "title": "Organizations",
         "children": [
             {"route": "admin.organizations", "title": "List organizations"},
@@ -90,19 +90,19 @@ _ADMIN_MENU = [
     },
     {
         "id": "staff",
-        "permission": Permission.AdminPage.STAFF,
+        "permission": Permission.AdminPage.HIGH_RISK,
         "title": "Staff",
         "route": "admin.staff",
     },
     {
         "id": "users",
-        "permission": Permission.AdminPage.USERS,
+        "permission": Permission.AdminPage.LOW_RISK,
         "title": "Users",
         "route": "admin.users",
     },
     {
         "id": "search",
-        "permission": Permission.AdminPage.SEARCH,
+        "permission": Permission.AdminPage.HIGH_RISK,
         "title": "Search",
         "route": "admin.search",
     },

--- a/h/security/permission_map.py
+++ b/h/security/permission_map.py
@@ -18,18 +18,8 @@ from h.security.predicates import resolve_predicates
 
 PERMISSION_MAP = {
     # Admin pages
-    Permission.AdminPage.ADMINS: [[p.user_is_admin]],
-    Permission.AdminPage.BADGE: [[p.user_is_admin]],
-    Permission.AdminPage.FEATURES: [[p.user_is_admin]],
-    Permission.AdminPage.GROUPS: [[p.user_is_admin], [p.user_is_staff]],
-    Permission.AdminPage.INDEX: [[p.user_is_admin], [p.user_is_staff]],
-    Permission.AdminPage.MAILER: [[p.user_is_admin], [p.user_is_staff]],
-    Permission.AdminPage.OAUTH_CLIENTS: [[p.user_is_admin]],
-    Permission.AdminPage.ORGANIZATIONS: [[p.user_is_admin], [p.user_is_staff]],
-    Permission.AdminPage.NIPSA: [[p.user_is_admin]],
-    Permission.AdminPage.SEARCH: [[p.user_is_admin]],
-    Permission.AdminPage.STAFF: [[p.user_is_admin]],
-    Permission.AdminPage.USERS: [[p.user_is_admin], [p.user_is_staff]],
+    Permission.AdminPage.HIGH_RISK: [[p.user_is_admin]],
+    Permission.AdminPage.LOW_RISK: [[p.user_is_admin], [p.user_is_staff]],
     # User modification permissions
     Permission.User.CREATE: [[p.authenticated_client]],
     Permission.User.UPDATE: [[p.user_authority_matches_authenticated_client]],

--- a/h/security/permissions.py
+++ b/h/security/permissions.py
@@ -32,18 +32,8 @@ class Permission:
         UPDATE = "profile:update"
 
     class AdminPage(Enum):
-        ADMINS = "admin:admins"
-        BADGE = "admin:badge"
-        FEATURES = "admin:features"
-        GROUPS = "admin:groups"
-        INDEX = "admin:index"
-        MAILER = "admin:mailer"
-        OAUTH_CLIENTS = "admin:oauth_clients"
-        ORGANIZATIONS = "admin:organizations"
-        NIPSA = "admin:nipsa"
-        SEARCH = "admin:search"
-        STAFF = "admin:staff"
-        USERS = "admin:users"
+        HIGH_RISK = "admin:high_risk"
+        LOW_RISK = "admin:low_risk"
 
     class API(Enum):
         BULK_ACTION = "api:bulk_action"

--- a/h/views/admin/admins.py
+++ b/h/views/admin/admins.py
@@ -10,7 +10,7 @@ from h.security import Permission
     route_name="admin.admins",
     request_method="GET",
     renderer="h:templates/admin/admins.html.jinja2",
-    permission=Permission.AdminPage.ADMINS,
+    permission=Permission.AdminPage.HIGH_RISK,
 )
 def admins_index(request):
     """Get a list of all the admin users as an HTML page."""
@@ -26,7 +26,7 @@ def admins_index(request):
     request_method="POST",
     request_param="add",
     renderer="h:templates/admin/admins.html.jinja2",
-    permission=Permission.AdminPage.ADMINS,
+    permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
 def admins_add(request):
@@ -51,7 +51,7 @@ def admins_add(request):
     request_method="POST",
     request_param="remove",
     renderer="h:templates/admin/admins.html.jinja2",
-    permission=Permission.AdminPage.ADMINS,
+    permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
 def admins_remove(request):

--- a/h/views/admin/badge.py
+++ b/h/views/admin/badge.py
@@ -11,7 +11,7 @@ from h.security import Permission
     route_name="admin.badge",
     request_method="GET",
     renderer="h:templates/admin/badge.html.jinja2",
-    permission=Permission.AdminPage.BADGE,
+    permission=Permission.AdminPage.HIGH_RISK,
 )
 def badge_index(request):
     return {"uris": request.db.query(models.Blocklist).all()}
@@ -21,7 +21,7 @@ def badge_index(request):
     route_name="admin.badge",
     request_method="POST",
     request_param="add",
-    permission=Permission.AdminPage.BADGE,
+    permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
 def badge_add(request):
@@ -46,7 +46,7 @@ def badge_add(request):
     route_name="admin.badge",
     request_method="POST",
     request_param="remove",
-    permission=Permission.AdminPage.BADGE,
+    permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
 def badge_remove(request):

--- a/h/views/admin/features.py
+++ b/h/views/admin/features.py
@@ -10,7 +10,7 @@ from h.security import Permission
     route_name="admin.features",
     request_method="GET",
     renderer="h:templates/admin/features.html.jinja2",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.AdminPage.HIGH_RISK,
 )
 def features_index(request):
 
@@ -25,7 +25,7 @@ def features_index(request):
 @view_config(
     route_name="admin.features",
     request_method="POST",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
 def features_save(request):
@@ -52,7 +52,7 @@ def features_save(request):
     route_name="admin.cohorts",
     request_method="GET",
     renderer="h:templates/admin/cohorts.html.jinja2",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.AdminPage.HIGH_RISK,
 )
 @paginator.paginate_query
 def cohorts_index(_context, request):
@@ -65,7 +65,7 @@ def cohorts_index(_context, request):
     request_method="POST",
     request_param="add",
     renderer="h:templates/admin/cohorts.html.jinja2",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
 def cohorts_add(request):
@@ -82,7 +82,7 @@ def cohorts_add(request):
     route_name="admin.cohorts_edit",
     request_method="GET",
     renderer="h:templates/admin/cohorts_edit.html.jinja2",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.AdminPage.HIGH_RISK,
 )
 def cohorts_edit(_context, request):
     id_ = request.matchdict["id"]
@@ -99,7 +99,7 @@ def cohorts_edit(_context, request):
     request_method="POST",
     request_param="add",
     renderer="h:templates/admin/cohorts_edit.html.jinja2",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
 def cohorts_edit_add(request):
@@ -131,7 +131,7 @@ def cohorts_edit_add(request):
     request_method="POST",
     request_param="remove",
     renderer="h:templates/admin/cohorts_edit.html.jinja2",
-    permission=Permission.AdminPage.FEATURES,
+    permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
 def cohorts_edit_remove(request):

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -16,7 +16,7 @@ _ = i18n.TranslationString
     route_name="admin.groups",
     request_method="GET",
     renderer="h:templates/admin/groups.html.jinja2",
-    permission=Permission.AdminPage.GROUPS,
+    permission=Permission.AdminPage.LOW_RISK,
 )
 @paginator.paginate_query
 def groups_index(_context, request):
@@ -31,7 +31,7 @@ def groups_index(_context, request):
 @view_defaults(
     route_name="admin.groups_create",
     renderer="h:templates/admin/groups_create.html.jinja2",
-    permission=Permission.AdminPage.GROUPS,
+    permission=Permission.AdminPage.LOW_RISK,
 )
 class GroupCreateViews:  # pylint: disable=too-many-instance-attributes
     """Views for admin create-group forms."""
@@ -126,7 +126,7 @@ class GroupCreateViews:  # pylint: disable=too-many-instance-attributes
 
 @view_defaults(
     route_name="admin.groups_edit",
-    permission=Permission.AdminPage.GROUPS,
+    permission=Permission.AdminPage.LOW_RISK,
     renderer="h:templates/admin/groups_edit.html.jinja2",
 )
 class GroupEditViews:  # pylint: disable=too-many-instance-attributes

--- a/h/views/admin/index.py
+++ b/h/views/admin/index.py
@@ -10,7 +10,7 @@ from h.security import Permission
     route_name="admin.index",
     request_method="GET",
     renderer="h:templates/admin/index.html.jinja2",
-    permission=Permission.AdminPage.INDEX,
+    permission=Permission.AdminPage.LOW_RISK,
 )
 def index(_request):
     return {

--- a/h/views/admin/mailer.py
+++ b/h/views/admin/mailer.py
@@ -10,7 +10,7 @@ from h.tasks import mailer
     route_name="admin.mailer",
     request_method="GET",
     renderer="h:templates/admin/mailer.html.jinja2",
-    permission=Permission.AdminPage.MAILER,
+    permission=Permission.AdminPage.LOW_RISK,
 )
 def mailer_index(request):
     """Show the mailer test tools."""
@@ -20,7 +20,7 @@ def mailer_index(request):
 @view_config(
     route_name="admin.mailer_test",
     request_method="POST",
-    permission=Permission.AdminPage.MAILER,
+    permission=Permission.AdminPage.LOW_RISK,
     require_csrf=True,
 )
 def mailer_test(request):

--- a/h/views/admin/nipsa.py
+++ b/h/views/admin/nipsa.py
@@ -14,7 +14,7 @@ class UserNotFoundError(Exception):
     route_name="admin.nipsa",
     request_method="GET",
     renderer="h:templates/admin/nipsa.html.jinja2",
-    permission=Permission.AdminPage.NIPSA,
+    permission=Permission.AdminPage.HIGH_RISK,
 )
 def nipsa_index(request):
     nipsa_service = request.find_service(name="nipsa")
@@ -28,7 +28,7 @@ def nipsa_index(request):
     route_name="admin.nipsa",
     request_method="POST",
     request_param="add",
-    permission=Permission.AdminPage.NIPSA,
+    permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
 def nipsa_add(request):
@@ -56,7 +56,7 @@ def nipsa_add(request):
     route_name="admin.nipsa",
     request_method="POST",
     request_param="remove",
-    permission=Permission.AdminPage.NIPSA,
+    permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
 def nipsa_remove(request):

--- a/h/views/admin/oauthclients.py
+++ b/h/views/admin/oauthclients.py
@@ -21,7 +21,7 @@ def _response_type_for_grant_type(grant_type):
 @view_config(
     route_name="admin.oauthclients",
     renderer="h:templates/admin/oauthclients.html.jinja2",
-    permission=Permission.AdminPage.OAUTH_CLIENTS,
+    permission=Permission.AdminPage.HIGH_RISK,
 )
 def index(request):
     clients = request.db.query(AuthClient).order_by(AuthClient.name.asc()).all()
@@ -30,7 +30,7 @@ def index(request):
 
 @view_defaults(
     route_name="admin.oauthclients_create",
-    permission=Permission.AdminPage.OAUTH_CLIENTS,
+    permission=Permission.AdminPage.HIGH_RISK,
     renderer="h:templates/admin/oauthclients_create.html.jinja2",
 )
 class AuthClientCreateController:
@@ -92,7 +92,7 @@ class AuthClientCreateController:
 
 @view_defaults(
     route_name="admin.oauthclients_edit",
-    permission=Permission.AdminPage.OAUTH_CLIENTS,
+    permission=Permission.AdminPage.HIGH_RISK,
     renderer="h:templates/admin/oauthclients_edit.html.jinja2",
 )
 class AuthClientEditController:

--- a/h/views/admin/organizations.py
+++ b/h/views/admin/organizations.py
@@ -15,7 +15,7 @@ _ = i18n.TranslationString
     route_name="admin.organizations",
     request_method="GET",
     renderer="h:templates/admin/organizations.html.jinja2",
-    permission=Permission.AdminPage.ORGANIZATIONS,
+    permission=Permission.AdminPage.LOW_RISK,
 )
 @paginator.paginate_query
 def index(_context, request):
@@ -35,7 +35,7 @@ def index(_context, request):
 @view_defaults(
     route_name="admin.organizations_create",
     renderer="h:templates/admin/organizations_create.html.jinja2",
-    permission=Permission.AdminPage.ORGANIZATIONS,
+    permission=Permission.AdminPage.LOW_RISK,
 )
 class OrganizationCreateController:
     def __init__(self, request):
@@ -80,7 +80,7 @@ class OrganizationCreateController:
 
 @view_defaults(
     route_name="admin.organizations_edit",
-    permission=Permission.AdminPage.ORGANIZATIONS,
+    permission=Permission.AdminPage.LOW_RISK,
     renderer="h:templates/admin/organizations_edit.html.jinja2",
 )
 class OrganizationEditController:

--- a/h/views/admin/search.py
+++ b/h/views/admin/search.py
@@ -16,7 +16,7 @@ def not_found(exc, request):
     return HTTPFound(location=request.route_url("admin.search"))
 
 
-@view_defaults(route_name="admin.search", permission=Permission.AdminPage.SEARCH)
+@view_defaults(route_name="admin.search", permission=Permission.AdminPage.HIGH_RISK)
 class SearchAdminViews:
     def __init__(self, request):
         self.request = request

--- a/h/views/admin/staff.py
+++ b/h/views/admin/staff.py
@@ -10,7 +10,7 @@ from h.security import Permission
     route_name="admin.staff",
     request_method="GET",
     renderer="h:templates/admin/staff.html.jinja2",
-    permission=Permission.AdminPage.STAFF,
+    permission=Permission.AdminPage.HIGH_RISK,
 )
 def staff_index(request):
     """Get a list of all the staff members as an HTML page."""
@@ -26,7 +26,7 @@ def staff_index(request):
     request_method="POST",
     request_param="add",
     renderer="h:templates/admin/staff.html.jinja2",
-    permission=Permission.AdminPage.STAFF,
+    permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
 def staff_add(request):
@@ -51,7 +51,7 @@ def staff_add(request):
     request_method="POST",
     request_param="remove",
     renderer="h:templates/admin/staff.html.jinja2",
-    permission=Permission.AdminPage.STAFF,
+    permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
 def staff_remove(request):

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -27,7 +27,7 @@ def format_date(date):
     route_name="admin.users",
     request_method="GET",
     renderer="h:templates/admin/users.html.jinja2",
-    permission=Permission.AdminPage.USERS,
+    permission=Permission.AdminPage.LOW_RISK,
 )
 def users_index(request):
     user = None
@@ -60,7 +60,7 @@ def users_index(request):
     route_name="admin.users_activate",
     request_method="POST",
     request_param="userid",
-    permission=Permission.AdminPage.USERS,
+    permission=Permission.AdminPage.LOW_RISK,
     require_csrf=True,
 )
 def users_activate(request):
@@ -87,7 +87,7 @@ def users_activate(request):
 @view_config(
     route_name="admin.users_rename",
     request_method="POST",
-    permission=Permission.AdminPage.USERS,
+    permission=Permission.AdminPage.LOW_RISK,
     require_csrf=True,
 )
 def users_rename(request):
@@ -125,7 +125,7 @@ def users_rename(request):
 @view_config(
     route_name="admin.users_delete",
     request_method="POST",
-    permission=Permission.AdminPage.USERS,
+    permission=Permission.AdminPage.LOW_RISK,
     require_csrf=True,
 )
 def users_delete(request):

--- a/tests/h/security/permits_test.py
+++ b/tests/h/security/permits_test.py
@@ -85,9 +85,9 @@ class TestIdentityPermitsIntegrated:
         assert identity_permits(identity, anno_context, Permission.Annotation.MODERATE)
 
         # Once a user is an admin they can do admin things
-        assert not identity_permits(identity, None, Permission.AdminPage.NIPSA)
+        assert not identity_permits(identity, None, Permission.AdminPage.HIGH_RISK)
         identity.user.admin = True
-        assert identity_permits(identity, None, Permission.AdminPage.NIPSA)
+        assert identity_permits(identity, None, Permission.AdminPage.HIGH_RISK)
 
     @pytest.fixture
     def user(self, factories, group):


### PR DESCRIPTION
This removes the permission per page in the admin section and divides the pages into two categories:

 * High risk
 * Low risk
 
 Admins get both, staff only get low risk