### PR TITLE
Use a subscription service to consolidate subscription preference behavior

### DIFF
--- a/h/models/subscriptions.py
+++ b/h/models/subscriptions.py
@@ -1,5 +1,6 @@
+from enum import Enum
+
 import sqlalchemy as sa
-from sqlalchemy import func
 
 from h.db import Base
 
@@ -7,10 +8,20 @@ from h.db import Base
 class Subscriptions(Base):
     """Permission from the user to send different types of communication."""
 
+    class Type(str, Enum):
+        """
+        All the different types of subscriptions we support.
+
+        Not integrated with the type field, but it would be nice if it was.
+        """
+
+        REPLY = "reply"
+
     __tablename__ = "subscriptions"
     __table_args__ = (sa.Index("subs_uri_idx_subscriptions", "uri"),)
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
     uri = sa.Column(sa.UnicodeText(), nullable=False)
     """Identifier of the entity that is subscribing.
 
@@ -25,10 +36,6 @@ class Subscriptions(Base):
 
     active = sa.Column(sa.Boolean, default=True, nullable=False)
     """Whether the subscription is active or not."""
-
-    @classmethod
-    def get_subscriptions_for_uri(cls, session, uri):
-        return session.query(cls).filter(func.lower(cls.uri) == func.lower(uri)).all()
 
     def __repr__(self):
         return f"<Subscription uri={self.uri} type={self.type} active={self.active}>"

--- a/h/notification/__init__.py
+++ b/h/notification/__init__.py
@@ -1,13 +1,2 @@
-from webob.cookies import SignedSerializer
-
-from ..security import derive_key
-
-
 def includeme(config):
     config.include(".reply")
-
-    secret = config.registry.settings["secret_key"]
-    salt = config.registry.settings["secret_salt"]
-    derived = derive_key(secret, salt, b"h.notification")
-
-    config.registry.notification_serializer = SignedSerializer(derived, None)

--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 
 from h import storage
 from h.models import Subscriptions
+from h.services import SubscriptionService
 
 log = logging.getLogger(__name__)
 
@@ -100,12 +101,11 @@ def get_notification(
 
     # Bail if there is no active 'reply' subscription for the user being
     # replied to.
-    sub = (
-        request.db.query(Subscriptions)
-        .filter_by(active=True, type="reply", uri=parent.userid)
-        .first()
-    )
-    if sub is None:
+    if (
+        not request.find_service(SubscriptionService)
+        .get_subscription(user_id=parent.userid, type_=Subscriptions.Type.REPLY)
+        .active
+    ):
         return None
 
     return Notification(reply, reply_user, parent, parent_user, reply.document)

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -1,5 +1,6 @@
 """Service definitions that handle business logic."""
 from h.services.auth_cookie import AuthCookieService
+from h.services.subscription import SubscriptionService
 
 
 def includeme(config):  # pragma: no cover
@@ -78,6 +79,9 @@ def includeme(config):  # pragma: no cover
     )
     config.register_service_factory(
         ".user_update.user_update_factory", name="user_update"
+    )
+    config.register_service_factory(
+        "h.services.subscription.service_factory", iface=SubscriptionService
     )
 
     config.add_directive(

--- a/h/services/subscription.py
+++ b/h/services/subscription.py
@@ -1,0 +1,44 @@
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from h.models import Subscriptions
+
+
+class SubscriptionService:
+    """A service for managing user communication preferences."""
+
+    MISSING_SUBSCRIPTION_ACTIVE = True
+    """Default behavior when we find a missing subscription."""
+
+    def __init__(self, db_session: Session):
+        self._db_session = db_session
+
+    def get_subscription(
+        self, user_id: str, type_: Subscriptions.Type
+    ) -> Subscriptions:
+        """
+        Get a subscription for a user, creating if it is missing.
+
+        :param user_id: Fully qualified user id (like 'acct:...')
+        :param type_: Subscription type
+        """
+        subscription = (
+            self._db_session.query(Subscriptions)
+            .filter(func.lower(Subscriptions.uri) == func.lower(user_id))
+            .filter(Subscriptions.type == type_.value)
+            .one_or_none()
+        )
+
+        if not subscription:
+            subscription = Subscriptions(
+                uri=user_id, type=type_, active=self.MISSING_SUBSCRIPTION_ACTIVE
+            )
+            self._db_session.add(subscription)
+
+        return subscription
+
+
+def service_factory(_context, request) -> SubscriptionService:
+    """Generate a subscription service object."""
+
+    return SubscriptionService(db_session=request.db)

--- a/h/services/subscription.py
+++ b/h/services/subscription.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -36,6 +38,14 @@ class SubscriptionService:
             self._db_session.add(subscription)
 
         return subscription
+
+    def get_all_subscriptions(self, user_id: str) -> List[Subscriptions]:
+        """
+        Get all subscriptions for a particular user, creating any missing ones.
+
+        :param user_id: User id to get the subscriptions of
+        """
+        return [self.get_subscription(user_id, type_) for type_ in Subscriptions.Type]
 
 
 def service_factory(_context, request) -> SubscriptionService:

--- a/h/services/subscription.py
+++ b/h/services/subscription.py
@@ -2,8 +2,14 @@ from typing import List
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
+from webob.cookies import SignedSerializer
 
 from h.models import Subscriptions
+from h.security import derive_key
+
+
+class InvalidUnsubscribeToken(Exception):
+    """When an unsubscribe token has an invalid format."""
 
 
 class SubscriptionService:
@@ -12,8 +18,12 @@ class SubscriptionService:
     MISSING_SUBSCRIPTION_ACTIVE = True
     """Default behavior when we find a missing subscription."""
 
-    def __init__(self, db_session: Session):
+    def __init__(self, db_session: Session, secret: bytes, salt: bytes):
         self._db_session = db_session
+        self._token_serializer = SignedSerializer(
+            secret=derive_key(key_material=secret, salt=salt, info=b"h.notification"),
+            salt=None,
+        )
 
     def get_subscription(
         self, user_id: str, type_: Subscriptions.Type
@@ -47,8 +57,40 @@ class SubscriptionService:
         """
         return [self.get_subscription(user_id, type_) for type_ in Subscriptions.Type]
 
+    def get_unsubscribe_token(self, user_id: str, type_: Subscriptions.Type) -> str:
+        """
+        Create a signed token encoding a user and subscription type.
+
+        This is intended to be placed in an email, so we can verify that a user
+        wants to unsubscribe from a particular subscription.
+
+        :param user_id: User id to unsubscribe
+        :param type_: The subscription type to unsubscribe from
+        """
+        return self._token_serializer.dumps({"type": type_.value, "uri": user_id})
+
+    def unsubscribe_using_token(self, token: str):
+        """
+        Unsubscribes a user based on details encoded in an unsubscribe token.
+
+        :param token: A token provided by `get_unsubscribe_token()`
+        :raises InvalidUnsubscribeToken: When the token format is invalid
+        """
+        try:
+            payload = self._token_serializer.loads(token)
+        except ValueError as err:
+            raise InvalidUnsubscribeToken() from err
+
+        self.get_subscription(
+            user_id=payload["uri"], type_=Subscriptions.Type(payload["type"])
+        ).active = False
+
 
 def service_factory(_context, request) -> SubscriptionService:
     """Generate a subscription service object."""
 
-    return SubscriptionService(db_session=request.db)
+    return SubscriptionService(
+        db_session=request.db,
+        secret=request.registry.settings["secret_key"],
+        salt=request.registry.settings["secret_salt"],
+    )

--- a/h/views/notification.py
+++ b/h/views/notification.py
@@ -1,23 +1,26 @@
 from pyramid.httpexceptions import HTTPNotFound
 from pyramid.view import view_config
 
-from h.models import Subscriptions
+from h.services import SubscriptionService
+from h.services.subscription import InvalidUnsubscribeToken
 
 
 @view_config(route_name="unsubscribe", renderer="h:templates/unsubscribe.html.jinja2")
 def unsubscribe(request):
-    token = request.matchdict["token"]
+    """
+    Unsubscribe a user from a particular type of notification.
+
+    This is powered by a token which is produced by the SubscriptionService
+    which encodes a user and subscription type.
+
+    This URL is visited from emails produced in, for example:
+    `h.emails.reply_notifications.py`.
+    """
     try:
-        payload = request.registry.notification_serializer.loads(token)
-    except ValueError as err:
+        request.find_service(SubscriptionService).unsubscribe_using_token(
+            token=request.matchdict["token"]
+        )
+    except InvalidUnsubscribeToken as err:
         raise HTTPNotFound() from err
-
-    subscriptions = request.db.query(Subscriptions).filter_by(
-        type=payload["type"], uri=payload["uri"]
-    )
-
-    for subscription in subscriptions:
-        if subscription.active:
-            subscription.active = False
 
     return {}

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -15,6 +15,7 @@ from tests.common.factories.group_scope import GroupScope
 from tests.common.factories.job import Job, SyncAnnotationJob
 from tests.common.factories.organization import Organization
 from tests.common.factories.setting import Setting
+from tests.common.factories.subscriptions import Subscriptions
 from tests.common.factories.token import DeveloperToken, OAuth2Token
 from tests.common.factories.user import User
 from tests.common.factories.user_identity import UserIdentity

--- a/tests/common/factories/subscriptions.py
+++ b/tests/common/factories/subscriptions.py
@@ -1,0 +1,18 @@
+import factory
+from factory import Faker
+
+from h import models
+from tests.common.factories.base import FAKER, ModelFactory
+
+
+class Subscriptions(ModelFactory):
+    class Meta:
+        model = models.Subscriptions
+
+    uri = factory.LazyAttribute(
+        lambda _: (
+            "acct:" + FAKER.user_name() + "@example.com"  # pylint:disable=no-member
+        )
+    )
+    type = models.Subscriptions.Type.REPLY.value
+    active = Faker("random_element", elements=[True, False])

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -22,6 +22,7 @@ from h.services.oauth.service import OAuthProviderService
 from h.services.organization import OrganizationService
 from h.services.search_index import SearchIndexService
 from h.services.search_index._queue import Queue
+from h.services.subscription import SubscriptionService
 from h.services.user import UserService
 from h.services.user_password import UserPasswordService
 from h.services.user_signup import UserSignupService
@@ -49,6 +50,7 @@ __all__ = (
     "oauth_provider_service",
     "organization_service",
     "search_index",
+    "subscription_service",
     "user_password_service",
     "user_service",
     "user_signup_service",
@@ -182,6 +184,11 @@ def search_index(mock_service):
         spec_set=False,
         _queue=create_autospec(Queue, spec_set=True, instance=True),
     )
+
+
+@pytest.fixture
+def subscription_service(mock_service):
+    return mock_service(SubscriptionService)
 
 
 @pytest.fixture

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -53,6 +53,7 @@ __all__ = (
     "subscription_service",
     "user_password_service",
     "user_service",
+    "user_password_service",
     "user_signup_service",
     "user_unique_service",
     "user_update_service",

--- a/tests/h/services/subscription_test.py
+++ b/tests/h/services/subscription_test.py
@@ -1,0 +1,56 @@
+from unittest.mock import sentinel
+
+import pytest
+from h_matchers import Any
+
+from h.models import Subscriptions
+from h.services import SubscriptionService
+from h.services.subscription import service_factory
+
+
+class TestSubscriptionService:
+    def test_get_subscription(self, svc, reply_subscription):
+        result = svc.get_subscription(
+            user_id=reply_subscription.uri, type_=Subscriptions.Type.REPLY
+        )
+
+        assert result == reply_subscription
+        assert result.active == reply_subscription.active
+
+    def test_get_subscription_with_a_missing_subscription(self, svc):
+        result = svc.get_subscription(
+            user_id="acct:new_user@example.com", type_=Subscriptions.Type.REPLY
+        )
+
+        assert result == Any.instance_of(Subscriptions).with_attrs(
+            {
+                "uri": "acct:new_user@example.com",
+                "type": Subscriptions.Type.REPLY.value,
+                "active": True,
+            }
+        )
+
+    @pytest.fixture
+    def reply_subscription(self, factories):
+        # Despite being named in the plural, this is only one subscription
+        return factories.Subscriptions(type=Subscriptions.Type.REPLY.value)
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return SubscriptionService(db_session=db_session)
+
+    @pytest.fixture(autouse=True)
+    def subscription_noise(self, factories):
+        factories.Subscriptions.create_batch(3)
+
+
+class TestServiceFactory:
+    def test_it(self, pyramid_request, SubscriptionService):
+        svc = service_factory(sentinel.context, pyramid_request)
+
+        SubscriptionService.assert_called_once_with(db_session=pyramid_request.db)
+        assert svc == SubscriptionService.return_value
+
+    @pytest.fixture
+    def SubscriptionService(self, patch):
+        return patch("h.services.subscription.SubscriptionService")

--- a/tests/h/services/subscription_test.py
+++ b/tests/h/services/subscription_test.py
@@ -5,10 +5,22 @@ from h_matchers import Any
 
 from h.models import Subscriptions
 from h.services import SubscriptionService
-from h.services.subscription import service_factory
+from h.services.subscription import InvalidUnsubscribeToken, service_factory
 
 
 class TestSubscriptionService:
+    def test_init(self, derive_key, SignedSerializer):
+        SubscriptionService(
+            db_session=sentinel.db_session, secret=sentinel.secret, salt=sentinel.salt
+        )
+
+        derive_key.assert_called_once_with(
+            key_material=sentinel.secret, salt=sentinel.salt, info=b"h.notification"
+        )
+        SignedSerializer.assert_called_once_with(
+            secret=derive_key.return_value, salt=None
+        )
+
     def test_get_subscription(self, svc, reply_subscription):
         result = svc.get_subscription(
             user_id=reply_subscription.uri, type_=Subscriptions.Type.REPLY
@@ -30,6 +42,34 @@ class TestSubscriptionService:
             }
         )
 
+    def test_get_unsubscribe_token(self, svc, SignedSerializer):
+        result = svc.get_unsubscribe_token(
+            user_id="acct:user@example.com", type_=Subscriptions.Type.REPLY
+        )
+
+        SignedSerializer.return_value.dumps.assert_called_once_with(
+            {"type": Subscriptions.Type.REPLY.value, "uri": "acct:user@example.com"}
+        )
+        assert result == SignedSerializer.return_value.dumps.return_value
+
+    def test_unsubscribe_using_token(self, svc, SignedSerializer, reply_subscription):
+        reply_subscription.active = True
+        SignedSerializer.return_value.loads.return_value = {
+            "uri": reply_subscription.uri,
+            "type": reply_subscription.type,
+        }
+
+        svc.unsubscribe_using_token(token=sentinel.good_token)
+
+        SignedSerializer.return_value.loads.assert_called_once_with(sentinel.good_token)
+        reply_subscription.active = False
+
+    def test_unsubscribe_using_token_with_invalid_token(self, svc, SignedSerializer):
+        SignedSerializer.return_value.loads.side_effect = ValueError
+
+        with pytest.raises(InvalidUnsubscribeToken):
+            svc.unsubscribe_using_token(token=sentinel.bad_token)
+
     @pytest.fixture
     def reply_subscription(self, factories):
         # Despite being named in the plural, this is only one subscription
@@ -37,7 +77,17 @@ class TestSubscriptionService:
 
     @pytest.fixture
     def svc(self, db_session):
-        return SubscriptionService(db_session=db_session)
+        return SubscriptionService(
+            db_session=db_session, secret=b"secret", salt=b"salt"
+        )
+
+    @pytest.fixture(autouse=True)
+    def derive_key(self, patch):
+        return patch("h.services.subscription.derive_key")
+
+    @pytest.fixture(autouse=True)
+    def SignedSerializer(self, patch):
+        return patch("h.services.subscription.SignedSerializer")
 
     @pytest.fixture(autouse=True)
     def subscription_noise(self, factories):
@@ -46,9 +96,18 @@ class TestSubscriptionService:
 
 class TestServiceFactory:
     def test_it(self, pyramid_request, SubscriptionService):
+        pyramid_request.registry.settings = {
+            "secret_key": sentinel.secret_key,
+            "secret_salt": sentinel.secret_salt,
+        }
+
         svc = service_factory(sentinel.context, pyramid_request)
 
-        SubscriptionService.assert_called_once_with(db_session=pyramid_request.db)
+        SubscriptionService.assert_called_once_with(
+            db_session=pyramid_request.db,
+            secret=sentinel.secret_key,
+            salt=sentinel.secret_salt,
+        )
         assert svc == SubscriptionService.return_value
 
     @pytest.fixture

--- a/tests/h/views/notification_test.py
+++ b/tests/h/views/notification_test.py
@@ -1,85 +1,28 @@
-from unittest import mock
+from unittest.mock import sentinel
 
 import pytest
 from pyramid.exceptions import HTTPNotFound
 
-from h.models import Subscriptions
+from h.services.subscription import InvalidUnsubscribeToken
 from h.views.notification import unsubscribe
 
 
-@pytest.mark.usefixtures("subscriptions", "token_serializer")
 class TestUnsubscribe:
-    def test_deserializes_token(self, pyramid_request, token_serializer):
-        pyramid_request.matchdict = {"token": "wibble"}
+    def test_it(self, pyramid_request, subscription_service):
+        pyramid_request.matchdict = {"token": sentinel.valid_token}
 
-        unsubscribe(pyramid_request)
+        result = unsubscribe(pyramid_request)
 
-        token_serializer.loads.assert_called_once_with("wibble")
+        subscription_service.unsubscribe_using_token.assert_called_once_with(
+            token=sentinel.valid_token
+        )
+        assert not result
 
-    def test_successfully_unsubscribes_user(
-        self, pyramid_request, subscriptions, token_serializer
-    ):
-        sub1, _, _ = subscriptions
-        pyramid_request.matchdict = {"token": "wibble"}
-        token_serializer.loads.return_value = {
-            "type": "reply",
-            "uri": "acct:foo@example.com",
-        }
-
-        unsubscribe(pyramid_request)
-
-        assert not sub1.active
-
-    def test_ignores_other_subscriptions(
-        self, pyramid_request, subscriptions, token_serializer
-    ):
-        _, sub2, sub3 = subscriptions
-        pyramid_request.matchdict = {"token": "wibble"}
-        token_serializer.loads.return_value = {
-            "type": "reply",
-            "uri": "acct:foo@example.com",
-        }
-
-        unsubscribe(pyramid_request)
-
-        assert sub2.active
-        assert sub3.active
-
-    def test_multiple_calls_ok(self, pyramid_request, subscriptions, token_serializer):
-        sub1, _, _ = subscriptions
-        pyramid_request.matchdict = {"token": "wibble"}
-        token_serializer.loads.return_value = {
-            "type": "reply",
-            "uri": "acct:foo@example.com",
-        }
-
-        unsubscribe(pyramid_request)
-        unsubscribe(pyramid_request)
-
-        assert not sub1.active
-
-    def test_raises_not_found_if_token_invalue(self, pyramid_request, token_serializer):
-
-        pyramid_request.matchdict = {"token": "wibble"}
-        token_serializer.loads.side_effect = ValueError("token invalid")
+    def test_it_with_invalid_token(self, pyramid_request, subscription_service):
+        pyramid_request.matchdict = {"token": sentinel.invalid_token}
+        subscription_service.unsubscribe_using_token.side_effect = (
+            InvalidUnsubscribeToken
+        )
 
         with pytest.raises(HTTPNotFound):
             unsubscribe(pyramid_request)
-
-    @pytest.fixture
-    def subscriptions(self, db_session):
-        subs = [
-            Subscriptions(type="reply", uri="acct:foo@example.com", active=True),
-            Subscriptions(type="dingo", uri="acct:foo@example.com", active=True),
-            Subscriptions(type="reply", uri="acct:bar@example.com", active=True),
-        ]
-        db_session.add_all(subs)
-        db_session.flush()
-        return subs
-
-    @pytest.fixture
-    def token_serializer(self, pyramid_config):
-        serializer = mock.Mock(spec_set=["loads"])
-        serializer.loads.return_value = {"type": "matches", "uri": "nothing"}
-        pyramid_config.registry.notification_serializer = serializer
-        return serializer


### PR DESCRIPTION
Based on refactors from:

 * https://github.com/hypothesis/h/pull/7742

This PR moves all the notification subscription access to a common service. This:

 * Simplifies the callers
 * Makes it easier to locate and understand the logic
 * Ensures that subscriptions are dealt with consistently
 * Ensures all subscriptions are created with a default if missing (this fixes a bug)

## Review notes

This PR is split into three commits which add the methods one by one to the service. The first two aren't technically independant, as we remove a function in the first commit which we still rely on in the second. The third is completely independant.

We could split this by into commits 1+2 / 3 if that makes it easier to review.

## Testing notes

### Setting notification preferences

 * `make services`
 * `make dev`
 * Visit: http://localhost:5000/ and login
 * On the cog on the top right click on "Notifications" (or visit http://localhost:5000/account/settings/notifications)
 * Ensure the box is ticked
 * Refresh the page and see the box is still ticked
 * Untick the box
 * Refresh the page and see the box is unticked

Testing the bug with missing subscriptions:

 * Do the above (box should be unticked)
 * `make sql`
 * `truncate subscriptions`
 * Refresh the page and see the box has changed from unticked to ticked
 * Check you can save your preference again

### Test signing up as a new user

 * If the directory `mail/` exists in `h` run: `rm mail/*.eml`
 * In an incognito window visit: http://localhost:5000/signup
 * Fill out some values
 * The "I would like to receive news about annotation and Hypothesis." is irrelevant and is stored on a separate "comms_opt_in" column on the user (:disappointed:  Why?)
 * Run `ls -lh mail/` in your `h` directory
 * Cat the most recent `eml` file and find the activiation link and copy it
 * Paste it into your incognito session and re-enter your password
 * Visit http://localhost:5000/account/settings/notifications
 * You should see the notification box ticked

### Testing reply notifications

 * Do the above - You should be logged into an incognito window with one user and a main tab with another
 * If the directory `mail/` exists in `h` run: `rm mail/*.eml`
 * Start the Client, Via and ViaHTML
 * Open the following link in both tabs: http://localhost:9083/http://example.com/
 * Annotate as the user in the incognito tab
 * Check to see if a mail is created in the following three situations:
    * Reply preference is enabled - Email **should** be sent
    * Reply preference is disabled - Email **should not** be sent
    * `make sql; truncate subscriptions` -  Email **should** be sent