### PR TITLE
Change the `AnnotationJSONPresenter` to be more service like

### DIFF
--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -10,59 +10,59 @@ from h.util.datetime import utc_iso8601
 class AnnotationJSONPresenter:
     """Present an annotation in the JSON format returned by API requests."""
 
-    def __init__(self, annotation, links_service, user_service):
-        self.annotation = annotation
+    def __init__(self, links_service, user_service):
         self._links_service = links_service
         self._user_service = user_service
 
-    def asdict(self):
-        model = deepcopy(self.annotation.extra) or {}
+    def present(self, annotation):
+        model = deepcopy(annotation.extra) or {}
 
         model.update(
             {
-                "id": self.annotation.id,
-                "created": utc_iso8601(self.annotation.created),
-                "updated": utc_iso8601(self.annotation.updated),
-                "user": self.annotation.userid,
-                "uri": self.annotation.target_uri,
-                "text": self.annotation.text or "",
-                "tags": self.annotation.tags or [],
-                "group": self.annotation.groupid,
+                "id": annotation.id,
+                "created": utc_iso8601(annotation.created),
+                "updated": utc_iso8601(annotation.updated),
+                "user": annotation.userid,
+                "uri": annotation.target_uri,
+                "text": annotation.text or "",
+                "tags": annotation.tags or [],
+                "group": annotation.groupid,
                 #  Convert our simple internal annotation storage format into the
                 #  legacy complex permissions dict format that is still used in
                 #  some places.
                 "permissions": {
-                    "read": [self._get_read_permission()],
-                    "admin": [self.annotation.userid],
-                    "update": [self.annotation.userid],
-                    "delete": [self.annotation.userid],
+                    "read": [self._get_read_permission(annotation)],
+                    "admin": [annotation.userid],
+                    "update": [annotation.userid],
+                    "delete": [annotation.userid],
                 },
-                "target": self.annotation.target,
-                "document": DocumentJSONPresenter(self.annotation.document).asdict(),
-                "links": self._links_service.get_all(self.annotation),
+                "target": annotation.target,
+                "document": DocumentJSONPresenter(annotation.document).asdict(),
+                "links": self._links_service.get_all(annotation),
             }
         )
 
-        model.update(user_info(self._user_service.fetch(self.annotation.userid)))
+        model.update(user_info(self._user_service.fetch(annotation.userid)))
 
-        if self.annotation.references:
-            model["references"] = self.annotation.references
+        if annotation.references:
+            model["references"] = annotation.references
 
         return model
 
-    def _get_read_permission(self):
-        if not self.annotation.shared:
+    @classmethod
+    def _get_read_permission(cls, annotation):
+        if not annotation.shared:
             # It's not shared so only the owner can read it
-            return self.annotation.userid
+            return annotation.userid
 
         # If the annotation's group is the public group, or an unauthorized person could
         # read the annotation, then the annotation is world readable.
-        if self.annotation.groupid == "__world__" or identity_permits(
+        if annotation.groupid == "__world__" or identity_permits(
             identity=None,
-            context=AnnotationContext(self.annotation),
+            context=AnnotationContext(annotation),
             permission=Permission.Annotation.READ,
         ):
             return "group:__world__"
 
         # Only people in the group can read it
-        return f"group:{self.annotation.groupid}"
+        return f"group:{annotation.groupid}"

--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -16,9 +16,9 @@ class AnnotationJSONPresenter:
         self._user_service = user_service
 
     def asdict(self):
-        annotation = deepcopy(self.annotation.extra) or {}
+        model = deepcopy(self.annotation.extra) or {}
 
-        annotation.update(
+        model.update(
             {
                 "id": self.annotation.id,
                 "created": utc_iso8601(self.annotation.created),
@@ -43,12 +43,12 @@ class AnnotationJSONPresenter:
             }
         )
 
-        annotation.update(user_info(self._user_service.fetch(self.annotation.userid)))
+        model.update(user_info(self._user_service.fetch(self.annotation.userid)))
 
         if self.annotation.references:
-            annotation["references"] = self.annotation.references
+            model["references"] = self.annotation.references
 
-        return annotation
+        return model
 
     def _get_read_permission(self):
         if not self.annotation.shared:

--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -18,12 +18,12 @@ class AnnotationJSONPresentationService:
         self.flag_svc = flag_svc
         self.user_svc = user_svc
         self._has_permission = has_permission
+        self._presenter = AnnotationJSONPresenter(
+            links_service=self.links_svc, user_service=self.user_svc
+        )
 
     def present(self, annotation):
-        model = AnnotationJSONPresenter(
-            annotation, links_service=self.links_svc, user_service=self.user_svc
-        ).asdict()
-
+        model = self._presenter.present(annotation)
         model.update(self._get_user_dependent_content(self.user, annotation))
 
         return model

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -4,7 +4,8 @@ from itertools import chain
 
 from gevent.queue import Full
 
-from h import presenters, realtime, storage
+from h import realtime, storage
+from h.presenters import AnnotationJSONPresenter
 from h.realtime import Consumer
 from h.security import Permission, identity_permits
 from h.streamer import websocket
@@ -159,15 +160,13 @@ def _generate_annotation_event(request, message, annotation):
     Returns None if the socket should not receive any message about this
     annotation event, otherwise a dict containing information about the event.
     """
-
     if message["action"] == "delete":
         payload = {"id": message["annotation_id"]}
     else:
-        payload = presenters.AnnotationJSONPresenter(
-            annotation,
+        payload = AnnotationJSONPresenter(
             links_service=request.find_service(name="links"),
             user_service=request.find_service(name="user"),
-        ).asdict()
+        ).present(annotation)
 
     return {
         "type": "annotation-notification",

--- a/tests/h/services/annotation_json_presentation_test/service_test.py
+++ b/tests/h/services/annotation_json_presentation_test/service_test.py
@@ -11,16 +11,13 @@ from h.traversal import AnnotationContext
 
 class TestAnnotationJSONPresentationService:
     def test_present(
-        self, svc, user, annotation, AnnotationJSONPresenter, flag_service, user_service
+        self, svc, user, annotation, AnnotationJSONPresenter, flag_service
     ):
-        AnnotationJSONPresenter.return_value.asdict.return_value = {"presenter": 1}
+        AnnotationJSONPresenter.return_value.present.return_value = {"presenter": 1}
 
         result = svc.present(annotation)
 
-        AnnotationJSONPresenter.assert_called_once_with(
-            annotation, links_service=svc.links_svc, user_service=user_service
-        )
-
+        AnnotationJSONPresenter.return_value.present.assert_called_once_with(annotation)
         flag_service.flagged.assert_called_once_with(user, annotation)
         flag_service.flag_count.assert_called_once_with(annotation)
         assert result == {
@@ -71,7 +68,7 @@ class TestAnnotationJSONPresentationService:
         self, svc, annotation, has_permission, AnnotationJSONPresenter
     ):
         has_permission.return_value = True
-        AnnotationJSONPresenter.return_value.asdict.return_value = {
+        AnnotationJSONPresenter.return_value.present.return_value = {
             "text": sentinel.text,
             "tags": [sentinel.tags],
         }
@@ -98,11 +95,9 @@ class TestAnnotationJSONPresentationService:
         flag_service.all_flagged.assert_called_once_with(user, annotation_ids)
         flag_service.flag_counts.assert_called_once_with(annotation_ids)
         user_service.fetch_all.assert_called_once_with([annotation.userid])
-        AnnotationJSONPresenter.assert_called_once_with(
-            annotation, links_service=svc.links_svc, user_service=user_service
-        )
+        AnnotationJSONPresenter.return_value.present.assert_called_once_with(annotation)
         assert result == [
-            AnnotationJSONPresenter.return_value.asdict.return_value,
+            AnnotationJSONPresenter.return_value.present.return_value,
         ]
 
     @pytest.mark.parametrize("attribute", ("document", "moderation", "group"))
@@ -169,5 +164,5 @@ class TestAnnotationJSONPresentationService:
         AnnotationJSONPresenter = patch(
             "h.services.annotation_json_presentation.service.AnnotationJSONPresenter"
         )
-        AnnotationJSONPresenter.return_value.asdict.return_value = {}
+        AnnotationJSONPresenter.return_value.present.return_value = {}
         return AnnotationJSONPresenter

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -131,11 +131,11 @@ class TestHandleAnnotationEvent:
         handle_annotation_event()
 
         AnnotationJSONPresenter.assert_called_once_with(
-            fetch_annotation.return_value,
-            links_service=links_service,
-            user_service=user_service,
+            links_service=links_service, user_service=user_service
         )
-        assert AnnotationJSONPresenter.return_value.asdict.called
+        AnnotationJSONPresenter.return_value.present.assert_called_once_with(
+            fetch_annotation.return_value
+        )
 
     @pytest.mark.parametrize("action", ["create", "update", "delete"])
     def test_notification_format(
@@ -148,7 +148,7 @@ class TestHandleAnnotationEvent:
         if action == "delete":
             expected_payload = {"id": message["annotation_id"]}
         else:
-            expected_payload = AnnotationJSONPresenter.return_value.asdict.return_value
+            expected_payload = AnnotationJSONPresenter.return_value.present.return_value
 
         socket.send_json.assert_called_once_with(
             {
@@ -284,7 +284,7 @@ class TestHandleAnnotationEvent:
 
     @pytest.fixture(autouse=True)
     def AnnotationJSONPresenter(self, patch):
-        return patch("h.streamer.messages.presenters.AnnotationJSONPresenter")
+        return patch("h.streamer.messages.AnnotationJSONPresenter")
 
     @pytest.fixture(autouse=True)
     def SocketFilter(self, patch):


### PR DESCRIPTION
For: 

 * https://github.com/hypothesis/h/issues/6769

Instead of constructing the presenter around an annotation and then calling `asdict()` on it, this changes the presenter to be initialised without a specific annotation, allowing you to then call `present(annotation)` so you can re-use it to present many annotations.

This is a preparatory step to inclining this into the presentation service.