### PR TITLE
Grant access to the FDW users to public schema

### DIFF
--- a/h/sql_tasks/tasks/report/fast_recreate/00_permissions/01_grant_schema.jinja2.sql
+++ b/h/sql_tasks/tasks/report/fast_recreate/00_permissions/01_grant_schema.jinja2.sql
@@ -1,3 +1,12 @@
+-- The public schema already exists but
+-- we need to grant usage to the user will map via fdw.
+{% for fdw_user in fdw_users %}
+GRANT USAGE ON SCHEMA public TO "{{fdw_user}}";
+GRANT SELECT ON  public.user_group TO "{{fdw_user}}";
+GRANT SELECT ON  public."user" TO "{{fdw_user}}";
+GRANT SELECT ON  public."group" TO "{{fdw_user}}";
+{% endfor %}
+
 {% for fdw_user in fdw_users %}
 GRANT USAGE ON SCHEMA report TO "{{fdw_user}}";
 GRANT SELECT ON ALL TABLES IN SCHEMA report TO "{{fdw_user}}";

--- a/h/sql_tasks/tasks/report/fast_recreate/00_permissions/01_grant_schema.jinja2.sql
+++ b/h/sql_tasks/tasks/report/fast_recreate/00_permissions/01_grant_schema.jinja2.sql
@@ -11,3 +11,7 @@ GRANT SELECT ON  public."group" TO "{{fdw_user}}";
 GRANT USAGE ON SCHEMA report TO "{{fdw_user}}";
 GRANT SELECT ON ALL TABLES IN SCHEMA report TO "{{fdw_user}}";
 {% endfor %}
+
+
+-- Empty query in case fdw_users is empty.
+select null;


### PR DESCRIPTION
## Testing

```
REPORT_FDW_USERS="postgres" tox -qe dev --run-command 'python bin/run_sql_task.py -c conf/development-app.ini -t report/create_from_scratch' | grep GRANT 
```

```
    0=> GRANT USAGE ON SCHEMA public TO "postgres";
    1=> GRANT SELECT ON  public.user_group TO "postgres";
    2=> GRANT SELECT ON  public."user" TO "postgres";
    3=> GRANT SELECT ON  public."group" TO "postgres";
    4=> GRANT USAGE ON SCHEMA report TO "postgres";
    5=> GRANT SELECT ON ALL TABLES IN SCHEMA report TO "postgres";
```