### PR TITLE
Fix GitHub environment names and URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,59 +25,69 @@ jobs:
   qa:
     needs: create-image
     name: ${{ github.event.repository.name }}
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: ${{ github.event.repository.name }}
-      Environment: qa
-      Region: us-west-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: QA
+      github_environment_url: https://qa.hypothes.is/search
+      aws_region: us-west-1
+      elasticbeanstalk_application: h
+      elasticbeanstalk_environment: qa
+      docker_tag: ${{ needs.create-image.outputs.docker_tag }}
     secrets: inherit
 
   qa-websocket:
     needs: create-image
     name: qa-websocket
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: h-websocket
-      Environment: qa
-      Region: us-west-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: QA (WebSocket)
+      github_environment_url: https://qa.hypothes.is/docs/help
+      aws_region: us-west-1
+      elasticbeanstalk_application: h-websocket
+      elasticbeanstalk_environment: qa
+      docker_tag: ${{ needs.create-image.outputs.docker_tag }}
     secrets: inherit
 
   prod:
     needs: [create-image, qa]
     name: ${{ github.event.repository.name }}
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: ${{ github.event.repository.name }}
-      Environment: prod
-      Region: us-west-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: Production
+      github_environment_url: https://hypothes.is/search
+      aws_region: us-west-1
+      elasticbeanstalk_application: h
+      elasticbeanstalk_environment: prod
+      docker_tag: ${{ needs.create-image.outputs.docker_tag }}
     secrets: inherit
 
   prod-websocket:
     needs: [create-image, qa-websocket]
     name: prod-websocket
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: h-websocket
-      Environment: prod
-      Region: us-west-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: Production (WebSocket)
+      github_environment_url: https://hypothes.is/docs/help
+      aws_region: us-west-1
+      elasticbeanstalk_application: h-websocket
+      elasticbeanstalk_environment: prod
+      docker_tag: ${{ needs.create-image.outputs.docker_tag }}
     secrets: inherit
 
   prod-ca-central-1:
     needs: [create-image, qa]
     name: ${{ github.event.repository.name }}
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: ${{ github.event.repository.name }}
-      Environment: prod
-      Region: ca-central-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: Production (Canada)
+      github_environment_url: https://ca.hypothes.is/search
+      aws_region: ca-central-1
+      elasticbeanstalk_application: h
+      elasticbeanstalk_environment: prod
+      docker_tag: ${{ needs.create-image.outputs.docker_tag }}
     secrets: inherit


### PR DESCRIPTION
Change from the `eb-update.yml` workflow to the new `deploy.yml` workflow and
use a separately nicely-named GitHub environment with a URL for each Elastic
Beanstalk environment.

Fixes https://github.com/hypothesis/h/issues/7670
