### PR TITLE
Don't run workflows unnecessarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,13 @@
 name: Continuous integration
 
 on:
+  workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - '.cookiecutter/*'
+      - '.gitignore'
+      - 'HACKING.md'
+      - 'LICENSE'
   workflow_call:
 
 env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,30 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.cookiecutter/*'
+      - '.github/*'
+      - 'bin/create-testdb'
+      - 'bin/install-python'
+      - 'conf/development-app.ini'
+      - 'conf/supervisord-dev.conf'
+      - 'conf/websocket-dev.ini'
+      - 'docs/*'
+      - 'requirements/*'
+      - '!requirements/requirements.txt'
+      - 'tests/*'
+      - '.coveragerc'
+      - '.eslintrc'
+      - '.gitignore'
+      - '.isort.cfg'
+      - '.pylintrc'
+      - 'HACKING.md'
+      - 'LICENSE'
+      - 'README.rst'
+      - 'docker-compose.yml'
+      - 'pyproject.toml'
+      - 'setup.cfg'
+      - 'tox.ini'
 jobs:
   ci:
     name: CI


### PR DESCRIPTION
Use `paths-ignore` to skip running the `ci.yml` and `deploy.yml` workflows for pull requests where the files modified make it unnecessary to run the workflow. For example: don't run the tests on a PR that only modifies the documentation, or don't deploy a PR that only modifies development dependencies.

This should save us a lot of unnecessary workflow runs. For example we get a lot of Dependabot PRs for test and development dependencies, this will skip deploying any of those PRs.

See:

* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths
* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
