### PR TITLE
Validate Redirect URL field is non-empty for "authorization_code" auth clients

### DIFF
--- a/tests/h/schemas/auth_client_test.py
+++ b/tests/h/schemas/auth_client_test.py
@@ -1,0 +1,46 @@
+import colander
+import pytest
+
+from h.schemas.auth_client import CreateAuthClientSchema
+
+pytestmark = pytest.mark.usefixtures("pyramid_config")
+
+
+class TestCreateAuthClientSchema:
+    def test_it_allows_valid_authcode_data(self, authcode_data, bound_schema):
+        bound_schema.deserialize(authcode_data)
+
+    def test_it_allows_valid_clientcredentials_data(
+        self, client_credentials_data, bound_schema
+    ):
+        bound_schema.deserialize(client_credentials_data)
+
+    def test_it_raises_if_redirect_url_missing(self, authcode_data, bound_schema):
+        authcode_data["redirect_url"] = None
+
+        with pytest.raises(
+            colander.Invalid, match='Required when grant type is "authorization_code"'
+        ):
+            bound_schema.deserialize(authcode_data)
+
+    @pytest.fixture
+    def authcode_data(self):
+        return {
+            "name": "Test client",
+            "authority": "example.com",
+            "grant_type": "authorization_code",
+            "trusted": False,
+            "redirect_url": "https://test-client.com/oauth-redirect",
+        }
+
+    @pytest.fixture
+    def client_credentials_data(self):
+        return {
+            "name": "Test client",
+            "authority": "example.com",
+            "grant_type": "client_credentials",
+        }
+
+    @pytest.fixture
+    def bound_schema(self, pyramid_csrf_request):
+        return CreateAuthClientSchema().bind(request=pyramid_csrf_request)


### PR DESCRIPTION
I added a note about a related issue when publishing browser extensions for the first time.

Fixes #7921 

**Testing:**

1. Go to http://localhost:5000/admin/oauthclients/new
2. Enter a name and set the "Grant type" field to "authorization_code"
3. Leave the Redirect URL field blank
4. Submit

On main, Step 4 will trigger a 500. On this branch, you should see this validation error:

<img width="956" alt="Redirect URL validation error" src="https://user-images.githubusercontent.com/2458/229536525-8a14353e-2792-405a-a508-ae05b9b7e012.png">

If you either fill in the Redirect URL (nb. format is not validated) or change the grant type to eg. "client_credentials", you should be able to save without the validation error.