### PR TITLE
Add feature flag to enable styled highlight clusters in the client

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -14,6 +14,7 @@ FEATURES = {
     "client_display_names": "Render display names instead of user names in the client",
     "html_side_by_side": "Enable side-by-side mode for web pages in the client",
     "book_as_single_document": "Treat VitalSource books as a single Hypothesis document",
+    "styled_highlight_clusters": "Style different clusters of highlights in the client",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.


### PR DESCRIPTION
This flag will allow users initially to try out a prototype for styling different "clusters" of highlights with different colors/styles. This flag is used by the `client` only.