### PR TITLE
Add pdf_custom_text_layer feature flag

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -14,6 +14,7 @@ FEATURES = {
     "client_display_names": "Render display names instead of user names in the client",
     "html_side_by_side": "Enable side-by-side mode for web pages in the client",
     "book_as_single_document": "Treat VitalSource books as a single Hypothesis document",
+    "pdf_custom_text_layer": "Use custom text layer in PDFs for improved text selection",
     "styled_highlight_clusters": "Style different clusters of highlights in the client",
 }
 


### PR DESCRIPTION
This flag will control whether a custom text PDF layer, developed originally for VitalSource PDF books, is used in PDF.js.

Part of https://github.com/hypothesis/client/issues/5023