### PR TITLE
Add full report jobs to H

### DIFF
--- a/.github/workflows/report_refresh.yml
+++ b/.github/workflows/report_refresh.yml
@@ -12,8 +12,8 @@ jobs:
     uses: hypothesis/workflows/.github/workflows/eb-task.yml@main
     with:
       App: ${{ github.event.repository.name }}
-      Env: 'qa'
+      Env: 'prod'
       Timeout: 3600
-      Region: 'us-west-1'
-      Command: 'python bin/run_sql_task.py --config-file conf/app.ini --task hello_world'
+      Region: 'all'
+      Command: 'python bin/run_sql_task.py --config-file conf/app.ini --task report/refresh'
     secrets: inherit

--- a/.github/workflows/report_tasks.yml
+++ b/.github/workflows/report_tasks.yml
@@ -9,6 +9,8 @@ on:
         description: "The SQL task to perform"
         required: true
         options:
+          - "report/refresh"
+          - "report/fast_recreate"
           - "report/create_from_scratch"
       Environment:
         type: choice
@@ -39,7 +41,9 @@ jobs:
     name: "Check for approval for dangerous actions"
     steps:
       - name: "Approval not given!"
-        if: contains(fromJson('["report/create_from_scratch"]'), inputs.Task) && inputs.Destructive == false
+        # Until we've run a full sync, running the refresh is dangerous. Then
+        # it's not and we can remove this once the nightly task is going
+        if: contains(fromJson('["report/refresh", "report/fast_recreate", "report/create_from_scratch"]'), inputs.Task) && inputs.Destructive == false
         run: |
           echo "::error::'${{ inputs.Task }}' needs destructive option"
           exit 1

--- a/h/sql_tasks/tasks/hello_world/01_hello_world.jinja2.sql
+++ b/h/sql_tasks/tasks/hello_world/01_hello_world.jinja2.sql
@@ -1,4 +1,0 @@
--- Comments are fine as long as they don't have semi-colons
-
-SELECT 'hello world 1 user={{ db_user }}'
-    AS hello_world;

--- a/h/sql_tasks/tasks/hello_world/02_hello_world.sql
+++ b/h/sql_tasks/tasks/hello_world/02_hello_world.sql
@@ -1,4 +1,0 @@
--- This should run after 01, but the ordering with the directory is undefined
-
-SELECT 'hello world 2a' AS hello;
-SELECT 'hello world 2b' AS hello;

--- a/h/sql_tasks/tasks/hello_world/02_sub_task/01_subtask_hello.sql
+++ b/h/sql_tasks/tasks/hello_world/02_sub_task/01_subtask_hello.sql
@@ -1,1 +1,0 @@
-SELECT 'hello world sub-task' AS hello;

--- a/h/sql_tasks/tasks/report/create_from_scratch/02_annotations/02_initial_fill.sql
+++ b/h/sql_tasks/tasks/report/create_from_scratch/02_annotations/02_initial_fill.sql
@@ -24,8 +24,7 @@ SELECT
     LENGTH(text) AS size,
     "references",
     tags
--- <<< Here is our fake-out partial run >>>
-FROM (SELECT * FROM annotation LIMIT 5000000) AS annotation
+FROM annotation
 JOIN "user" users ON
     users.authority = SPLIT_PART(annotation.userid, '@', 2)
     AND users.username = SUBSTRING(SPLIT_PART(annotation.userid, '@', 1), 6)

--- a/h/sql_tasks/tasks/report/fast_recreate/01_authorities/01_initial_fill.sql
+++ b/h/sql_tasks/tasks/report/fast_recreate/01_authorities/01_initial_fill.sql
@@ -1,0 +1,1 @@
+../../create_from_scratch/01_authorities/02_initial_fill.sql

--- a/h/sql_tasks/tasks/report/fast_recreate/02_annotations/01_refresh.sql
+++ b/h/sql_tasks/tasks/report/fast_recreate/02_annotations/01_refresh.sql
@@ -1,0 +1,1 @@
+../../refresh/01_annotations_refresh.sql

--- a/h/sql_tasks/tasks/report/fast_recreate/03_annotation_group_counts
+++ b/h/sql_tasks/tasks/report/fast_recreate/03_annotation_group_counts
@@ -1,0 +1,1 @@
+../create_from_scratch/03_annotation_group_counts

--- a/h/sql_tasks/tasks/report/fast_recreate/04_annotation_user_counts
+++ b/h/sql_tasks/tasks/report/fast_recreate/04_annotation_user_counts
@@ -1,0 +1,1 @@
+../create_from_scratch/04_annotation_user_counts

--- a/h/sql_tasks/tasks/report/fast_recreate/README.md
+++ b/h/sql_tasks/tasks/report/fast_recreate/README.md
@@ -1,0 +1,11 @@
+Fast recreate
+-------------
+
+This task will partially re-create the reporting environment from its
+definitions. This will not update anything which might take a long time and is
+good for example, when changing materialized views.
+
+This is a **dangerous** task:
+
+ * It will disrupt reporting as it's run
+ * It _shouldn't_ take any longer than a normal refresh

--- a/h/sql_tasks/tasks/report/refresh/01_annotations_refresh.sql
+++ b/h/sql_tasks/tasks/report/refresh/01_annotations_refresh.sql
@@ -1,0 +1,59 @@
+WITH
+    last_update_date AS (
+        SELECT MAX(last_update) FROM (
+            -- We remove a time segment here to ensure an overlap. If the date
+            -- is accurate to a day, it should be a day, if it's accurate to
+            -- the second, it can be a second
+            SELECT MAX(updated) - INTERVAL '1 second' AS last_update FROM report.annotations
+            UNION
+            -- Looks like the table is empty... start from scratch. This
+            -- shouldn't really happen, but this prevents us from crashing if
+            -- it does
+            SELECT NOW() - INTERVAL '100 year'
+        ) AS data
+    )
+
+INSERT INTO report.annotations (
+    uuid,
+    user_id, group_id, document_id, authority_id,
+    created, updated,
+    deleted, shared, size,
+    parent_uuids, tags
+)
+SELECT
+    annotation.id as uuid,
+    users.id as user_id,
+    groups.id as group_id,
+    document_id,
+    authorities.id as authority_id,
+    annotation.created::date,
+    annotation.updated::date,
+    deleted,
+    shared,
+    LENGTH(text) AS size,
+    "references",
+    tags
+FROM annotation
+JOIN "user" users ON
+    users.authority = SPLIT_PART(annotation.userid, '@', 2)
+    AND users.username =  SUBSTRING(SPLIT_PART(annotation.userid, '@', 1), 6)
+JOIN "group" as groups ON
+    groups.pubid = annotation.groupid
+JOIN report.authorities ON
+    authorities.authority = users.authority
+WHERE
+    annotation.updated >= (SELECT * FROM last_update_date)
+-- Ensure our data is in created order for nice correlation
+ORDER BY annotation.created
+-- None of the fields in this table change over time
+ON CONFLICT (uuid) DO UPDATE SET
+    updated=EXCLUDED.updated,
+    group_id=EXCLUDED.group_id,
+    deleted=EXCLUDED.deleted,
+    shared=EXCLUDED.shared,
+    size=EXCLUDED.size,
+    parent_uuids=EXCLUDED.parent_uuids,
+    tags=EXCLUDED.tags;
+
+-- Do we want to analyze every time we insert? This could take a while?
+ANALYSE report.annotations;

--- a/h/sql_tasks/tasks/report/refresh/02_annotation_group_counts_refresh.sql
+++ b/h/sql_tasks/tasks/report/refresh/02_annotation_group_counts_refresh.sql
@@ -1,0 +1,3 @@
+REFRESH MATERIALIZED VIEW CONCURRENTLY report.annotation_group_counts;
+
+ANALYSE report.annotation_group_counts;

--- a/h/sql_tasks/tasks/report/refresh/03_annotation_user_counts_refresh.sql
+++ b/h/sql_tasks/tasks/report/refresh/03_annotation_user_counts_refresh.sql
@@ -1,0 +1,3 @@
+REFRESH MATERIALIZED VIEW CONCURRENTLY report.annotation_user_counts;
+
+ANALYSE report.annotation_user_counts;

--- a/h/sql_tasks/tasks/report/refresh/README.md
+++ b/h/sql_tasks/tasks/report/refresh/README.md
@@ -1,0 +1,10 @@
+Refresh
+-------
+
+This is the refresh task which will update numbers since the last time it was
+run.
+
+This is a **safe** task:
+
+ * It should be quick to run
+ * It should not lock any tables it is updating

--- a/tests/functional/bin/run_sql_task_test.py
+++ b/tests/functional/bin/run_sql_task_test.py
@@ -13,7 +13,16 @@ class TestRunSQLTask:
     # We use "clean DB" here to ensure the schema is created
     @pytest.mark.usefixtures("with_clean_db")
     def test_reporting_tasks(self, environ):
-        for task_name in ("report/create_from_scratch",):
+        for task_name in (
+            # Run all the jobs in one line in the order they are expected to
+            # be able to run. We need "create from scratch" to have been done
+            # to tests the others, but doing it over and over is slow
+            "report/create_from_scratch",
+            "report/fast_recreate",
+            "report/refresh",
+            # Ensure we can run the "create from scratch" after everything
+            "report/create_from_scratch",
+        ):
             result = check_output(
                 [
                     sys.executable,


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/h/issues/7650

Requires:

 * https://github.com/hypothesis/h/pull/7654
 * https://github.com/hypothesis/h/pull/7660

This adds three new SQL jobs:

 * `report/create_from_scratch` - Starts over from scratch. Destructive and slow
 * `report/fast_recreate` - Recreates everything that isn't very slow to recreate. Destructive and fast
 * `report/refresh` - Refreshes data since last run. Non-destructive and fast