### PR TITLE
Add admin tool for moving annotations from one URL to another

### DIFF
--- a/h/celery.py
+++ b/h/celery.py
@@ -34,7 +34,12 @@ celery.conf.update(
     task_acks_late=True,
     worker_disable_rate_limits=True,
     task_ignore_result=True,
-    imports=("h.tasks.cleanup", "h.tasks.indexer", "h.tasks.mailer"),
+    imports=(
+        "h.tasks.cleanup",
+        "h.tasks.indexer",
+        "h.tasks.mailer",
+        "h.tasks.url_migration",
+    ),
     task_routes={
         "h.tasks.indexer.add_annotation": "indexer",
         "h.tasks.indexer.add_annotations_between_times": "indexer",

--- a/h/celery.py
+++ b/h/celery.py
@@ -32,7 +32,6 @@ celery.conf.update(
     # want for all of our queues, but it makes the failure-mode behaviour of
     # Celery the same as our old NSQ worker:
     task_acks_late=True,
-    worker_disable_rate_limits=True,
     task_ignore_result=True,
     imports=(
         "h.tasks.cleanup",

--- a/h/jinja_extensions/navbar_data_admin.py
+++ b/h/jinja_extensions/navbar_data_admin.py
@@ -44,6 +44,12 @@ _ADMIN_MENU = [
         "route": "admin.badge",
     },
     {
+        "id": "documents",
+        "permission": Permission.AdminPage.HIGH_RISK,
+        "title": "Documents",
+        "route": "admin.documents",
+    },
+    {
         "id": "features",
         "permission": Permission.AdminPage.HIGH_RISK,
         "title": "Feature flags",

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -1,4 +1,5 @@
 import datetime
+from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
@@ -135,6 +136,16 @@ class Annotation(Base):
         viewonly=True,
         uselist=True,
     )
+
+    @property
+    def uuid(self):
+        """
+        Return the UUID representation of the annotation's ID.
+
+        Annotation IDs are stored in the DB as a UUID but represented in the app
+        and API in a different format. This property returns the UUID version.
+        """
+        return UUID(types.URLSafeUUID.url_safe_to_hex(self.id))
 
     @hybrid_property
     def target_uri(self):

--- a/h/routes.py
+++ b/h/routes.py
@@ -35,6 +35,7 @@ def includeme(config):  # pylint: disable=too-many-statements
     config.add_route("admin.features", "/admin/features")
     config.add_route("admin.cohorts", "/admin/features/cohorts")
     config.add_route("admin.cohorts_edit", "/admin/features/cohorts/{id}")
+    config.add_route("admin.documents", "/admin/documents")
     config.add_route("admin.groups", "/admin/groups")
     config.add_route("admin.groups_create", "/admin/groups/new")
     config.add_route(

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -168,7 +168,7 @@ class CreateAnnotationSchema:
         if new_appstruct["references"] and "groupid" in new_appstruct:
             del new_appstruct["groupid"]
 
-        new_appstruct["document"] = _document(
+        new_appstruct["document"] = transform_document(
             appstruct.pop("document", {}), new_appstruct["target_uri"]
         )
 
@@ -222,7 +222,7 @@ class UpdateAnnotationSchema:
                 new_appstruct[key] = appstruct.pop(key)
 
         if "document" in appstruct:
-            new_appstruct["document"] = _document(
+            new_appstruct["document"] = transform_document(
                 appstruct.pop("document"),
                 new_appstruct.get("target_uri", self.existing_target_uri),
             )
@@ -232,7 +232,7 @@ class UpdateAnnotationSchema:
         return new_appstruct
 
 
-def _document(document, claimant):
+def transform_document(document, claimant):
     """
     Return document meta and document URI data from the given document dict.
 

--- a/h/schemas/base.py
+++ b/h/schemas/base.py
@@ -43,7 +43,7 @@ class CSRFSchema(colander.Schema):
 
 class JSONSchema:
     """
-    Validate data according to a Draft 4 JSON Schema.
+    Validate data according to a JSON Schema.
 
     Inherit from this class and override the `schema` class property with a
     valid JSON schema.
@@ -51,11 +51,20 @@ class JSONSchema:
 
     schema = {}
 
+    schema_version = 4
+    """The JSON Schema version used by this schema."""
+
     def __init__(self):
         format_checker = jsonschema.FormatChecker()
-        self.validator = jsonschema.Draft4Validator(
-            self.schema, format_checker=format_checker
-        )
+
+        if self.schema_version == 4:
+            validator_cls = jsonschema.Draft4Validator
+        elif self.schema_version == 7:
+            validator_cls = jsonschema.Draft7Validator
+        else:
+            raise ValueError("Unsupported schema version")
+
+        self.validator = validator_cls(self.schema, format_checker=format_checker)
 
     def validate(self, data):
         """

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -67,6 +67,9 @@ def includeme(config):  # pragma: no cover
     )
     config.register_service_factory(".search_index.factory", name="search_index")
     config.register_service_factory(".settings.settings_factory", name="settings")
+    config.register_service_factory(
+        ".url_migration.url_migration_factory", name="url_migration"
+    )
     config.register_service_factory(".user.user_service_factory", name="user")
     config.register_service_factory(
         ".user_unique.user_unique_factory", name="user_unique"

--- a/h/services/url_migration.py
+++ b/h/services/url_migration.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import load_only
 
 import h.storage
 from h.models import Annotation, DocumentURI
-from h.schemas.annotation import _document as transform_document
+from h.schemas.annotation import transform_document
 from h.tasks.url_migration import move_annotations
 from h.util.uri import normalize
 

--- a/h/services/url_migration.py
+++ b/h/services/url_migration.py
@@ -126,19 +126,15 @@ class URLMigrationService:
         # Schedule async tasks to move the remaining annotations.
         ann_ids = ann_ids[1:]
         anns_per_batch = 100
-        batch_count = 0
         for batch in chunks(iter(ann_ids), anns_per_batch):
             move_annotations.delay(batch, url, new_url_info)
-            batch_count += 1
 
-        if len(ann_ids) > 0:
-            log.info(
-                "Scheduled migration of %s annotations from %s to %s in %s batches",
-                len(ann_ids),
-                url,
-                new_url_info["url"],
-                batch_count,
-            )
+        log.info(
+            "Migrating %s annotations from %s to %s",
+            len(ann_ids) + 1,
+            url,
+            new_url_info["url"],
+        )
 
 
 def url_migration_factory(_context, request):

--- a/h/services/url_migration.py
+++ b/h/services/url_migration.py
@@ -78,8 +78,6 @@ class URLMigrationService:
                 ann_update_data,
                 # Don't update "edited" timestamp on annotation cards.
                 update_timestamp=False,
-                # Queue job to reindex annotation ASAP.
-                reindex=True,
                 reindex_tag="URLMigrationService.move_annotations",
             )
 

--- a/h/services/url_migration.py
+++ b/h/services/url_migration.py
@@ -1,0 +1,147 @@
+import copy
+import logging
+
+from celery.utils import chunks
+from sqlalchemy.orm import load_only
+
+import h.storage
+from h.models import Annotation, DocumentURI
+from h.schemas.annotation import _document as transform_document
+from h.tasks.url_migration import move_annotations
+from h.util.uri import normalize
+
+log = logging.getLogger(__name__)
+
+
+class URLMigrationService:
+    """Moves annotations from one URL to another."""
+
+    def __init__(self, request):
+        self.request = request
+
+    def move_annotations(self, annotation_ids, current_uri, new_url_info):
+        """
+        Migrate a set of annotations from one URL to another.
+
+        This command is invoked as a Celery task by `update_annotation_urls`.
+
+        :param annotation_ids: IDs of annotations to migrate
+        :param current_uri: The expected `target_uri` of each annotation.
+        :param new_url_info: URL and document metadata to migrate annotations to.
+            This is an entry from the mappings defined by the `URLMigrationSchema`
+            schema.
+        """
+
+        annotations = self.request.db.query(Annotation).filter(
+            Annotation.id.in_(annotation_ids)
+        )
+        current_uri_normalized = normalize(current_uri)
+
+        for ann in annotations:
+            if ann.target_uri_normalized != current_uri_normalized:
+                # Skip annotation if it was updated since the task was
+                # scheduled.
+                log.info("Skipping annotation %s", ann.uuid)
+                continue
+
+            ann_update_data = {
+                "target_uri": new_url_info["url"],
+            }
+
+            if "document" in new_url_info:
+                ann_update_data["document"] = transform_document(
+                    new_url_info["document"], new_url_info["url"]
+                )
+
+            # Add selectors to annotation if there is no selector of the same
+            # type.
+            #
+            # This change is specifically to aid in the migration of ebook
+            # annotations from a chapter/page URL to the containing book.
+            # The information about which chapter/page the annotation refers
+            # to is then moved into selectors.
+            #
+            # See https://github.com/hypothesis/h/issues/7709
+            if new_selectors := new_url_info.get("selectors"):
+                selectors = copy.deepcopy(ann.target_selectors)
+                for new_sel in new_selectors:
+                    if not any(s for s in selectors if s["type"] == new_sel["type"]):
+                        selectors.append(new_sel)
+                ann_update_data["target_selectors"] = selectors
+
+            # Update the annotation's `target_uri` and associated document,
+            # and create `Document*` entities for the new URL if they don't
+            # already exist.
+            h.storage.update_annotation(
+                self.request,
+                ann.id,
+                ann_update_data,
+                # Don't update "edited" timestamp on annotation cards.
+                update_timestamp=False,
+                # Queue job to reindex annotation ASAP.
+                reindex=True,
+                reindex_tag="URLMigrationService.move_annotations",
+            )
+
+            log.info("Moved annotation %s to URL %s", ann.uuid, ann.target_uri)
+
+    def move_annotations_by_url(self, url, new_url_info):
+        """
+        Find annotations with a given target URL and move them to another URL.
+
+        :param url: The current URL of the annotations
+        :param new_url_info: The URL and document metadata of the new URL.
+             This is an entry matching the `URLMigrationSchema` schema.
+        """
+
+        session = self.request.db
+        uri_normalized = normalize(url)
+
+        # Get the IDs of all annotations on the old URL, and divide into
+        # fixed-sized batches. A separate Celery task is then launched per
+        # batch to migrate those annotations. This limits the amount of
+        # work per task in case there are a large number of annotations on
+        # a given URL.
+        annotations = (
+            session.query(Annotation)
+            .join(DocumentURI, Annotation.document_id == DocumentURI.document_id)
+            .filter(DocumentURI.uri_normalized == uri_normalized)
+            .options(load_only(Annotation.id, Annotation.target_uri))
+        )
+
+        ann_ids = [ann.id for ann in annotations]
+
+        if not ann_ids:
+            return
+
+        # Move the first matching annotation. This will create the
+        # document-related entities for the new URL if they don't already exist,
+        # This avoids errors related to concurrent document URL/metadata updates
+        # when the remaining annotations are moved in parallel.
+        first_ann = ann_ids[0]
+        self.move_annotations([first_ann], url, new_url_info)
+
+        # Ensure new document is visible in tasks that move remaining
+        # annotations.
+        self.request.tm.commit()
+
+        # Schedule async tasks to move the remaining annotations.
+        ann_ids = ann_ids[1:]
+        anns_per_batch = 100
+        batch_count = 0
+        for batch in chunks(iter(ann_ids), anns_per_batch):
+            move_annotations.delay(batch, url, new_url_info)
+            batch_count += 1
+
+        if len(ann_ids) > 0:
+            log.info(
+                "Scheduled migration of %s annotations from %s to %s in %s batches",
+                len(ann_ids),
+                url,
+                new_url_info["url"],
+                batch_count,
+            )
+
+
+def url_migration_factory(_context, request):
+    return URLMigrationService(request)

--- a/h/services/url_migration.py
+++ b/h/services/url_migration.py
@@ -21,12 +21,12 @@ class URLMigrationService:
 
     def move_annotations(self, annotation_ids, current_uri, new_url_info):
         """
-        Migrate a set of annotations from one URL to another.
-
-        This command is invoked as a Celery task by `update_annotation_urls`.
+        Migrate a set of annotations to a new URL.
 
         :param annotation_ids: IDs of annotations to migrate
         :param current_uri: The expected `target_uri` of each annotation.
+            This is used to catch cases where the URI changes in between the
+            move being scheduled and later executed (eg. via a Celery task).
         :param new_url_info: URL and document metadata to migrate annotations to.
             This is an entry from the mappings defined by the `URLMigrationSchema`
             schema.

--- a/h/services/url_migration.py
+++ b/h/services/url_migration.py
@@ -125,7 +125,7 @@ class URLMigrationService:
 
         # Schedule async tasks to move the remaining annotations.
         ann_ids = ann_ids[1:]
-        anns_per_batch = 100
+        anns_per_batch = 50
         for batch in chunks(iter(ann_ids), anns_per_batch):
             move_annotations.delay(batch, url, new_url_info)
 

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -127,7 +127,7 @@ def handle_annotation_event(message, sockets, request, session):
 
     for socket in matching_sockets:
         # Don't send notifications back to the person who sent them
-        if message["src_client_id"] == socket.client_id:
+        if socket.client_id and message.get("src_client_id") == socket.client_id:
             continue
 
         # Only send NIPSA'd annotations to the author

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -127,7 +127,7 @@ def handle_annotation_event(message, sockets, request, session):
 
     for socket in matching_sockets:
         # Don't send notifications back to the person who sent them
-        if socket.client_id and message.get("src_client_id") == socket.client_id:
+        if message["src_client_id"] == socket.client_id:
             continue
 
         # Only send NIPSA'd annotations to the author

--- a/h/tasks/url_migration.py
+++ b/h/tasks/url_migration.py
@@ -2,13 +2,13 @@
 from h.celery import celery
 
 
-@celery.task
+@celery.task(rate_limit="30/m")
 def move_annotations_by_url(old_url, new_url_info):
     migration_svc = celery.request.find_service(name="url_migration")
     migration_svc.move_annotations_by_url(old_url, new_url_info)
 
 
-@celery.task
+@celery.task(rate_limit="20/m")
 def move_annotations(annotation_ids, current_uri_normalized, url_info):
     migration_svc = celery.request.find_service(name="url_migration")
     migration_svc.move_annotations(annotation_ids, current_uri_normalized, url_info)

--- a/h/tasks/url_migration.py
+++ b/h/tasks/url_migration.py
@@ -1,0 +1,14 @@
+# pylint: disable=no-member # Instance of 'Celery' has no 'request' member
+from h.celery import celery
+
+
+@celery.task
+def move_annotations_by_url(old_url, new_url_info):
+    migration_svc = celery.request.find_service(name="url_migration")
+    migration_svc.move_annotations_by_url(old_url, new_url_info)
+
+
+@celery.task
+def move_annotations(annotation_ids, current_uri_normalized, url_info):
+    migration_svc = celery.request.find_service(name="url_migration")
+    migration_svc.move_annotations(annotation_ids, current_uri_normalized, url_info)

--- a/h/templates/admin/documents.html.jinja2
+++ b/h/templates/admin/documents.html.jinja2
@@ -1,0 +1,76 @@
+{% extends "h:templates/layouts/admin.html.jinja2" %}
+{% set page_id = 'documents' %}
+{% set page_title = 'Documents' %}
+{% macro form(heading, action, submit_label) %}
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">{{ heading }}</h3>
+    </div>
+
+    <div class="panel-body">
+      <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}" />
+        {{ caller() }}
+        <div class="form-group">
+          <input
+            type="submit"
+            class="btn btn-default"
+            name="{{ action }}"
+            value="{{ submit_label }}"
+          />
+        </div>
+      </form>
+    </div>
+  </div>
+{% endmacro %}
+{% block content %}
+  <p>This page provides tools related to document metadata and URLs.</p>
+
+  {% call form(heading="Update annotation URLs", action="update_annotation_urls", submit_label="Update URLs") %}
+    <div class="form-group">
+      <p>
+        This will move annotations from one set of URLs to another. You must
+        provide a JSON object that maps old URLs to new URLs and document
+        metadata.
+      </p>
+      <p>
+        <b>This action cannot be undone</b>, so please review your URL mappings
+        and document metadata carefully.
+      </p>
+      <details>
+        <summary>Example JSON structure</summary>
+        <pre>
+{
+  "https://oldsite.com/page-a": {
+    "url": "https://newsite.com/page-a",
+    "document": { "title": "Welcome to page A" }
+  },
+  "https://oldsite.com/1234": {
+    "url": "https://newsite.com/articles/1234",
+    "document": { "title": "Welcome to page B" }
+  }
+}
+      </pre
+        >
+        <p>The keys of this object must exactly match the URL of the annotation(s) you want to move.</p>
+        <p>
+          The <code>document</code> field's structure is the same as in the
+          <a
+            href="https://h.readthedocs.io/en/latest/api-reference/#tag/annotations/paths/~1annotations/post"
+            >API for creating annotations</a
+          >.
+        </p>
+      </details>
+      <label for="url_mappings">URL updates:</label>
+      <textarea
+        id="url_mappings"
+        required
+        name="url_mappings"
+        style="display: block"
+        rows="10"
+        cols="80"
+        placeholder="URL mapping JSON..."
+      ></textarea>
+    </div>
+  {% endcall %}
+{% endblock %}

--- a/h/views/admin/documents.py
+++ b/h/views/admin/documents.py
@@ -1,0 +1,53 @@
+import json
+
+from pyramid.view import view_config, view_defaults
+
+from h.schemas import ValidationError
+from h.schemas.annotation import URLMigrationSchema
+from h.security import Permission
+from h.tasks.url_migration import move_annotations_by_url
+
+
+@view_defaults(route_name="admin.documents", permission=Permission.AdminPage.HIGH_RISK)
+class DocumentsAdminViews:
+    def __init__(self, request):
+        self.request = request
+
+    @view_config(
+        request_method="GET", renderer="h:templates/admin/documents.html.jinja2"
+    )
+    def get(self):
+        return {}
+
+    @view_config(
+        request_method="POST",
+        request_param="update_annotation_urls",
+        require_csrf=True,
+        renderer="h:templates/admin/documents.html.jinja2",
+    )
+    def update_annotation_urls(self):
+        try:
+            url_mappings_json = json.loads(self.request.params["url_mappings"])
+        except ValueError as err:
+            return self.report_error(f"Failed to parse URL mappings: {err}")
+
+        schema = URLMigrationSchema()
+
+        try:
+            url_mappings = schema.validate(url_mappings_json)
+        except ValidationError as err:
+            return self.report_error(f"Failed to validate URL mappings: {err}")
+
+        # Chunk up the URLs into batches to limit the work per task.
+        move_annotations_by_url.chunks(url_mappings.items(), 10).apply_async()
+
+        self.request.session.flash(
+            f"URL migration started for {len(url_mappings)} URL(s)", "success"
+        )
+
+        return {}
+
+    def report_error(self, message):
+        self.request.session.flash(message, "error")
+        self.request.response.status_code = 400
+        return {}

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -1,5 +1,8 @@
+from uuid import UUID
+
 import pytest
 
+from h.db.types import URLSafeUUID
 from h.models.annotation import Annotation
 
 
@@ -240,6 +243,11 @@ def test_is_hidden(factories, has_moderation):
     )
 
     assert annotation.is_hidden == has_moderation
+
+
+def test_uuid(factories):
+    annotation = factories.Annotation()
+    assert annotation.uuid == UUID(URLSafeUUID.url_safe_to_hex(annotation.id))
 
 
 @pytest.fixture

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -42,6 +42,7 @@ def test_includeme():
         call("admin.features", "/admin/features"),
         call("admin.cohorts", "/admin/features/cohorts"),
         call("admin.cohorts_edit", "/admin/features/cohorts/{id}"),
+        call("admin.documents", "/admin/documents"),
         call("admin.groups", "/admin/groups"),
         call("admin.groups_create", "/admin/groups/new"),
         call(

--- a/tests/h/services/url_migration_test.py
+++ b/tests/h/services/url_migration_test.py
@@ -60,7 +60,6 @@ class TestURLMigrationService:
                 ann.id,
                 {"target_uri": "https://example.org"},
                 update_timestamp=False,
-                reindex=True,
                 reindex_tag="URLMigrationService.move_annotations",
             )
 
@@ -92,7 +91,6 @@ class TestURLMigrationService:
                 ],
             },
             update_timestamp=False,
-            reindex=True,
             reindex_tag="URLMigrationService.move_annotations",
         )
 
@@ -128,7 +126,6 @@ class TestURLMigrationService:
                 "document": transform_document.return_value,
             },
             update_timestamp=False,
-            reindex=True,
             reindex_tag="URLMigrationService.move_annotations",
         )
 
@@ -161,7 +158,6 @@ class TestURLMigrationService:
             Any.of([a.id for a in anns]),
             {"target_uri": "https://example.org"},
             update_timestamp=False,
-            reindex=True,
             reindex_tag="URLMigrationService.move_annotations",
         )
         pyramid_request.tm.commit.assert_called_once()

--- a/tests/h/services/url_migration_test.py
+++ b/tests/h/services/url_migration_test.py
@@ -1,0 +1,215 @@
+from unittest.mock import Mock
+
+import pytest
+from h_matchers import Any
+
+from h.services.url_migration import URLMigrationService
+
+
+class TestURLMigrationService:
+    def test_move_annotations_does_nothing_if_annotation_was_deleted(
+        self, pyramid_request, update_annotation
+    ):
+        svc = URLMigrationService(pyramid_request)
+        svc.move_annotations(
+            ["id-that-does-not-exist"],
+            "https://somesite.com",
+            {"url": "https://example.org"},
+        )
+        update_annotation.assert_not_called()
+
+    def test_move_annotations_does_nothing_if_url_no_longer_matches(
+        self, db_session, factories, pyramid_request, update_annotation
+    ):
+        ann = factories.Annotation(target_uri="https://example.com")
+        db_session.flush()
+
+        svc = URLMigrationService(pyramid_request)
+        svc.move_annotations(
+            [ann.id],
+            # Use a different URL to simulate the case where the annotation's
+            # URL is changed in between a move being scheduled, and the move
+            # being executed.
+            "https://wrongsite.com",
+            {"url": "https://example.org"},
+        )
+
+        assert ann.target_uri == "https://example.com"
+        update_annotation.assert_not_called()
+
+    def test_move_annotations_updates_urls(
+        self, db_session, factories, pyramid_request, update_annotation
+    ):
+        anns = [
+            factories.Annotation(target_uri="https://example.com"),
+            factories.Annotation(target_uri="https://example.com"),
+        ]
+        db_session.flush()
+
+        svc = URLMigrationService(pyramid_request)
+        svc.move_annotations(
+            [anns[0].id, anns[1].id],
+            "https://example.com",
+            {"url": "https://example.org"},
+        )
+
+        assert update_annotation.call_count == 2
+        for ann in anns[0:2]:
+            update_annotation.assert_any_call(
+                pyramid_request,
+                ann.id,
+                {"target_uri": "https://example.org"},
+                update_timestamp=False,
+                reindex=True,
+                reindex_tag="URLMigrationService.move_annotations",
+            )
+
+    def test_move_annotations_updates_selectors(
+        self, db_session, factories, pyramid_request, update_annotation
+    ):
+        ann = factories.Annotation(target_uri="https://example.com")
+        ann.target_selectors = [{"type": "TextQuoteSelector", "exact": "foobar"}]
+        db_session.flush()
+
+        svc = URLMigrationService(pyramid_request)
+        svc.move_annotations(
+            [ann.id],
+            "https://example.com",
+            {
+                "url": "https://example.org",
+                "selectors": [{"type": "PageSelector", "label": "3"}],
+            },
+        )
+
+        update_annotation.assert_called_with(
+            pyramid_request,
+            ann.id,
+            {
+                "target_uri": "https://example.org",
+                "target_selectors": [
+                    {"type": "TextQuoteSelector", "exact": "foobar"},
+                    {"type": "PageSelector", "label": "3"},
+                ],
+            },
+            update_timestamp=False,
+            reindex=True,
+            reindex_tag="URLMigrationService.move_annotations",
+        )
+
+    def test_move_annotations_updates_documents(
+        self,
+        db_session,
+        factories,
+        pyramid_request,
+        update_annotation,
+        transform_document,
+    ):
+        ann = factories.Annotation(target_uri="https://example.com")
+        db_session.flush()
+
+        svc = URLMigrationService(pyramid_request)
+        svc.move_annotations(
+            [ann.id],
+            "https://example.com",
+            {
+                "url": "https://example.org",
+                "document": {"title": "The new example.com"},
+            },
+        )
+
+        transform_document.assert_called_with(
+            {"title": "The new example.com"}, "https://example.org"
+        )
+        update_annotation.assert_called_with(
+            pyramid_request,
+            ann.id,
+            {
+                "target_uri": "https://example.org",
+                "document": transform_document.return_value,
+            },
+            update_timestamp=False,
+            reindex=True,
+            reindex_tag="URLMigrationService.move_annotations",
+        )
+
+    def test_move_annotations_by_url_moves_matching_annotations(
+        self,
+        db_session,
+        factories,
+        pyramid_request,
+        update_annotation,
+        move_annotations_task,
+    ):
+        anns = [
+            factories.Annotation(target_uri="https://example.com"),
+            factories.Annotation(target_uri="https://example.com"),
+            factories.Annotation(target_uri="https://othersite.com"),
+            factories.Annotation(target_uri="https://example.com"),
+        ]
+        db_session.flush()
+
+        svc = URLMigrationService(pyramid_request)
+        svc.move_annotations_by_url(
+            "https://example.com",
+            {"url": "https://example.org"},
+        )
+
+        # First annotation should be moved synchronously.
+        assert update_annotation.call_count == 1
+        update_annotation.assert_called_with(
+            pyramid_request,
+            Any.of([a.id for a in anns]),
+            {"target_uri": "https://example.org"},
+            update_timestamp=False,
+            reindex=True,
+            reindex_tag="URLMigrationService.move_annotations",
+        )
+        pyramid_request.tm.commit.assert_called_once()
+
+        # Remaining matching annotations should be moved in separate tasks.
+        assert move_annotations_task.delay.call_count == 1
+        move_annotations_task.delay.assert_called_with(
+            [anns[1].id, anns[3].id],
+            "https://example.com",
+            {"url": "https://example.org"},
+        )
+
+    def test_move_annotations_by_url_handles_no_matches(
+        self,
+        db_session,
+        factories,
+        pyramid_request,
+        update_annotation,
+        move_annotations_task,
+    ):
+        # Make sure there are some non-matching annotations in the DB.
+        factories.Annotation(target_uri="https://foo.com")
+        factories.Annotation(target_uri="https://bar.com")
+        factories.Annotation(target_uri="https://baz.com")
+        db_session.flush()
+
+        svc = URLMigrationService(pyramid_request)
+        svc.move_annotations_by_url(
+            "https://example.com",
+            {"url": "https://example.org"},
+        )
+
+        update_annotation.assert_not_called()
+        move_annotations_task.delay.assert_not_called()
+
+    @pytest.fixture
+    def transform_document(self, patch):
+        return patch("h.services.url_migration.transform_document")
+
+    @pytest.fixture
+    def update_annotation(self, patch):
+        return patch("h.storage.update_annotation")
+
+    @pytest.fixture
+    def move_annotations_task(self, patch):
+        return patch("h.services.url_migration.move_annotations")
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.tm = Mock(spec_set=["commit"])
+        return pyramid_request

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -384,11 +384,15 @@ class TestUpdateAnnotation:
             annotation.id, tag="h.services.SomeService", schedule_in=60, force=False
         )
 
-    def test_it_forces_reindexing(self, annotation, pyramid_request, search_index):
-        storage.update_annotation(pyramid_request, annotation.id, {}, reindex=True)
+    def test_it_forces_reindexing_if_update_timestamp_is_false(
+        self, annotation, pyramid_request, search_index
+    ):
+        storage.update_annotation(
+            pyramid_request, annotation.id, {}, update_timestamp=False
+        )
 
         search_index._queue.add_by_id.assert_called_once_with(  # pylint:disable=protected-access
-            annotation.id, tag=Any(), schedule_in=0, force=True
+            annotation.id, tag=Any(), schedule_in=60, force=True
         )
 
     @pytest.fixture

--- a/tests/h/views/admin/documents_test.py
+++ b/tests/h/views/admin/documents_test.py
@@ -1,0 +1,60 @@
+import json
+from unittest.mock import create_autospec
+
+import pytest
+from h_matchers import Any
+
+from h.views.admin.documents import DocumentsAdminViews
+
+
+class TestDocumentsAdminViews:
+    def test_update_annotation_urls_schedules_update(
+        self, pyramid_request, move_annotations_by_url, flash
+    ):
+        mappings = {"https://example.com": {"url": "https://example.org"}}
+        pyramid_request.POST["url_mappings"] = json.dumps(mappings)
+        views = DocumentsAdminViews(pyramid_request)
+
+        views.update_annotation_urls()
+
+        move_annotations_by_url.chunks.assert_called_with(mappings.items(), 10)
+        move_annotations_by_url.chunks.return_value.apply_async.assert_called_once()
+        flash.assert_called_with("URL migration started for 1 URL(s)", "success")
+
+    def test_it_raises_if_json_does_not_parse(
+        self, pyramid_request, move_annotations_by_url, flash
+    ):
+        pyramid_request.POST["url_mappings"] = "not-json"
+        views = DocumentsAdminViews(pyramid_request)
+
+        views.update_annotation_urls()
+
+        flash.assert_called_with(
+            Any.string.matching("Failed to parse URL mappings:.*"), "error"
+        )
+        assert pyramid_request.response.status_code == 400
+        move_annotations_by_url.chunks.assert_not_called()
+
+    def test_it_raises_if_validation_fails(
+        self, pyramid_request, move_annotations_by_url, flash
+    ):
+        pyramid_request.POST["url_mappings"] = json.dumps({"not-a-url": "foo"})
+        views = DocumentsAdminViews(pyramid_request)
+
+        views.update_annotation_urls()
+
+        flash.assert_called_with(
+            Any.string.matching("Failed to validate URL mappings:.*"), "error"
+        )
+        assert pyramid_request.response.status_code == 400
+        move_annotations_by_url.chunks.assert_not_called()
+
+    @pytest.fixture
+    def move_annotations_by_url(self, patch):
+        return patch("h.views.admin.documents.move_annotations_by_url")
+
+    @pytest.fixture
+    def flash(self, pyramid_request):
+        flash = create_autospec(pyramid_request.session.flash)
+        pyramid_request.session.flash = flash
+        return flash

--- a/tests/h/views/admin/documents_test.py
+++ b/tests/h/views/admin/documents_test.py
@@ -17,11 +17,11 @@ class TestDocumentsAdminViews:
 
         views.update_annotation_urls()
 
-        move_annotations_by_url.chunks.assert_called_with(mappings.items(), 10)
+        move_annotations_by_url.chunks.assert_called_once_with(mappings.items(), 10)
         move_annotations_by_url.chunks.return_value.apply_async.assert_called_once()
-        flash.assert_called_with("URL migration started for 1 URL(s)", "success")
+        flash.assert_called_once_with("URL migration started for 1 URL(s)", "success")
 
-    def test_it_raises_if_json_does_not_parse(
+    def test_it_errors_if_json_does_not_parse(
         self, pyramid_request, move_annotations_by_url, flash
     ):
         pyramid_request.POST["url_mappings"] = "not-json"
@@ -29,13 +29,13 @@ class TestDocumentsAdminViews:
 
         views.update_annotation_urls()
 
-        flash.assert_called_with(
+        flash.assert_called_once_with(
             Any.string.matching("Failed to parse URL mappings:.*"), "error"
         )
         assert pyramid_request.response.status_code == 400
         move_annotations_by_url.chunks.assert_not_called()
 
-    def test_it_raises_if_validation_fails(
+    def test_it_errors_if_validation_fails(
         self, pyramid_request, move_annotations_by_url, flash
     ):
         pyramid_request.POST["url_mappings"] = json.dumps({"not-a-url": "foo"})
@@ -43,13 +43,13 @@ class TestDocumentsAdminViews:
 
         views.update_annotation_urls()
 
-        flash.assert_called_with(
+        flash.assert_called_once_with(
             Any.string.matching("Failed to validate URL mappings:.*"), "error"
         )
         assert pyramid_request.response.status_code == 400
         move_annotations_by_url.chunks.assert_not_called()
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def move_annotations_by_url(self, patch):
         return patch("h.views.admin.documents.move_annotations_by_url")
 


### PR DESCRIPTION
Add an admin tool at `/admin/documents` that enables moving all annotations on a set of URLs to a new set of URLs. The user of this tool needs to provide a JSON document which contains the mappings between the old URLs and the new URLs and their metadata. These mappings would typically be generated with a script such as the one in https://github.com/hypothesis/vitalsource-url-migration/tree/main.

The implementation reuses several pieces of the code that handle annotation updates via `PATCH /api/annotations`, to make sure that the annotation and document tables are updated in the same way.

Screenshot (pardon the ugliness of our admin UI):

<img width="1162" alt="Document URL migration screenshot" src="https://user-images.githubusercontent.com/2458/212326741-4edf25ca-1b2f-40ec-a815-6774be13dece.png">

**Part of https://github.com/hypothesis/h/issues/7709**

---

**Example usage:**

Before doing this, you must have `h-periodic` running locally.

1. Visit http://localhost:3000/document/burns and make an annotation
2. Open http://localhost:3000/document/doyle in another tab
3. Go to http://localhost:5000/admin/documents. Enter this JSON payload in the text field and click "Update URLs":

```json
{
  "http://localhost:3000/document/burns": {
    "url": "http://localhost:3000/document/doyle"
  }
}
```
4. You should see a message in the admin UI indicating that a URL migration has started.
5. Check the h debug logs and there should be some messages from Celery, but no errors
6. **Wait for h-periodic to trigger the "sync_annotations" task. This may take up to 60s** (_Perhaps we should trigger this automatically from the migrations task_)
7. Refresh the page at http://localhost:3000/document/burns and the annotation should have disappeared
8. Go to the tab containing http://localhost:3000/document/doyle and you should see the update notification. When you click it, the annotation that was originally made on the Burns poem should have moved to this page.

**Schema validation:**

Try entering text that doesn't parse as JSON, JSON that doesn't match the above schema or a mapping with non-HTTP(S) URLs in the admin UI textbox. You should see an error when submitting. The restriction to HTTP URLs is to catch accidental mistakes and is something we could relax in future.

**Advanced usage:**

The payload can optionally contain:

- A `document` field with document metadata for the new URL, in case it does not already exist in Hypothesis
- A `selectors` field with a list of selectors to add to migrated annotations. This is specifically useful when migrating annotations from book pages/chapter URLs to whole-book URLs. In this case the information about which chapter/page an annotation is on is captured in selectors rather than the URL, after the migration

<details>
<summary>Example of using `document` and `selectors` in the VitalSource migration</summary>

```json
{
  "https://jigsaw.vitalsource.com/books/0077387627/pages/650063327/content": {
    "url": "https://bookshelf.vitalsource.com/reader/books/0077387627",
    "selectors": [
      {
        "type": "EPUBContentSelector",
        "url": "https://jigsaw.vitalsource.com/books/0077387627/pages/650063327/content",
        "cfi": "/51",
        "title": "Chapter 02"
      },
      {
        "type": "PageSelector",
        "index": 51,
        "label": "52"
      }
    ],
    "document": {
      "title": "Essentials of Marketing Research"
    }
  }
}
```

</details>