### PR TITLE
Replace `client_authority` for direct access when auth clients are mandatory

### DIFF
--- a/h/views/api/bulk.py
+++ b/h/views/api/bulk.py
@@ -4,7 +4,6 @@ from itertools import chain
 from h_api.bulk_api import BulkAPI
 from pyramid.response import Response
 
-from h.auth.util import client_authority
 from h.security import Permission
 from h.services.bulk_executor import BulkExecutor
 from h.views.api.config import api_config
@@ -35,7 +34,9 @@ def bulk(request):
 
     results = BulkAPI.from_byte_stream(
         request.body_file,
-        executor=BulkExecutor(db=request.db, authority=client_authority(request)),
+        executor=BulkExecutor(
+            db=request.db, authority=request.identity.auth_client.authority
+        ),
     )
 
     if results is None:


### PR DESCRIPTION
This is about cutting down the `h.auth` directory until it's gone.

For these end-points there is always an auth client, so the method call adds nothing (as it's basically `if auth_client...`).