### PR TITLE
Add logging as well as a warning to test the permission system warning

### DIFF
--- a/h/security/permits.py
+++ b/h/security/permits.py
@@ -1,4 +1,5 @@
 import warnings
+from logging import getLogger
 from typing import Optional
 
 from pyramid.authorization import ACLAuthorizationPolicy
@@ -6,6 +7,8 @@ from pyramid.authorization import ACLAuthorizationPolicy
 from h.security import permission_map
 from h.security.identity import Identity
 from h.security.principals import principals_for_identity
+
+LOG = getLogger(__name__)
 
 
 def identity_permits(identity: Optional[Identity], context, permission) -> bool:
@@ -32,9 +35,8 @@ def identity_permits(identity: Optional[Identity], context, permission) -> bool:
         map_allows = err  # pylint: disable=redefined-variable-type
 
     if map_allows != acl_allows:  # pragma: no cover
-        warnings.warn(
-            f"Permissions system disagree about {permission}: ACL={acl_allows}, MAP={map_allows}",
-            PendingDeprecationWarning,
-        )
+        message = f"Permissions system disagree about {permission}: ACL={acl_allows}, MAP={map_allows}"
+        warnings.warn(message, PendingDeprecationWarning)
+        LOG.warning(message)
 
     return acl_allows

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -1,3 +1,6 @@
+import warnings
+from logging import getLogger
+
 import deform
 from pyramid import httpexceptions
 from pyramid.view import view_config, view_defaults
@@ -7,6 +10,9 @@ from h.schemas.forms.group import group_schema
 from h.security import Permission
 
 _ = i18n.TranslationString
+
+
+LOG = getLogger(__name__)
 
 
 @view_defaults(
@@ -106,6 +112,14 @@ class GroupEditController:
     def _update_group(self, appstruct):
         self.group.name = appstruct["name"]
         self.group.description = appstruct["description"]
+
+        # This is to test that we can see warnings in the logs as part of our
+        # switch over to the new permissions system. This is temporary code
+        # and can be safely removed if you see it.
+        if self.group.description == "__TEMP_WARNING_TEST__":  # pragma: no cover
+            message = "Test warning has been triggered"
+            warnings.warn(message, PendingDeprecationWarning)
+            LOG.warning(message)
 
 
 @view_config(route_name="group_read_noslug", request_method="GET")


### PR DESCRIPTION
We we're attempting to use a warning to show when the permissions systems diverged, but I'm not convinced they show up. This offers a temporary way of triggering the same situation in live on demand to prove it.

Locally I don't see the warning, but I do see the log message.

I think the warning still has value as a method which will cause the tests to fail without causing trouble in live.

## Testing notes

 * `make services`
 * `make dev`
 * Visit http://localhost:5000
 * Create a group
 * Change the description to `__TEMP_WARNING_TEST__`
 * You should see a log message at warning level