### PR TITLE
Remove notebook feature flag part 1: prepare for removal

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -12,7 +12,6 @@ FEATURES = {
         "using a cached version?"
     ),
     "client_display_names": "Render display names instead of user names in the client",
-    "notebook_launch": "Allow access to notebook feature",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.
@@ -33,7 +32,7 @@ FEATURES = {
 #
 # 4. Finally, remove the feature from FEATURES_PENDING_REMOVAL.
 #
-FEATURES_PENDING_REMOVAL = {}
+FEATURES_PENDING_REMOVAL = {"notebook_launch": "Allow access to notebook feature"}
 
 
 class Feature(Base):


### PR DESCRIPTION
This PR takes Step 1 of the standard 2-step feature-flag removal process for the "launch notebook" feature flag. This feature flag was for the front end, which has removed code that references it. This feature flag will no longer show up on the admin page for feature flags after this change.