### PR TITLE
Remove the WebSocket kill switch

### DIFF
--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -8,6 +8,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL
 stopasgroup = true
+autostart = %(ENV_ENABLE_WEB)s
 
 [program:websocket]
 command = pserve --reload conf/websocket-dev.ini
@@ -15,6 +16,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL
 stopasgroup = true
+autostart = %(ENV_ENABLE_WEBSOCKET)s
 
 [program:worker]
 command = sh bin/hypothesis --dev celery worker --loglevel=INFO
@@ -22,6 +24,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL
 stopasgroup = true
+autostart = %(ENV_ENABLE_WORKER)s
 
 [program:assets]
 command = node_modules/.bin/gulp watch

--- a/h/streamer/app.py
+++ b/h/streamer/app.py
@@ -1,27 +1,12 @@
-import os
-
 import pyramid
 
 from h.config import configure
 from h.security import BearerTokenPolicy
 from h.sentry_filters import SENTRY_FILTERS
-from h.streamer.worker import log
 
 
 def create_app(_global_config, **settings):
     config = configure(settings=settings)
-
-    if os.environ.get("KILL_SWITCH_WEBSOCKET"):
-        log.warning("Websocket kill switch has been enabled.")
-        log.warning("The switch is the environment variable 'KILL_SWITCH_WEBSOCKET'")
-        log.warning("No websocket functionality will work until the switch is disabled")
-
-        # Add views to return messages so we don't get confused between
-        # disabled and missing end-points in the logs
-        config.scan("h.streamer.kill_switch_views")
-
-        # Quit out early without configuring any routes etc.
-        return config.make_wsgi_app()
 
     config.include("pyramid_services")
 

--- a/h/streamer/kill_switch_views.py
+++ b/h/streamer/kill_switch_views.py
@@ -1,9 +1,0 @@
-"""Routes registered when the kill switch is enabled."""
-from pyramid.response import Response
-from pyramid.view import notfound_view_config
-
-
-@notfound_view_config()
-def not_found(_exc, _request):
-    """Handle any request we get with the shortest possible response."""
-    return Response(status="429 Offline", headerlist=[])

--- a/tests/h/streamer/app_test.py
+++ b/tests/h/streamer/app_test.py
@@ -19,22 +19,6 @@ class TestIncludeMe:
             }
         )
 
-    @pytest.mark.usefixtures("with_kill_switch_on", "configure")
-    def test_it_respects_the_kill_switch(self, config):
-        create_app(None)
-
-        config.add_settings.assert_not_called()
-        config.add_tween.assert_not_called()
-        config.set_authentication_policy.assert_not_called()
-        config.add_route.assert_not_called()
-
-        config.scan.assert_called_once_with("h.streamer.kill_switch_views")
-
-    @pytest.fixture
-    def with_kill_switch_on(self, patch):
-        os = patch("h.streamer.app.os")
-        os.environ.get.side_effect = {"KILL_SWITCH_WEBSOCKET": 1}.get
-
     @pytest.fixture
     def config(self):
         return mock.create_autospec(Configurator, instance=True)

--- a/tests/h/streamer/kill_switch_views_test.py
+++ b/tests/h/streamer/kill_switch_views_test.py
@@ -1,8 +1,0 @@
-from h.streamer.kill_switch_views import not_found
-
-
-def test_not_found_view(pyramid_request):
-    response = not_found(Exception(), pyramid_request)
-
-    assert response.status_code == 429
-    assert response.content_type is None

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,6 @@ passenv =
     dev: NEW_RELIC_LICENSE_KEY
     dev: NEW_RELIC_APP_NAME
     dev: NODE_ENV
-    dev: KILL_SWITCH_WEBSOCKET
     dev: PROXY_AUTH
     dev: REPORT_FDW_USERS
     {tests,functests}: TEST_DATABASE_URL
@@ -69,6 +68,9 @@ setenv =
     dev: PYTHONPATH = .
     dev: APP_URL = {env:APP_URL:http://localhost:5000}
     dev: WEBSOCKET_URL = {env:WEBSOCKET_URL:ws://localhost:5001/ws}
+    dev: ENABLE_WEB = {env:ENABLE_WEB:true}
+    dev: ENABLE_WEBSOCKET = {env:ENABLE_WEBSOCKET:true}
+    dev: ENABLE_WORKER = {env:ENABLE_WORKER:true}
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 deps =
     -r requirements/{env:TOX_ENV_NAME}.txt


### PR DESCRIPTION
The WebSocket process is now toggle-able at the Supervisor level (https://github.com/hypothesis/h/pull/7674) so I don't think the WebSocket kill-switch is needed anymore.

This PR does introduce a functional change: when the WebSocket is disabled the previous 429 Offline response from the Pyramid app is now a 502 Bad Gateway from NGINX. Changing a 4xx to a 5xx might be undesirable for monitoring. Having said that, I don't think the WebSocket URLs get much traffic in the non-WebSocket environment since the client is configured to talk to the separate WebSocket environments, so the 502 shouldn't affect monitoring too much.

Technically actually it's already a 502 Bad Gateway in prod because the WebSocket process is currently disabled in prod at the Supervisor level in the non-WebSocket environments. And before I disabled the WebSocket process in Supervisor the response was never a 429 either: the WebSocket kill-switch was never enabled in the non-WebSocket environments so the real WebSocket views would have still been responding!

I'm wondering if, for now, we should re-enable the WebSocket process in the non-WebSocket environments and also enable the WebSocket kill-switch so that the response is a 429.

I think it'll be different once we've [changed things to always run the WebSocket on a port](https://github.com/hypothesis/playbook/issues/1003) never behind NGINX: then in the non-WebSocket environments the WebSocket's port `5001` shouldn't even be exposed by Elastic Beanstalk, and the internal NGINX instance won't be listening on a file socket for the non-existent WebSocket process.

### Testing

#### On `main`

On `main` you can disable the WebSocket by setting:

    export KILL_SWITCH_WEBSOCKET=true

Then run `make dev` and you should see this in the logs:

    [h.streamer.worker:WARNING] Websocket kill switch has been enabled.

Visit <http://localhost:5000/ws> and you'll see a 429 Offline response.

#### On this branch

On this branch to disable the WebSocket you should set:

    export ENABLE_WEBSOCKET=false

Then run `make dev`. You won't see any particular message in the logs: instead you should see that no messages are logged from the `websocket` process at all.

Visit <http://localhost:5001/ws> and you should get no response at all: nothing is running on port `5001`.

To test what will happen in production you can change `make run-docker`'s `ENABLE_WEBSOCKET` envvar to `false`:

```diff
diff --git a/Makefile b/Makefile
index 248388868..e948035f6 100644
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ run-docker:
 		-e "SECRET_KEY=notasecret" \
 		-e "ENABLE_NGINX=true" \
 		-e "ENABLE_WEB=true" \
-		-e "ENABLE_WEBSOCKET=true" \
+		-e "ENABLE_WEBSOCKET=false" \
 		-e "WEBSOCKET_CONFIG=conf/websocket-monolithic.ini" \
 		-e "ENABLE_WORKER=true" \
 		-p 5000:5000 \
```

Then run `make docker run-docker` and visit <http://localhost:5000/ws> (note: when run in Docker the WebSocket currently runs on `5000` not `5001`). You'll see a 502 Bad Gateway from NGINX.