### PR TITLE
Remove test logging which has now shown this works

### DIFF
--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -1,6 +1,3 @@
-import warnings
-from logging import getLogger
-
 import deform
 from pyramid import httpexceptions
 from pyramid.view import view_config, view_defaults
@@ -10,9 +7,6 @@ from h.schemas.forms.group import group_schema
 from h.security import Permission
 
 _ = i18n.TranslationString
-
-
-LOG = getLogger(__name__)
 
 
 @view_defaults(
@@ -112,14 +106,6 @@ class GroupEditController:
     def _update_group(self, appstruct):
         self.group.name = appstruct["name"]
         self.group.description = appstruct["description"]
-
-        # This is to test that we can see warnings in the logs as part of our
-        # switch over to the new permissions system. This is temporary code
-        # and can be safely removed if you see it.
-        if self.group.description == "__TEMP_WARNING_TEST__":  # pragma: no cover
-            message = "Test warning has been triggered"
-            warnings.warn(message, PendingDeprecationWarning)
-            LOG.warning(message)
 
 
 @view_config(route_name="group_read_noslug", request_method="GET")


### PR DESCRIPTION
Remove the testing portion of this PR:

 * https://github.com/hypothesis/h/pull/7065
 
I've tested this in live and the logging shows up, but the warning does not.