### PR TITLE
Add html_side_by_side feature flag

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -12,6 +12,7 @@ FEATURES = {
         "using a cached version?"
     ),
     "client_display_names": "Render display names instead of user names in the client",
+    "html_side_by_side": "Enable side-by-side mode for web pages in the client",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.


### PR DESCRIPTION
When enabled, this will cause the client to adjust the layout of web
pages when the sidebar is open, in order to display the page's content
alongside rather than under the sidebar. This feature does not work on
all pages, and the client uses heuristics to determine whether to
perform this layout adjustment or not.

Part of https://github.com/hypothesis/client/issues/4332