### PR TITLE
Rename `TokenPolicy` to `BearerTokenPolicy` to match the filename

### DIFF
--- a/h/security/__init__.py
+++ b/h/security/__init__.py
@@ -11,11 +11,11 @@ from h.security.encryption import (  # noqa:F401
 from h.security.identity import Identity  # noqa:F401
 from h.security.permissions import Permission  # noqa:F401
 from h.security.permits import identity_permits
-from h.security.policy import SecurityPolicy, TokenPolicy
+from h.security.policy import BearerTokenPolicy, SecurityPolicy
 from h.security.principals import principals_for_identity  # noqa:F401
 
 # We export this for the websocket to use as it's main policy
-__all__ = ("TokenPolicy",)
+__all__ = ("BearerTokenPolicy",)
 
 
 log = logging.getLogger(__name__)

--- a/h/security/policy/__init__.py
+++ b/h/security/policy/__init__.py
@@ -1,2 +1,2 @@
-from h.security.policy.bearer_token import TokenPolicy
+from h.security.policy.bearer_token import BearerTokenPolicy
 from h.security.policy.combined import SecurityPolicy

--- a/h/security/policy/bearer_token.py
+++ b/h/security/policy/bearer_token.py
@@ -7,7 +7,7 @@ from h.security.policy._identity_base import IdentityBasedPolicy
 
 
 @implementer(ISecurityPolicy)
-class TokenPolicy(IdentityBasedPolicy):
+class BearerTokenPolicy(IdentityBasedPolicy):
     """
     A Bearer token authentication policy.
 

--- a/h/security/policy/combined.py
+++ b/h/security/policy/combined.py
@@ -6,13 +6,13 @@ from h.security.policy._basic_http_auth import AuthClientPolicy
 from h.security.policy._cookie import CookiePolicy
 from h.security.policy._identity_base import IdentityBasedPolicy
 from h.security.policy._remote_user import RemoteUserPolicy
-from h.security.policy.bearer_token import TokenPolicy
+from h.security.policy.bearer_token import BearerTokenPolicy
 
 
 @implementer(ISecurityPolicy)
 class SecurityPolicy(IdentityBasedPolicy):
     def __init__(self, proxy_auth=False):
-        self._bearer_token_policy = TokenPolicy()
+        self._bearer_token_policy = BearerTokenPolicy()
         self._http_basic_auth_policy = AuthClientPolicy()
         self._identity_cache = RequestLocalCache(self._load_identity)
 

--- a/h/streamer/app.py
+++ b/h/streamer/app.py
@@ -3,7 +3,7 @@ import os
 import pyramid
 
 from h.config import configure
-from h.security import TokenPolicy
+from h.security import BearerTokenPolicy
 from h.sentry_filters import SENTRY_FILTERS
 from h.streamer.worker import log
 
@@ -28,7 +28,7 @@ def create_app(_global_config, **settings):
     config.include("h.auth")
     config.include("h.security")
     # Override the default authentication policy.
-    config.set_security_policy(TokenPolicy())
+    config.set_security_policy(BearerTokenPolicy())
 
     config.include("h.db")
     config.include("h.session")

--- a/tests/h/security/policy/bearer_token_test.py
+++ b/tests/h/security/policy/bearer_token_test.py
@@ -3,13 +3,13 @@ from unittest.mock import sentinel
 import pytest
 
 from h.security import Identity
-from h.security.policy.bearer_token import TokenPolicy
+from h.security.policy.bearer_token import BearerTokenPolicy
 
 
 @pytest.mark.usefixtures("user_service", "auth_token_service")
-class TestTokenPolicy:
+class TestBearerTokenPolicy:
     def test_identity(self, pyramid_request, auth_token_service, user_service):
-        identity = TokenPolicy().identity(pyramid_request)
+        identity = BearerTokenPolicy().identity(pyramid_request)
 
         auth_token_service.get_bearer_token.assert_called_once_with(pyramid_request)
         auth_token_service.validate.assert_called_once_with(
@@ -21,7 +21,7 @@ class TestTokenPolicy:
         assert identity == Identity.from_models(user=user_service.fetch.return_value)
 
     def test_identity_caches(self, pyramid_request, auth_token_service):
-        policy = TokenPolicy()
+        policy = BearerTokenPolicy()
 
         policy.identity(pyramid_request)
         policy.identity(pyramid_request)
@@ -32,7 +32,7 @@ class TestTokenPolicy:
         pyramid_request.path = "/ws"
         pyramid_request.GET["access_token"] = sentinel.access_token
 
-        TokenPolicy().identity(pyramid_request)
+        BearerTokenPolicy().identity(pyramid_request)
 
         auth_token_service.get_bearer_token.assert_not_called()
         auth_token_service.validate.assert_called_once_with(sentinel.access_token)
@@ -42,18 +42,18 @@ class TestTokenPolicy:
     ):
         auth_token_service.get_bearer_token.return_value = None
 
-        assert TokenPolicy().identity(pyramid_request) is None
+        assert BearerTokenPolicy().identity(pyramid_request) is None
 
     def test_identity_returns_None_for_invalid_tokens(
         self, pyramid_request, auth_token_service
     ):
         auth_token_service.validate.return_value = None
 
-        assert TokenPolicy().identity(pyramid_request) is None
+        assert BearerTokenPolicy().identity(pyramid_request) is None
 
     def test_identity_returns_None_for_invalid_users(
         self, pyramid_request, user_service
     ):
         user_service.fetch.return_value = None
 
-        assert TokenPolicy().identity(pyramid_request) is None
+        assert BearerTokenPolicy().identity(pyramid_request) is None

--- a/tests/h/security/policy/combined_test.py
+++ b/tests/h/security/policy/combined_test.py
@@ -8,11 +8,11 @@ from h.security.policy import SecurityPolicy
 
 
 class TestSecurityPolicy:
-    def test_construction(self, TokenPolicy, AuthClientPolicy, CookiePolicy):
+    def test_construction(self, BearerTokenPolicy, AuthClientPolicy, CookiePolicy):
         policy = SecurityPolicy(proxy_auth=False)
 
-        TokenPolicy.assert_called_once_with()
-        assert policy._bearer_token_policy == TokenPolicy.return_value
+        BearerTokenPolicy.assert_called_once_with()
+        assert policy._bearer_token_policy == BearerTokenPolicy.return_value
         AuthClientPolicy.assert_called_once_with()
         assert policy._http_basic_auth_policy == AuthClientPolicy.return_value
         CookiePolicy.assert_called_once_with()
@@ -128,8 +128,8 @@ class TestSecurityPolicy:
             assert result == policy._bearer_token_policy.remember.return_value
 
     @pytest.fixture(autouse=True)
-    def TokenPolicy(self, patch):
-        return patch("h.security.policy.combined.TokenPolicy")
+    def BearerTokenPolicy(self, patch):
+        return patch("h.security.policy.combined.BearerTokenPolicy")
 
     @pytest.fixture(autouse=True)
     def AuthClientPolicy(self, patch):


### PR DESCRIPTION
This is ever so slightly misleading as it can also be read from the query param at which point is it a Bearer token? I'm not sure. But I think this puts you in the right head-space to understand what it is, rather than being vague for the sake of being technically accurate. Which I think is better.