### PR TITLE
Renamed default branch to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ node {
         }
     }
 
-    onlyOnMaster {
+    onlyOnMain {
         stage('release') {
             releaseApp(image: image)
             releaseApp(image: ws_only_image)
@@ -55,7 +55,7 @@ node {
     }
 }
 
-onlyOnMaster {
+onlyOnMain {
     milestone()
     stage('qa deploy') {
         parallel(

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 h
 =
 
-.. image:: https://github.com/hypothesis/h/workflows/Continuous%20integration/badge.svg?branch=master
-   :target: https://github.com/hypothesis/h/actions?query=branch%3Amaster
+.. image:: https://github.com/hypothesis/h/workflows/Continuous%20integration/badge.svg?branch=main
+   :target: https://github.com/hypothesis/h/actions?query=branch%3Amain
    :alt: Continuous integration
 .. image:: https://img.shields.io/badge/license-BSD-blue.svg
-   :target: https://github.com/hypothesis/h/blob/master/LICENSE
+   :target: https://github.com/hypothesis/h/blob/main/LICENSE
    :alt: BSD licensed
 .. image:: https://img.shields.io/badge/python-3.6-blue.svg
    :target: https://www.python.org/

--- a/docs/developing/documentation.rst
+++ b/docs/developing/documentation.rst
@@ -26,7 +26,7 @@ a JavaScript tool for generating OpenAPI/Swagger reference documentation.
 The documentation-building process above will regenerate API documentation output without intervention,
 but if you are making changes to an API description document (e.g. `hypothesis-v1.yaml`
 for v1 on the API),you may find it convenient to use the
-`ReDoc CLI tool <https://github.com/Rebilly/ReDoc/blob/master/cli/README.md>`_,
+`ReDoc CLI tool <https://github.com/Rebilly/ReDoc/blob/main/cli/README.md>`_,
 which can watch the spec file for changes:
 
 .. code-block:: bash

--- a/docs/developing/making-changes-to-model-code.rst
+++ b/docs/developing/making-changes-to-model-code.rst
@@ -39,7 +39,7 @@ previous to your new schema.
 
 We use `Alembic <https://alembic.readthedocs.io/en/latest/>`_ to create and run
 migration scripts. See the Alembic docs (and look at existing scripts in
-`h/migrations/versions <https://github.com/hypothesis/h/tree/master/h/migrations/versions>`_)
+`h/migrations/versions <https://github.com/hypothesis/h/tree/main/h/migrations/versions>`_)
 for details. The ``make db`` command is a wrapper around Alembic. The
 steps to create a new migration script for h are:
 

--- a/docs/developing/submitting-a-pr.rst
+++ b/docs/developing/submitting-a-pr.rst
@@ -4,7 +4,7 @@ Submitting a Pull Request
 To submit code or documentation to h you should submit a pull request.
 
 For trivial changes, such as documentation changes or minor errors,
-PRs may be submitted directly to master. This also applies to changes
+PRs may be submitted directly to main. This also applies to changes
 made through the GitHub editing interface. Authors do not need to
 sign the CLA for these, or follow fork or branch naming guidelines.
 


### PR DESCRIPTION
1. Replaced onlyOnMaster function with onlyOnMain in the Jenkinsfile
2. Replaced master with main in:
  - README.rst
  - docs/developing/documentation.rst
  - docs/developing/making-changes-to-model-code.rst
  - docs/developing/submitting-a-pr.rst