### PR TITLE
Add the missed packaging requirement used for version parsing

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -159,6 +159,8 @@ newrelic==7.10.0.175
     # via -r requirements/requirements.txt
 oauthlib==3.2.0
     # via -r requirements/requirements.txt
+packaging==21.3
+    # via -r requirements/requirements.txt
 parso==0.8.2
     # via jedi
 passlib==1.7.4
@@ -208,7 +210,9 @@ pygments==2.9.0
 pyjwt==2.3.0
     # via -r requirements/requirements.txt
 pyparsing==3.0.8
-    # via -r requirements/requirements.txt
+    # via
+    #   -r requirements/requirements.txt
+    #   packaging
 pyramid==2.0
     # via
     #   -r requirements/requirements.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -142,8 +142,10 @@ newrelic==7.10.0.175
     # via -r requirements/requirements.txt
 oauthlib==3.2.0
     # via -r requirements/requirements.txt
-packaging==20.4
-    # via pytest
+packaging==21.3
+    # via
+    #   -r requirements/requirements.txt
+    #   pytest
 passlib==1.7.4
     # via -r requirements/requirements.txt
 pastedeploy==2.1.0
@@ -250,7 +252,6 @@ six==1.15.0
     #   click-repl
     #   elasticsearch-dsl
     #   jsonschema
-    #   packaging
     #   python-dateutil
 soupsieve==2.2.1
     # via beautifulsoup4

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -221,7 +221,7 @@ oauthlib==3.2.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-packaging==20.4
+packaging==21.3
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -387,7 +387,6 @@ six==1.15.0
     #   click-repl
     #   elasticsearch-dsl
     #   jsonschema
-    #   packaging
     #   python-dateutil
 snowballstemmer==2.1.0
     # via pydocstyle

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -27,6 +27,7 @@ kombu
 markdown
 newrelic
 oauthlib
+packaging
 passlib
 psycogreen
 psycopg2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -107,6 +107,8 @@ newrelic==7.10.0.175
     # via -r requirements/requirements.in
 oauthlib==3.2.0
     # via -r requirements/requirements.in
+packaging==21.3
+    # via -r requirements/requirements.in
 passlib==1.7.4
     # via -r requirements/requirements.in
 pastedeploy==2.1.0
@@ -132,7 +134,9 @@ pycryptodomex==3.14.1
 pyjwt==2.3.0
     # via -r requirements/requirements.in
 pyparsing==3.0.8
-    # via -r requirements/requirements.in
+    # via
+    #   -r requirements/requirements.in
+    #   packaging
 pyramid==2.0
     # via
     #   -r requirements/requirements.in

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -145,8 +145,10 @@ newrelic==7.10.0.175
     # via -r requirements/requirements.txt
 oauthlib==3.2.0
     # via -r requirements/requirements.txt
-packaging==20.4
-    # via pytest
+packaging==21.3
+    # via
+    #   -r requirements/requirements.txt
+    #   pytest
 passlib==1.7.4
     # via -r requirements/requirements.txt
 pastedeploy==2.1.0
@@ -249,7 +251,6 @@ six==1.15.0
     #   click-repl
     #   elasticsearch-dsl
     #   jsonschema
-    #   packaging
     #   python-dateutil
 sortedcontainers==2.3.0
     # via hypothesis


### PR DESCRIPTION
This is required for our version parsing. If I'd know it wasn't already installed I probably wouldn't have gone this way, but it's an easy fix.

## Testing notes

 * `make dev`
 * Visit http://localhost:5000

I run inside an IDE which meant it worked for me for various reasons.