### PR TITLE
Fix broken overflow for `pre code` content in activity-pages annotations

### DIFF
--- a/h/static/styles/core/_typography.scss
+++ b/h/static/styles/core/_typography.scss
@@ -1,4 +1,4 @@
-@use "color";
+@use 'color';
 
 // Core: Typography
 // ============================================================================
@@ -6,7 +6,8 @@
 // Variables
 // ----------------------------------------------------------------------------
 
-$sans-font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif !default;
+$sans-font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande',
+  sans-serif !default;
 $mono-font-family: Open Sans Mono, Menlo, DejaVu Sans Mono, monospace !default;
 
 // Standard font sizes
@@ -54,11 +55,27 @@ $touch-input-font-size: 16px;
   // Reset the line-height in case any parent elements have set it.
   line-height: normal;
 
-  h1, h2, h3, h4, h5, h6, p, ol, ul, img, pre, blockquote {
-    margin: .618em 0;
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  ol,
+  ul,
+  img,
+  pre,
+  blockquote {
+    margin: 0.618em 0;
   }
 
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     font-family: $sans-font-family;
   }
 
@@ -67,40 +84,42 @@ $touch-input-font-size: 16px;
   h1 {
     font-size: 2.618em;
     font-weight: bold;
-    margin: .2327em 0;
+    margin: 0.2327em 0;
   }
 
   h2 {
     font-size: 1.991em;
     font-weight: bold;
-    margin: .309em 0;
+    margin: 0.309em 0;
   }
 
   h3 {
     font-size: 1.991em;
-    margin: .309em 0;
+    margin: 0.309em 0;
   }
 
   h4 {
     font-size: 1.618em;
-    margin: .3803em 0;
+    margin: 0.3803em 0;
   }
 
   h5 {
     font-size: 1.231em;
-    margin: .4944em 0;
+    margin: 0.4944em 0;
   }
 
   h6 {
     font-size: 1.231em;
-    margin: .4944em 0;
+    margin: 0.4944em 0;
   }
 
-  ol, ul {
+  ol,
+  ul {
     list-style-position: inside;
     padding-left: 0;
 
-    ol, ul {
+    ol,
+    ul {
       padding-left: 1em;
     }
   }
@@ -113,17 +132,19 @@ $touch-input-font-size: 16px;
     list-style-type: disc;
   }
 
-  ol, ul {
+  ol,
+  ul {
     ul {
       list-style-type: circle;
     }
   }
 
   li {
-    margin-bottom: .291em;
+    margin-bottom: 0.291em;
   }
 
-  li, p {
+  li,
+  p {
     line-height: 1.3;
   }
 
@@ -148,22 +169,29 @@ $touch-input-font-size: 16px;
     padding: 0 1em;
     margin: 1em 0;
 
-    p, ol, ul, img, pre, blockquote {
-      margin: .7063em 0;
+    p,
+    ol,
+    ul,
+    img,
+    pre,
+    blockquote {
+      margin: 0.7063em 0;
     }
 
-    p, li {
+    p,
+    li {
       line-height: 1.5;
     }
   }
 
   code {
     font-family: $mono-font-family;
-    font-size: .875em;
+    font-size: 0.875em;
     color: black;
   }
 
   pre code {
+    overflow: scroll;
     padding: 10px;
     display: block;
     background-color: color.$grey-1;


### PR DESCRIPTION
This PR makes a single-rule addition (`overflow: scroll`) to `pre code` styling for rendered markdown-as-HTML in activity pages. Long lines of code are no longer cut off; they scroll within the `pre code` block now.

My editor also updated the formatting of the SCSS module to more recent `prettier` standards.

Before:

![image](https://user-images.githubusercontent.com/439947/152155395-63f49295-7604-4f02-b391-91d000b34441.png)

After:

![overflow-scroll](https://user-images.githubusercontent.com/439947/152155833-0970a903-6d8e-49a8-8716-b6b16cfc02fc.gif)

Fixes https://github.com/hypothesis/product-backlog/issues/1296