### PR TITLE
Created workflow: tasks.yml

### DIFF
--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -1,0 +1,128 @@
+# Run database migration commands inside the Docker container running
+# the Elastic Beanstalk application
+
+name: Tasks
+
+on:
+  workflow_dispatch:
+    inputs:
+      Task:
+        type: choice
+        description: "The task to perform"
+        required: true
+        options:
+          - 'db current revision'
+          - 'db upgrade to head'
+          - 'db upgrade to next'
+          - 'db downgrade to previous'
+          - 'search reindex'
+      Environment:
+        type: choice
+        description: "The environment to target"
+        required: true
+        default: 'qa'
+        options:
+          - 'qa'
+          - 'prod'
+      Timeout:
+        type: string
+        description: "The timeout in seconds"
+        default: '600'
+      Region:
+        type: choice
+        description: "The AWS region to target"
+        required: true
+        default: 'all'
+        options:
+          - 'all'
+          - 'ca-cental-1'
+          - 'us-west-1'
+      Destructive:
+        description: Check to confirm you are happy to proceed with a destructive operation
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+    - name: catch unauthorised destructive operations
+      run: |
+        if [[ "${{ inputs.Task }}" = 'db upgrade to head' ]] &&
+           [[ "${{ github.event.inputs.Destructive }}" = 'false' ]] ||
+           [[ "${{ inputs.Task }}" = 'db upgrade to next' ]] &&
+           [[ "${{ github.event.inputs.Destructive }}" = 'false' ]] ||
+           [[ "${{ inputs.Task }}" = 'db downgrade to previous' ]] &&
+           [[ "${{ github.event.inputs.Destructive }}" = 'false' ]]
+           [[ "${{ inputs.Task }}" = 'search reindex' ]] &&
+           [[ "${{ github.event.inputs.Destructive }}" = 'false' ]] ; then
+             echo "::error::'${{ inputs.Task }}' needs destructive option"
+             exit 1
+        else
+             echo "::notice::Preparing '${{ inputs.Task }}' update in ${{ inputs.Environment }}"
+             echo "::notice::Targeting regions - '${{ inputs.region }}'"
+             echo "::notice::Timeout - '${{ inputs.Timeout }}'"
+             exit 0
+        fi
+
+  current:
+    if: inputs.Task == 'db current revision'
+    needs: preflight
+    uses: hypothesis/workflows/.github/workflows/eb-task.yml@main
+    with:
+      App: ${{ github.event.repository.name }}
+      Env: ${{ inputs.Environment }}
+      Timeout: ${{ inputs.Timeout }}
+      Region: ${{ inputs.Region }}
+      Command: 'hypothesis migrate current'
+    secrets: inherit
+
+  head:
+    if: inputs.Task == 'db upgrade to head' && github.event.inputs.Destructive == 'true'
+    needs: preflight
+    uses: hypothesis/workflows/.github/workflows/eb-task.yml@main
+    with:
+      App: ${{ github.event.repository.name }}
+      Env: ${{ inputs.Environment }}
+      Timeout: ${{ inputs.Timeout }}
+      Region: ${{ inputs.Region }}
+      Command: 'hypothesis migrate upgrade head'
+    secrets: inherit
+
+  next:
+    if: inputs.Task == 'db upgrade to next' && github.event.inputs.Destructive == 'true'
+    needs: preflight
+    uses: hypothesis/workflows/.github/workflows/eb-task.yml@main
+    with:
+      App: ${{ github.event.repository.name }}
+      Env: ${{ inputs.Environment }}
+      Timeout: ${{ inputs.Timeout }}
+      Region: ${{ inputs.Region }}
+      Command: 'hypothesis migrate upgrade +1'
+    secrets: inherit
+
+  downgrade:
+    if: inputs.Task == 'db downgrade to previous' && github.event.inputs.Destructive == 'true'
+    needs: preflight
+    uses: hypothesis/workflows/.github/workflows/eb-task.yml@main
+    with:
+      App: ${{ github.event.repository.name }}
+      Env: ${{ inputs.Environment }}
+      Timeout: ${{ inputs.Timeout }}
+      Region: ${{ inputs.Region }}
+      Command: 'hypothesis migrate downgrade -1'
+    secrets: inherit
+
+  search:
+    if: inputs.Task == 'search reindex' && github.event.inputs.Destructive == 'true'
+    needs: preflight
+    uses: hypothesis/workflows/.github/workflows/eb-task.yml@main
+    with:
+      App: ${{ github.event.repository.name }}
+      Env: ${{ inputs.Environment }}
+      Timeout: ${{ inputs.Timeout }}
+      Region: ${{ inputs.Region }}
+      Command: 'hypothesis search reindex'
+    secrets: inherit


### PR DESCRIPTION
#### Overview

A workflow for running hypothesis commands inside an Elastic Beanstalk
Docker container. A direct replacement for the Jenkins Task workflow.

Part of the work towards: https://github.com/hypothesis/playbook/issues/957

#### What are we doing

This is a form based manually dispatched workflow that encapsulates running common `hypothesis` commands against H environments. Here is an example of what the form looks like:


<img width="321" alt="Screenshot 2022-08-31 at 14 25 49" src="https://user-images.githubusercontent.com/18003117/187689457-529b3317-9090-4ddf-92c0-a4d68c284895.png">

The following tasks are available

|Name|Command|
|:-|:-|
 |`db current revision`|`hypothesis migrate current`|
 |`db upgrade to head`|`hypothesis migrate upgrade head`|
 |`db upgrade to next`|`hypothesis migrate upgrade +1`|
 |`db downgrade to previous`|`hypothesis migrate downgrade -1`|
 |`search reindex`|`hypothesis search reindex`|

Options to running against `all` or a specific AWS environment have been provided.

#### How is the workflow been structured.

_I have gone for a simple approach that can be easily extended, yep there is some duplication, but its quick and easy to work with. 30 or so lines could probably be removed by using a `matrix` / array to hold the commands being executed._

The workflow starts by running a job called `preflight`. This job runs some conditional checks that look at the options submitted. If we are running a `destructive` operation a checkbox needs to be `checked` before things continue.

Once the `preflight` job completes successfully. One of the dedicated jobs called:  `current`, `head`, `next`, `downgrade` or `search` is executed based on a conditional statement. These jobs call a reusable workflow to perform an update in Elastic Beanstalk.

The reusable workflow can be found here: [eb-task.yml](https://github.com/hypothesis/workflows/blob/main/.github/workflows/eb-task.yml)


#### Testing

The workflow has had limited production testing. A mock can be found here: [dummy-h-periodic tasks.yml](https://github.com/hypothesis/dummy-h-periodic/actions/runs/2963919257). It looks complicated at first glance, but only one of the sections will ever run due to the conditional way the jobs are executed.

<img width="998" alt="Screenshot 2022-08-31 at 15 58 50" src="https://user-images.githubusercontent.com/18003117/187712084-a96daf5f-cf70-4e1e-8e24-756ef39bf898.png">


**Notice:** The only task that has been tested against H is: `db current revision`. We are gonna need to test the other options as we need to use them.

#### What are we not doing

Some of the Jenkins functionality around sending Slack notifications was not implemented in the task.yml workflow. If we feel that functionality is useful we are going to need to develop that functionality. 
