### PR TITLE
Add route for the new profile mini-app

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -181,6 +181,9 @@ def includeme(config):  # pylint: disable=too-many-statements
     # Client
     config.add_route("sidebar_app", "/app.html")
     config.add_route("notebook_app", "/notebook")
+    # This URL is temporary. Pending discussions to choose on the final one
+    # See also https://github.com/hypothesis/h/issues/7820
+    config.add_route("profile_app", "/user-profile")
     config.add_route("embed", "/embed.js")
 
     # Feeds

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -39,6 +39,12 @@ def _client_url(request):
     csp_insecure_optout=True,  # This view adds its own custom Content Security Policy
     http_cache=(60 * 5, {"public": True}),
 )
+@view_config(
+    route_name="profile_app",
+    renderer="h:templates/app.html.jinja2",
+    csp_insecure_optout=True,  # This view adds its own custom Content Security Policy
+    http_cache=(60 * 5, {"public": True}),
+)
 def sidebar_app(request, extra=None):
     """
     Return the HTML for the Hypothesis client's sidebar application.

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -174,6 +174,7 @@ def test_includeme():
         call("oauth_revoke", "/oauth/revoke"),
         call("sidebar_app", "/app.html"),
         call("notebook_app", "/notebook"),
+        call("profile_app", "/user-profile"),
         call("embed", "/embed.js"),
         call("stream_atom", "/stream.atom"),
         call("stream_rss", "/stream.rss"),


### PR DESCRIPTION
This adds preliminary support for a new mini-app handled by `client`, which purpose will be to manage the user profile settings, and eventually replace the server-side handled `/account/settings` route.

Refs: #7820

> I'm creating this as a draft, as I'm adding the changes to client in parallel, and it's likely that I need to push some extra changes.