### PR TITLE
Change to HTTPS for the devdata clone URL

### DIFF
--- a/h/cli/commands/devdata.py
+++ b/h/cli/commands/devdata.py
@@ -147,10 +147,10 @@ def devdata(ctx):
         git_dir = os.path.join(tmpdirname, "devdata")
 
         # Clone the private devdata repo from GitHub.
-        # This will fail if your SSH key doesn't have access to the private
-        # repo.
+        # This will fail if Git->GitHub HTTPS authentication isn't set up or if
+        # your GitHub account doesn't have access to the private repo.
         subprocess.check_call(
-            ["git", "clone", "git@github.com:hypothesis/devdata.git", git_dir]
+            ["git", "clone", "https://github.com/hypothesis/devdata.git", git_dir]
         )
 
         # Copy environment variables file into place.


### PR DESCRIPTION
The easiest way to set up Git->GitHub.com authentication nowadays is by
installing [GitHub CLI](https://cli.github.com/), running
[gh auth login](https://cli.github.com/manual/gh_auth_login), and
answering "Yes" (the default) when it asks "Authenticate Git with your
GitHub credentials?". By default this will set up authentication for
HTTPS git clone URLs but not SSH ones so `make devdata` will fail with
an authentication error because it tries to clone the private devdata
repo using the SSH clone URL.

Fix this by changing the devdata clone URL to the HTTPS one.
