### PR TITLE
Prepare for Elasticsearch 6.8 and 7.x migrations (refactor)

### DIFF
--- a/h/cli/commands/search.py
+++ b/h/cli/commands/search.py
@@ -27,8 +27,7 @@ def reindex(ctx):
 
     es_client = request.es
 
-    es_server_version = es_client.conn.info()["version"]["number"]
-    click.echo(f"reindexing into Elasticsearch {es_server_version} cluster")
+    click.echo(f"reindexing into Elasticsearch {es_client.server_version} cluster")
 
     indexer.reindex(request.db, es_client, request)
 

--- a/h/search/client.py
+++ b/h/search/client.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Tuple
 
 import elasticsearch
+from packaging.version import Version
 
 
 @dataclass(frozen=True)
@@ -28,22 +28,16 @@ class Client:
         # removed but indexing APIs use the dummy value `_doc`.
         # See: https://www.elastic.co/guide/en/elasticsearch/reference/6.x/removal-of-types.html
 
-        if self.server_version < (7, 0, 0):
+        if self.server_version < Version("7.0.0"):
             return "annotation"
 
         return "_doc"
 
     @cached_property
-    def server_version(self) -> Tuple[int, int, int]:
+    def server_version(self) -> Version:
         """Get the version of the connected Elasticsearch cluster."""
 
-        version_str = self.conn.info()["version"]["number"]
-
-        # We assume the ES version has 3 parts. This has been true of all
-        # non pre-release versions historically.
-        major, minor, patch = [int(part) for part in version_str.split(".")]
-
-        return major, minor, patch
+        return Version(self.conn.info()["version"]["number"])
 
 
 def get_client(settings):

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -124,10 +124,16 @@ def configure_index(client):
     """Create a new randomly-named index and return its name."""
     index_name = client.index + "-" + _random_id()
     mapping = ANNOTATION_MAPPING
+
+    if client.server_version >= (7, 0, 0):
+        mappings = mapping
+    else:
+        mappings = {client.mapping_type: mapping}
+
     client.conn.indices.create(
         index_name,
         body={
-            "mappings": {client.mapping_type: mapping},
+            "mappings": mappings,
             "settings": {"analysis": ANALYSIS_SETTINGS},
         },
     )

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -11,6 +11,7 @@ import logging
 import os
 
 import elasticsearch
+from packaging.version import Version
 
 log = logging.getLogger(__name__)
 
@@ -123,12 +124,10 @@ def init(client, check_icu_plugin=True):
 def configure_index(client):
     """Create a new randomly-named index and return its name."""
     index_name = client.index + "-" + _random_id()
-    mapping = ANNOTATION_MAPPING
+    mappings = ANNOTATION_MAPPING
 
-    if client.server_version >= (7, 0, 0):
-        mappings = mapping
-    else:
-        mappings = {client.mapping_type: mapping}
+    if client.server_version < Version("7.0.0"):
+        mappings = {client.mapping_type: mappings}
 
     client.conn.indices.create(
         index_name,

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -116,7 +116,7 @@ class Search:
 
         response = self._search(modifiers, self._aggregations, params)
 
-        total = response["hits"]["total"]
+        total = _get_total_hits(response)
         annotation_ids = [hit["_id"] for hit in response["hits"]["hits"]]
         aggregations = self._parse_aggregation_results(response.aggregations)
         return (total, annotation_ids, aggregations)
@@ -134,7 +134,7 @@ class Search:
             MultiDict({"limit": self._replies_limit}),
         )
 
-        if len(response["hits"]["hits"]) < response["hits"]["total"]:
+        if len(response["hits"]["hits"]) < _get_total_hits(response):
             log.warning(
                 "The number of reply annotations exceeded the page size "
                 "of the Elasticsearch query. We currently don't handle "
@@ -152,3 +152,10 @@ class Search:
         for agg in self._aggregations:
             results[agg.name] = agg.parse_result(aggregations)
         return results
+
+
+def _get_total_hits(response):
+    total = response["hits"]["total"]
+    if isinstance(total, int):
+        return total  # ES 6.x
+    return total["value"]  # ES 7.x

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -116,7 +116,7 @@ class Search:
 
         response = self._search(modifiers, self._aggregations, params)
 
-        total = _get_total_hits(response)
+        total = self._get_total_hits(response)
         annotation_ids = [hit["_id"] for hit in response["hits"]["hits"]]
         aggregations = self._parse_aggregation_results(response.aggregations)
         return (total, annotation_ids, aggregations)
@@ -134,7 +134,7 @@ class Search:
             MultiDict({"limit": self._replies_limit}),
         )
 
-        if len(response["hits"]["hits"]) < _get_total_hits(response):
+        if len(response["hits"]["hits"]) < self._get_total_hits(response):
             log.warning(
                 "The number of reply annotations exceeded the page size "
                 "of the Elasticsearch query. We currently don't handle "
@@ -153,9 +153,9 @@ class Search:
             results[agg.name] = agg.parse_result(aggregations)
         return results
 
-
-def _get_total_hits(response):
-    total = response["hits"]["total"]
-    if isinstance(total, int):
-        return total  # ES 6.x
-    return total["value"]  # ES 7.x
+    @staticmethod
+    def _get_total_hits(response):
+        total = response["hits"]["total"]
+        if isinstance(total, int):
+            return total  # ES 6.x
+        return total["value"]  # ES 7.x

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -77,10 +77,12 @@ class BatchIndexer:
         action = {
             self.op_type: {
                 "_index": self._target_index,
-                "_type": self.es_client.mapping_type,
                 "_id": annotation.id,
             }
         }
+
+        if self.es_client.server_version < (7, 0, 0):
+            action[self.op_type]["_type"] = self.es_client.mapping_type
 
         data = presenters.AnnotationSearchIndexPresenter(
             annotation, self.request

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -75,21 +75,18 @@ class BatchIndexer:
         return errored
 
     def _prepare(self, annotation):
-        action = {
-            self.op_type: {
-                "_index": self._target_index,
-                "_id": annotation.id,
-            }
+        operation = {
+            "_index": self._target_index,
+            "_id": annotation.id,
         }
-
         if self.es_client.server_version < Version("7.0.0"):
-            action[self.op_type]["_type"] = self.es_client.mapping_type
+            operation["_type"] = self.es_client.mapping_type
 
         data = presenters.AnnotationSearchIndexPresenter(
             annotation, self.request
         ).asdict()
 
-        return action, data
+        return {self.op_type: operation}, data
 
 
 def _all_annotations(session, windowsize=2000):

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -5,6 +5,7 @@ import time
 
 import sqlalchemy as sa
 from elasticsearch import helpers as es_helpers
+from packaging.version import Version
 from sqlalchemy.orm import subqueryload
 
 from h import models, presenters
@@ -81,7 +82,7 @@ class BatchIndexer:
             }
         }
 
-        if self.es_client.server_version < (7, 0, 0):
+        if self.es_client.server_version < Version("7.0.0"):
             action[self.op_type]["_type"] = self.es_client.mapping_type
 
         data = presenters.AnnotationSearchIndexPresenter(

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -3,6 +3,7 @@ from unittest.mock import create_autospec
 
 import elasticsearch_dsl
 import pytest
+from packaging.version import Version
 
 from h import search
 
@@ -44,7 +45,7 @@ def mock_es_client(es_client):
         spec_set=True,
         index="hypothesis",
         mapping_type="annotation",
-        server_version=(6, 2, 0),
+        server_version=Version("6.2.0"),
     )
 
 

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -44,6 +44,7 @@ def mock_es_client(es_client):
         spec_set=True,
         index="hypothesis",
         mapping_type="annotation",
+        server_version=(6, 2, 0),
     )
 
 

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, create_autospec, sentinel
 import pytest
 from elasticsearch import Elasticsearch
 from h_matchers import Any
+from packaging.version import Version
 
 from h.search.client import Client, get_client
 
@@ -23,7 +24,7 @@ class TestClient:
         assert client.mapping_type == mapping_type
 
     def test_server_version(self, client):
-        assert client.server_version == (1, 2, 3)
+        assert client.server_version == Version("1.2.3")
 
     @pytest.fixture
     def conn(self):

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -13,10 +13,24 @@ class TestClient:
 
         conn.transport.close.assert_called_once_with()
 
+    @pytest.mark.parametrize(
+        "version,mapping_type",
+        (("6.9.9", "annotation"), ("7.0.0", "_doc"), ("7.0.1", "_doc")),
+    )
+    def test_mapping_type(self, client, conn, version, mapping_type):
+        conn.info.return_value = {"version": {"number": version}}
+
+        assert client.mapping_type == mapping_type
+
+    def test_server_version(self, client):
+        assert client.server_version == (1, 2, 3)
+
     @pytest.fixture
     def conn(self):
         # The ES library really confuses autospeccing
-        return create_autospec(Elasticsearch, instance=True, transport=MagicMock())
+        conn = create_autospec(Elasticsearch, instance=True, transport=MagicMock())
+        conn.info.return_value = {"version": {"number": "1.2.3"}}
+        return conn
 
     @pytest.fixture
     def client(self, conn):

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -167,6 +167,24 @@ class TestConfigureIndex:
             },
         )
 
+    def test_sets_correct_mappings_and_settings_for_es7(self, mock_es_client_v7):
+        configure_index(mock_es_client_v7)
+
+        mock_es_client_v7.conn.indices.create.assert_called_once_with(
+            Any(),
+            body={
+                "mappings": ANNOTATION_MAPPING,
+                "settings": {"analysis": ANALYSIS_SETTINGS},
+            },
+        )
+
+    @pytest.fixture
+    def mock_es_client_v7(self, mock_es_client):
+        mock_es_client.mapping_type = "_doc"
+        mock_es_client.server_version = (7, 10, 0)
+
+        return mock_es_client
+
 
 class TestGetAliasedIndex:
     def test_returns_underlying_index_name(self, mock_es_client):

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -6,6 +6,7 @@ from urllib.parse import quote_plus
 import elasticsearch
 import pytest
 from h_matchers import Any
+from packaging.version import Version
 
 from h.search.config import (
     ANALYSIS_SETTINGS,
@@ -181,7 +182,7 @@ class TestConfigureIndex:
     @pytest.fixture
     def mock_es_client_v7(self, mock_es_client):
         mock_es_client.mapping_type = "_doc"
-        mock_es_client.server_version = (7, 10, 0)
+        mock_es_client.server_version = Version("7.10.0")
 
         return mock_es_client
 

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -168,23 +168,19 @@ class TestConfigureIndex:
             },
         )
 
-    def test_sets_correct_mappings_and_settings_for_es7(self, mock_es_client_v7):
-        configure_index(mock_es_client_v7)
+    def test_sets_correct_mappings_and_settings_for_es7(self, mock_es_client):
+        mock_es_client.mapping_type = "_doc"
+        mock_es_client.server_version = Version("7.10.0")
 
-        mock_es_client_v7.conn.indices.create.assert_called_once_with(
+        configure_index(mock_es_client)
+
+        mock_es_client.conn.indices.create.assert_called_once_with(
             Any(),
             body={
                 "mappings": ANNOTATION_MAPPING,
                 "settings": {"analysis": ANALYSIS_SETTINGS},
             },
         )
-
-    @pytest.fixture
-    def mock_es_client_v7(self, mock_es_client):
-        mock_es_client.mapping_type = "_doc"
-        mock_es_client.server_version = Version("7.10.0")
-
-        return mock_es_client
 
 
 class TestGetAliasedIndex:


### PR DESCRIPTION
A reworking of:

 * https://github.com/hypothesis/h/pull/7335

Please see that ticket for full notes.
 
Based on top of:

 * https://github.com/hypothesis/h/pull/7391
 * https://github.com/hypothesis/h/pull/7389