### PR TITLE
Allow searching for annotations by multiple references with the API

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -530,7 +530,11 @@ paths:
             type: string
         - name: references
           in: query
-          description: Returns annotations that are replies to this parent annotation ID.
+          description: |
+            Returns annotations that are replies to this parent annotation ID.
+
+            This can be specified multiple times to retrieve replies to
+            multiple annotations.
           schema:
             type: string
         - name: text

--- a/docs/_extra/api-reference/hypothesis-v2.yaml
+++ b/docs/_extra/api-reference/hypothesis-v2.yaml
@@ -532,7 +532,11 @@ paths:
             type: string
         - name: references
           in: query
-          description: Returns annotations that are replies to this parent annotation ID.
+          description: |
+            Returns annotations that are replies to this parent annotation ID.
+
+            This can be specified multiple times to retrieve replies to
+            multiple annotations.
           schema:
             type: string
         - name: text

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -51,6 +51,7 @@ class Search:
             query.DeletedFilter(),
             query.AuthFilter(request),
             query.GroupFilter(request),
+            query.RepliesFilter(),
             query.UserFilter(),
             query.HiddenFilter(request),
             query.AnyMatcher(),

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -362,6 +362,17 @@ class HiddenFilter:
         return search.filter(Q("bool", should=should_clauses))
 
 
+class RepliesFilter:
+    """A filter to limit to replies to specified ids."""
+
+    def __call__(self, search, params):
+        # Pop the key, so it's not picked up by the `KeyValueMatcher`
+        if references := popall(params, "references"):
+            return search.filter("terms", references=references)
+
+        return search
+
+
 class AnyMatcher:
     """Match the contents of a selection of fields against the `any` parameter."""
 

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -753,6 +753,25 @@ class TestHiddenFilter:
         return group_service
 
 
+class TestRepliesFilter:
+    def test_it(self, search, Annotation):
+        parents = [Annotation(), Annotation()]
+        children = [Annotation(references=[parent.id]) for parent in parents]
+
+        result = search.run(
+            webob.multidict.MultiDict((("references", parent.id) for parent in parents))
+        )
+
+        assert sorted(result.annotation_ids) == sorted(child.id for child in children)
+
+    @pytest.fixture
+    def search(self, search):
+        # This filter is the code under test
+        search.append_modifier(query.RepliesFilter())
+
+        return search
+
+
 class TestAnyMatcher:
     def test_matches_uriparts(self, search, Annotation):
         Annotation(target_uri="http://bar.com")


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4197

This allows a user to specify the `references` multiple times in a search and retrieve replies to multiple annotations. This is particularly useful in combination with the new LMS Gateway we are building.

### Is this a bug?

What's quite strange here is, I think this might have been meant to work all along. The `references` value was specified as a list, but it was handled by the `KeyValueMatcher` which applied a "match" clause per reference instead of one "term" for all of them.

I think the effect of this was it usually ended up returning nothing as it's effectively an and between the values.