### PR TITLE
Allow RPC messages from LMS when using HTTPS

### DIFF
--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -11,7 +11,7 @@ pyramid.reload_templates: True
 
 h.authority: localhost
 h.bouncer_url: http://localhost:8000
-h.client_rpc_allowed_origins: http://localhost:8001
+h.client_rpc_allowed_origins: http://localhost:8001 https://localhost:48001
 h.client_url: {current_scheme}://{current_host}:3001/hypothesis
 h.websocket_url: ws://localhost:5001/ws
 


### PR DESCRIPTION
The client white lists origins for RPC messages. Adding the missing one for LMS while using HTTPS.


HTTPS support was added in LMS here https://github.com/hypothesis/lms/pull/4575