### PR TITLE
Changed container name created by release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     needs: continuous-integration
     uses: hypothesis/workflows/.github/workflows/dockerhub.yml@main
     with:
-      Application: ${{ github.event.repository.name }}
+      Application: hypothesis
     secrets: inherit
 
   qa:


### PR DESCRIPTION
A small update to what has been provided by: https://github.com/hypothesis/h/pull/7560

The name of the container used by `h` is `hypothesis `. 
