### PR TITLE
Remove tox-pip-sync

### DIFF
--- a/requirements/checkdocs.txt
+++ b/requirements/checkdocs.txt
@@ -1,0 +1,1 @@
+docs.txt

--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -1,0 +1,1 @@
+format.txt

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = tests
 skipsdist = true
 minversion = 3.16.1
 requires =
-  tox-pip-sync
   tox-pyenv
   tox-envfile
   tox-run-command
@@ -41,7 +40,6 @@ skip_install = true
 sitepackages = {env:SITE_PACKAGES:false}
 passenv =
     HOME
-    EXTRA_DEPS
     dev: AUTHORITY
     dev: BOUNCER_URL
     dev: CLIENT_OAUTH_ID
@@ -71,19 +69,15 @@ setenv =
     dev: WEBSOCKET_URL = {env:WEBSOCKET_URL:ws://localhost:5001/ws}
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 deps =
-    tests: -r requirements/tests.txt
-    functests: -r requirements/functests.txt
-    lint: -r requirements/lint.txt
-    {format,checkformatting}: -r requirements/format.txt
-    coverage: -r requirements/coverage.txt
-    {docs,checkdocs}: -r requirements/docs.txt
-    dev: -r requirements/dev.txt
-    dockercompose: -r requirements/dockercompose.txt
-    {env:EXTRA_DEPS:}
+    pip-tools
 whitelist_externals =
+    true
     {dev,tests,functests}: sh
+list_dependencies_command = true
 depends =
     {coverage,functests}: tests
+commands_pre =
+    pip-sync requirements/{env:TOX_ENV_NAME}.txt --pip-args '--disable-pip-version-check'
 commands =
     dev: sh bin/hypothesis --dev init
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}


### PR DESCRIPTION
Problem
-------

[`tox-pip-sync`](https://github.com/hypothesis/tox-pip-sync) is a pretty complicated plugin. I think it's complicated enough to be a problem for us to maintain, and complicated enough that it's difficult to tell whether tox-pip-sync is correct or not. It:

* Has its own configuration settings that it reads from `pyproject.toml`
* Also parses the `tox.ini` file
* Parses the dependencies in the `tox.ini` file
* Also reads `setup.py` and `setup.cfg`
* Also actually parses requirements files (`# comment`'s, `-r` lines, `-e`, `-c`, ...)
* Recursively finds requirements files imported by other requirements files
* Computes hashes of requirements files to determine whether they've changed
* Actually compiles requirements files for any unpinned dependencies and installs them
* Installs `pip-tools` into the venv

The actual plugin is about 500 lines of Python code (not counting tests). The repo looks to be about 1400 lines of Python in total.

And it has limitations: as documented in the README it doesn't support requirements files that contain unpinned requirements, or fancy stuff in `setup.py`.

It also has bugs. For example we should be running `pip-compile` with the `--generate-hashes` option to enable pip's hash-checking mode for security reasons. But this causes `tox-pip-sync` to crash: it breaks `tox-pip-sync`'s parsing of requirements.txt files.

I *think* I also noticed a bug where it wasn't updating the venv when it should be, though I'm not 100% sure this was tox-pip-sync's fault.

tox 4.0 is overdue and completely rewrites tox's plugin system, breaking all plugins.

If possible I think we want to get out of the game of having any complex tox plugins to maintain ourselves.

Solution
---------

I *think* most of the complexity of `tox-pip-sync` is because it seems to be solving a case that's much more general than what we actually have to solve:

* In our applications *all* of the dependencies come from pinned requirements files. In fact, each environment gets all of its dependencies from one pinned requirements file: `tests.txt`, `lint.txt`, etc. Since these requirements files are generated by `pip-compile` they don't contain any unpinned requirements, `-r`'s, `-c`'s, etc. I don't think we have any `-e .`'s in our `tox.ini`'s either. Just simple pinned requirements.

  `pip-sync <REQUIREMENTS_FILE(S)>` is already a command that synchronizes a venv with one or more requirements files. We don't need a tox plugin, we just need one line in `tox.ini` to run that command.

* It's beyond the scope of this PR (which is for an application) but in our Python _packages_ we don't pin our requirements so the whole topic of requirements files, `pip-compile`, `pip-sync`, and the idea of updating the venv in place (rather than recreating it from scratch) doesn't apply. Just detect when any of the files that might contain dependencies have changed (`setup.cfg`, `setup.py`, `pyproject.toml`, `tox.ini`) and recreate the whole env from scratch. Since packages have far fewer dependencies it doesn't take long to recreate the env from scratch, and since they don't pin their dependencies the dependencies don't change nearly as often.

  I haven't tested it but I believe there's an issue here for our Python libraries that tox will detect changes to the `deps` in `tox.ini` and automatically trigger a recreate but it won't detect changes to `setup.py` and other files. You're expected to pass `tox --recreate` manually if things have changed. To be honest we could just do that. This however would be easy to automate with a much simpler tox plugin that detects changes to a hard-coded or configurable list of files and triggers a full recreate (there's an existing plugin called `tox-battery` that does basically this, we could copy from that) or with [a handful of lines in the `Makefile`](https://stackoverflow.com/questions/23032580/reinstall-virtualenv-with-tox-when-requirements-txt-or-setup-py-changes/23039826#23039826).

This PR presents an alternative solution for our applications (not our packages) where we relieve tox from the duty of installing or updating the requirements and instead just call `pip-sync` directly:

1. Don't list the `-r requirements/foo.txt` in the `deps` section of `tox.ini`
2. Do put `pip-tools` in the `deps`, we need tox to install that for us so we can run `pip-sync`
3. Put `pip-sync requirements/foo.txt` in the `commands_pre` section of `tox.ini`

Done! Congratulations, you've integrated `pip-sync` into tox.

I think that's actually all that's needed??

Here's what it actually looks like in `tox.ini`:

```ini
deps = pip-tools
commands_pre = pip-sync requirements/{env:TOX_ENV_NAME}.txt
```

`{env:TOX_ENV_NAME}` resolves to the name of the currently running environment (`lint`, `tests`, etc). This works because our requirements file names happen to be the same as our environment names. There are two exceptions: the `checkformatting` tox env uses `format.txt` (also used by the `format` tox env) and `checkdocs` uses `docs.txt` (also used by the `docs` env). I've solved this by adding two symlinks:

```
requirements/
    docs.txt
    checkdocs.txt -> ./docs.txt
    format.txt
    checkformatting.txt -> ./format.txt
```

The alternative (no need for symlinks) would be to do something like this in `tox.ini` (not tested):

```ini
commands_pre =
    {!checkformatting,!checkdocs}: pip-sync requirements/{env:TOX_ENV_NAME}.txt
    checkformatting: pip-sync requirements/format.txt
    checkdocs: pip-sync requirements/docs.txt
```

Alternatively maybe tox has a setting to just disable the listing? Or write a very simple `tox-disable-listing` plugin to do just that.

Performance
-----------

TLDR: tox commands on this branch are a bit slower than on master. I think the simplicity gain is worth the cost but if we want to get the speed back we should be able to do so with a simple optimising `pip-sync` wrapper script.

On my machine, in the majority case where the venv is already up to date (the only case really worth caring about the performance of), `pip-sync` usually takes about 600ms (it's faster for smaller envs, lint is our biggest env):

```terminal
$ time .tox/lint/bin/pip-sync requirements/lint.txt
Everything up-to-date

________________________________________________________
Executed in  611.53 millis    fish           external
   usr time  545.20 millis  217.00 micros  544.98 millis
   sys time   67.53 millis   89.00 micros   67.44 millis
```

On this branch it takes about 1.6s to run a trivial command in a venv:

```terminal
$ time tox -e lint --run-command 'python --version'
...
Executed in    1.58 secs    fish           external
   usr time    1.40 secs  291.00 micros    1.40 secs
   sys time    0.19 secs    0.00 micros    0.19 secs
```

On master the same command takes about half a second, so it looks like tox-pip-sync saves about one second compared to using pip-sync directly:

```terminal
$ time tox -e lint --run-command 'python --version'
Executed in  482.50 millis    fish           external
   usr time  441.15 millis  180.00 micros  440.97 millis
   sys time   46.55 millis   69.00 micros   46.48 millis
```

1s is equivalent to a 0.005% increase in the time to run `make sure`, a 17% increase in the time to run `tox -e format`, and something in-between for other operations:

* `tox -e format`: 6s total
* `tox -e functests`: 28s
* `tox -e lint`: 60s
* `tox -e tests`: 83s
* `make sure`: 188s

### If we want to get the performance back

I think we could write a simple `pip-sync` wrapper script called `pip-sync-faster` that optimises the majority case when the venv is already up to date. This would have nothing to do with tox and would not be a tox plugin: `pip-sync-faster` would be a standalone Python package that depends on `pip-tools` and provides a `pip-sync-faster` command that wraps `pip-sync` and forwards command line options and arguments to it. `pip-sync-faster` should:

* Compute a hash of each requirements file given in the command line args
* Save the hash somewhere, perhaps `~/.cache/pip-sync-faster/venvs/<HASH_OF_ABSOLUTE_PATH_TO_VENV>/requirements_files/<HASH_OF_ABSOLUTE_PATH_TO_REQUIREMENTS_FILE>`. The contents of this file would be a hash of the contents of the requirements file. Note that it needs to resolve the venv and requirements file paths to absolute paths. You can get the path to the current venv from the `VIRTUAL_ENV` envvar. Alternatively it could be based on file size and mtime rather than hashes, whatever's faster
* If *any* of the requirements files given as command line arguments are either missing from `pip-sync-faster`'s cache or have hashes that differ from what's cached then `pip-sync-faster` should call `pip-sync` forwarding *all* command line args (all requirements files given, not just the ones that failed to match)
* If *all* of the requirements files are found with matching hashes in the cache then `pip-sync-faster` should exit with status 0 without calling `pip-sync` because we know that `pip-sync` wouldn't do anything. This is the majority case that we're optimising for

`pip-sync-faster` would *not* have to parse the requirements files looking for other files imported with `-r`'s and `-c`'s. Since all our requirements files are generated by `pip-compile` they don't contain any `-r`'s or `-c`'s, these are resolved at compile time. This is already a [documented limitation of `pip-sync`](https://pip-tools.readthedocs.io/en/latest/#example-usage-for-pip-sync) (that it only works with requirements files from `pip-compile`).

We might want a more amusing name, e.g. `pip-sync-maybe`, `pip-sync-if-really-necessary`, etc.

Testing
-------

Testing the `tox.ini` file on this branch. Seems to work:

It creates the venv if it doesn't yet exist and installs the deps:

```terminal
$ rm -rf .tox/format
$ tox -e format
format create: /home/seanh/Projects/h/.tox/format
format installdeps: pip-tools
format run-test-pre: commands[0] | pip-sync requirements/format.txt
Collecting black==22.3.0
  Using cached black-22.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.5 MB)
Collecting isort==5.10.1
  Using cached isort-5.10.1-py3-none-any.whl (103 kB)
Collecting mypy-extensions==0.4.3
  Using cached mypy_extensions-0.4.3-py2.py3-none-any.whl (4.5 kB)
Collecting pathspec==0.9.0
  Using cached pathspec-0.9.0-py2.py3-none-any.whl (31 kB)
Collecting platformdirs==2.2.0
  Using cached platformdirs-2.2.0-py3-none-any.whl (13 kB)
Collecting tomli==2.0.0
  Using cached tomli-2.0.0-py3-none-any.whl (12 kB)
Collecting typing-extensions==3.10.0.1
  Using cached typing_extensions-3.10.0.1-py3-none-any.whl (26 kB)
Requirement already satisfied: click>=8.0.0 in ./.tox/format/lib/python3.8/site-packages (from black==22.3.0->-r /tmp/tmp6tdqor_6 (line 1)) (8.1.3)
Installing collected packages: typing-extensions, mypy-extensions, tomli, platformdirs, pathspec, isort, black
  Attempting uninstall: tomli
    Found existing installation: tomli 2.0.1
    Uninstalling tomli-2.0.1:
      Successfully uninstalled tomli-2.0.1
Successfully installed black-22.3.0 isort-5.10.1 mypy-extensions-0.4.3 pathspec-0.9.0 platformdirs-2.2.0 tomli-2.0.0 typing-extensions-3.10.0.1
...
```

If the venv already exists and is up to date it does nothing:

```terminal
$ tox -e format
...
format run-test-pre: commands[0] | pip-sync requirements/format.txt
Everything up-to-date
...
```

If there's a package in the venv that is not in the requirements file it'll uninstall it:

```terminal
$ .tox/format/bin/pip install coverage
...
$ tox -e format
...
format run-test-pre: commands[0] | pip-sync requirements/format.txt
Found existing installation: coverage 6.4.1
Uninstalling coverage-6.4.1:
  Successfully uninstalled coverage-6.4.1
...
```

If one package is missing it'll install it:

```terminal
$ .tox/format/bin/pip uninstall black
...
$ tox -e format
...
format run-test-pre: commands[0] | pip-sync requirements/format.txt
Collecting black==22.3.0
  Using cached black-22.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.5 MB)
...
Installing collected packages: black
Successfully installed black-22.3.0
...
```

If one package is on the wrong version it'll upgrade or downgrade it:

```terminal
$ .tox/format/bin/pip install black===22.1.0
...
$ tox -e format
...
format run-test-pre: commands[0] | pip-sync requirements/format.txt
Collecting black==22.3.0
  Using cached black-22.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.5 MB)
...
Installing collected packages: black
  Attempting uninstall: black
    Found existing installation: black 22.1.0
    Uninstalling black-22.1.0:
      Successfully uninstalled black-22.1.0
Successfully installed black-22.3.0
...
```