### PR TITLE
Add a bulk annotation service to make the end-point real

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -1,5 +1,6 @@
 """Service definitions that handle business logic."""
 from h.services.auth_cookie import AuthCookieService
+from h.services.bulk_annotation import BulkAnnotationService
 from h.services.subscription import SubscriptionService
 
 
@@ -92,4 +93,8 @@ def includeme(config):  # pragma: no cover
     )
     config.add_request_method(
         ".feature.FeatureRequestProperty", name="feature", reify=True
+    )
+
+    config.register_service_factory(
+        "h.services.bulk_annotation.service_factory", iface=BulkAnnotationService
     )

--- a/h/services/bulk_annotation.py
+++ b/h/services/bulk_annotation.py
@@ -1,0 +1,191 @@
+from typing import List, Union
+
+import sqlalchemy as sa
+from sqlalchemy.engine import Row
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import Select
+
+from h.models import Annotation, AnnotationModeration, Group, User
+
+
+class BadDateFilter(Exception):
+    """There is something wrong with the date filter provided."""
+
+
+class BadFieldSpec(Exception):
+    """There is something wrong with the field you have specified."""
+
+
+def date_match(column: sa.Column, spec: dict):
+    """
+    Get an SQL comparator for a date column based on dict spec.
+
+    The dict can contain operators as keys and dates as values as per the
+    following complete (but nonsensical) filter:
+
+        {
+            "gt": "2012-11-30",
+            "gte": "2012-11-30",
+            "lt": "2012-11-30",
+            "lte": "2012-11-30",
+            "eq": "2012-11-30",
+            "ne": "2012-11-30",
+        }
+
+    :raises BadDateFilter: For unrecognised operators or no spec
+    """
+    if not spec:
+        raise BadDateFilter(f"No spec given to filter '{column}' on")
+
+    clauses = []
+
+    for op_key, value in spec.items():
+        if op_key == "gt":
+            clauses.append(column > value)
+        elif op_key == "gte":
+            clauses.append(column >= value)
+        elif op_key == "lt":
+            clauses.append(column < value)
+        elif op_key == "lte":
+            clauses.append(column <= value)
+        elif op_key == "eq":
+            clauses.append(column == value)
+        elif op_key == "ne":
+            clauses.append(column != value)
+        else:
+            raise BadDateFilter(f"Unknown date filter operator: {op_key}")
+
+    return sa.and_(*clauses)
+
+
+class BulkAnnotationService:
+    """A service for retrieving annotations in bulk."""
+
+    # Aliases to distinguish between different types of user
+    _AUTHOR = sa.orm.aliased(User, name="author")
+    _AUDIENCE = sa.orm.aliased(User, name="audience")
+
+    # Acceptable values to pass in as `fields`
+    _FIELDS = {
+        "author.username": _AUTHOR.username,
+        "group.authority_provided_id": Group.authority_provided_id,
+    }
+
+    def __init__(self, db_session: Session):
+        """Initialise the service."""
+
+        self._db = db_session
+
+    # pylint: disable=too-many-arguments
+    def annotation_search(
+        self,
+        authority: str,
+        audience: dict,
+        updated: dict,
+        fields: list = None,
+        limit=100000,
+    ) -> Union[List[Annotation], Row]:
+        """
+        Get a list of annotations or rows viewable by an audience of users.
+
+        Using a fields argument will switch the return type from annotation
+        objects to row objects. This is more efficient if you only need a
+        few fields but less convenient if you want many fields. Check the
+        `_FIELDS` attribute for acceptable fields and names.
+
+        :param authority: The authority to search by
+        :param audience: A specification of how to find the users. e.g.
+            {"username": [...]}
+        :param updated: A specification of how to filter the updated date. e.g.
+            {"gt": "2019-01-20", "lte": "2019-01-21"}
+        :param fields: A list of string descriptions of fields to return
+            instead of full annotation objects.
+        :param limit: A limit of results to generate
+
+        :raises BadDateFilter: For poorly specified date conditions
+        :raises BadFieldSpec: For poorly specified fields
+        """
+
+        results = self._db.execute(
+            self._search_query(
+                authority, audience=audience, updated=updated, fields=fields
+            ).limit(limit)
+        )
+
+        if fields is None:
+            results = results.scalars()
+
+        return results.all()
+
+    @classmethod
+    def _search_query(cls, authority, audience, updated, fields=None) -> Select:
+        """Generate a query which can then be executed to find annotations."""
+
+        if fields is None:
+            query = sa.select(Annotation)
+        else:
+            query = sa.select(list(cls._field_names_to_columns(fields))).select_from(
+                Annotation
+            )
+
+        # Updated
+        query = query.where(date_match(Annotation.updated, updated))
+
+        # Shared
+        query = query.where(Annotation.shared.is_(True))
+
+        # Deleted
+        query = query.where(Annotation.deleted.is_(False))
+
+        # Audience
+        query = query.join(Group, Annotation.groupid == Group.pubid).where(
+            Group.id.in_(cls._audience_groups_subquery(authority, audience))
+        )
+
+        # NIPSA
+        query = query.join(
+            cls._AUTHOR,
+            cls._AUTHOR.username
+            == sa.func.split_part(sa.func.split_part(Annotation.userid, "@", 1), ":", 2)
+            and cls._AUTHOR.authority == authority,
+        ).where(cls._AUTHOR.nipsa.is_(False))
+
+        # Moderated
+        query = query.outerjoin(AnnotationModeration).where(
+            AnnotationModeration.id.is_(None)
+        )
+
+        return query
+
+    @classmethod
+    def _field_names_to_columns(cls, field_names):
+        if not field_names:
+            raise BadFieldSpec("Fields cannot be present but empty")
+
+        for field_name in field_names:
+            column = cls._FIELDS.get(field_name)
+            if column is None:
+                raise BadFieldSpec(f"Unrecognised field: {field_name}")
+            yield column
+
+    @classmethod
+    def _audience_groups_subquery(cls, authority, audience):
+        return sa.select(Group.id).join(
+            cls._AUDIENCE,
+            Group.members.any(
+                # pylint: disable=protected-access
+                User._username.in_(
+                    [
+                        username.lower().replace(".", "")
+                        for username in audience["username"]
+                    ]
+                ),
+                authority=authority,
+            ),
+        )
+
+
+def service_factory(_context, request) -> BulkAnnotationService:
+    """Service factory for the bulk annotation service."""
+
+    return BulkAnnotationService(db_session=request.db)

--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -1,4 +1,5 @@
 import factory
+from factory import Faker
 
 from h import models
 from h.models.group import JoinableBy, ReadableBy, WriteableBy
@@ -20,6 +21,7 @@ class Group(ModelFactory):
     readable_by = ReadableBy.members
     writeable_by = WriteableBy.members
     members = factory.LazyAttribute(lambda obj: [obj.creator])
+    authority_provided_id = Faker("hexify", text="^" * 30)
     enforce_scope = True
 
     @factory.post_generation

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -2,6 +2,7 @@ from unittest.mock import create_autospec
 
 import pytest
 
+from h.services import BulkAnnotationService
 from h.services.annotation_delete import AnnotationDeleteService
 from h.services.annotation_json import AnnotationJSONService
 from h.services.annotation_moderation import AnnotationModerationService
@@ -35,6 +36,7 @@ __all__ = (
     "annotation_json_service",
     "auth_cookie_service",
     "auth_token_service",
+    "bulk_annotation_service",
     "delete_group_service",
     "links_service",
     "list_organizations_service",
@@ -94,6 +96,11 @@ def auth_cookie_service(mock_service):
 @pytest.fixture
 def auth_token_service(mock_service):
     return mock_service(AuthTokenService, name="auth_token")
+
+
+@pytest.fixture
+def bulk_annotation_service(mock_service):
+    return mock_service(BulkAnnotationService)
 
 
 @pytest.fixture

--- a/tests/functional/api/groups/update_test.py
+++ b/tests/functional/api/groups/update_test.py
@@ -221,6 +221,7 @@ def first_party_group(db_session, factories, first_party_user):
         description="Original description",
         creator=first_party_user,
         authority=first_party_user.authority,
+        authority_provided_id=None,
     )
     db_session.commit()
     return group

--- a/tests/h/models/group_test.py
+++ b/tests/h/models/group_test.py
@@ -81,7 +81,7 @@ def test_it_returns_None_by_default_for_authority_provided_id():
 
 
 def test_it_returns_None_for_groupid_if_authority_provided_id_is_None(factories):
-    group = factories.Group()
+    group = factories.Group(authority_provided_id=None)
 
     assert group.groupid is None
 

--- a/tests/h/services/bulk_annotation_test.py
+++ b/tests/h/services/bulk_annotation_test.py
@@ -1,0 +1,195 @@
+from unittest.mock import sentinel
+
+import pytest
+from _pytest.mark import param
+from h_matchers import Any
+from sqlalchemy import select
+
+from h.models import Annotation
+from h.services.bulk_annotation import (
+    BadDateFilter,
+    BadFieldSpec,
+    BulkAnnotationService,
+    date_match,
+)
+
+
+class TestDateMatch:
+    @pytest.mark.parametrize(
+        "spec,expected",
+        (
+            param({"gt": "2001-01-01"}, ["2"], id="gt"),
+            param({"gte": "2001-01-01"}, ["1", "2"], id="gte"),
+            param({"lt": "2001-01-01"}, ["0"], id="lt"),
+            param({"lte": "2001-01-01"}, ["0", "1"], id="lte"),
+            param({"eq": "2001-01-01"}, ["1"], id="eq"),
+            param({"ne": "2001-01-01"}, ["0", "2"], id="ne"),
+            param({"gt": "2000-01-01", "lt": "2002-01-01"}, ["1"], id="combo"),
+        ),
+    )
+    def test_it(self, db_session, factories, spec, expected):
+        factories.Annotation(text="0", created="2000-01-01")
+        factories.Annotation(text="1", created="2001-01-01")
+        factories.Annotation(text="2", created="2002-01-01")
+
+        annotations = (
+            db_session.execute(
+                select(Annotation).where(date_match(Annotation.created, spec))
+            )
+            .scalars()
+            .all()
+        )
+
+        assert [anno.text for anno in annotations] == Any.list.containing(
+            expected
+        ).only()
+
+    @pytest.mark.parametrize(
+        "bad_spec",
+        (
+            param({}, id="empty"),
+            param({"bad_op": "2002-01-01"}, id="bad_op"),
+        ),
+    )
+    def test_it_raises_for_bad_spec(self, bad_spec):
+        with pytest.raises(BadDateFilter):
+            date_match(sentinel.column, bad_spec)
+
+
+class TestBulkAnnotationService:
+    AUTHORITY = "my.authority"
+
+    @pytest.mark.parametrize(
+        "key,value,visible",
+        (
+            (None, None, True),
+            ("shared", False, False),
+            ("deleted", True, False),
+            ("nipsad", True, False),
+            ("moderated", True, False),
+            ("updated", "2020-01-01", False),
+            ("updated", "2020-01-02", True),
+            ("updated", "2022-01-01", True),
+            ("updated", "2022-01-02", False),
+        ),
+    )
+    def test_it_with_single_annotation(self, svc, factories, key, value, visible):
+        values = {
+            "shared": True,
+            "deleted": False,
+            "nipsad": False,
+            "moderated": False,
+            "updated": "2021-01-01",
+        }
+        if key:
+            values[key] = value
+
+        viewer = factories.User(authority=self.AUTHORITY)
+        author = factories.User(authority=self.AUTHORITY, nipsa=values["nipsad"])
+        anno = factories.Annotation(
+            userid=author.userid,
+            group=factories.Group(members=[author, viewer]),
+            shared=values["shared"],
+            deleted=values["deleted"],
+            updated=values["updated"],
+        )
+        if values["moderated"]:
+            factories.AnnotationModeration(annotation=anno)
+
+        annotations = svc.annotation_search(
+            authority=self.AUTHORITY,
+            audience={"username": [viewer.username]},
+            updated={"gt": "2020-01-01", "lte": "2022-01-01"},
+        )
+
+        if visible:
+            assert annotations == [anno]
+        else:
+            assert not annotations
+
+    def test_it_with_more_complex_grouping(self, svc, factories):
+        *viewers, author = factories.User.create_batch(3, authority=self.AUTHORITY)
+
+        annotations = [
+            factories.Annotation(
+                userid=author.userid,
+                group=factories.Group(members=group_members),
+                shared=True,
+                deleted=False,
+            )
+            for group_members in (
+                # The first two annotations should match, because they are in
+                # groups the viewers are in
+                [author, viewers[0]],
+                [author, viewers[1]],
+                # This one is just noise and shouldn't match
+                [author],
+            )
+        ]
+
+        matched_annos = svc.annotation_search(
+            authority=self.AUTHORITY,
+            audience={"username": [viewer.username for viewer in viewers]},
+            updated={"gt": "2020-01-01", "lte": "2099-01-01"},
+        )
+
+        # Only the first two annotations should match
+        assert matched_annos == Any.list.containing(annotations[:2]).only()
+
+    @pytest.mark.parametrize(
+        "fields,expected",
+        (
+            (["author.username"], ("USERNAME",)),
+            (["group.authority_provided_id"], ("AUTHORITY_PROVIDED_ID",)),
+            (
+                ["author.username", "group.authority_provided_id"],
+                ("USERNAME", "AUTHORITY_PROVIDED_ID"),
+            ),
+            (
+                ["group.authority_provided_id", "author.username"],
+                ("AUTHORITY_PROVIDED_ID", "USERNAME"),
+            ),
+        ),
+    )
+    def test_it_with_fields(self, svc, factories, fields, expected):
+        viewer = factories.User(authority=self.AUTHORITY)
+        author = factories.User(authority=self.AUTHORITY, username="USERNAME")
+        group = factories.Group(
+            members=[viewer, author], authority_provided_id="AUTHORITY_PROVIDED_ID"
+        )
+        factories.Annotation(
+            userid=author.userid,
+            group=group,
+            shared=True,
+            deleted=False,
+            updated="2021-01-01",
+        )
+
+        results = svc.annotation_search(
+            authority=self.AUTHORITY,
+            audience={"username": [viewer.username]},
+            updated={"gt": "2020-01-01", "lte": "2099-01-01"},
+            fields=fields,
+        )
+
+        assert results == [expected]
+
+    @pytest.mark.parametrize(
+        "bad_fields",
+        (
+            param([], id="empty_list"),
+            param(["not.a_field"], id="bad_value"),
+        ),
+    )
+    def test_it_with_bad_fields(self, svc, bad_fields):
+        with pytest.raises(BadFieldSpec):
+            svc.annotation_search(
+                authority=self.AUTHORITY,
+                audience={"username": ["something"]},
+                updated={"gt": "2020-01-01", "lte": "2099-01-01"},
+                fields=bad_fields,
+            )
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return BulkAnnotationService(db_session)

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,9 @@ filterwarnings =
     ignore:^the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses$:DeprecationWarning:newrelic.api.import_hook
     ignore:^The behavior of AcceptLanguageValidHeader\.__iter__ is currently maintained for backward compatibility, but will change in the future.$:DeprecationWarning:webob.acceptparse
 
+    # pkg_resources is calling its own deprecated function? Anyway I don't think the problem is with us.
+    ignore:^Deprecated call to .pkg_resources\.declare_namespace\('.*'\).\.:DeprecationWarning:pkg_resources
+
 [testenv]
 skip_install = true
 sitepackages = {env:SITE_PACKAGES:false}


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/h/issues/7857

This adds a real version of the service. This PR doesn't actually do anything, it's here just as a split to make it easier to review. The actual usage of this in the view is in a separate PR here:

 * https://github.com/hypothesis/h/pull/7865

## Implementation notes

 * We are expecting pretty strict validation from the view
 * We are _mostly_ sticking to the exact use case of the current design of the API
 * ... but where it's easy enough to support some variation we do. Examples include:
    * Supporting more than `gt` and `lte` in date comparisons
    * Supporting sub sets of the fields, or the fields in a different order
    * Supporting getting annotation objects instead of rows