### PR TITLE
Add feature flag for treating VitalSource books as a single document

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -13,6 +13,7 @@ FEATURES = {
     ),
     "client_display_names": "Render display names instead of user names in the client",
     "html_side_by_side": "Enable side-by-side mode for web pages in the client",
+    "book_as_single_document": "Treat VitalSource books as a single Hypothesis document",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.


### PR DESCRIPTION
This flag will control whether the Hypothesis client treats VitalSource books as a single document, with the same URL for annotations across all chapters/pages, as opposed to the status quo where each chapter/page has a separate document URL in annotations.