### PR TITLE
Finish the CI tasks for running report jobs

### DIFF
--- a/.github/workflows/report_refresh.yml
+++ b/.github/workflows/report_refresh.yml
@@ -14,6 +14,6 @@ jobs:
       App: ${{ github.event.repository.name }}
       Env: 'qa'
       Timeout: 3600
-      Region: 'all'
-      Command: 'python bin/run_sql_task.py --task hello_world'
+      Region: 'us-west-1'
+      Command: 'python bin/run_sql_task.py --config-file conf/app.ini --task hello_world'
     secrets: inherit

--- a/.github/workflows/report_tasks.yml
+++ b/.github/workflows/report_tasks.yml
@@ -1,6 +1,6 @@
-# Run various tasks related to the report aggregations
+# Run various SQL defined tasks, usually related to the report aggregations
 
-name: SQL tasks for report
+name: SQL tasks
 on:
   workflow_dispatch:
     inputs:
@@ -21,6 +21,15 @@ on:
         options:
           - 'qa'
           - 'prod'
+      Region:
+        type: choice
+        description: "The AWS region to target"
+        required: true
+        default: 'all'
+        options:
+          - 'all'
+          - 'ca-cental-1'
+          - 'us-west-1'
       Destructive:
         description: Check to confirm you are happy to proceed with a destructive operation
         type: boolean
@@ -28,22 +37,24 @@ on:
         default: false
 
 jobs:
-  explode_on_danger:
+  check_for_danger:
+    runs-on: ubuntu-latest
     name: "Check for approval for dangerous actions"
-    if: ${{ contains(fromJson('["danger", "danger2"]'), input.Task) && (inputs.Destructive == 'false')}}
     steps:
       - name: "Approval not given!"
+        if: contains(fromJson('["danger", "danger2"]'), inputs.Task) && inputs.Destructive == false
         run: |
           echo "::error::'${{ inputs.Task }}' needs destructive option"
           exit 1
 
   run_task:
-    name: "Run ${{ inputs.Task }} SQL task"
+    needs: check_for_danger
+    name: "Run '${{ inputs.Task }}' SQL task in ${{ inputs.Environment }} / ${{ inputs.Region }}"
     uses: hypothesis/workflows/.github/workflows/eb-task.yml@main
     with:
       App: ${{ github.event.repository.name }}
       Env: ${{ inputs.Environment }}
       Timeout: 3600
-      Region: 'all'
-      Command: 'python bin/run_sql_task.py --task ${{ inputs.Task }}'
+      Region: ${{ inputs.Region }}
+      Command: 'python bin/run_sql_task.py --config-file conf/app.ini --task ${{ inputs.Task }}'
     secrets: inherit


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/h/issues/7650

Some notes here about mixing "schedule" with "workflow_dispatch", but I don't think we want to get into it necessarily.

* https://dev.to/mrmike/github-action-handling-input-default-value-5f2g

This fixes the two SQL tasks related jobs so they actually work.

## Testing notes

 * Visit: https://github.com/hypothesis/h/actions/workflows/report_tasks.yml
 * Click "Run workflow"
 * Choose "Use workflow from": `sql-actions-ci`
 * Noodle about. In particular:
    * Try running `hello_world` in QA us-west-1 only
    * Try running the breaking invalid SQL task
    * Try running the "dangerous" tasks without giving approval

You can do the same thing with the dedicated refresh action with: https://github.com/hypothesis/h/actions/workflows/report_refresh.yml
