### PR TITLE
Fix the search reindexing admin form

### DIFF
--- a/h/templates/admin/search.html.jinja2
+++ b/h/templates/admin/search.html.jinja2
@@ -10,7 +10,7 @@
     </div>
 
     <div class="panel-body">
-      <form method="POST" class="form-inline">
+      <form method="POST">
         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         {{ caller() }}
         <div class="form-group">
@@ -37,13 +37,17 @@
   {% endcall %}
 
   {% call reindex_form(heading="Reindex all annotations by a user", action="reindex_user") %}
-    <label for="username">Username</label>
-    <input required class="form-control" name="username" id="username">
+    <div class="form-group">
+      <label for="username">Username</label>
+      <input required class="form-control" name="username" id="username">
+    </div>
   {% endcall %}
 
   {% call reindex_form(heading="Reindex all annotations in a group", action="reindex_group") %}
-    <label for="groupid">Group ID</label>
-    <input required class="form-control" name="groupid" id="groupid">
+    <div class="form-group">
+      <label for="groupid">Group ID</label>
+      <input required class="form-control" name="groupid" id="groupid">
+    </div>
   {% endcall %}
 {% endblock %}
 


### PR DESCRIPTION
This form is kind of messed up. I'm not sure what the problem is but all the elements are run together without whitespace.

Changing it from an inline form to an normal form seems to fix most of the breakage.

Before:

![Screenshot from 2021-10-12 15-57-39](https://user-images.githubusercontent.com/22498/137003004-41551178-f72c-43a3-b69f-55ce0bffb386.png)

After:

![Screenshot from 2021-10-12 18-36-01](https://user-images.githubusercontent.com/22498/137003073-2e8a36a6-c62d-4d85-bcfa-5ee2cd8c0122.png)
