### PR TITLE
Make sure the network dbs exists for make services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ help:
 .PHONY: services
 services: args?=up -d
 services: python
+	@tox -qe dockercompose --run-command 'sh -c "docker network create dbs 2>/dev/null || true"'
 	@tox -qe dockercompose -- $(args)
 
 .PHONY: db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,8 @@ services:
       - '127.0.0.1:15672:15672'
 
 networks:
+  # This external network allows FDW connections between H, LMS and report DBs.
+  # To avoid having unnecessary dependencies between the projects
+  # the network is created with `docker network crate dbs` in each project's Makefile (make services)
   dbs:
     external: true

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ setenv =
 deps =
     -r requirements/{env:TOX_ENV_NAME}.txt
 whitelist_externals =
-    {dev,tests,functests}: sh
+    {dev,tests,functests,dockercompose}: sh
 depends =
     {coverage,functests}: tests
 commands =


### PR DESCRIPTION
(Needs to be tested together with the equivalent in LMS https://github.com/hypothesis/lms/pull/4601)


The `dbs` network is used by multiple projects is available without needing to synchronize which project creates it first.


## Testing

- `docker-compose down` in both H and LMS
- `docker network rm dbs` (if you have created it manually)
- `make services` in both H and LMS, in any other.