### PR TITLE
Remove `websocketUrl` client setting

### DIFF
--- a/h/views/api/links.py
+++ b/h/views/api/links.py
@@ -21,6 +21,8 @@ def links(_context, request):
     oauth_authorize_url = request.route_url("oauth_authorize")
     oauth_revoke_url = request.route_url("oauth_revoke")
 
+    websocket_url = request.registry.settings.get("h.websocket_url")
+
     return {
         "account.settings": request.route_url("account"),
         "forgot-password": request.route_url("forgot_password"),
@@ -31,4 +33,5 @@ def links(_context, request):
         "search.tag": tag_search_url,
         "signup": request.route_url("signup"),
         "user": templater.route_template("stream.user_query"),
+        "websocket": websocket_url,
     }

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -49,7 +49,6 @@ def sidebar_app(request, extra=None):
 
     settings = request.registry.settings
     sentry_public_dsn = settings.get("h.sentry_dsn_client")
-    websocket_url = settings.get("h.websocket_url")
 
     app_config = {
         "apiUrl": request.route_url("api.index"),
@@ -59,9 +58,6 @@ def sidebar_app(request, extra=None):
         # requests from.
         "rpcAllowedOrigins": settings.get("h.client_rpc_allowed_origins"),
     }
-
-    if websocket_url:
-        app_config.update({"websocketUrl": websocket_url})
 
     if sentry_public_dsn:
         # `h.sentry_environment` primarily refers to h's Sentry environment,

--- a/tests/h/views/api/links_test.py
+++ b/tests/h/views/api/links_test.py
@@ -14,6 +14,7 @@ class TestLinks:
         pyramid_config.add_route("activity.search", "/search")
         pyramid_config.add_route("signup", "/signup")
         pyramid_config.add_route("stream.user_query", "/u/{user}")
+        pyramid_request.registry.settings["h.websocket_url"] = "wss://example.com/ws"
 
         links = views.links(testing.DummyResource(), pyramid_request)
 
@@ -28,4 +29,5 @@ class TestLinks:
             "search.tag": host + "/search?q=tag%3A%22:tag%22",
             "signup": host + "/signup",
             "user": host + "/u/:user",
+            "websocket": "wss://example.com/ws",
         }

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -12,7 +12,6 @@ class TestSidebarApp:
         ctx = client.sidebar_app(pyramid_request)
         expected_config = {
             "apiUrl": "http://example.com/api",
-            "websocketUrl": "wss://example.com/ws",
             "sentry": {"dsn": "test-sentry-dsn", "environment": "dev"},
             "authDomain": "example.com",
             "oauthClientId": "test-client-id",


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/h/pull/7253 and https://github.com/hypothesis/client/pull/4148.**

This has been replaced by the "websocket" entry in the `/api/links` response.