### PR TITLE
Lower rate limit for URL migration

### DIFF
--- a/h/tasks/url_migration.py
+++ b/h/tasks/url_migration.py
@@ -2,13 +2,15 @@
 from h.celery import celery
 
 
-@celery.task(rate_limit="30/m")
+@celery.task(rate_limit="10/m")
 def move_annotations_by_url(old_url, new_url_info):
     migration_svc = celery.request.find_service(name="url_migration")
     migration_svc.move_annotations_by_url(old_url, new_url_info)
 
 
-@celery.task(rate_limit="20/m")
+# nb. Each `move_annotations` task moves a batch of annotations, so the
+# rate limit is `10 * batch_size` annotations per worker per minute.
+@celery.task(rate_limit="10/m")
 def move_annotations(annotation_ids, current_uri_normalized, url_info):
     migration_svc = celery.request.find_service(name="url_migration")
     migration_svc.move_annotations(annotation_ids, current_uri_normalized, url_info)


### PR DESCRIPTION
During this morning's migration of ~15,600 VitalSource annotations, tasks from the URL migration saturated available Celery workers. The best way to solve this would likely involve leveraging the job queue more to manage processing, as we do for annotation syncing. As a quick and easy improvement though, lower the rate limit.