### PR TITLE
Use dataclasses instead SQLAlchemy objects for identity

### DIFF
--- a/h/security/policy/_basic_http_auth.py
+++ b/h/security/policy/_basic_http_auth.py
@@ -74,7 +74,7 @@ class AuthClientPolicy(IdentityBasedPolicy):
             if not user or user.authority != auth_client.authority:
                 return None
 
-        return Identity(auth_client=auth_client, user=user)
+        return Identity.from_models(auth_client=auth_client, user=user)
 
     @classmethod
     def _get_auth_client(cls, request):

--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -13,7 +13,7 @@ class CookiePolicy(IdentityBasedPolicy):
         if not user:
             return None
 
-        return Identity(user=user)
+        return Identity.from_models(user=user)
 
     def remember(self, request, userid, **kw):  # pylint:disable=unused-argument
         """Get a list of headers which will remember the user in a cookie."""

--- a/h/security/policy/_remote_user.py
+++ b/h/security/policy/_remote_user.py
@@ -14,4 +14,4 @@ class RemoteUserPolicy(IdentityBasedPolicy):
         if user is None:
             return None
 
-        return Identity(user=user)
+        return Identity.from_models(user=user)

--- a/h/security/policy/bearer_token.py
+++ b/h/security/policy/bearer_token.py
@@ -53,7 +53,7 @@ class TokenPolicy(IdentityBasedPolicy):
         if user is None:
             return None
 
-        return Identity(user=user)
+        return Identity.from_models(user=user)
 
     @staticmethod
     def _is_ws_request(request):

--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -15,15 +15,6 @@ def websocket_view(request):
         }
     )
 
-    # Trigger lazy loading of the user groups so they are available later on
-    # when we do permissions checks. We do this here so it's done once, instead
-    # of per annotation. This means the groups are only correct as of now.
-    # We also need to do this while the user is associated with an SQLAlchemy
-    # session. By the time this reaches the socket server, the user will be
-    # disconnected.
-    if request.identity and request.identity.user:
-        _ = request.identity.user.groups
-
     app = WebSocketWSGIApplication(handler_cls=websocket.WebSocket)
     return request.get_response(app)
 

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -11,7 +11,7 @@ class TestClientAuthority:
         assert result is None
 
     def test_it_with_auth_client(self, pyramid_request, pyramid_config, factories):
-        identity = Identity(auth_client=factories.AuthClient())
+        identity = Identity.from_models(auth_client=factories.AuthClient())
         pyramid_config.testing_securitypolicy(identity=identity)
 
         result = client_authority(pyramid_request)

--- a/tests/h/security/identity_test.py
+++ b/tests/h/security/identity_test.py
@@ -1,0 +1,91 @@
+from unittest.mock import sentinel
+
+import pytest
+from h_matchers import Any
+
+from h.security.identity import (
+    Identity,
+    LongLivedAuthClient,
+    LongLivedGroup,
+    LongLivedUser,
+)
+
+
+class TestLongLivedGroup:
+    def test_from_models(self, factories):
+        group = factories.Group.build()
+
+        model = LongLivedGroup.from_model(group)
+
+        assert model == Any.instance_of(LongLivedGroup).with_attrs(
+            {"id": group.id, "pubid": group.pubid}
+        )
+
+
+class TestLongLivedUser:
+    def test_from_models(self, factories, LongLivedGroup):
+        group = factories.Group.build()
+        user = factories.User.build(groups=[group])
+
+        model = LongLivedUser.from_model(user)
+
+        LongLivedGroup.from_model.assert_called_once_with(group)
+        assert model == Any.instance_of(LongLivedUser).with_attrs(
+            {
+                "id": user.id,
+                "userid": user.userid,
+                "authority": user.authority,
+                "admin": user.admin,
+                "staff": user.staff,
+                "groups": [LongLivedGroup.from_model.return_value],
+            }
+        )
+
+    @pytest.fixture(autouse=True)
+    def LongLivedGroup(self, patch):
+        return patch("h.security.identity.LongLivedGroup")
+
+
+class TestLongLivedAuthClient:
+    def test_from_models(self, factories):
+        auth_client = factories.AuthClient.build()
+
+        model = LongLivedAuthClient.from_model(auth_client)
+
+        assert model == Any.instance_of(LongLivedAuthClient).with_attrs(
+            {"id": auth_client.id, "authority": auth_client.authority}
+        )
+
+
+class TestIdentity:
+    def test_from_models(self, LongLivedUser, LongLivedAuthClient):
+        identity = Identity.from_models(
+            user=sentinel.user, auth_client=sentinel.auth_client
+        )
+
+        LongLivedUser.from_model.assert_called_once_with(sentinel.user)
+        LongLivedAuthClient.from_model.assert_called_once_with(sentinel.auth_client)
+        assert identity == Any.instance_of(Identity).with_attrs(
+            {
+                "user": LongLivedUser.from_model.return_value,
+                "auth_client": LongLivedAuthClient.from_model.return_value,
+            }
+        )
+
+    def test_from_models_with_None(self, LongLivedUser, LongLivedAuthClient):
+        identity = Identity.from_models()
+
+        LongLivedUser.from_model.assert_not_called()
+        LongLivedAuthClient.from_model.assert_not_called()
+
+        assert identity == Any.instance_of(Identity).with_attrs(
+            {"user": None, "auth_client": None}
+        )
+
+    @pytest.fixture(autouse=True)
+    def LongLivedUser(self, patch):
+        return patch("h.security.identity.LongLivedUser")
+
+    @pytest.fixture(autouse=True)
+    def LongLivedAuthClient(self, patch):
+        return patch("h.security.identity.LongLivedAuthClient")

--- a/tests/h/security/permits_test.py
+++ b/tests/h/security/permits_test.py
@@ -38,7 +38,7 @@ class TestIdentityPermitsIntegrated:
         # particular failure, but just give us sensitivity if this doesn't work
         # at all when you hook it together for real.
 
-        identity = Identity(user)
+        identity = Identity.from_models(user=user)
         anno_context = AnnotationContext(annotation=annotation)
 
         # A user can delete their own annotation
@@ -54,7 +54,7 @@ class TestIdentityPermitsIntegrated:
         # Once a user is an admin they can do admin things
         admin_context = Root(sentinel.request)
         assert not identity_permits(identity, admin_context, Permission.AdminPage.NIPSA)
-        user.admin = True
+        identity.user.admin = True
         assert identity_permits(identity, admin_context, Permission.AdminPage.NIPSA)
 
         # We need the right context

--- a/tests/h/security/policy/_basic_http_auth_test.py
+++ b/tests/h/security/policy/_basic_http_auth_test.py
@@ -34,7 +34,7 @@ class TestAuthClientPolicy:
         identity = AuthClientPolicy().identity(pyramid_request)
 
         user_service.fetch.assert_called_once_with(sentinel.forwarded_user)
-        assert identity == Identity(
+        assert identity == Identity.from_models(
             auth_client=auth_client, user=user_service.fetch.return_value
         )
 
@@ -43,7 +43,7 @@ class TestAuthClientPolicy:
 
         identity = AuthClientPolicy().identity(pyramid_request)
 
-        assert identity == Identity(auth_client=auth_client)
+        assert identity == Identity.from_models(auth_client=auth_client)
 
     def test_identity_returns_None_without_credentials(self, pyramid_request):
         pyramid_request.headers["Authorization"] = None

--- a/tests/h/security/policy/_cookie_test.py
+++ b/tests/h/security/policy/_cookie_test.py
@@ -13,7 +13,9 @@ class TestCookiePolicy:
         identity = CookiePolicy().identity(pyramid_request)
 
         auth_cookie_service.verify_cookie.assert_called_once()
-        assert identity == Identity(user=auth_cookie_service.verify_cookie.return_value)
+        assert identity == Identity.from_models(
+            user=auth_cookie_service.verify_cookie.return_value
+        )
 
     def test_identity_with_no_cookie(self, pyramid_request, auth_cookie_service):
         auth_cookie_service.verify_cookie.return_value = None

--- a/tests/h/security/policy/_identity_base_test.py
+++ b/tests/h/security/policy/_identity_base_test.py
@@ -43,7 +43,7 @@ class TestIdentityBasedPolicy:
 
     @pytest.fixture
     def identity(self, factories):
-        return Identity(user=factories.User())
+        return Identity.from_models(user=factories.User())
 
     @pytest.fixture
     def policy(self, identity):

--- a/tests/h/security/policy/_remote_user_test.py
+++ b/tests/h/security/policy/_remote_user_test.py
@@ -14,7 +14,7 @@ class TestRemoteUserPolicy:
         identity = RemoteUserPolicy().identity(pyramid_request)
 
         user_service.fetch.assert_called_once_with(sentinel.forwarded_user)
-        assert identity == Identity(user=user_service.fetch.return_value)
+        assert identity == Identity.from_models(user=user_service.fetch.return_value)
 
     def test_identity_returns_None_for_no_forwarded_user(self, pyramid_request):
         pyramid_request.environ["HTTP_X_FORWARDED_USER"] = None

--- a/tests/h/security/policy/bearer_token_test.py
+++ b/tests/h/security/policy/bearer_token_test.py
@@ -18,7 +18,7 @@ class TestTokenPolicy:
         user_service.fetch.assert_called_once_with(
             auth_token_service.validate.return_value.userid
         )
-        assert identity == Identity(user=user_service.fetch.return_value)
+        assert identity == Identity.from_models(user=user_service.fetch.return_value)
 
     def test_identity_caches(self, pyramid_request, auth_token_service):
         policy = TokenPolicy()

--- a/tests/h/security/principals_test.py
+++ b/tests/h/security/principals_test.py
@@ -59,7 +59,7 @@ class TestPrincipalsForIdentity:
 
     @pytest.fixture
     def identity(self, factories):
-        return Identity(
+        return Identity.from_models(
             user=factories.User(groups=factories.Group.create_batch(2)),
             auth_client=factories.AuthClient(),
         )

--- a/tests/h/streamer/conftest.py
+++ b/tests/h/streamer/conftest.py
@@ -11,6 +11,6 @@ from h.streamer.websocket import WebSocket
 def socket(factories):
     socket = create_autospec(WebSocket, instance=True)
     socket.effective_principals = [Everyone, "group:__world__"]
-    socket.identity = Identity(user=factories.User())
+    socket.identity = Identity.from_models(user=factories.User())
 
     return socket

--- a/tests/h/streamer/views_test.py
+++ b/tests/h/streamer/views_test.py
@@ -1,5 +1,3 @@
-from unittest.mock import PropertyMock
-
 import pytest
 
 from h.security import Identity
@@ -20,16 +18,6 @@ class TestWebsocketView:
         assert (
             pyramid_request.environ["h.ws.streamer_work_queue"] == streamer.WORK_QUEUE
         )
-
-    def test_it_preloads_groups(self, pyramid_request, pyramid_config, factories):
-        user = factories.User.build()
-        groups = PropertyMock()
-        type(user).groups = groups
-        pyramid_config.testing_securitypolicy(identity=Identity(user=user))
-
-        views.websocket_view(pyramid_request)
-
-        groups.assert_called_once_with()
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
For: https://sentry.io/organizations/hypothesis/issues/2676845925/?referrer=slack

This stands up a parallel set of `dataclass` objects which mirror the elements we need from each SQLAlchemy object which is currently required by the auth system.

The only field which isn't strictly necessary is the `id` in all cases, but it seems like a sane addition.

### Suspected cause

This happens out of the main session in an event handler. I think this happened as a result of starting to cache the identity object. Previously this would have started from scratch and resulted in issuing more queries that would bind the objects to the DB session inside the event handler.

Now we authenticate in the main loop, keep the user, and attempt to re-use it in the event handler. This results in a user associated with the wrong SQLAlchemy session.
