### PR TITLE
Move the `default_authority` method to `h.security`

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -78,7 +78,6 @@ def includeme(config):
 
     # Core site modules
     config.include("h.assets")
-    config.include("h.auth")
     config.include("h.db")
     config.include("h.eventqueue")
     config.include("h.form")

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -1,8 +1,0 @@
-"""Authentication configuration."""
-
-from h.auth.util import default_authority
-
-
-def includeme(config):  # pragma: no cover
-    # Allow retrieval of the authority from the request object.
-    config.add_request_method(default_authority, name="default_authority", reify=True)

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -1,12 +1,3 @@
-def default_authority(request):
-    """
-    Return the value of the h.authority config settings.
-
-    Falls back on returning request.domain if h.authority isn't set.
-    """
-    return request.registry.settings.get("h.authority", request.domain)
-
-
 def client_authority(request):
     """
     Return the authority associated with an authenticated auth_client or None.

--- a/h/security/__init__.py
+++ b/h/security/__init__.py
@@ -20,6 +20,8 @@ log = logging.getLogger(__name__)
 
 
 def includeme(config):  # pragma: no cover
+    config.include("h.security.request_methods")
+
     settings = config.registry.settings
 
     settings["h_auth_cookie_secret"] = derive_key(

--- a/h/security/request_methods.py
+++ b/h/security/request_methods.py
@@ -1,0 +1,12 @@
+def default_authority(request):
+    """
+    Return the value of the h.authority config settings.
+
+    Falls back on returning request.domain if h.authority isn't set.
+    """
+    return request.registry.settings.get("h.authority", request.domain)
+
+
+def includeme(config):  # pragma: no cover
+    # Allow retrieval of the authority from the request object.
+    config.add_request_method(default_authority, reify=True)

--- a/h/services/links.py
+++ b/h/services/links.py
@@ -2,7 +2,7 @@
 
 from pyramid.request import Request
 
-from h.auth import default_authority
+from h.security.request_methods import default_authority
 
 LINK_GENERATORS_KEY = "h.links.link_generators"
 

--- a/h/streamer/app.py
+++ b/h/streamer/app.py
@@ -25,7 +25,6 @@ def create_app(_global_config, **settings):
 
     config.include("pyramid_services")
 
-    config.include("h.auth")
     config.include("h.security")
     # Override the default authentication policy.
     config.set_security_policy(BearerTokenPolicy())

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -1,4 +1,4 @@
-from h.auth.util import client_authority, default_authority
+from h.auth.util import client_authority
 from h.security import Identity
 
 
@@ -17,19 +17,3 @@ class TestClientAuthority:
         result = client_authority(pyramid_request)
 
         assert result == identity.auth_client.authority
-
-
-class TestAuthDomain:
-    def test_it_returns_the_request_domain_if_authority_isnt_set(self, pyramid_request):
-        # Make sure h.authority isn't set.
-        pyramid_request.registry.settings.pop("h.authority", None)
-
-        assert default_authority(pyramid_request) == pyramid_request.domain
-
-    def test_it_allows_overriding_request_domain(self, pyramid_request):
-        pyramid_request.registry.settings["h.authority"] = "foo.org"
-        assert default_authority(pyramid_request) == "foo.org"
-
-    def test_it_returns_str(self, pyramid_request):
-        pyramid_request.domain = str(pyramid_request.domain)
-        assert isinstance(default_authority(pyramid_request), str)

--- a/tests/h/security/request_methods_test.py
+++ b/tests/h/security/request_methods_test.py
@@ -1,0 +1,12 @@
+from h.security.request_methods import default_authority
+
+
+class TestDefaultAuthority:
+    def test_it(self, pyramid_request):
+        pyramid_request.registry.settings["h.authority"] = "foo.org"
+        assert default_authority(pyramid_request) == "foo.org"
+
+    def test_it_returns_the_request_domain_if_authority_isnt_set(self, pyramid_request):
+        pyramid_request.registry.settings.pop("h.authority", None)
+
+        assert default_authority(pyramid_request) == pyramid_request.domain


### PR DESCRIPTION
Part of removing `h.auth`, this PR moves `default_authority()` from `h.auth` to `h.security`. This is a fairly straight move, but I cut down the tests a little.