### PR TITLE
Make `AnnotationJSONPresentationService` accept a user as an argument

### DIFF
--- a/h/services/annotation_json_presentation/factory.py
+++ b/h/services/annotation_json_presentation/factory.py
@@ -6,8 +6,6 @@ from h.services.annotation_json_presentation.service import (
 def annotation_json_presentation_service_factory(_context, request):
     return AnnotationJSONPresentationService(
         session=request.db,
-        user=request.user,
-        has_permission=request.has_permission,
         # Services
         links_svc=request.find_service(name="links"),
         flag_svc=request.find_service(name="flag"),

--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -22,16 +22,16 @@ class AnnotationJSONPresentationService:
             links_service=self.links_svc, user_service=self.user_svc
         )
 
-    def present(self, annotation):
+    def present_for_user(self, annotation):
         model = self._presenter.present(annotation)
         model.update(self._get_user_dependent_content(self.user, annotation))
 
         return model
 
-    def present_all(self, annotation_ids):
+    def present_all_for_user(self, annotation_ids):
         annotations = self._preload_data(self.user, annotation_ids)
 
-        return [self.present(annotation) for annotation in annotations]
+        return [self.present_for_user(annotation) for annotation in annotations]
 
     def _get_user_dependent_content(self, user, annotation):
         # The flagged value depends on whether this particular user has flagged

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -52,11 +52,15 @@ def search(request):
 
     out = {
         "total": result.total,
-        "rows": svc.present_all_for_user(result.annotation_ids),
+        "rows": svc.present_all_for_user(
+            annotation_ids=result.annotation_ids, user=request.user
+        ),
     }
 
     if separate_replies:
-        out["replies"] = svc.present_all_for_user(result.reply_ids)
+        out["replies"] = svc.present_all_for_user(
+            annotation_ids=result.reply_ids, user=request.user
+        )
 
     return out
 
@@ -79,7 +83,7 @@ def create(request):
     _publish_annotation_event(request, annotation, "create")
 
     svc = request.find_service(name="annotation_json_presentation")
-    return svc.present_for_user(annotation)
+    return svc.present_for_user(annotation=annotation, user=request.user)
 
 
 @api_config(
@@ -93,7 +97,7 @@ def create(request):
 def read(context, request):
     """Return the annotation (simply how it was stored in the database)."""
     return request.find_service(name="annotation_json_presentation").present_for_user(
-        context.annotation
+        annotation=context.annotation, user=request.user
     )
 
 
@@ -135,7 +139,7 @@ def update(context, request):
     _publish_annotation_event(request, annotation, "update")
 
     return request.find_service(name="annotation_json_presentation").present_for_user(
-        annotation
+        annotation=annotation, user=request.user
     )
 
 

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -50,10 +50,13 @@ def search(request):
 
     svc = request.find_service(name="annotation_json_presentation")
 
-    out = {"total": result.total, "rows": svc.present_all(result.annotation_ids)}
+    out = {
+        "total": result.total,
+        "rows": svc.present_all_for_user(result.annotation_ids),
+    }
 
     if separate_replies:
-        out["replies"] = svc.present_all(result.reply_ids)
+        out["replies"] = svc.present_all_for_user(result.reply_ids)
 
     return out
 
@@ -76,7 +79,7 @@ def create(request):
     _publish_annotation_event(request, annotation, "create")
 
     svc = request.find_service(name="annotation_json_presentation")
-    return svc.present(annotation)
+    return svc.present_for_user(annotation)
 
 
 @api_config(
@@ -89,7 +92,7 @@ def create(request):
 )
 def read(context, request):
     """Return the annotation (simply how it was stored in the database)."""
-    return request.find_service(name="annotation_json_presentation").present(
+    return request.find_service(name="annotation_json_presentation").present_for_user(
         context.annotation
     )
 
@@ -131,7 +134,9 @@ def update(context, request):
 
     _publish_annotation_event(request, annotation, "update")
 
-    return request.find_service(name="annotation_json_presentation").present(annotation)
+    return request.find_service(name="annotation_json_presentation").present_for_user(
+        annotation
+    )
 
 
 @api_config(

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -4,6 +4,7 @@ import pytest
 
 from h.services import AuthCookieService
 from h.services.annotation_delete import AnnotationDeleteService
+from h.services.annotation_json_presentation import AnnotationJSONPresentationService
 from h.services.annotation_moderation import AnnotationModerationService
 from h.services.auth_token import AuthTokenService
 from h.services.delete_group import DeleteGroupService
@@ -24,6 +25,7 @@ from h.services.search_index._queue import Queue
 __all__ = (
     "mock_service",
     "annotation_delete_service",
+    "annotation_json_presentation_service",
     "auth_cookie_service",
     "auth_token_service",
     "delete_group_service",
@@ -65,6 +67,13 @@ def mock_service(pyramid_config):
 @pytest.fixture
 def annotation_delete_service(mock_service):
     return mock_service(AnnotationDeleteService, name="annotation_delete")
+
+
+@pytest.fixture
+def annotation_json_presentation_service(mock_service):
+    return mock_service(
+        AnnotationJSONPresentationService, name="annotation_json_presentation"
+    )
 
 
 @pytest.fixture

--- a/tests/h/services/annotation_json_presentation_test/factory_test.py
+++ b/tests/h/services/annotation_json_presentation_test/factory_test.py
@@ -25,8 +25,6 @@ class TestAnnotationJSONPresentationServiceFactory:
 
         AnnotationJSONPresentationService.assert_called_once_with(
             session=pyramid_request.db,
-            user=pyramid_request.user,
-            has_permission=pyramid_request.has_permission,
             links_svc=links_service,
             flag_svc=flag_service,
             user_svc=user_service,

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -31,7 +31,7 @@ class TestSearch:
         views.search(pyramid_request)
 
         annotation_json_presentation_service.present_all_for_user.assert_called_once_with(
-            ["row-1", "row-2"]
+            annotation_ids=["row-1", "row-2"], user=pyramid_request.user
         )
 
     def test_it_returns_search_results(
@@ -55,7 +55,7 @@ class TestSearch:
         views.search(pyramid_request)
 
         annotation_json_presentation_service.present_all_for_user.assert_called_with(
-            ["reply-1", "reply-2"]
+            annotation_ids=["reply-1", "reply-2"], user=pyramid_request.user
         )
 
     def test_it_returns_replies(
@@ -67,10 +67,10 @@ class TestSearch:
         expected = {
             "total": 1,
             "rows": annotation_json_presentation_service.present_all_for_user(
-                ["row-1"]
+                annotation_ids=["row-1"], user=pyramid_request.user
             ),
             "replies": annotation_json_presentation_service.present_all_for_user(
-                ["reply-1", "reply-2"]
+                annotation_ids=["reply-1", "reply-2"], user=pyramid_request.user
             ),
         }
 
@@ -111,7 +111,7 @@ class TestCreate:
         )
 
         annotation_json_presentation_service.present_for_user.assert_called_once_with(
-            storage.create_annotation.return_value
+            annotation=storage.create_annotation.return_value, user=pyramid_request.user
         )
 
         assert (
@@ -177,7 +177,7 @@ class TestRead:
         result = views.read(annotation_context, pyramid_request)
 
         annotation_json_presentation_service.present_for_user.assert_called_once_with(
-            annotation_context.annotation
+            annotation=annotation_context.annotation, user=pyramid_request.user
         )
         assert (
             result == annotation_json_presentation_service.present_for_user.return_value
@@ -259,7 +259,7 @@ class TestUpdate:
         )
 
         annotation_json_presentation_service.present_for_user.assert_called_once_with(
-            storage.update_annotation.return_value
+            annotation=storage.update_annotation.return_value, user=pyramid_request.user
         )
 
         assert (


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/h/issues/6769

The presentation here is actually for a specific user, although it doesn't say so. Moving these makes room to create a `present` which isn't for a specific user, and accepts the user as an argument.

This stops us from having to create the entire service around the user.