### PR TITLE
Add force checkboxes to reindex admin pages

### DIFF
--- a/h/templates/admin/search.html.jinja2
+++ b/h/templates/admin/search.html.jinja2
@@ -21,6 +21,13 @@
   </div>
 {% endmacro %}
 
+{% macro force_checkbox(name) %}
+  <div class="form-group form-check">
+    <input class="form-check-input" type="checkbox" checked id="{{ name }}" name="{{ name }}">
+    <label class="form-check-label" for="{{ name }}">Force <small class="text-muted">(Reindex all matching annotations even if they're already up to date in Elasticsearch.)</small></label>
+  </div>
+{% endmacro %}
+
 {% block content %}
   <p>This is the search index admin page.</p>
 
@@ -41,6 +48,8 @@
       <label for="username">Username</label>
       <input required class="form-control" name="username" id="username">
     </div>
+
+    {{ force_checkbox("reindex_user_force") }}
   {% endcall %}
 
   {% call reindex_form(heading="Reindex all annotations in a group", action="reindex_group") %}
@@ -48,6 +57,8 @@
       <label for="groupid">Group ID</label>
       <input required class="form-control" name="groupid" id="groupid">
     </div>
+
+    {{ force_checkbox("reindex_group_force") }}
   {% endcall %}
 {% endblock %}
 

--- a/h/views/admin/search.py
+++ b/h/views/admin/search.py
@@ -50,6 +50,8 @@ class SearchAdminViews:
     )
     def reindex_user(self):
         username = self.request.params["username"].strip()
+        force = bool(self.request.params.get("reindex_user_force"))
+
         user = models.User.get_by_username(
             self.request.db, username, self.request.default_authority
         )
@@ -57,7 +59,7 @@ class SearchAdminViews:
             raise NotFoundError(f"User {username} not found")
 
         self.request.find_service(name="search_index").add_users_annotations(
-            user.userid, tag="reindex_user"
+            user.userid, tag="reindex_user", force=force
         )
         return self._notify_reindexing_started(
             f"Began reindexing annotations by {user.userid}"
@@ -71,12 +73,14 @@ class SearchAdminViews:
     )
     def reindex_group(self):
         groupid = self.request.params["groupid"].strip()
+        force = bool(self.request.params.get("reindex_group_force"))
+
         group = self.request.find_service(name="group").fetch_by_pubid(groupid)
         if not group:
             raise NotFoundError(f"Group {groupid} not found")
 
         self.request.find_service(name="search_index").add_group_annotations(
-            groupid, tag="reindex_group"
+            groupid, tag="reindex_group", force=force
         )
         return self._notify_reindexing_started(
             f"Began reindexing annotations in group {groupid} ({group.name})"


### PR DESCRIPTION
Depends on: https://github.com/hypothesis/h/pull/7110

Add checkboxes to the search reindexing admin page to force reindex all of a user or group's annotations:

![Screenshot from 2021-10-12 19-09-22](https://user-images.githubusercontent.com/22498/137007330-a99c4c02-231d-47c1-84a5-8e734a59e377.png)

There's no force checkbox when indexing annotations in a date range because force reindexing annotations in a date range is not supported at the service level and I don't want to deal with that now (it looks like support would have to be added to both the service and the indexer):

https://github.com/hypothesis/h/blob/37d710aa37e4595ad51c2dbb87ae953cdd844edd/h/services/search_index/service.py#L70-L82