### PR TITLE
Replace "body" with "detail" which can be see in the output

### DIFF
--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -205,10 +205,11 @@ class OAuthAccessTokenController:
             self.request.POST,
             self.request.headers,
         )
+
         if status == 200:
             return json.loads(body)
 
-        raise exception_response(status, body=body)
+        raise exception_response(status, detail=body)
 
 
 class OAuthRevocationController:
@@ -229,7 +230,7 @@ class OAuthRevocationController:
         if status == 200:
             return {}
 
-        raise exception_response(status, body=body)
+        raise exception_response(status, detail=body)
 
 
 @api_config(versions=["v1", "v2"], route_name="api.debug_token", request_method="GET")

--- a/tests/h/views/api/auth_test.py
+++ b/tests/h/views/api/auth_test.py
@@ -295,7 +295,7 @@ class TestOAuthAccessTokenController:
         with pytest.raises(httpexceptions.HTTPBadRequest) as exc:
             controller.post()
 
-        assert exc.value.body == body.encode()
+        assert exc.value.detail == body
 
     def test_get_raises_for_invalid_request(self, controller):
         controller.oauth.create_token_response.side_effect = InvalidRequestFatalError(
@@ -347,7 +347,7 @@ class TestOAuthRevocationController:
         with pytest.raises(httpexceptions.HTTPBadRequest) as exc:
             controller.post()
 
-        assert exc.value.body == body.encode()
+        assert exc.value.detail == body
 
     def test_get_raises_for_invalid_request(self, controller):
         controller.oauth.create_revocation_response.side_effect = (


### PR DESCRIPTION
Otherwise you get an error with a "null" in it.

When things go wrong in the auth token stuff we set a "body" attribute, but nothing reads it. We only output the results of "detail". This results in a error like this:

```{"status": "failure": "reason": null}```

The part where this gets serialised is here: https://github.com/hypothesis/h/blob/master/h/views/api/errors.py#L56