### PR TITLE
Add WebSocket URL to `/api/links` response

### DIFF
--- a/h/views/api/links.py
+++ b/h/views/api/links.py
@@ -21,6 +21,8 @@ def links(_context, request):
     oauth_authorize_url = request.route_url("oauth_authorize")
     oauth_revoke_url = request.route_url("oauth_revoke")
 
+    websocket_url = request.registry.settings.get("h.websocket_url")
+
     return {
         "account.settings": request.route_url("account"),
         "forgot-password": request.route_url("forgot_password"),
@@ -31,4 +33,5 @@ def links(_context, request):
         "search.tag": tag_search_url,
         "signup": request.route_url("signup"),
         "user": templater.route_template("stream.user_query"),
+        "websocket": websocket_url,
     }

--- a/tests/h/views/api/links_test.py
+++ b/tests/h/views/api/links_test.py
@@ -14,6 +14,7 @@ class TestLinks:
         pyramid_config.add_route("activity.search", "/search")
         pyramid_config.add_route("signup", "/signup")
         pyramid_config.add_route("stream.user_query", "/u/{user}")
+        pyramid_request.registry.settings["h.websocket_url"] = "wss://example.com/ws"
 
         links = views.links(testing.DummyResource(), pyramid_request)
 
@@ -28,4 +29,5 @@ class TestLinks:
             "search.tag": host + "/search?q=tag%3A%22:tag%22",
             "signup": host + "/signup",
             "user": host + "/u/:user",
+            "websocket": "wss://example.com/ws",
         }


### PR DESCRIPTION
Add the URL of the WebSocket endpoint to the `/api/links` response. This
will allow the client to talk to the correct WebSocket when it is
connecting to an API endpoint specified via the client's `services` [1]
configuration that is different than the default.

This setting will replace the `websocketUrl` config setting in the `/app.html` route. Once the client has been updated to read this value from the `/api/links` response, we can remove `websocketUrl`.

The corresponding client change is https://github.com/hypothesis/client/pull/4148.

[1] https://h.readthedocs.io/projects/client/en/latest/publishers/config/#cmdoption-arg-services