### PR TITLE
Remove IRC reference from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ environment and contributing to h.
 Community
 ---------
 
-Join us on Slack (`request an invite`_ or `log in once you've created an account`_) or in `#hypothes.is`_ on freenode_ for discussion.
+Join us on Slack (`request an invite`_ or `log in once you've created an account`_).
 
 If you'd like to contribute to the project, you should also `subscribe`_ to the
 `development mailing list`_ and read our `Contributor's guide`_. Then consider
@@ -44,8 +44,6 @@ By participating in this project you agree to abide by its terms.
 
 .. _`request an invite`: https://slack.hypothes.is
 .. _`log in once you've created an account`: https://hypothesis-open.slack.com/
-.. _#hypothes.is: https://www.irccloud.com/invite?channel=%23hypothes.is&amp;hostname=irc.freenode.net&amp;port=6667&amp;ssl=1
-.. _freenode: http://freenode.net/
 .. _subscribe: mailto:dev+subscribe@list.hypothes.is
 .. _development mailing list: https://groups.google.com/a/list.hypothes.is/forum/#!forum/dev
 .. _Contributor's guide: https://h.readthedocs.io/en/latest/developing/


### PR DESCRIPTION
As far as I am aware, nobody at Hypothesis is checking or responding in IRC or has done for years, so just mention Slack and the development mailing list.