### PR TITLE
Add ability to delete feature cohorts

### DIFF
--- a/h/templates/admin/cohorts_edit.html.jinja2
+++ b/h/templates/admin/cohorts_edit.html.jinja2
@@ -59,6 +59,12 @@
       {% else %}
         <p><em>This cohort has no members&hellip;</em></p>
       {% endif %}
+
+      <form method="post">
+        <input type="hidden" name="delete" value="yes">
+        <button data-confirm-message="Are you sure you want to delete this cohort?"
+                class="btn btn--danger js-confirm-submit">Delete cohort</button>
+      </form>
     </div>
   </div>
 

--- a/h/views/admin/features.py
+++ b/h/views/admin/features.py
@@ -97,6 +97,19 @@ def cohorts_edit(_context, request):
 @view_config(
     route_name="admin.cohorts_edit",
     request_method="POST",
+    request_param="delete",
+    permission=Permission.AdminPage.HIGH_RISK,
+)
+def cohorts_delete(_context, request):
+    id_ = request.matchdict["id"]
+    cohort = request.db.query(models.FeatureCohort).get(id_)
+    request.db.delete(cohort)
+    return httpexceptions.HTTPFound(location=request.route_url("admin.cohorts"))
+
+
+@view_config(
+    route_name="admin.cohorts_edit",
+    request_method="POST",
     request_param="add",
     renderer="h:templates/admin/cohorts_edit.html.jinja2",
     permission=Permission.AdminPage.HIGH_RISK,


### PR DESCRIPTION
Add a "Delete cohort" button to the edit page for a cohort. Cohorts can be deleted whether they still have members or not.

This will enabling cleaning up a bunch of long-obsolete cohorts that we have in production.

**Testing:**

1. Go to http://localhost:5000/admin/features/cohorts and create a feature cohort
2. Click on the new cohort to view its details page
3. Click the "Delete cohort" button at the bottom. After accepting the prompt, the cohort will be deleted and you will be redirected to the index page