### PR TITLE
Fix a flakey test which failed 1 in 6 times as it required tags

### DIFF
--- a/tests/h/services/annotation_json_test.py
+++ b/tests/h/services/annotation_json_test.py
@@ -243,7 +243,9 @@ class TestAnnotationJSONService:
 
     @pytest.fixture
     def annotation(self, factories):
-        return factories.Annotation(moderation=None, groupid="NOT WORLD")
+        return factories.Annotation(
+            moderation=None, groupid="NOT WORLD", tags=["some-tags"]
+        )
 
     @pytest.fixture
     def with_hidden_annotation(self, annotation, factories):


### PR DESCRIPTION
We were relying on there being a tag in the output of a factory, but the factory returns between 0 and 5 tags, so 1 in 6 times it failed.