### PR TITLE
Allow searching for annotations by multiple groups with the API

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -472,7 +472,10 @@ paths:
         - name: group
           in: query
           example: '8JmD3iz1'
-          description: Limit the results to annotations made in the specified group (by group ID).
+          description: |
+            Limit the results to annotations made in the specified group (by group ID).
+
+            This can be specified multiple times to retrieve multiple groups.
           schema:
             type: string
         - name: tag

--- a/docs/_extra/api-reference/hypothesis-v2.yaml
+++ b/docs/_extra/api-reference/hypothesis-v2.yaml
@@ -474,7 +474,10 @@ paths:
         - name: group
           in: query
           example: '8JmD3iz1'
-          description: Limit the results to annotations made in the specified group (by group ID).
+          description: |
+            Limit the results to annotations made in the specified group (by group ID).
+
+            This can be specified multiple times to retrieve multiple groups.
           schema:
             type: string
         - name: tag

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -320,7 +320,8 @@ class SearchParamsSchema(colander.Schema):
                        instead.""",
     )
     group = colander.SchemaNode(
-        colander.String(),
+        colander.Sequence(),
+        colander.SchemaNode(colander.String()),
         missing=colander.drop,
         description="Limit the results to this group of annotations.",
     )

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -210,12 +210,9 @@ class GroupFilter:
         self.group_service = request.find_service(name="group")
 
     def __call__(self, search, params):
-        group_ids = None
-        if "group" in params:
-            # Remove parameter if passed, preventing it being passed to default query
-            group_ids = [params.pop("group")]
+        # Remove parameter if passed, preventing it being passed to default query
+        group_ids = popall(params, "group") or None
         groups = self.group_service.groupids_readable_by(self.user, group_ids)
-
         return search.filter("terms", group=groups)
 
 

--- a/tests/h/schemas/annotation_test.py
+++ b/tests/h/schemas/annotation_test.py
@@ -625,18 +625,19 @@ class TestSearchParamsSchema:
 
         assert params == expected_params
 
-    def test_it_handles_duplicate_keys(self, schema):
-        expected_params = MultiDict(
-            [("url", "http://foobar"), ("url", "http://foobat")]
-        )
+    @pytest.mark.parametrize(
+        "key,examples",
+        (
+            ("url", ["http://foobar", "http://foobat"]),
+            ("group", ["inu3340958u", "97jdm5o457"]),
+        ),
+    )
+    def test_it_handles_duplicate_keys(self, schema, key, examples):
+        expected_params = MultiDict([(key, example) for example in examples])
         input_params = deepcopy(expected_params)
-        input_params.add("unknownparam", "foo")
-        input_params.add("unknownparam", "bar")
 
         params = validate_query_params(schema, NestedMultiDict(input_params))
-
-        assert params.getall("url") == ["http://foobar", "http://foobat"]
-        assert "unknownparam" not in params
+        assert params.getall(key) == examples
 
     def test_it_defaults_limit(self, schema):
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4197

This allows a user to specify the `groupid` multiple times in a search and retrieve annotations across the different groups. This is particularly useful in combination with the new LMS Gateway we are building.