### PR TITLE
Inline the helper methods to make flow more obvious

### DIFF
--- a/h/services/annotation_json_presentation/service.py
+++ b/h/services/annotation_json_presentation/service.py
@@ -54,8 +54,33 @@ class AnnotationJSONPresentationService:
         :return: A dict suitable for JSON serialisation
         """
 
+        # Get the basic version which isn't user specific
         model = self.present(annotation)
-        model.update(self._get_user_dependent_content(annotation, user))
+
+        # The flagged value depends on whether this particular user has flagged
+        model["flagged"] = self._flag_service.flagged(user=user, annotation=annotation)
+
+        # Only moderators see the full flag count
+        user_is_moderator = identity_permits(
+            identity=Identity.from_models(user=user),
+            context=AnnotationContext(annotation),
+            permission=Permission.Annotation.MODERATE,
+        )
+        if user_is_moderator:
+            model["moderation"] = {
+                "flagCount": self._flag_service.flag_count(annotation)
+            }
+
+        # The hidden value depends on whether you are the author
+        user_is_author = user and user.userid == annotation.userid
+        if user_is_author or not annotation.is_hidden:
+            model["hidden"] = False
+        else:
+            model["hidden"] = True
+
+            # Non moderators have bad content hidden from them
+            if not user_is_moderator:
+                model.update({"text": "", "tags": []})
 
         return model
 
@@ -72,69 +97,34 @@ class AnnotationJSONPresentationService:
         :return: A list of dicts suitable for JSON serialisation.
         """
 
-        annotations = self._preload_data(user, annotation_ids)
-
-        return [self.present_for_user(annotation, user) for annotation in annotations]
-
-    def _get_user_dependent_content(self, annotation, user):
-        # The flagged value depends on whether this particular user has flagged
-        model = {
-            "flagged": self._flag_service.flagged(user=user, annotation=annotation)
-        }
-
-        # Only moderators see the full flag count
-        user_is_moderator = identity_permits(
-            identity=Identity.from_models(user=user),
-            context=AnnotationContext(annotation),
-            permission=Permission.Annotation.MODERATE,
-        )
-        if user_is_moderator:
-            model["moderation"] = {
-                "flagCount": self._flag_service.flag_count(annotation)
-            }
-
-        # The hidden value depends on whether you are the author
-        if not annotation.is_hidden or self._user_is_author(user, annotation):
-            model["hidden"] = False
-        else:
-            model["hidden"] = True
-
-            # Non moderators have bad content hidden from them
-            if not user_is_moderator:
-                model.update({"text": "", "tags": []})
-
-        return model
-
-    @classmethod
-    def _user_is_author(cls, user, annotation):
-        return user and user.userid == annotation.userid
-
-    def _preload_data(self, user, annotation_ids):
-        def eager_load_related_items(query):
-            # Ensure that accessing `annotation.document` or `.moderation`
-            # doesn't trigger any more queries by pre-loading these
-
-            return query.options(
-                # Optimise access to the document which is called in
-                # `AnnotationJSONPresenter`
-                subqueryload(Annotation.document),
-                # Optimise the check used for "hidden" above
-                subqueryload(Annotation.moderation),
-                # Optimise the permissions check for MODERATE permissions,
-                # which ultimately depends on group permissions, causing a
-                # group lookup for every annotation without this
-                subqueryload(Annotation.group),
-            )
-
-        annotations = storage.fetch_ordered_annotations(
-            self._session, annotation_ids, query_processor=eager_load_related_items
-        )
-
         # This primes the cache for `flagged()` and `flag_count()`
         self._flag_service.all_flagged(user, annotation_ids)
         self._flag_service.flag_counts(annotation_ids)
 
-        # Optimise the user service `fetch()` call in the AnnotationJSONPresenter
+        annotations = storage.fetch_ordered_annotations(
+            self._session,
+            annotation_ids,
+            query_processor=self._eager_load_related_items,
+        )
+
+        # Optimise the user service `fetch()` call
         self._user_service.fetch_all([annotation.userid for annotation in annotations])
 
-        return annotations
+        return [self.present_for_user(annotation, user) for annotation in annotations]
+
+    @staticmethod
+    def _eager_load_related_items(query):
+        # Ensure that accessing `annotation.document` or `.moderation`
+        # doesn't trigger any more queries by pre-loading these
+
+        return query.options(
+            # Optimise access to the document which is called in
+            # `AnnotationJSONPresenter`
+            subqueryload(Annotation.document),
+            # Optimise the check used for "hidden" above
+            subqueryload(Annotation.moderation),
+            # Optimise the permissions check for MODERATE permissions,
+            # which ultimately depends on group permissions, causing a
+            # group lookup for every annotation without this
+            subqueryload(Annotation.group),
+        )


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/h/issues/6769
 
This one is a bit more opinion based, but I think all the private methods here were actually making the logic harder to follow.

There's not much point in totally empty public methods that just call other methods. The logic is actually kind of easier to follow if it's inline.

This might be different if we were calling lots of big chunks, but these were mostly just calling one other thing.