### PR TITLE
LMS Instructor Email Digests Prototype

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -173,6 +173,7 @@ def includeme(config):  # pylint: disable=too-many-statements
         factory="h.traversal.UserByNameRoot",
         traverse="/{username}",
     )
+    config.add_route("api.email_digests", "/api/email_digests", request_method="GET")
     config.add_route("badge", "/api/badge")
     config.add_route("token", "/api/token")
     config.add_route("oauth_authorize", "/oauth/authorize")

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -1,6 +1,7 @@
 """Service definitions that handle business logic."""
 from h.services.auth_cookie import AuthCookieService
 from h.services.subscription import SubscriptionService
+from h.services.email_digests import EmailDigestsService
 
 
 def includeme(config):  # pragma: no cover
@@ -85,6 +86,9 @@ def includeme(config):  # pragma: no cover
     )
     config.register_service_factory(
         "h.services.subscription.service_factory", iface=SubscriptionService
+    )
+    config.register_service_factory(
+        "h.services.email_digests.factory", iface=EmailDigestsService
     )
 
     config.add_directive(

--- a/h/services/email_digests.py
+++ b/h/services/email_digests.py
@@ -1,0 +1,46 @@
+from sqlalchemy import func, select
+
+from h.models import Annotation, AnnotationModeration, User, Group
+
+
+class EmailDigestsService:
+    def __init__(self, db, group_service):
+        self.db = db
+        self.group_service = group_service
+
+    def get(self, user, since, until):
+        groupids = self.group_service.groupids_readable_by(user)
+
+        stmt = (
+            select(Group.pubid, Group.authority_provided_id, User.username, func.count(1))
+            .join(Annotation, Annotation.groupid == Group.pubid)
+            .outerjoin(AnnotationModeration)
+            .join(
+                User,
+                User.username
+                == func.split_part(func.split_part(Annotation.userid, "@", 1), ":", 2)
+                and User.authority == func.split_part(Annotation.userid, "@", 2),
+            )
+            .group_by(Group.pubid, Group.authority_provided_id, User.username)
+            .where(Annotation.shared.is_(True))
+            .where(Annotation.deleted.is_(False))
+            .where(Annotation.groupid.in_(groupids))
+
+            # FIXME: This should be annotation.created rather than updated but
+            # we need to add an index to created first.
+            .where(Annotation.updated > since)
+            .where(Annotation.updated <= until)
+
+            .where(AnnotationModeration.id.is_(None))
+            .where(User.nipsa.is_(False))
+        )
+
+        result = self.db.execute(stmt).all()
+
+        return result
+
+
+def factory(context, request):
+    return EmailDigestsService(
+        db=request.db, group_service=request.find_service(name="group")
+    )

--- a/h/views/api/email_digests.py
+++ b/h/views/api/email_digests.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from h.services import EmailDigestsService
+from h.views.api.config import api_config
+
+
+@api_config(versions=["v2"], route_name="api.email_digests")
+def email_digests(request):
+    email_digests_service = request.find_service(EmailDigestsService)
+    user_service = request.find_service(name="user")
+
+    user = user_service.fetch(request.params["user"])
+    since = datetime.fromisoformat(request.params["since"])
+    until = datetime.fromisoformat(request.params["until"])
+
+    result = email_digests_service.get(user, since, until)
+
+    groups = {}
+    for pubid, authority_provided_id, username, num_annotations in result:
+        groups.setdefault(
+            authority_provided_id,
+            {"pubid": pubid, "authority_provided_id": authority_provided_id, "users": []},
+        )
+        groups[authority_provided_id]["users"].append(
+            {"userid": username, "num_annotations": num_annotations}
+        )
+
+    return {"groups": list(groups.values())}

--- a/tests/h/services/email_digests_test.py
+++ b/tests/h/services/email_digests_test.py
@@ -1,0 +1,63 @@
+import datetime
+
+import pytest
+from h_matchers import Any
+
+from h.services.email_digests import EmailDigestsService
+
+
+def test_it(svc, group_service, factories):
+    since = datetime.datetime(year=2023, month=2, day=7)
+    until = datetime.datetime(year=2023, month=2, day=8)
+
+    user = factories.User()
+    groups = factories.Group.create_batch(size=2, members=[user])
+    group_service.groupids_readable_by.return_value = groups
+
+    other_user = factories.User()
+    other_group = factories.Group()
+
+    nipsad_user = factories.User(nipsa=True)
+
+    class AnnotationFactory(factories.Annotation):
+        """A factory that creates matching annotations by default."""
+        userid = other_user.userid
+        shared = True
+        deleted = False
+        groupid = groups[0].pubid
+        updated = since + ((until - since) / 2)
+
+    # Create some annotations that *should* be counted.
+    # The first group should have a count of one annotation.
+    AnnotationFactory()
+    # The second group should have a count of two annotations.
+    AnnotationFactory.create_batch(size=2, groupid=groups[1].pubid)
+
+    # Create some annotations that should *not* be counted.
+    AnnotationFactory(deleted=True)
+    AnnotationFactory(shared=False)
+    AnnotationFactory(userid=user.userid)
+    AnnotationFactory(groupid=other_group.pubid)
+    AnnotationFactory(updated=until + datetime.timedelta(seconds=1))
+    AnnotationFactory(updated=since - datetime.timedelta(seconds=1))
+    AnnotationFactory(userid=nipsad_user.userid)
+
+    # An annotation that shouldn't be counted because it has been hidden by moderation.
+    hidden_annotation = AnnotationFactory()
+    hidden_annotation.moderation = factories.AnnotationModeration(
+        annotation=hidden_annotation
+    )
+
+    result = svc.get(user, since, until)
+
+    assert (
+        result
+        == Any.iterable.containing([(groups[0].pubid, 1), (groups[1].pubid, 2)]).only()
+    )
+    group_service.groupids_readable_by.assert_called_once_with(user)
+    assert False
+
+
+@pytest.fixture
+def svc(db_session, group_service):
+    return EmailDigestsService(db_session, group_service)


### PR DESCRIPTION
This is part of the code for a local prototype that was used to explore the architecture plan for the LMS Instructor Email Digests feature.

See https://github.com/hypothesis/lms/issues/5075 for a write-up.