### PR TITLE
Lock down FDW access to the tables needed for the LMS report

### DIFF
--- a/h/sql_tasks/tasks/report/create_dev_users/01_create_schema.jinja2
+++ b/h/sql_tasks/tasks/report/create_dev_users/01_create_schema.jinja2
@@ -1,0 +1,1 @@
+../create_from_scratch/00_schema/01_create.jinja2.sql

--- a/h/sql_tasks/tasks/report/create_dev_users/02_create_users.jinja2.sql
+++ b/h/sql_tasks/tasks/report/create_dev_users/02_create_users.jinja2.sql
@@ -1,0 +1,19 @@
+{% for fdw_user in fdw_users %}
+    -- You can't remove a user if they have permissions on anything, so we need
+    -- to scrub the permissions before we can start. However you can't remove
+    -- permissions from a user that doesn't exist, so we end up with a
+    -- Catch-22, forcing us to check and conditionally execute the following.
+    DO
+    $$BEGIN
+        IF EXISTS (SELECT FROM pg_roles WHERE rolname = '{{ fdw_user }}') THEN
+            EXECUTE 'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM "{{ fdw_user }}"';
+            EXECUTE 'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA report FROM "{{ fdw_user }}"';
+            EXECUTE 'REVOKE USAGE ON SCHEMA public FROM "{{ fdw_user }}"';
+            EXECUTE 'REVOKE USAGE ON SCHEMA report FROM "{{ fdw_user }}"';
+            EXECUTE 'DROP USER IF EXISTS "{{ fdw_user }}"';
+        END IF;
+    END$$;
+
+    CREATE USER "{{ fdw_user }}";
+    ALTER USER "{{ fdw_user }}" PASSWORD 'password';  -- No need to hide this
+{% endfor %}

--- a/h/sql_tasks/tasks/report/create_dev_users/README.md
+++ b/h/sql_tasks/tasks/report/create_dev_users/README.md
@@ -1,0 +1,16 @@
+Create dev users
+----------------
+
+This task is intended to be run as a once off should you scrub your DB in
+development and need to add back the FDW users.
+
+You need to run this script once to create the required users, after which the
+normal tasks will maintain the permissions.
+
+This is only intended to be run in dev and is mostly for the benefit of testing
+upstream consumers of the tables via FDW.
+
+This is a **dangerous** task:
+
+ * It will empty the schema
+ * It will drop permissions on users

--- a/h/sql_tasks/tasks/report/create_from_scratch/05_grant_permissions/01_grant_schema.jinja2.sql
+++ b/h/sql_tasks/tasks/report/create_from_scratch/05_grant_permissions/01_grant_schema.jinja2.sql
@@ -1,16 +1,26 @@
 -- The public schema already exists but we need to grant usage to the user we
 -- will map via FDW.
+
 {% for fdw_user in fdw_users %}
+    -- Permissions exist independently of the schema, so dropping the schema
+    -- does not revoke permissions. We need to remove the existing permissions
+    -- otherwise removing something the list below does not remove the
+    -- permission.
+    REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM "{{fdw_user}}";
+
     GRANT USAGE ON SCHEMA public TO "{{fdw_user}}";
+
     GRANT SELECT ON public.user_group TO "{{fdw_user}}";
     GRANT SELECT ON public."user" TO "{{fdw_user}}";
     GRANT SELECT ON public."group" TO "{{fdw_user}}";
 {% endfor %}
 
 {% for fdw_user in fdw_users %}
-    GRANT USAGE ON SCHEMA report TO "{{fdw_user}}";
-    GRANT SELECT ON ALL TABLES IN SCHEMA report TO "{{fdw_user}}";
-{% endfor %}
+    REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA report FROM "{{fdw_user}}";
 
--- Empty query in case `fdw_users` is empty.
-SELECT NULL;
+    GRANT USAGE ON SCHEMA report TO "{{fdw_user}}";
+
+    GRANT SELECT ON report.authorities TO "{{fdw_user}}";
+    GRANT SELECT ON report.annotation_group_counts TO "{{fdw_user}}";
+    GRANT SELECT ON report.annotation_user_counts TO "{{fdw_user}}";
+{% endfor %}

--- a/tests/functional/bin/run_sql_task_test.py
+++ b/tests/functional/bin/run_sql_task_test.py
@@ -17,6 +17,7 @@ class TestRunSQLTask:
             # Run all the jobs in one line in the order they are expected to
             # be able to run. We need "create from scratch" to have been done
             # to tests the others, but doing it over and over is slow
+            "report/create_dev_users",
             "report/create_from_scratch",
             "report/fast_recreate",
             "report/refresh",

--- a/tox.ini
+++ b/tox.ini
@@ -58,13 +58,14 @@ passenv =
     dev: NEW_RELIC_APP_NAME
     dev: NODE_ENV
     dev: PROXY_AUTH
-    dev: REPORT_FDW_USERS
+
     {tests,functests}: TEST_DATABASE_URL
     {tests,functests}: ELASTICSEARCH_URL
     {tests,functests}: PYTEST_ADDOPTS
     functests: BROKER_URL
 setenv =
     PYTHONUNBUFFERED = 1
+    REPORT_FDW_USERS=lms-fdw report-fdw
     dev: PYTHONPATH = .
     dev: APP_URL = {env:APP_URL:http://localhost:5000}
     dev: WEBSOCKET_URL = {env:WEBSOCKET_URL:ws://localhost:5001/ws}


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/49
 
We can't really test this locally until we have a way of replicating the user structure.

## Testing notes

Check it works from scratch:

 * `make services args=down`
 * `make services`
 * `tox -e dev --run-command "python bin/run_sql_task.py --config-file conf/development-app.ini --task report/create_dev_users"`

Check it works after create:

 * `make db`
 * `tox -e dev --run-command "python bin/run_sql_task.py --config-file conf/development-app.ini --task report/create_from_scratch"`
 * `tox -e dev --run-command "python bin/run_sql_task.py --config-file conf/development-app.ini --task report/create_dev_users"`