### PR TITLE
Upgrade sentry-sdk to 1.14.0

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -277,7 +277,7 @@ repoze-sendmail==4.3
     #   pyramid-mailer
 rfc3339-validator==0.1.4
     # via -r requirements/requirements.txt
-sentry-sdk==0.17.6
+sentry-sdk==1.17.0
     # via
     #   -r requirements/requirements.txt
     #   h-pyramid-sentry
@@ -339,7 +339,7 @@ typing-extensions==4.5.0
     # via
     #   -r requirements/requirements.txt
     #   alembic
-urllib3==1.26.5
+urllib3==1.26.15
     # via
     #   -r requirements/requirements.txt
     #   elasticsearch

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -258,7 +258,7 @@ repoze-sendmail==4.3
     #   pyramid-mailer
 rfc3339-validator==0.1.4
     # via -r requirements/requirements.txt
-sentry-sdk==0.17.6
+sentry-sdk==1.17.0
     # via
     #   -r requirements/requirements.txt
     #   h-pyramid-sentry
@@ -315,7 +315,7 @@ typing-extensions==4.5.0
     # via
     #   -r requirements/requirements.txt
     #   alembic
-urllib3==1.26.5
+urllib3==1.26.15
     # via
     #   -r requirements/requirements.txt
     #   elasticsearch

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -408,7 +408,7 @@ rfc3339-validator==0.1.4
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-sentry-sdk==0.17.6
+sentry-sdk==1.17.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -491,7 +491,7 @@ typing-extensions==4.5.0
     #   alembic
     #   astroid
     #   pylint
-urllib3==1.26.5
+urllib3==1.26.15
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -181,7 +181,7 @@ repoze-sendmail==4.3
     # via pyramid-mailer
 rfc3339-validator==0.1.4
     # via -r requirements/requirements.in
-sentry-sdk==0.17.6
+sentry-sdk==1.17.0
     # via h-pyramid-sentry
 six==1.15.0
     # via
@@ -223,7 +223,7 @@ translationstring==1.4
     #   pyramid
 typing-extensions==4.5.0
     # via alembic
-urllib3==1.26.5
+urllib3==1.26.15
     # via
     #   elasticsearch
     #   sentry-sdk

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -259,7 +259,7 @@ repoze-sendmail==4.3
     #   pyramid-mailer
 rfc3339-validator==0.1.4
     # via -r requirements/requirements.txt
-sentry-sdk==0.17.6
+sentry-sdk==1.17.0
     # via
     #   -r requirements/requirements.txt
     #   h-pyramid-sentry
@@ -316,7 +316,7 @@ typing-extensions==4.5.0
     # via
     #   -r requirements/requirements.txt
     #   alembic
-urllib3==1.26.5
+urllib3==1.26.15
     # via
     #   -r requirements/requirements.txt
     #   elasticsearch

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,9 @@ filterwarnings =
     # pkg_resources is calling its own deprecated function? Anyway I don't think the problem is with us.
     ignore:^Deprecated call to .pkg_resources\.declare_namespace\('.*'\).\.:DeprecationWarning:pkg_resources
 
+    # Usage of deprecated method of urllib3 within the elasticsearch library
+    ignore:^HTTPResponse.getheaders\(\) is deprecated and will be removed in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.$:DeprecationWarning:elasticsearch
+
 [testenv]
 skip_install = true
 sitepackages = {env:SITE_PACKAGES:false}


### PR DESCRIPTION
It was not clear on https://github.com/hypothesis/h/pull/7891/files diff but this also upgrades urllib3. which now deprecates `getheaders`:

https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html

```
Deprecated the HTTPResponse.getheaders() method in favor of HTTPResponse.headers, will be removed in v2.1.0.
```

Unfortunately this happens inside the elastic search lib, I reckon the best option here is top ignore the warning for now.




```
h/search/config.py:112: in init
    _ensure_icu_plugin(client.conn)
h/search/config.py:213: in _ensure_icu_plugin
    names = [x.strip() for x in conn.cat.plugins(h="component").split("\n")]
.tox/tests/lib/python3.8/site-packages/elasticsearch/client/utils.py:101: in _wrapped
    return func(*args, params=params, **kwargs)
.tox/tests/lib/python3.8/site-packages/elasticsearch/client/cat.py:288: in plugins
    return self.transport.perform_request("GET", "/_cat/plugins", params=params)
.tox/tests/lib/python3.8/site-packages/elasticsearch/transport.py:402: in perform_request
    status, headers_response, data = connection.perform_request(
.tox/tests/lib/python3.8/site-packages/elasticsearch/connection/http_urllib3.py:258: in perform_request
    return response.status, response.getheaders(), raw_data
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib3.response.HTTPResponse object at 0x7fd3be6c41f0>

    def getheaders(self):
>       warnings.warn(
            "HTTPResponse.getheaders() is deprecated and will be removed "
            "in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.",
            category=DeprecationWarning,
            stacklevel=2,
        )
E       DeprecationWarning: HTTPResponse.getheaders() is deprecated and will be removed in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.
```