### PR TITLE
Increased default timeout: tasks.yml

### DIFF
--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -27,7 +27,7 @@ on:
       Timeout:
         type: string
         description: "The timeout in seconds"
-        default: '600'
+        default: '900'
       Region:
         type: choice
         description: "The AWS region to target"


### PR DESCRIPTION
Changed default timeout to 900 seconds. This value is used in two contexts:

- It is passed to AWS when requesting an ODIC token. The timeout defines the life of the token, and the default is 900 seconds. If you pass a value lower it will result in an error. This happens through the reusable [eb-task.yml](https://github.com/hypothesis/workflows/blob/main/.github/workflows/eb-task.yml) workflow being called.

- The value is also used to constrain the length of the H task being executed.