### PR TITLE
Simplify the elasticsearch `Client`

### DIFF
--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -1,5 +1,6 @@
 import itertools
 import re
+from unittest.mock import MagicMock
 from urllib.parse import quote_plus
 
 import elasticsearch
@@ -127,7 +128,9 @@ class TestInit:
     def mock_es_client(self, mock_es_client):
         # By default, pretend that no index exists already...
         mock_es_client.conn.indices.exists.return_value = False
-        # Simulate the ICU Analysis plugin
+        # Simulate the ICU Analysis plugin, and get around some funky stuff
+        # the ES client library does which confuses autospeccing
+        mock_es_client.conn.cat.plugins = MagicMock()
         mock_es_client.conn.cat.plugins.return_value = "\n".join(
             ["foo", "analysis-icu"]
         )

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import call, create_autospec, patch, sentinel
+from unittest.mock import MagicMock, call, create_autospec, patch, sentinel
 
 import pytest
 from h_matchers import Any
@@ -343,3 +343,11 @@ def report_exception(patch):
 @pytest.fixture(autouse=True)
 def storage(patch):
     return patch("h.services.search_index.service.storage")
+
+
+@pytest.fixture
+def mock_es_client(mock_es_client):
+    # The ES library uses some fancy decorators which confuse autospeccing
+    mock_es_client.conn.index = MagicMock()
+
+    return mock_es_client


### PR DESCRIPTION
This has quite a few features I don't think we need:

 * We never change the `elasticsearch` library (was this an old testing in?)
 * We never look at the version
 
So I've made the class a simple `dataclass` with the configuration outside it. There's also an increase in test coverage with a decrease in overall size.

## Autospec hell

This change has caused a number of headaches with `autospec` mocks:

 * `create_autospec` doesn't appear to understand `dataclass` classes, but will work with an instance to work from
 * _However_ if we do that the mock becomes aware that `conn` should be an `Elasticsearch` instance, which it wasn't before
 * This means it attempts to enforce we are calling it right (which is good), but that code is written in such a way to also confuse `autospec`
 * To get around this in a few places I've replaced chunks of the `conn` object with plain `MagicMocks`