### PR TITLE
Prepare for Elasticsearch 6.8 and 7.x migrations

### DIFF
--- a/h/search/config.py
+++ b/h/search/config.py
@@ -124,10 +124,16 @@ def configure_index(client):
     """Create a new randomly-named index and return its name."""
     index_name = client.index + "-" + _random_id()
     mapping = ANNOTATION_MAPPING
+
+    if client.server_version >= (7, 0, 0):
+        mappings = mapping
+    else:
+        mappings = {client.mapping_type: mapping}
+
     client.conn.indices.create(
         index_name,
         body={
-            "mappings": {client.mapping_type: mapping},
+            "mappings": mappings,
             "settings": {"analysis": ANALYSIS_SETTINGS},
         },
     )

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -116,7 +116,7 @@ class Search:
 
         response = self._search(modifiers, self._aggregations, params)
 
-        total = response["hits"]["total"]
+        total = _get_total_hits(response)
         annotation_ids = [hit["_id"] for hit in response["hits"]["hits"]]
         aggregations = self._parse_aggregation_results(response.aggregations)
         return (total, annotation_ids, aggregations)
@@ -134,7 +134,7 @@ class Search:
             MultiDict({"limit": self._replies_limit}),
         )
 
-        if len(response["hits"]["hits"]) < response["hits"]["total"]:
+        if len(response["hits"]["hits"]) < _get_total_hits(response):
             log.warning(
                 "The number of reply annotations exceeded the page size "
                 "of the Elasticsearch query. We currently don't handle "
@@ -152,3 +152,10 @@ class Search:
         for agg in self._aggregations:
             results[agg.name] = agg.parse_result(aggregations)
         return results
+
+
+def _get_total_hits(response):
+    total = response["hits"]["total"]
+    if isinstance(total, int):
+        return total  # ES 6.x
+    return total["value"]  # ES 7.x

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -77,10 +77,12 @@ class BatchIndexer:
         action = {
             self.op_type: {
                 "_index": self._target_index,
-                "_type": self.es_client.mapping_type,
                 "_id": annotation.id,
             }
         }
+
+        if self.es_client.server_version < (7, 0, 0):
+            action[self.op_type]["_type"] = self.es_client.mapping_type
 
         data = presenters.AnnotationSearchIndexPresenter(
             annotation, self.request

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -5,32 +5,31 @@ from h.search.client import Client, get_client
 
 
 class TestClient:
-    def test_it_sets_the_index_property(self):
-        client = Client(host="http://localhost:9200", index="hypothesis")
-
+    def test_it_sets_the_index_property(self, client):
         assert client.index == "hypothesis"
 
-    def test_it_sets_the_version_property(self):
-        client = Client(host="http://localhost:9200", index="hypothesis")
-
+    def test_it_sets_version(self, client):
         assert client.version >= (6, 4, 0) and client.version < (7, 0, 0)
 
-    def test_it_sets_the_conn_property(self):
-        client = Client(host="http://localhost:9200", index="hypothesis")
+    def test_it_sets_server_version(self, client):
+        assert client.server_version >= (6, 2, 0) and client.server_version < (8, 0, 0)
 
+    def test_it_sets_the_conn_property(self, client):
         assert isinstance(client.conn, elasticsearch.Elasticsearch)
 
-    def test_index_is_read_only(self):
-        client = Client(host="http://localhost:9200", index="hypothesis")
-
+    def test_index_is_read_only(self, client):
         with pytest.raises(AttributeError, match="can't set attribute"):
             client.index = "changed"
 
-    def test_conn_is_read_only(self):
-        client = Client(host="http://localhost:9200", index="hypothesis")
-
+    def test_conn_is_read_only(self, client):
         with pytest.raises(AttributeError, match="can't set attribute"):
             client.conn = "changed"
+
+    @pytest.fixture
+    def client(self):
+        client = Client(host="http://localhost:9200", index="hypothesis")
+        yield client
+        client.close()
 
 
 class TestGetClient:

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -164,6 +164,17 @@ class TestConfigureIndex:
             },
         )
 
+    def test_sets_correct_mappings_and_settings_for_es7(self, client_es7):
+        configure_index(client_es7)
+
+        client_es7.conn.indices.create.assert_called_once_with(
+            Any(),
+            body={
+                "mappings": ANNOTATION_MAPPING,
+                "settings": {"analysis": ANALYSIS_SETTINGS},
+            },
+        )
+
 
 class TestGetAliasedIndex:
     def test_returns_underlying_index_name(self, client):
@@ -278,8 +289,26 @@ def groups(pattern, text):
 @pytest.fixture
 def client():
     client = mock.create_autospec(
-        Client, spec_set=True, instance=True, version=elasticsearch.__version__
+        Client,
+        spec_set=True,
+        instance=True,
+        version=elasticsearch.__version__,
+        server_version=(6, 2, 0),
     )
     client.index = "foo"
     client.mapping_type = "annotation"
+    return client
+
+
+@pytest.fixture
+def client_es7():
+    client = mock.create_autospec(
+        Client,
+        spec_set=True,
+        instance=True,
+        version=elasticsearch.__version__,
+        server_version=(7, 10, 0),
+    )
+    client.index = "foo"
+    client.mapping_type = "_doc"
     return client


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/private-issues/issues/107

Prepare for migrating from Elasticsearch 6.2 to ES 6.8 and then to ES 7.x by making h support each of these versions. 

## What's changed in the code?

See the commit notes for full details, but in summary there are two changes that affect h: 

 * [Removal of mapping types](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html)
 * A change to the `hits.total` field of search responses. 

## What's changed in ES?

For ES 6.x servers there are no changes when using this PR. 

For ES 7.x servers there is a minor change to how the document indexing API is called and a change to how mappings are configured when creating a new index. The changes for ES 7 are backwards compatible with indexes created with ES 6, so won't have to reindex in production as part of the migration.

The ES client library version has not changed. 

## Notes

In my testing the ES 6.8 client library works against servers running ES 6.2, 6.8 and 7.10.0, at least for the subset of functionality we require. We are supposed to use a client library that matches the major version of the server though, so we should upgrade the `elasticsearch` and `elasticsearch-dsl` dependencies as soon as the migration is complete.

We haven't decided yet whether we want to eventually end up on Elasticsearch 7.x or OpenSearch 1.x (Amazon's ES fork). The current version of OpenSearch can be treated as ES 7.10 for our purposes. See https://github.com/hypothesis/h/pull/7335#issuecomment-1076462876. Due to the [upgrade paths](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/version-migration.html) supported by AWS, we will need to go via ES 6.8 first.

This PR essentially solves https://github.com/hypothesis/private-issues/issues/103 by making it possible for developers on ARM systems to use an ES 7.10 container locally in development, prior to us switching to ES 7.x in production.

## Testing notes

So far I have tested creating variants of the [hypothesis/elasticsearch](https://github.com/hypothesis/elasticsearch_docker) Docker image locally using ES 6.8.23 and 7.10.0. For each of these versions I tested:

- Running the unit and functional tests against
- Basic usage of the client (creating annotations, refreshing the page, deleting annotations)
- Activity pages
- Recreating the search index
- Re-indexing annotations from http://localhost:5000/admin/search

### TODO ###

- [x] Get someone to build an arm64 version of the ES 7.x container image and test this PR with that, since making the dev environment work better on M1 Macs is one of the motivations for the upgrade. _Update: Lyza tested this, it works._
- [x] Test what happens if we try to switch to OpenSearch 1.x instead of ES 7.x. (See https://github.com/hypothesis/h/pull/7335#issuecomment-1076462876)
- [x] Test what happens when creating an index using ES 6.2, and then upgrading the container to ES 6.8 and ES 7.x while using the same data volume. (See https://github.com/hypothesis/h/pull/7335#issuecomment-1077291741).

