### PR TITLE
Use a unified fixture for the mocked ES client

### DIFF
--- a/tests/common/fixtures/__init__.py
+++ b/tests/common/fixtures/__init__.py
@@ -1,3 +1,0 @@
-from tests.common.fixtures.elasticsearch import es_client, init_elasticsearch
-
-__all__ = ("es_client", "init_elasticsearch")

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -1,12 +1,16 @@
 import os
+from unittest.mock import create_autospec
 
 import elasticsearch_dsl
 import pytest
 
 from h import search
+from h.search.client import Client
 
 ELASTICSEARCH_INDEX = "hypothesis-test"
 ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9200")
+
+__all__ = ("es_client", "mock_es_client", "init_elasticsearch")
 
 
 @pytest.fixture
@@ -28,6 +32,18 @@ def es_client():
 
     # Close connection to ES server to avoid ResourceWarning about a leaked TCP socket.
     client.close()
+
+
+@pytest.fixture
+def mock_es_client():
+    return create_autospec(
+        Client,
+        instance=True,
+        spec_set=True,
+        index="hypothesis",
+        version=(6, 2, 0),
+        mapping_type="annotation",
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -7,9 +7,12 @@ from webtest import TestApp
 from h import db
 from h.app import create_app
 from tests.common import factories as factories_common
-from tests.common.fixtures import es_client  # pylint:disable=unused-import
-from tests.common.fixtures import init_elasticsearch  # pylint:disable=unused-import
-from tests.common.fixtures.elasticsearch import ELASTICSEARCH_INDEX, ELASTICSEARCH_URL
+from tests.common.fixtures.elasticsearch import (  # pylint: disable=unused-import
+    ELASTICSEARCH_INDEX,
+    ELASTICSEARCH_URL,
+    es_client,
+    init_elasticsearch,
+)
 from tests.functional.fixtures.authentication import *  # pylint:disable=wildcard-import,unused-wildcard-import
 from tests.functional.fixtures.groups import *  # pylint:disable=wildcard-import,unused-wildcard-import
 

--- a/tests/h/cli/commands/search_test.py
+++ b/tests/h/cli/commands/search_test.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pytest
 
 from h.cli.commands import search
-from h.search.client import Client
 
 
 class TestReindexCommand:
@@ -53,8 +52,3 @@ class TestUpdateSettingsCommand:
 def cliconfig(pyramid_request, mock_es_client):
     pyramid_request.es = mock_es_client
     return {"bootstrap": mock.Mock(return_value=pyramid_request)}
-
-
-@pytest.fixture
-def mock_es_client():
-    return mock.create_autospec(Client, spec_set=True, instance=True)

--- a/tests/h/cli/commands/search_test.py
+++ b/tests/h/cli/commands/search_test.py
@@ -50,6 +50,11 @@ class TestUpdateSettingsCommand:
 
 
 @pytest.fixture
-def cliconfig(pyramid_request):
-    pyramid_request.es = mock.create_autospec(Client, spec_set=True, instance=True)
+def cliconfig(pyramid_request, mock_es_client):
+    pyramid_request.es = mock_es_client
     return {"bootstrap": mock.Mock(return_value=pyramid_request)}
+
+
+@pytest.fixture
+def mock_es_client():
+    return mock.create_autospec(Client, spec_set=True, instance=True)

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -15,8 +15,7 @@ from h import db
 from h.models import Organization
 from h.settings import database_url
 from tests.common import factories as common_factories
-from tests.common.fixtures import es_client  # pylint:disable=unused-import
-from tests.common.fixtures import init_elasticsearch  # pylint:disable=unused-import
+from tests.common.fixtures.elasticsearch import *  # pylint:disable=wildcard-import,unused-wildcard-import
 from tests.common.fixtures.services import *  # pylint:disable=wildcard-import,unused-wildcard-import
 
 TEST_AUTHORITY = "example.com"

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -3,7 +3,6 @@ from unittest import mock
 import pytest
 
 from h.indexer.reindexer import reindex
-from h.search import client
 
 
 @pytest.mark.usefixtures(
@@ -161,18 +160,6 @@ class TestReindex:
         indexer = BatchIndexer.return_value
         indexer.index.return_value = []
         return indexer
-
-    @pytest.fixture
-    def mock_es_client(self):
-        mock_es = mock.create_autospec(
-            client.Client,
-            instance=True,
-            spec_set=True,
-            index="hypothesis",
-            version=(1, 5, 0),
-        )
-        mock_es.mapping_type = "annotation"
-        return mock_es
 
     @pytest.fixture
     def settings_service(self, pyramid_config):

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -16,112 +16,122 @@ from h.search import client
     "settings_service",
 )
 class TestReindex:
-    def test_sets_op_type_to_create(self, pyramid_request, es, BatchIndexer):
-        reindex(mock.sentinel.session, es, pyramid_request)
+    def test_sets_op_type_to_create(
+        self, pyramid_request, mock_es_client, BatchIndexer
+    ):
+        reindex(mock.sentinel.session, mock_es_client, pyramid_request)
 
         _, kwargs = BatchIndexer.call_args
         assert kwargs["op_type"] == "create"
 
-    def test_indexes_annotations(self, pyramid_request, es, batchindexer):
+    def test_indexes_annotations(self, pyramid_request, mock_es_client, batchindexer):
         """Should call .index() on the batch indexer instance."""
-        reindex(mock.sentinel.session, es, pyramid_request)
+        reindex(mock.sentinel.session, mock_es_client, pyramid_request)
 
         batchindexer.index.assert_called_once_with()
 
-    def test_retries_failed_annotations(self, pyramid_request, es, batchindexer):
+    def test_retries_failed_annotations(
+        self, pyramid_request, mock_es_client, batchindexer
+    ):
         """Should call .index() a second time with any failed annotation IDs."""
         batchindexer.index.return_value = ["abc123", "def456"]
 
-        reindex(mock.sentinel.session, es, pyramid_request)
+        reindex(mock.sentinel.session, mock_es_client, pyramid_request)
 
         assert batchindexer.index.mock_calls == [
             mock.call(),
             mock.call(["abc123", "def456"]),
         ]
 
-    def test_creates_new_index(self, pyramid_request, es, configure_index):
+    def test_creates_new_index(self, pyramid_request, mock_es_client, configure_index):
         """Creates a new target index."""
-        reindex(mock.sentinel.session, es, pyramid_request)
+        reindex(mock.sentinel.session, mock_es_client, pyramid_request)
 
-        configure_index.assert_called_once_with(es)
+        configure_index.assert_called_once_with(mock_es_client)
 
     def test_passes_new_index_to_indexer(
-        self, pyramid_request, es, configure_index, BatchIndexer
+        self, pyramid_request, mock_es_client, configure_index, BatchIndexer
     ):
         """Pass the name of the new index as target_index to indexer."""
         configure_index.return_value = "hypothesis-abcd1234"
 
-        reindex(mock.sentinel.session, es, pyramid_request)
+        reindex(mock.sentinel.session, mock_es_client, pyramid_request)
 
         _, kwargs = BatchIndexer.call_args
         assert kwargs["target_index"] == "hypothesis-abcd1234"
 
     def test_updates_alias_when_reindexed(
-        self, pyramid_request, es, configure_index, update_aliased_index
+        self, pyramid_request, mock_es_client, configure_index, update_aliased_index
     ):
         """Call update_aliased_index on the client with the new index name."""
         configure_index.return_value = "hypothesis-abcd1234"
 
-        reindex(mock.sentinel.session, es, pyramid_request)
+        reindex(mock.sentinel.session, mock_es_client, pyramid_request)
 
-        update_aliased_index.assert_called_once_with(es, "hypothesis-abcd1234")
+        update_aliased_index.assert_called_once_with(
+            mock_es_client, "hypothesis-abcd1234"
+        )
 
     def test_does_not_update_alias_if_indexing_fails(
-        self, pyramid_request, es, batchindexer, update_aliased_index
+        self, pyramid_request, mock_es_client, batchindexer, update_aliased_index
     ):
         """Don't call update_aliased_index if index() fails..."""
         batchindexer.index.side_effect = RuntimeError("fail")
 
         try:
-            reindex(mock.sentinel.session, es, pyramid_request)
+            reindex(mock.sentinel.session, mock_es_client, pyramid_request)
         except RuntimeError:
             pass
 
         assert not update_aliased_index.called
 
-    def test_raises_if_index_not_aliased(self, es, get_aliased_index):
+    def test_raises_if_index_not_aliased(self, mock_es_client, get_aliased_index):
         get_aliased_index.return_value = None
 
         with pytest.raises(RuntimeError):
-            reindex(mock.sentinel.session, es, mock.sentinel.request)
+            reindex(mock.sentinel.session, mock_es_client, mock.sentinel.request)
 
     def test_stores_new_index_name_in_settings(
-        self, pyramid_request, es, settings_service, configure_index
+        self, pyramid_request, mock_es_client, settings_service, configure_index
     ):
         configure_index.return_value = "hypothesis-abcd1234"
 
-        reindex(mock.sentinel.session, es, pyramid_request)
+        reindex(mock.sentinel.session, mock_es_client, pyramid_request)
 
         settings_service.put.assert_called_once_with(
             "reindex.new_index", "hypothesis-abcd1234"
         )
 
-    def test_deletes_index_name_setting(self, pyramid_request, es, settings_service):
-        reindex(mock.sentinel.session, es, pyramid_request)
+    def test_deletes_index_name_setting(
+        self, pyramid_request, mock_es_client, settings_service
+    ):
+        reindex(mock.sentinel.session, mock_es_client, pyramid_request)
 
         settings_service.delete.assert_called_once_with("reindex.new_index")
 
     def test_deletes_index_name_setting_when_exception_raised(
-        self, pyramid_request, es, settings_service, batchindexer
+        self, pyramid_request, mock_es_client, settings_service, batchindexer
     ):
         batchindexer.index.side_effect = RuntimeError("boom!")
 
         with pytest.raises(RuntimeError):
-            reindex(mock.sentinel.session, es, pyramid_request)
+            reindex(mock.sentinel.session, mock_es_client, pyramid_request)
 
         settings_service.delete.assert_called_once_with("reindex.new_index")
 
     def test_deletes_old_index(
-        self, pyramid_request, es, delete_index, get_aliased_index
+        self, pyramid_request, mock_es_client, delete_index, get_aliased_index
     ):
         get_aliased_index.return_value = "original_index"
 
-        reindex(mock.sentinel.session, es, pyramid_request)
+        reindex(mock.sentinel.session, mock_es_client, pyramid_request)
 
-        delete_index.assert_called_once_with(es, "original_index")
+        delete_index.assert_called_once_with(mock_es_client, "original_index")
 
-    def test_populates_nipsa_cache(self, pyramid_request, es, nipsa_service):
-        reindex(mock.sentinel.session, es, pyramid_request)
+    def test_populates_nipsa_cache(
+        self, pyramid_request, mock_es_client, nipsa_service
+    ):
+        reindex(mock.sentinel.session, mock_es_client, pyramid_request)
         nipsa_service.fetch_all_flagged_userids.assert_called_once_with()
 
     @pytest.fixture
@@ -153,7 +163,7 @@ class TestReindex:
         return indexer
 
     @pytest.fixture
-    def es(self):
+    def mock_es_client(self):
         mock_es = mock.create_autospec(
             client.Client,
             instance=True,

--- a/tests/h/services/search_index/service_test.py
+++ b/tests/h/services/search_index/service_test.py
@@ -5,7 +5,6 @@ import pytest
 from h_matchers import Any
 
 from h.events import AnnotationEvent
-from h.search.client import Client
 from h.services.search_index._queue import Queue
 from h.services.search_index.service import SearchIndexService
 from h.services.settings import SettingsService
@@ -329,11 +328,6 @@ def search_index(mock_es_client, pyramid_request, settings_service, queue):
         settings=settings_service,
         queue=queue,
     )
-
-
-@pytest.fixture(autouse=True)
-def mock_es_client():
-    return create_autospec(Client, instance=True)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Our tests repeatedly re-create the `es_client` fixture in different places with different names. The name `es_client` is also used for a real instance, as well as a mocked one.

In this PR:

 * There is a single mocked fixture called `mock_es_client`
 * A single real fixture called `es_client`

This allows us to update the single fixture as the class changes instead of chasing through multiple failing tests.

## Review notes

There are two commits here. The first one just changes the names of things, and all the actual changes are in the second.