### PR TITLE
POC - Add a subscription managment service

### DIFF
--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -1,6 +1,8 @@
 from pyramid.renderers import render
 
 from h import links
+from h.models import Subscriptions
+from h.services import SubscriptionService
 
 
 def generate(request, notification):
@@ -15,6 +17,10 @@ def generate(request, notification):
     :returns: a 4-element tuple containing: recipients, subject, text, html
     """
 
+    unsubscribe_token = request.find_service(SubscriptionService).get_unsubscribe_token(
+        user_id=notification.parent_user.userid, type_=Subscriptions.Type.REPLY
+    )
+
     context = {
         "document_title": notification.document.title or notification.parent.target_uri,
         "document_url": notification.parent.target_uri,
@@ -25,7 +31,7 @@ def generate(request, notification):
         "parent_user_url": _get_user_url(notification.parent_user, request),
         "unsubscribe_url": request.route_url(
             "unsubscribe",
-            token=_unsubscribe_token(request, notification.parent_user),
+            token=unsubscribe_token,
         ),
         # Reply related
         "reply": notification.reply,
@@ -52,8 +58,3 @@ def _get_user_url(user, request):
         return request.route_url("stream.user_query", user=user.username)
 
     return None
-
-
-def _unsubscribe_token(request, user):
-    serializer = request.registry.notification_serializer
-    return serializer.dumps({"type": "reply", "uri": user.userid})

--- a/h/models/subscriptions.py
+++ b/h/models/subscriptions.py
@@ -1,10 +1,22 @@
+from enum import Enum
+
 import sqlalchemy as sa
-from sqlalchemy import func
 
 from h.db import Base
 
 
 class Subscriptions(Base):
+    """Permission from the user to send different types of communication."""
+
+    class Type(str, Enum):
+        """All the different types of subscriptions we support.
+
+        This isn't integrated with the type field, but it would be nice if it
+        was.
+        """
+
+        REPLY = "reply"
+
     __tablename__ = "subscriptions"
     __table_args__ = (sa.Index("subs_uri_idx_subscriptions", "uri"),)
 
@@ -12,10 +24,6 @@ class Subscriptions(Base):
     uri = sa.Column(sa.UnicodeText(), nullable=False)
     type = sa.Column(sa.VARCHAR(64), nullable=False)
     active = sa.Column(sa.Boolean, default=True, nullable=False)
-
-    @classmethod
-    def get_subscriptions_for_uri(cls, session, uri):
-        return session.query(cls).filter(func.lower(cls.uri) == func.lower(uri)).all()
 
     def __repr__(self):
         return f"<Subscription uri={self.uri} type={self.type} active={self.active}>"

--- a/h/notification/__init__.py
+++ b/h/notification/__init__.py
@@ -1,13 +1,2 @@
-from webob.cookies import SignedSerializer
-
-from ..security import derive_key
-
-
 def includeme(config):
     config.include(".reply")
-
-    secret = config.registry.settings["secret_key"]
-    salt = config.registry.settings["secret_salt"]
-    derived = derive_key(secret, salt, b"h.notification")
-
-    config.registry.notification_serializer = SignedSerializer(derived, None)

--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 
 from h import storage
 from h.models import Subscriptions
+from h.services import SubscriptionService
 
 log = logging.getLogger(__name__)
 
@@ -100,12 +101,11 @@ def get_notification(
 
     # Bail if there is no active 'reply' subscription for the user being
     # replied to.
-    sub = (
-        request.db.query(Subscriptions)
-        .filter_by(active=True, type="reply", uri=parent.userid)
-        .first()
-    )
-    if sub is None:
+    if (
+        not request.find_service(SubscriptionService)
+        .get_subscription(user_id=parent.userid, type_=Subscriptions.Type.REPLY)
+        .active
+    ):
         return None
 
     return Notification(reply, reply_user, parent, parent_user, reply.document)

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -1,5 +1,6 @@
 """Service definitions that handle business logic."""
 from h.services.auth_cookie import AuthCookieService
+from h.services.subscription import SubscriptionService
 
 
 def includeme(config):  # pragma: no cover
@@ -78,6 +79,9 @@ def includeme(config):  # pragma: no cover
     )
     config.register_service_factory(
         ".user_update.user_update_factory", name="user_update"
+    )
+    config.register_service_factory(
+        "h.services.subscription.service_factory", iface=SubscriptionService
     )
 
     config.add_directive(

--- a/h/services/subscription.py
+++ b/h/services/subscription.py
@@ -1,0 +1,96 @@
+from typing import List
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+from webob.cookies import SignedSerializer
+
+from h.models import Subscriptions
+from h.security import derive_key
+
+
+class InvalidUnsubscribeToken(Exception):
+    """When an unsubscribe token has an invalid format."""
+
+
+class SubscriptionService:
+    """A service for managing user communication preferences."""
+
+    MISSING_SUBSCRIPTION_ACTIVE = True
+    """Default behavior when we find a missing subscription."""
+
+    def __init__(self, db_session: Session, secret: bytes, salt: bytes):
+        self._db_session = db_session
+        self._token_serializer = SignedSerializer(
+            secret=derive_key(key_material=secret, salt=salt, info=b"h.notification"),
+            salt=None,
+        )
+
+    def get_subscription(
+        self, user_id: str, type_: Subscriptions.Type
+    ) -> Subscriptions:
+        """
+        Get a subscription for a user, creating if it is missing.
+
+        :param user_id: User id to get the subscription of
+        :param type_: Subscription type
+        """
+        subscription = (
+            self._db_session.query(Subscriptions)
+            .filter(func.lower(Subscriptions.uri) == func.lower(user_id))
+            .filter(Subscriptions.type == type_.value)
+            .one_or_none()
+        )
+
+        if not subscription:
+            subscription = Subscriptions(
+                uri=user_id, type=type_, active=self.MISSING_SUBSCRIPTION_ACTIVE
+            )
+            self._db_session.add(subscription)
+
+        return subscription
+
+    def get_all_subscriptions(self, user_id: str) -> List[Subscriptions]:
+        """
+        Get all subscriptions for a particular user, creating any missing ones.
+
+        :param user_id: User id to get the subscriptions of
+        """
+        return [self.get_subscription(user_id, type_) for type_ in Subscriptions.Type]
+
+    def get_unsubscribe_token(self, user_id: str, type_: Subscriptions.Type) -> str:
+        """
+        Create a signed token encoding a user and subscription type.
+
+        This is intended to be placed in an email, so we can verify that a user
+        wants to unsubscribe from a particular subscription.
+
+        :param user_id: User id to unsubscribe
+        :param type_: The subscription type to unsubscribe from
+        """
+        return self._token_serializer.dumps({{"type": type_.value, "uri": user_id}})
+
+    def unsubscribe_using_token(self, token: str):
+        """
+        Unsubscribes a user based on details encoded in an unsubscribe token.
+
+        :param token: A token provided by `get_unsubscribe_token()`
+        :raises InvalidUnsubscribeToken: When the token format is invalid
+        """
+        try:
+            payload = self._token_serializer.loads(token)
+        except ValueError as err:
+            raise InvalidUnsubscribeToken() from err
+
+        self.get_subscription(
+            user_id=payload["uri"], type_=Subscriptions.Type(payload["type"])
+        ).active = False
+
+
+def service_factory(_context, request) -> SubscriptionService:
+    """Generate a subscription service object."""
+
+    return SubscriptionService(
+        db_session=request.db,
+        secret=request.registry.settings["secret_key"],
+        salt=request.registry.settings["secret_salt"],
+    )

--- a/h/views/notification.py
+++ b/h/views/notification.py
@@ -1,23 +1,26 @@
 from pyramid.httpexceptions import HTTPNotFound
 from pyramid.view import view_config
 
-from h.models import Subscriptions
+from h.services import SubscriptionService
+from h.services.subscription import InvalidUnsubscribeToken
 
 
 @view_config(route_name="unsubscribe", renderer="h:templates/unsubscribe.html.jinja2")
 def unsubscribe(request):
-    token = request.matchdict["token"]
+    """
+    Unsubscribe a user from a particular type of notification.
+
+    This is powered by a token which is produced by the SubscriptionService
+    which encodes a user and subscription type.
+
+    This URL is visited from emails produced in, for example:
+    `h.emails.reply_notifications.py`.
+    """
     try:
-        payload = request.registry.notification_serializer.loads(token)
-    except ValueError as err:
+        request.find_service(SubscriptionService).unsubscribe_using_token(
+            token=request.matchdict["token"]
+        )
+    except InvalidUnsubscribeToken as err:
         raise HTTPNotFound() from err
-
-    subscriptions = request.db.query(Subscriptions).filter_by(
-        type=payload["type"], uri=payload["uri"]
-    )
-
-    for subscription in subscriptions:
-        if subscription.active:
-            subscription.active = False
 
     return {}


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/h/issues/7724

This PR:

 * Introduces a subscription service
 * Collects all subscription preference management into it
 * Fixes a bug where missing rows are never added

## Review notes

 * This is a POC and has no tests
 * This defaults to subscriptions being active if missing. Is this the right call?
 * We could make this bigger and deal with replies too, but perhaps it's best to just deal with the preferences, and not the task
 * This whole thing is setup like there's more than one kind of subscription. There isn't. Perhaps we should chuck that complexity out and reap the simplicity dividend if we don't think we'll ever add more
 * If we were going to do this for real we might want to break this down a bit