### PR TITLE
Add annotation types to the annotation group counts and authority activity

### DIFF
--- a/h/sql_tasks/tasks/report/create_from_scratch/04_annotation_group_counts/01_create_view.sql
+++ b/h/sql_tasks/tasks/report/create_from_scratch/04_annotation_group_counts/01_create_view.sql
@@ -6,7 +6,9 @@ CREATE MATERIALIZED VIEW report.annotation_group_counts AS (
         DATE_TRUNC('week', created)::date AS created_week,
         authority_id,
         group_id,
-        COUNT(1)::integer AS count
+        COUNT(1)::INTEGER AS count,
+        (COUNT(1) FILTER (WHERE shared IS TRUE))::INTEGER AS shared,
+        (COUNT(1) FILTER (WHERE ARRAY_LENGTH(parent_uuids, 1) > 0))::INTEGER AS replies
     FROM report.annotations
     GROUP BY created_week, authority_id, group_id
     ORDER BY created_week, authority_id, group_id


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/91

Requires:

 * https://github.com/hypothesis/h/pull/7717

We have various reports which rely in total annotation counts, but we also have some future requirements / opportunity to go above and beyond by adding in shared and replies too.

## Testing notes

 * `tox -e dev --run-command "python bin/run_sql_task.py --task report/create_from_scratch --config conf/development-app.ini"`
 * `make sql`
 * `\d+ report.authority_activity;`
 * You should see the new columns