### PR TITLE
Move `URLMigrationService` annotation queries to annotations service

### DIFF
--- a/h/services/annotation.py
+++ b/h/services/annotation.py
@@ -1,9 +1,10 @@
 from typing import Iterable, List, Optional
 
 from sqlalchemy import select
-from sqlalchemy.orm import Session, subqueryload
+from sqlalchemy.orm import Query, Session, subqueryload
 
-from h.models import Annotation
+from h.models import Annotation, DocumentURI
+from h.util.uri import normalize
 
 
 class AnnotationService:
@@ -26,12 +27,60 @@ class AnnotationService:
         if not ids:
             return []
 
-        query = select(Annotation).where(Annotation.id.in_(ids))
+        annotations = self._db.execute(
+            self._annotation_search_query(ids=ids, eager_load=eager_load)
+        ).scalars()
+
+        return sorted(annotations, key=lambda annotation: ids.index(annotation.id))
+
+    def search_annotations(
+        self,
+        ids: Optional[List[str]] = None,
+        target_uri: Optional[str] = None,
+        document_uri: Optional[str] = None,
+    ) -> Iterable[Annotation]:
+        """
+        Search for annotations using information stored in Postgres.
+
+        :param ids: Search by specified annotation ids
+        :param target_uri: Search by annotation target URI
+        :param document_uri: Search by document URI
+        """
+        query = self._annotation_search_query(
+            ids=ids, document_uri=document_uri, target_uri=target_uri
+        )
+
+        return self._db.execute(query).scalars().all()
+
+    @staticmethod
+    def _annotation_search_query(
+        ids: Optional[List[str]] = None,
+        document_uri: Optional[str] = None,
+        target_uri: Optional[str] = None,
+        eager_load: Optional[List] = None,
+    ) -> Query:
+        """Create a query for searching for annotations."""
+
+        query = select(Annotation)
+
+        if ids:
+            query = query.where(Annotation.id.in_(ids))
+
+        if target_uri:
+            query = query.where(
+                Annotation.target_uri_normalized == normalize(target_uri)
+            )
+
+        if document_uri:
+            document_subquery = select(DocumentURI.document_id).where(
+                DocumentURI.uri_normalized == normalize(document_uri)
+            )
+            query = query.where(Annotation.document_id.in_(document_subquery))
+
         if eager_load:
             query = query.options(subqueryload(*eager_load))
 
-        annotations = self._db.execute(query).scalars()
-        return sorted(annotations, key=lambda annotation: ids.index(annotation.id))
+        return query
 
 
 def service_factory(_context, request) -> AnnotationService:

--- a/h/services/url_migration.py
+++ b/h/services/url_migration.py
@@ -2,13 +2,11 @@ import copy
 import logging
 
 from celery.utils import chunks
-from sqlalchemy.orm import load_only
 
 import h.storage
-from h.models import Annotation, DocumentURI
 from h.schemas.annotation import transform_document
+from h.services import AnnotationService
 from h.tasks.url_migration import move_annotations
-from h.util.uri import normalize
 
 log = logging.getLogger(__name__)
 
@@ -16,8 +14,12 @@ log = logging.getLogger(__name__)
 class URLMigrationService:
     """Moves annotations from one URL to another."""
 
-    def __init__(self, request):
+    BATCH_SIZE = 50
+    """How many annotations to migrate at once."""
+
+    def __init__(self, request, annotation_service: AnnotationService):
         self.request = request
+        self._annotation_service = annotation_service
 
     def move_annotations(self, annotation_ids, current_uri, new_url_info):
         """
@@ -26,30 +28,20 @@ class URLMigrationService:
         :param annotation_ids: IDs of annotations to migrate
         :param current_uri: The expected `target_uri` of each annotation.
             This is used to catch cases where the URI changes in between the
-            move being scheduled and later executed (eg. via a Celery task).
-        :param new_url_info: URL and document metadata to migrate annotations to.
-            This is an entry from the mappings defined by the `URLMigrationSchema`
-            schema.
+            move being scheduled and later executed (e.g. via a Celery task).
+        :param new_url_info: URL and document metadata to migrate annotations
+            to. This is an entry from the mappings defined by the
+            `URLMigrationSchema` schema.
         """
 
-        annotations = self.request.db.query(Annotation).filter(
-            Annotation.id.in_(annotation_ids)
-        )
-        current_uri_normalized = normalize(current_uri)
-
-        for ann in annotations:
-            if ann.target_uri_normalized != current_uri_normalized:
-                # Skip annotation if it was updated since the task was
-                # scheduled.
-                log.info("Skipping annotation %s", ann.uuid)
-                continue
-
-            ann_update_data = {
-                "target_uri": new_url_info["url"],
-            }
+        # Skip annotation if it was updated since the task was scheduled
+        for annotation in self._annotation_service.search_annotations(
+            ids=annotation_ids, target_uri=current_uri
+        ):
+            update_data = {"target_uri": new_url_info["url"]}
 
             if "document" in new_url_info:
-                ann_update_data["document"] = transform_document(
+                update_data["document"] = transform_document(
                     new_url_info["document"], new_url_info["url"]
                 )
 
@@ -63,25 +55,32 @@ class URLMigrationService:
             #
             # See https://github.com/hypothesis/h/issues/7709
             if new_selectors := new_url_info.get("selectors"):
-                selectors = copy.deepcopy(ann.target_selectors)
-                for new_sel in new_selectors:
-                    if not any(s for s in selectors if s["type"] == new_sel["type"]):
-                        selectors.append(new_sel)
-                ann_update_data["target_selectors"] = selectors
+                selectors = copy.deepcopy(annotation.target_selectors)
+                existing_types = {selector["type"] for selector in selectors}
+
+                selectors.extend(
+                    selector
+                    for selector in new_selectors
+                    if selector["type"] not in existing_types
+                )
+
+                update_data["target_selectors"] = selectors
 
             # Update the annotation's `target_uri` and associated document,
             # and create `Document*` entities for the new URL if they don't
             # already exist.
             h.storage.update_annotation(
                 self.request,
-                ann.id,
-                ann_update_data,
+                annotation.id,
+                update_data,
                 # Don't update "edited" timestamp on annotation cards.
                 update_timestamp=False,
                 reindex_tag="URLMigrationService.move_annotations",
             )
 
-            log.info("Moved annotation %s to URL %s", ann.uuid, ann.target_uri)
+            log.info(
+                "Moved annotation %s to URL %s", annotation.uuid, annotation.target_uri
+            )
 
     def move_annotations_by_url(self, url, new_url_info):
         """
@@ -91,51 +90,35 @@ class URLMigrationService:
         :param new_url_info: The URL and document metadata of the new URL.
              This is an entry matching the `URLMigrationSchema` schema.
         """
-
-        session = self.request.db
-        uri_normalized = normalize(url)
-
-        # Get the IDs of all annotations on the old URL, and divide into
-        # fixed-sized batches. A separate Celery task is then launched per
-        # batch to migrate those annotations. This limits the amount of
-        # work per task in case there are a large number of annotations on
-        # a given URL.
-        annotations = (
-            session.query(Annotation)
-            .join(DocumentURI, Annotation.document_id == DocumentURI.document_id)
-            .filter(DocumentURI.uri_normalized == uri_normalized)
-            .options(load_only(Annotation.id, Annotation.target_uri))
-        )
-
-        ann_ids = [ann.id for ann in annotations]
-
-        if not ann_ids:
+        # Get the IDs of all annotations on the old URL
+        annotations = self._annotation_service.search_annotations(document_uri=url)
+        annotation_ids = [annotation.id for annotation in annotations]
+        if not annotation_ids:
             return
 
-        # Move the first matching annotation. This will create the
-        # document-related entities for the new URL if they don't already exist,
-        # This avoids errors related to concurrent document URL/metadata updates
-        # when the remaining annotations are moved in parallel.
-        first_ann = ann_ids[0]
-        self.move_annotations([first_ann], url, new_url_info)
+        # Move the one matching annotation first to create the document-related
+        # entities for the new URL if they don't already exist. This avoids
+        # errors related to concurrent document URL/metadata updates when the
+        # remaining annotations are moved in parallel.
+        self.move_annotations([annotation_ids.pop()], url, new_url_info)
 
         # Ensure new document is visible in tasks that move remaining
         # annotations.
         self.request.tm.commit()
 
-        # Schedule async tasks to move the remaining annotations.
-        ann_ids = ann_ids[1:]
-        anns_per_batch = 50
-        for batch in chunks(iter(ann_ids), anns_per_batch):
+        # Schedule async tasks to move the remaining annotations in chunks
+        for batch in chunks(iter(annotation_ids), n=self.BATCH_SIZE):
             move_annotations.delay(batch, url, new_url_info)
 
         log.info(
             "Migrating %s annotations from %s to %s",
-            len(ann_ids) + 1,
+            len(annotation_ids) + 1,
             url,
             new_url_info["url"],
         )
 
 
 def url_migration_factory(_context, request):
-    return URLMigrationService(request)
+    return URLMigrationService(
+        request=request, annotation_service=request.find_service(AnnotationService)
+    )

--- a/tests/h/services/annotation_test.py
+++ b/tests/h/services/annotation_test.py
@@ -43,6 +43,26 @@ class TestAnnotationService:
         # If we preloaded, we shouldn't execute any queries
         assert not query_counter.count
 
+    def test_search_annotations_with_document_uri(self, svc, factories):
+        annotation = factories.Annotation()
+        factories.Annotation()  # Add some noise
+
+        results = svc.search_annotations(
+            document_uri=annotation.document.document_uris[0].uri
+        )
+
+        assert results == [annotation]
+
+    def test_search_annotations_with_target_uri_and_ids(self, svc, factories):
+        annotation_1 = factories.Annotation()
+        factories.Annotation(target_uri=annotation_1.target_uri)
+
+        results = svc.search_annotations(
+            ids=[annotation_1.id], target_uri=annotation_1.target_uri
+        )
+
+        assert results == [annotation_1]
+
     @pytest.fixture
     def query_counter(self, db_engine):
         class QueryCounter:


### PR DESCRIPTION
This PR moves the queries that the `URLMigrationService` makes to retrieve annotation to the annotation service. This accumulates related code in the same place and simplifies the `URLMigrationService` and it's tests.

This also paves the way to replace the `update_annotation` call made in `URLMigrationService` with a method in the annotation service as well.