### PR TITLE
Remove `tox-pip-sync`

### DIFF
--- a/requirements/checkdocs.in
+++ b/requirements/checkdocs.in
@@ -1,3 +1,5 @@
+pip-tools
+pip-sync-faster
 sphinx-autobuild
 sphinx
 sphinx-rtd-theme

--- a/requirements/checkdocs.txt
+++ b/requirements/checkdocs.txt
@@ -8,10 +8,14 @@ alabaster==0.7.12
     # via sphinx
 babel==2.10.3
     # via sphinx
+build==0.8.0
+    # via pip-tools
 certifi==2022.6.15
     # via requests
 charset-normalizer==2.1.0
     # via requests
+click==8.1.3
+    # via pip-tools
 colorama==0.4.5
     # via sphinx-autobuild
 docutils==0.17.1
@@ -31,7 +35,17 @@ livereload==2.6.3
 markupsafe==2.1.1
     # via jinja2
 packaging==21.3
-    # via sphinx
+    # via
+    #   build
+    #   sphinx
+pep517==0.13.0
+    # via build
+pip-sync-faster==0.0.2
+    # via -r requirements/checkdocs.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/checkdocs.in
+    #   pip-sync-faster
 pygments==2.12.0
     # via sphinx
 pyparsing==3.0.9
@@ -65,9 +79,21 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
+tomli==2.0.1
+    # via
+    #   build
+    #   pep517
 tornado==6.2
     # via livereload
 urllib3==1.26.11
     # via requests
+wheel==0.37.1
+    # via pip-tools
 zipp==3.8.1
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+pip==22.2.2
+    # via pip-tools
+setuptools==65.3.0
+    # via pip-tools

--- a/requirements/checkformatting.in
+++ b/requirements/checkformatting.in
@@ -1,2 +1,4 @@
+pip-tools
+pip-sync-faster
 black
 isort

--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -6,17 +6,44 @@
 #
 black==22.6.0
     # via -r requirements/checkformatting.in
+build==0.8.0
+    # via pip-tools
 click==8.1.3
-    # via black
+    # via
+    #   black
+    #   pip-tools
 isort==5.10.1
     # via -r requirements/checkformatting.in
 mypy-extensions==0.4.3
     # via black
+packaging==21.3
+    # via build
 pathspec==0.9.0
     # via black
+pep517==0.13.0
+    # via build
+pip-sync-faster==0.0.2
+    # via -r requirements/checkformatting.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/checkformatting.in
+    #   pip-sync-faster
 platformdirs==2.5.2
     # via black
+pyparsing==3.0.9
+    # via packaging
 tomli==2.0.1
-    # via black
+    # via
+    #   black
+    #   build
+    #   pep517
 typing-extensions==4.3.0
     # via black
+wheel==0.37.1
+    # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+pip==22.2.2
+    # via pip-tools
+setuptools==65.3.0
+    # via pip-tools

--- a/requirements/coverage.in
+++ b/requirements/coverage.in
@@ -1,1 +1,3 @@
+pip-tools
+pip-sync-faster
 coverage

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -4,5 +4,33 @@
 #
 #    pip-compile --allow-unsafe requirements/coverage.in
 #
+build==0.8.0
+    # via pip-tools
+click==8.1.3
+    # via pip-tools
 coverage==6.4.4
     # via -r requirements/coverage.in
+packaging==21.3
+    # via build
+pep517==0.13.0
+    # via build
+pip-sync-faster==0.0.2
+    # via -r requirements/coverage.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/coverage.in
+    #   pip-sync-faster
+pyparsing==3.0.9
+    # via packaging
+tomli==2.0.1
+    # via
+    #   build
+    #   pep517
+wheel==0.37.1
+    # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+pip==22.2.2
+    # via pip-tools
+setuptools==65.3.0
+    # via pip-tools

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,5 @@
+pip-tools
+pip-sync-faster
 ipython
 ipdb
 factory-boy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,6 +26,8 @@ billiard==3.6.4.0
     #   celery
 bleach==5.0.1
     # via -r requirements/requirements.txt
+build==0.8.0
+    # via pip-tools
 celery==5.2.7
     # via -r requirements/requirements.txt
 certifi==2022.6.15
@@ -47,6 +49,7 @@ click==8.1.3
     #   click-didyoumean
     #   click-plugins
     #   click-repl
+    #   pip-tools
 click-didyoumean==0.0.3
     # via
     #   -r requirements/requirements.txt
@@ -160,7 +163,9 @@ newrelic==8.0.0.179
 oauthlib==3.2.0
     # via -r requirements/requirements.txt
 packaging==21.3
-    # via -r requirements/requirements.txt
+    # via
+    #   -r requirements/requirements.txt
+    #   build
 parso==0.8.2
     # via jedi
 passlib==1.7.4
@@ -169,6 +174,8 @@ pastedeploy==2.1.0
     # via
     #   -r requirements/requirements.txt
     #   plaster-pastedeploy
+pep517==0.13.0
+    # via build
 peppercorn==0.6
     # via
     #   -r requirements/requirements.txt
@@ -177,6 +184,12 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pip-sync-faster==0.0.2
+    # via -r requirements/dev.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/dev.in
+    #   pip-sync-faster
 plaster==1.0
     # via
     #   -r requirements/requirements.txt
@@ -265,6 +278,7 @@ sentry-sdk==0.17.6
 six==1.15.0
     # via
     #   -r requirements/requirements.txt
+    #   asttokens
     #   bleach
     #   click-repl
     #   elasticsearch-dsl
@@ -286,6 +300,10 @@ text-unidecode==1.3
     #   python-slugify
 toml==0.10.2
     # via ipdb
+tomli==2.0.1
+    # via
+    #   build
+    #   pep517
 traitlets==5.0.5
     # via
     #   ipython
@@ -330,6 +348,8 @@ webob==1.8.7
     # via
     #   -r requirements/requirements.txt
     #   pyramid
+wheel==0.37.1
+    # via pip-tools
 wired==0.2.2
     # via
     #   -r requirements/requirements.txt
@@ -368,6 +388,8 @@ zope-sqlalchemy==1.6
     # via -r requirements/requirements.txt
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==22.2.2
+    # via pip-tools
 setuptools==63.2.0
     # via
     #   -r requirements/requirements.txt
@@ -377,6 +399,7 @@ setuptools==63.2.0
     #   ipdb
     #   ipython
     #   jsonschema
+    #   pip-tools
     #   plaster
     #   pyramid
     #   repoze-sendmail

--- a/requirements/dockercompose.in
+++ b/requirements/dockercompose.in
@@ -1,1 +1,3 @@
+pip-tools
+pip-sync-faster
 docker-compose

--- a/requirements/dockercompose.txt
+++ b/requirements/dockercompose.txt
@@ -8,6 +8,8 @@ attrs==20.3.0
     # via jsonschema
 bcrypt==3.2.2
     # via paramiko
+build==0.8.0
+    # via pip-tools
 certifi==2022.6.15
     # via requests
 cffi==1.15.1
@@ -17,6 +19,8 @@ cffi==1.15.1
     #   pynacl
 chardet==4.0.0
     # via requests
+click==8.1.3
+    # via pip-tools
 cryptography==3.4.7
     # via paramiko
 distro==1.5.0
@@ -33,12 +37,24 @@ idna==2.10
     # via requests
 jsonschema==3.2.0
     # via docker-compose
+packaging==21.3
+    # via build
 paramiko==2.10.1
     # via docker
+pep517==0.13.0
+    # via build
+pip-sync-faster==0.0.2
+    # via -r requirements/dockercompose.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/dockercompose.in
+    #   pip-sync-faster
 pycparser==2.20
     # via cffi
 pynacl==1.4.0
     # via paramiko
+pyparsing==3.0.9
+    # via packaging
 pyrsistent==0.17.3
     # via jsonschema
 python-dotenv==0.17.1
@@ -58,13 +74,23 @@ six==1.15.0
     #   websocket-client
 texttable==1.6.3
     # via docker-compose
+tomli==2.0.1
+    # via
+    #   build
+    #   pep517
 urllib3==1.26.5
     # via requests
 websocket-client==0.58.0
     # via
     #   docker
     #   docker-compose
+wheel==0.37.1
+    # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==22.2.2
+    # via pip-tools
 setuptools==63.2.0
-    # via jsonschema
+    # via
+    #   jsonschema
+    #   pip-tools

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,3 +1,5 @@
+pip-tools
+pip-sync-faster
 sphinx-autobuild
 sphinx
 sphinx-rtd-theme

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,10 +8,14 @@ alabaster==0.7.12
     # via sphinx
 babel==2.9.1
     # via sphinx
+build==0.8.0
+    # via pip-tools
 certifi==2022.6.15
     # via requests
 chardet==4.0.0
     # via requests
+click==8.1.3
+    # via pip-tools
 colorama==0.4.4
     # via sphinx-autobuild
 docutils==0.16
@@ -31,7 +35,17 @@ livereload==2.6.3
 markupsafe==1.1.1
     # via jinja2
 packaging==21.3
-    # via sphinx
+    # via
+    #   build
+    #   sphinx
+pep517==0.13.0
+    # via build
+pip-sync-faster==0.0.2
+    # via -r requirements/docs.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/docs.in
+    #   pip-sync-faster
 pygments==2.9.0
     # via sphinx
 pyparsing==3.0.9
@@ -65,9 +79,21 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
+tomli==2.0.1
+    # via
+    #   build
+    #   pep517
 tornado==6.1
     # via livereload
 urllib3==1.26.5
     # via requests
+wheel==0.37.1
+    # via pip-tools
 zipp==3.7.0
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+pip==22.2.2
+    # via pip-tools
+setuptools==65.3.0
+    # via pip-tools

--- a/requirements/format.in
+++ b/requirements/format.in
@@ -1,2 +1,4 @@
+pip-tools
+pip-sync-faster
 black
 isort

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -6,17 +6,44 @@
 #
 black==22.6.0
     # via -r requirements/format.in
+build==0.8.0
+    # via pip-tools
 click==8.1.3
-    # via black
+    # via
+    #   black
+    #   pip-tools
 isort==5.10.1
     # via -r requirements/format.in
 mypy-extensions==0.4.3
     # via black
+packaging==21.3
+    # via build
 pathspec==0.9.0
     # via black
+pep517==0.13.0
+    # via build
+pip-sync-faster==0.0.2
+    # via -r requirements/format.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/format.in
+    #   pip-sync-faster
 platformdirs==2.2.0
     # via black
+pyparsing==3.0.9
+    # via packaging
 tomli==2.0.0
-    # via black
+    # via
+    #   black
+    #   build
+    #   pep517
 typing-extensions==3.10.0.1
     # via black
+wheel==0.37.1
+    # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+pip==22.2.2
+    # via pip-tools
+setuptools==65.3.0
+    # via pip-tools

--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -1,3 +1,5 @@
+pip-tools
+pip-sync-faster
 pytest
 factory-boy
 webtest

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -25,6 +25,8 @@ billiard==3.6.4.0
     #   celery
 bleach==5.0.1
     # via -r requirements/requirements.txt
+build==0.8.0
+    # via pip-tools
 celery==5.2.7
     # via -r requirements/requirements.txt
 certifi==2022.6.15
@@ -46,6 +48,7 @@ click==8.1.3
     #   click-didyoumean
     #   click-plugins
     #   click-repl
+    #   pip-tools
 click-didyoumean==0.0.3
     # via
     #   -r requirements/requirements.txt
@@ -145,6 +148,7 @@ oauthlib==3.2.0
 packaging==21.3
     # via
     #   -r requirements/requirements.txt
+    #   build
     #   pytest
 passlib==1.7.4
     # via -r requirements/requirements.txt
@@ -152,10 +156,18 @@ pastedeploy==2.1.0
     # via
     #   -r requirements/requirements.txt
     #   plaster-pastedeploy
+pep517==0.13.0
+    # via build
 peppercorn==0.6
     # via
     #   -r requirements/requirements.txt
     #   deform
+pip-sync-faster==0.0.2
+    # via -r requirements/functests.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/functests.in
+    #   pip-sync-faster
 plaster==1.0
     # via
     #   -r requirements/requirements.txt
@@ -267,7 +279,10 @@ text-unidecode==1.3
     #   faker
     #   python-slugify
 tomli==2.0.0
-    # via pytest
+    # via
+    #   build
+    #   pep517
+    #   pytest
 transaction==3.0.1
     # via
     #   -r requirements/requirements.txt
@@ -313,6 +328,8 @@ webob==1.8.7
     #   webtest
 webtest==3.0.0
     # via -r requirements/functests.in
+wheel==0.37.1
+    # via pip-tools
 wired==0.2.2
     # via
     #   -r requirements/requirements.txt
@@ -351,6 +368,8 @@ zope-sqlalchemy==1.6
     # via -r requirements/requirements.txt
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==22.2.2
+    # via pip-tools
 setuptools==63.2.0
     # via
     #   -r requirements/requirements.txt
@@ -358,6 +377,7 @@ setuptools==63.2.0
     #   gevent
     #   gunicorn
     #   jsonschema
+    #   pip-tools
     #   plaster
     #   pyramid
     #   repoze-sendmail

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -1,3 +1,5 @@
+pip-tools
+pip-sync-faster
 pylint
 pydocstyle
 pycodestyle

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -39,6 +39,11 @@ bleach==5.0.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+build==0.8.0
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   pip-tools
 celery==5.2.7
     # via
     #   -r requirements/functests.txt
@@ -66,6 +71,7 @@ click==8.1.3
     #   click-didyoumean
     #   click-plugins
     #   click-repl
+    #   pip-tools
 click-didyoumean==0.0.3
     # via
     #   -r requirements/functests.txt
@@ -229,6 +235,7 @@ packaging==21.3
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+    #   build
     #   pytest
 passlib==1.7.4
     # via
@@ -239,11 +246,27 @@ pastedeploy==2.1.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   plaster-pastedeploy
+pep517==0.13.0
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   build
 peppercorn==0.6
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   deform
+pip-sync-faster==0.0.2
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/lint.in
+    #   -r requirements/tests.txt
+pip-tools==6.8.0
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/lint.in
+    #   -r requirements/tests.txt
+    #   pip-sync-faster
 plaster==1.0
     # via
     #   -r requirements/functests.txt
@@ -421,6 +444,8 @@ tomli==2.0.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+    #   build
+    #   pep517
     #   pylint
     #   pytest
 tomlkit==0.11.0
@@ -484,6 +509,11 @@ webob==1.8.7
     #   webtest
 webtest==3.0.0
     # via -r requirements/functests.txt
+wheel==0.37.1
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   pip-tools
 wired==0.2.2
     # via
     #   -r requirements/functests.txt
@@ -535,6 +565,11 @@ zope-sqlalchemy==1.6
     #   -r requirements/tests.txt
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==22.2.2
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   pip-tools
 setuptools==63.2.0
     # via
     #   -r requirements/functests.txt
@@ -544,6 +579,7 @@ setuptools==63.2.0
     #   gevent
     #   gunicorn
     #   jsonschema
+    #   pip-tools
     #   plaster
     #   pyramid
     #   repoze-sendmail

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,3 +1,5 @@
+pip-tools
+pip-sync-faster
 coverage
 pytest
 factory-boy

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -24,6 +24,8 @@ billiard==3.6.4.0
     #   celery
 bleach==5.0.1
     # via -r requirements/requirements.txt
+build==0.8.0
+    # via pip-tools
 celery==5.2.7
     # via -r requirements/requirements.txt
 certifi==2022.6.15
@@ -45,6 +47,7 @@ click==8.1.3
     #   click-didyoumean
     #   click-plugins
     #   click-repl
+    #   pip-tools
 click-didyoumean==0.0.3
     # via
     #   -r requirements/requirements.txt
@@ -150,6 +153,7 @@ oauthlib==3.2.0
 packaging==21.3
     # via
     #   -r requirements/requirements.txt
+    #   build
     #   pytest
 passlib==1.7.4
     # via -r requirements/requirements.txt
@@ -157,10 +161,18 @@ pastedeploy==2.1.0
     # via
     #   -r requirements/requirements.txt
     #   plaster-pastedeploy
+pep517==0.13.0
+    # via build
 peppercorn==0.6
     # via
     #   -r requirements/requirements.txt
     #   deform
+pip-sync-faster==0.0.2
+    # via -r requirements/tests.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/tests.in
+    #   pip-sync-faster
 plaster==1.0
     # via
     #   -r requirements/requirements.txt
@@ -268,7 +280,10 @@ text-unidecode==1.3
     #   faker
     #   python-slugify
 tomli==2.0.0
-    # via pytest
+    # via
+    #   build
+    #   pep517
+    #   pytest
 transaction==3.0.1
     # via
     #   -r requirements/requirements.txt
@@ -309,6 +324,8 @@ webob==1.8.7
     # via
     #   -r requirements/requirements.txt
     #   pyramid
+wheel==0.37.1
+    # via pip-tools
 wired==0.2.2
     # via
     #   -r requirements/requirements.txt
@@ -347,6 +364,8 @@ zope-sqlalchemy==1.6
     # via -r requirements/requirements.txt
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==22.2.2
+    # via pip-tools
 setuptools==63.2.0
     # via
     #   -r requirements/requirements.txt
@@ -354,6 +373,7 @@ setuptools==63.2.0
     #   gevent
     #   gunicorn
     #   jsonschema
+    #   pip-tools
     #   plaster
     #   pyramid
     #   repoze-sendmail

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = tests
 skipsdist = true
 minversion = 3.16.1
 requires =
-  tox-pip-sync
+  tox-faster
   tox-pyenv
   tox-envfile
   tox-run-command
@@ -76,6 +76,7 @@ whitelist_externals =
 depends =
     {coverage,functests}: tests
 commands =
+    pip-sync-faster requirements/{env:TOX_ENV_NAME}.txt --pip-args '--disable-pip-version-check'
     dev: sh bin/hypothesis --dev init
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}
     lint: pylint {posargs:h}


### PR DESCRIPTION
**Developers will have to `rm -rf .tox` in their dev envs after merging this** if they see `command not found: pip-sync-faster`.

Simplify our development tooling by removing the `tox-pip-sync` plugin in favour of calling [`pip-sync-faster`](https://github.com/hypothesis/pip-sync-faster) directly from `tox.ini`.

Also add the [`tox-faster`](https://github.com/hypothesis/tox-faster) plugin to `tox.ini`: `tox-faster` is a standalone implementation of a small `tox` speedup that was previously implemented in `tox-pip-sync`.

We did this in LMS a while ago and haven't noticed any problems there:

https://github.com/hypothesis/lms/pull/4191/files

Details
-------

* `pip-sync-faster` is added to all the `requirements/*.in` files (except the production `requirements/requirements.in`). `pip-sync-faster` needs to be installed in each tox env so that we can call it
* Ran `make requirements` to recompile the `requirements/*.txt` files from the changed `*.in`'s
* Replaced `tox-pip-sync` with `tox-faster` in the tox plugins in `tox.ini`
* Added a `pip-sync-faster` command to the top of the `commands` section in `tox.ini`

Testing
-------

* You'll need to run `rm -rf .tox` to get this working

* `make sure` should work

* If you repeatedly run a `tox` command you should see that it does not recreate or update the venv each time (`pip-sync-faster` does not call `pip-sync`). For example:

  ```terminal
  tox -e format
  ```

* If you change one of the `*.txt` files you should see that the next time you run tox it does update the venv (`pip-sync-faster` calls `pip-sync`, the output from `pip-sync` is obvious) and then subsequent runs after that do not update the venv again. Example:

  ```terminal
  echo flask >> requirements/format.in
  make requirements/format.txt
  tox -e format  # This will call pip-sync and update .tox/format.
  tox -e format  # Subsequent calls do not call pip-sync again.
  ```