### PR TITLE
Make the Annotation JSON service have sole responsibility

### DIFF
--- a/h/presenters/__init__.py
+++ b/h/presenters/__init__.py
@@ -1,5 +1,4 @@
 from h.presenters.annotation_html import AnnotationHTMLPresenter
-from h.presenters.annotation_json import AnnotationJSONPresenter
 from h.presenters.annotation_jsonld import AnnotationJSONLDPresenter
 from h.presenters.annotation_searchindex import AnnotationSearchIndexPresenter
 from h.presenters.document_html import DocumentHTMLPresenter
@@ -10,7 +9,6 @@ from h.presenters.user_json import TrustedUserJSONPresenter, UserJSONPresenter
 
 __all__ = (
     "AnnotationHTMLPresenter",
-    "AnnotationJSONPresenter",
     "AnnotationJSONLDPresenter",
     "AnnotationSearchIndexPresenter",
     "DocumentHTMLPresenter",

--- a/h/services/annotation_json_presentation/_basic_presenter.py
+++ b/h/services/annotation_json_presentation/_basic_presenter.py
@@ -7,8 +7,8 @@ from h.traversal import AnnotationContext
 from h.util.datetime import utc_iso8601
 
 
-class AnnotationJSONPresenter:
-    """Present an annotation in the JSON format returned by API requests."""
+class BasicJSONPresenter:
+    """Present an annotation in JSON without reference to the user."""
 
     def __init__(self, links_service, user_service):
         self._links_service = links_service

--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -2,9 +2,9 @@ from sqlalchemy.orm import subqueryload
 
 from h import storage
 from h.models import Annotation
-from h.presenters import AnnotationJSONPresenter
 from h.security import Identity, identity_permits
 from h.security.permissions import Permission
+from h.services.annotation_json_presentation._basic_presenter import BasicJSONPresenter
 from h.traversal import AnnotationContext
 
 
@@ -13,15 +13,18 @@ class AnnotationJSONPresentationService:
         self, session, links_svc, flag_svc, user_svc
     ):
         self._session = session
-        self._flag_service = flag_svc
         self._links_service = links_svc
         self._user_service = user_svc
-        self._presenter = AnnotationJSONPresenter(
+        self._flag_service = flag_svc
+        self._presenter = BasicJSONPresenter(
             links_service=self._links_service, user_service=self._user_service
         )
 
+    def present(self, annotation):
+        return self._presenter.present(annotation)
+
     def present_for_user(self, annotation, user):
-        model = self._presenter.present(annotation)
+        model = self.present(annotation)
         model.update(self._get_user_dependent_content(annotation, user))
 
         return model

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -5,7 +5,6 @@ from itertools import chain
 from gevent.queue import Full
 
 from h import realtime, storage
-from h.presenters import AnnotationJSONPresenter
 from h.realtime import Consumer
 from h.security import Permission, identity_permits
 from h.streamer import websocket
@@ -163,10 +162,9 @@ def _generate_annotation_event(request, message, annotation):
     if message["action"] == "delete":
         payload = {"id": message["annotation_id"]}
     else:
-        payload = AnnotationJSONPresenter(
-            links_service=request.find_service(name="links"),
-            user_service=request.find_service(name="user"),
-        ).present(annotation)
+        payload = request.find_service(name="annotation_json_presentation").present(
+            annotation
+        )
 
     return {
         "type": "annotation-notification",

--- a/tests/h/services/annotation_json_presentation_test/_basic_presenter_test.py
+++ b/tests/h/services/annotation_json_presentation_test/_basic_presenter_test.py
@@ -3,10 +3,10 @@ import datetime
 import pytest
 from pyramid.authorization import Everyone
 
-from h.presenters.annotation_json import AnnotationJSONPresenter
+from h.services.annotation_json_presentation._basic_presenter import BasicJSONPresenter
 
 
-class TestAnnotationJSONPresenter:
+class TestBasicJSONPresenter:
     def test_asdict(
         self, present, annotation, links_service, user_service, DocumentJSONPresenter
     ):
@@ -102,7 +102,7 @@ class TestAnnotationJSONPresenter:
 
     @pytest.fixture
     def present(self, annotation, links_service, user_service):
-        presenter = AnnotationJSONPresenter(
+        presenter = BasicJSONPresenter(
             links_service=links_service, user_service=user_service
         )
 
@@ -117,8 +117,12 @@ class TestAnnotationJSONPresenter:
 
     @pytest.fixture(autouse=True)
     def DocumentJSONPresenter(self, patch):
-        return patch("h.presenters.annotation_json.DocumentJSONPresenter")
+        return patch(
+            "h.services.annotation_json_presentation._basic_presenter.DocumentJSONPresenter"
+        )
 
     @pytest.fixture(autouse=True)
     def identity_permits(self, patch):
-        return patch("h.presenters.annotation_json.identity_permits")
+        return patch(
+            "h.services.annotation_json_presentation._basic_presenter.identity_permits"
+        )

--- a/tests/h/services/annotation_json_presentation_test/service_test.py
+++ b/tests/h/services/annotation_json_presentation_test/service_test.py
@@ -10,14 +10,22 @@ from h.traversal import AnnotationContext
 
 
 class TestAnnotationJSONPresentationService:
+    def test_present(self, svc, BasicJSONPresenter):
+        result = svc.present(annotation=sentinel.annotation)
+
+        BasicJSONPresenter.return_value.present.assert_called_once_with(
+            sentinel.annotation
+        )
+        assert result == BasicJSONPresenter.return_value.present.return_value
+
     def test_present_for_user(
-        self, svc, user, annotation, AnnotationJSONPresenter, flag_service
+        self, svc, user, annotation, BasicJSONPresenter, flag_service
     ):
-        AnnotationJSONPresenter.return_value.present.return_value = {"presenter": 1}
+        BasicJSONPresenter.return_value.present.return_value = {"presenter": 1}
 
         result = svc.present_for_user(annotation, user)
 
-        AnnotationJSONPresenter.return_value.present.assert_called_once_with(annotation)
+        BasicJSONPresenter.return_value.present.assert_called_once_with(annotation)
         flag_service.flagged.assert_called_once_with(user, annotation)
         flag_service.flag_count.assert_called_once_with(annotation)
         assert result == {
@@ -69,10 +77,10 @@ class TestAnnotationJSONPresentationService:
 
     @pytest.mark.usefixtures("with_hidden_annotation")
     def test_present_for_user_hidden_shows_everything_to_moderators(
-        self, svc, annotation, user, identity_permits, AnnotationJSONPresenter
+        self, svc, annotation, user, identity_permits, BasicJSONPresenter
     ):
         identity_permits.return_value = True
-        AnnotationJSONPresenter.return_value.present.return_value = {
+        BasicJSONPresenter.return_value.present.return_value = {
             "text": sentinel.text,
             "tags": [sentinel.tags],
         }
@@ -88,7 +96,7 @@ class TestAnnotationJSONPresentationService:
         svc,
         annotation,
         user,
-        AnnotationJSONPresenter,
+        BasicJSONPresenter,
         flag_service,
         user_service,
     ):
@@ -99,9 +107,9 @@ class TestAnnotationJSONPresentationService:
         flag_service.all_flagged.assert_called_once_with(user, annotation_ids)
         flag_service.flag_counts.assert_called_once_with(annotation_ids)
         user_service.fetch_all.assert_called_once_with([annotation.userid])
-        AnnotationJSONPresenter.return_value.present.assert_called_once_with(annotation)
+        BasicJSONPresenter.return_value.present.assert_called_once_with(annotation)
         assert result == [
-            AnnotationJSONPresenter.return_value.present.return_value,
+            BasicJSONPresenter.return_value.present.return_value,
         ]
 
     @pytest.mark.parametrize("attribute", ("document", "moderation", "group"))
@@ -166,9 +174,9 @@ class TestAnnotationJSONPresentationService:
         return patch("h.services.annotation_json_presentation.service.identity_permits")
 
     @pytest.fixture(autouse=True)
-    def AnnotationJSONPresenter(self, patch):
-        AnnotationJSONPresenter = patch(
-            "h.services.annotation_json_presentation.service.AnnotationJSONPresenter"
+    def BasicJSONPresenter(self, patch):
+        BasicJSONPresenter = patch(
+            "h.services.annotation_json_presentation.service.BasicJSONPresenter"
         )
-        AnnotationJSONPresenter.return_value.present.return_value = {}
-        return AnnotationJSONPresenter
+        BasicJSONPresenter.return_value.present.return_value = {}
+        return BasicJSONPresenter


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/h/issues/6769

Previously the way we presented an annotation for a user, and one for a users in general was completely different. In one case you called a service, in another you instantiated an object.

Now you use the service for both.

This is done by moving the basic presentation into the service.