### PR TITLE
Add the postgres container to an external network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     healthcheck:
         test: ["CMD", "pg_isready", "-U", "postgres"]
         interval: 1s
+    networks:
+      - dbs
   elasticsearch:
     image: hypothesis/elasticsearch:latest
     ports:
@@ -18,3 +20,7 @@ services:
     ports:
       - '127.0.0.1:5672:5672'
       - '127.0.0.1:15672:15672'
+
+networks:
+  dbs:
+    external: true


### PR DESCRIPTION
This allows containers in other projects to talk directly to H's DB.

With this change we can mimic the foreign data wrapper setup we have in production locally.