### PR TITLE
Grant SELECT to fdw users on the report schema

### DIFF
--- a/h/sql_tasks/tasks/report/fast_recreate/00_permissions/01_grant_schema.jinja2.sql
+++ b/h/sql_tasks/tasks/report/fast_recreate/00_permissions/01_grant_schema.jinja2.sql
@@ -1,3 +1,4 @@
 {% for fdw_user in fdw_users %}
 GRANT USAGE ON SCHEMA report TO "{{fdw_user}}";
+GRANT SELECT ON ALL TABLES IN SCHEMA report TO "{{fdw_user}}";
 {% endfor %}


### PR DESCRIPTION
Getting:


```
ERROR: permission denied for table authorities Where: remote SQL command: SELECT id, created, authority FROM report.authorities
```

without it.￼
