### PR TITLE
Replace `storage.fetch_annotation` with an `AnnotationReadService`

### DIFF
--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -1,9 +1,9 @@
 import logging
 from collections import namedtuple
 
-from h import storage
 from h.models import Subscriptions
 from h.services import SubscriptionService
+from h.services.annotation_read import AnnotationReadService
 
 log = logging.getLogger(__name__)
 
@@ -55,14 +55,15 @@ def get_notification(
 
     # If the annotation doesn't have a parent, or we can't find its parent,
     # then we can't send a notification email.
-    parent_id = annotation.parent_id
-    if parent_id is None:
+    if annotation.parent_id is None:
         return None
 
     # Now we know we're dealing with a reply
     reply = annotation
 
-    parent = storage.fetch_annotation(request.db, parent_id)
+    parent = request.find_service(AnnotationReadService).get_annotation_by_id(
+        annotation.parent_id
+    )
     if parent is None:
         return None
 

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -1,4 +1,5 @@
 """Service definitions that handle business logic."""
+from h.services.annotation_read import AnnotationReadService
 from h.services.auth_cookie import AuthCookieService
 from h.services.bulk_annotation import BulkAnnotationService
 from h.services.subscription import SubscriptionService
@@ -6,6 +7,9 @@ from h.services.subscription import SubscriptionService
 
 def includeme(config):  # pragma: no cover
     config.register_service_factory(".annotation_json.factory", name="annotation_json")
+    config.register_service_factory(
+        "h.services.annotation_read.service_factory", iface=AnnotationReadService
+    )
     config.register_service_factory(
         ".annotation_moderation.annotation_moderation_service_factory",
         name="annotation_moderation",

--- a/h/services/annotation_read.py
+++ b/h/services/annotation_read.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from h.db.types import InvalidUUID
+from h.models import Annotation
+
+
+class AnnotationReadService:
+    """A service for storing and retrieving annotations."""
+
+    def __init__(self, db_session: Session):
+        self._db = db_session
+
+    def get_annotation_by_id(self, id_: str) -> Optional[Annotation]:
+        """
+        Fetch the annotation with the given id.
+
+        :param id_: Annotation ID to retrieve
+        """
+        try:
+            return self._db.query(Annotation).get(id_)
+        except InvalidUUID:
+            return None
+
+
+def service_factory(_context, request) -> AnnotationReadService:
+    """Get an annotation service instance."""
+
+    return AnnotationReadService(db_session=request.db)

--- a/h/services/search_index/service_factory.py
+++ b/h/services/search_index/service_factory.py
@@ -1,4 +1,5 @@
 from h.search.index import BatchIndexer
+from h.services import AnnotationReadService
 from h.services.search_index._queue import Queue
 from h.services.search_index.service import SearchIndexService
 
@@ -16,4 +17,5 @@ def factory(_context, request):
             es=request.es,
             batch_indexer=BatchIndexer(request.db, request.es, request),
         ),
+        annotation_read_service=request.find_service(AnnotationReadService),
     )

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -4,9 +4,10 @@ from itertools import chain
 
 from gevent.queue import Full
 
-from h import realtime, storage
+from h import realtime
 from h.realtime import Consumer
 from h.security import Permission, identity_permits
+from h.services.annotation_read import AnnotationReadService
 from h.streamer import websocket
 from h.streamer.contexts import request_context
 from h.streamer.filter import SocketFilter
@@ -99,7 +100,7 @@ def handle_user_event(message, sockets, _request, _session):
 
 def handle_annotation_event(message, sockets, request, session):
     id_ = message["annotation_id"]
-    annotation = storage.fetch_annotation(session, id_)
+    annotation = request.find_service(AnnotationReadService).get_annotation_by_id(id_)
 
     if annotation is None:
         log.warning("received annotation event for missing annotation: %s", id_)

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -2,10 +2,11 @@ from h_pyramid_sentry import report_exception
 from kombu.exceptions import OperationalError
 from pyramid.events import BeforeRender, subscriber
 
-from h import __version__, emails, storage
+from h import __version__, emails
 from h.events import AnnotationEvent
 from h.exceptions import RealtimeMessageQueueError
 from h.notification import reply
+from h.services.annotation_read import AnnotationReadService
 from h.tasks import mailer
 
 
@@ -71,7 +72,9 @@ def send_reply_notifications(event):
     request = event.request
 
     with request.tm:
-        annotation = storage.fetch_annotation(request.db, event.annotation_id)
+        annotation = request.find_service(AnnotationReadService).get_annotation_by_id(
+            event.annotation_id
+        )
         notification = reply.get_notification(request, annotation, event.action)
 
         if notification is None:

--- a/h/traversal/annotation.py
+++ b/h/traversal/annotation.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
-from h import storage
 from h.models import Annotation
+from h.services.annotation_read import AnnotationReadService
 
 
 @dataclass
@@ -19,10 +19,12 @@ class AnnotationRoot:
     """Root factory for routes whose context is an `AnnotationContext`."""
 
     def __init__(self, request):
-        self.request = request
+        self._annotation_read_service: AnnotationReadService = request.find_service(
+            AnnotationReadService
+        )
 
     def __getitem__(self, annotation_id):
-        annotation = storage.fetch_annotation(self.request.db, annotation_id)
+        annotation = self._annotation_read_service.get_annotation_by_id(annotation_id)
         if annotation is None:
             raise KeyError()
 

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -6,6 +6,7 @@ from h.services import BulkAnnotationService
 from h.services.annotation_delete import AnnotationDeleteService
 from h.services.annotation_json import AnnotationJSONService
 from h.services.annotation_moderation import AnnotationModerationService
+from h.services.annotation_read import AnnotationReadService
 from h.services.auth_cookie import AuthCookieService
 from h.services.auth_token import AuthTokenService
 from h.services.delete_group import DeleteGroupService
@@ -34,6 +35,7 @@ __all__ = (
     "mock_service",
     "annotation_delete_service",
     "annotation_json_service",
+    "annotation_read_service",
     "auth_cookie_service",
     "auth_token_service",
     "bulk_annotation_service",
@@ -86,6 +88,11 @@ def annotation_delete_service(mock_service):
 @pytest.fixture
 def annotation_json_service(mock_service):
     return mock_service(AnnotationJSONService, name="annotation_json")
+
+
+@pytest.fixture
+def annotation_read_service(mock_service):
+    return mock_service(AnnotationReadService)
 
 
 @pytest.fixture

--- a/tests/h/notification/reply_test.py
+++ b/tests/h/notification/reply_test.py
@@ -1,161 +1,142 @@
+from unittest.mock import call
+
 import pytest
 
-from h.models import Annotation, Document, DocumentMeta, Subscriptions
+from h.models import Subscriptions
 from h.notification.reply import Notification, get_notification
-
-FIXTURE_DATA = {
-    "reply": {
-        "id": "OECV3AmDEeaAtTt8rjCjIg",
-        "groupid": "__world__",
-        "shared": True,
-        "userid": "acct:elephant@safari.net",
-    },
-    "parent": {
-        "id": "SucHcAmDEeaAtf_ZeH-rhA",
-        "groupid": "__world__",
-        "shared": True,
-        "userid": "acct:giraffe@safari.net",
-    },
-}
 
 
 class TestGetNotification:
-    def test_returns_correct_params_when_subscribed(
-        self, parent, pyramid_request, reply, user_service, subscription_service
+    def test_it(
+        self,
+        annotation,
+        parent,
+        annotation_user,
+        parent_user,
+        pyramid_request,
+        user_service,
+        subscription_service,
+        annotation_read_service,
     ):
-        result = get_notification(pyramid_request, reply, "create")
+        result = get_notification(pyramid_request, annotation, "create")
 
+        annotation_read_service.get_annotation_by_id.assert_called_once_with(
+            annotation.parent_id
+        )
+        user_service.fetch.assert_has_calls(
+            [call(parent.userid), call(annotation.userid)]
+        )
         subscription_service.get_subscription.assert_called_once_with(
             user_id=parent.userid, type_=Subscriptions.Type.REPLY
         )
 
         assert isinstance(result, Notification)
-        assert result.reply == reply
+        assert result.reply == annotation
         assert result.parent == parent
-        assert result.reply_user == user_service.fetch(reply.userid)
-        assert result.parent_user == user_service.fetch(parent.userid)
-        assert result.document == reply.document
+        assert result.reply_user == annotation_user
+        assert result.parent_user == parent_user
+        assert result.document == annotation.document
 
-    def test_returns_none_when_action_is_not_create(self, pyramid_request, reply):
-        assert get_notification(pyramid_request, reply, "update") is None
-        assert get_notification(pyramid_request, reply, "delete") is None
-        assert get_notification(pyramid_request, reply, "frobnicate") is None
-
-    def test_returns_none_when_annotation_is_not_reply(self, pyramid_request, reply):
-        reply.references = None
-
-        assert get_notification(pyramid_request, reply, "create") is None
-
-    def test_returns_none_when_parent_does_not_exist(
-        self, annotations, parent, pyramid_request, reply
+    def test_it_returns_none_when_action_is_not_create(
+        self, pyramid_request, annotation
     ):
-        del annotations[parent.id]
+        assert get_notification(pyramid_request, annotation, "NOT_CREATE") is None
 
-        assert get_notification(pyramid_request, reply, "create") is None
-
-    def test_returns_none_when_parent_user_does_not_exist(
-        self, factories, pyramid_request, reply, user_service
+    def test_it_returns_none_when_annotation_is_not_reply(
+        self, pyramid_request, annotation
     ):
-        users = {"acct:elephant@safari.net": factories.User()}
-        user_service.fetch.side_effect = users.get
+        annotation.references = None
 
-        assert get_notification(pyramid_request, reply, "create") is None
+        assert get_notification(pyramid_request, annotation, "create") is None
 
-    def test_returns_none_when_parent_user_has_no_email_address(
-        self, factories, pyramid_request, reply, user_service
+    def test_it_returns_none_when_parent_does_not_exist(
+        self,
+        pyramid_request,
+        annotation,
+        annotation_read_service,
     ):
-        users = {
-            "acct:giraffe@safari.net": factories.User(email=None),
-            "acct:elephant@safari.net": factories.User(),
-        }
-        user_service.fetch.side_effect = users.get
+        annotation_read_service.get_annotation_by_id.return_value = None
 
-        assert get_notification(pyramid_request, reply, "create") is None
+        assert get_notification(pyramid_request, annotation, "create") is None
 
-    def test_returns_none_when_reply_user_does_not_exist(
-        self, factories, pyramid_request, reply, user_service
+    def test_it_returns_none_when_parent_user_does_not_exist(
+        self, pyramid_request, annotation, user_service, factories
     ):
-        """
-        Don't send a reply if somehow the replying user ceased to exist.
+        user_service.fetch.side_effect = (None, factories.User())
 
-        It's not clear when or why this would ever happen, but we can't
-        construct the reply email without the user who replied existing. We log
-        a warning if this happens.
-        """
-        users = {"acct:giraffe@safari.net": factories.User()}
-        user_service.fetch.side_effect = users.get
+        assert get_notification(pyramid_request, annotation, "create") is None
 
-        assert get_notification(pyramid_request, reply, "create") is None
-
-    def test_returns_none_when_reply_by_same_user(self, parent, pyramid_request, reply):
-        parent.userid = "acct:elephant@safari.net"
-
-        assert get_notification(pyramid_request, reply, "create") is None
-
-    def test_returns_none_when_parent_user_cannot_read_reply(
-        self, pyramid_request, reply
+    def test_it_returns_none_when_reply_user_does_not_exist(
+        self, pyramid_request, annotation, user_service, factories
     ):
-        reply.shared = False
+        user_service.fetch.side_effect = (factories.User(), None)
 
-        assert get_notification(pyramid_request, reply, "create") is None
+        assert get_notification(pyramid_request, annotation, "create") is None
 
-    def test_returns_none_when_subscription_inactive(
-        self, pyramid_request, reply, subscription_service
+    def test_it_returns_none_when_parent_user_has_no_email_address(
+        self, pyramid_request, annotation, parent_user
+    ):
+        parent_user.email = None
+        assert get_notification(pyramid_request, annotation, "create") is None
+
+    def test_it_returns_none_when_reply_by_same_user(
+        self, pyramid_request, annotation, user_service, factories
+    ):
+        single_user = factories.User()
+        user_service.fetch.side_effect = (single_user, single_user)
+
+        assert get_notification(pyramid_request, annotation, "create") is None
+
+    def test_it_returns_none_when_parent_user_cannot_read_reply(
+        self, pyramid_request, annotation
+    ):
+        annotation.shared = False
+
+        assert get_notification(pyramid_request, annotation, "create") is None
+
+    def test_it_returns_none_when_subscription_inactive(
+        self, pyramid_request, annotation, subscription_service
     ):
         subscription_service.get_subscription.return_value.active = False
 
-        assert get_notification(pyramid_request, reply, "create") is None
+        assert get_notification(pyramid_request, annotation, "create") is None
+
+    # This would all be a lot more pleasant if we had some SQLAlchemy
+    # relationships between these very important items
+    @pytest.fixture
+    def annotation_user(self, factories, db_session):
+        annotation_user = factories.User()
+        db_session.flush()
+        return annotation_user
 
     @pytest.fixture
-    def annotations(self):
-        return {}
+    def annotation(self, factories, annotation_user, parent):
+        return factories.Annotation(
+            userid=annotation_user.userid, shared=True, references=[parent.id]
+        )
 
     @pytest.fixture
-    def parent(self, annotations):
-        parent = Annotation(**FIXTURE_DATA["parent"])
-        annotations[parent.id] = parent
+    def parent_user(self, factories, db_session):
+        parent_user = factories.User()
+        db_session.flush()
+        return parent_user
+
+    @pytest.fixture
+    def parent(self, factories, db_session, parent_user, annotation_read_service):
+        parent = factories.Annotation(userid=parent_user.userid)
+        db_session.flush()
+
+        annotation_read_service.get_annotation_by_id.return_value = parent
         return parent
 
-    @pytest.fixture
-    def reply(self, annotations, db_session, parent):
-        # We need to create a document object to provide the title, and
-        # ensure it is associated with the annotation through the
-        # annotation's `target_uri`
-        doc = Document.find_or_create_by_uris(
-            db_session, claimant_uri="http://example.net/foo", uris=[]
-        ).one()
-        doc.meta.append(
-            DocumentMeta(
-                type="title", value=["Some document"], claimant="http://example.com/foo"
-            )
-        )
-        reply = Annotation(**FIXTURE_DATA["reply"])
-        reply.target_uri = "http://example.net/foo"
-        reply.references = [parent.id]
-        reply.document = doc
-        db_session.add(reply)
-        db_session.flush()
-        annotations[reply.id] = reply
-        return reply
-
     @pytest.fixture(autouse=True)
-    def fetch_annotation(self, patch, annotations):
-        fetch_annotation = patch("h.notification.reply.storage.fetch_annotation")
-        fetch_annotation.side_effect = lambda _, id: annotations.get(id)
-        return fetch_annotation
+    def user_service(self, user_service, parent_user, annotation_user):
+        user_service.fetch.side_effect = (parent_user, annotation_user)
+        return user_service
 
     @pytest.fixture(autouse=True)
     def subscription_service(self, subscription_service, factories):
         subscription_service.get_subscription.return_value = factories.Subscriptions(
-            active=True, type=Subscriptions.Type.REPLY.value
+            active=True
         )
         return subscription_service
-
-    @pytest.fixture(autouse=True)
-    def user_service(self, user_service, factories):
-        users = {
-            "acct:giraffe@safari.net": factories.User(),
-            "acct:elephant@safari.net": factories.User(),
-        }
-        user_service.fetch.side_effect = users.get
-        return user_service

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -47,7 +47,7 @@ def index_annotations(es_client, search_index):
 
 @pytest.fixture
 def search_index(  # pylint:disable=unused-argument
-    es_client, pyramid_request, moderation_service
+    es_client, pyramid_request, moderation_service, annotation_read_service
 ):
     return SearchIndexService(
         pyramid_request,
@@ -55,6 +55,7 @@ def search_index(  # pylint:disable=unused-argument
         session=pyramid_request.db,
         settings={},
         queue=mock.create_autospec(Queue, spec_set=True, instance=True),
+        annotation_read_service=annotation_read_service,
     )
 
 

--- a/tests/h/services/annotation_read_test.py
+++ b/tests/h/services/annotation_read_test.py
@@ -1,0 +1,33 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from h.services.annotation_read import AnnotationReadService, service_factory
+
+
+class TestAnnotationReadService:
+    def test_get_annotation_by_id(self, svc, annotation):
+        assert svc.get_annotation_by_id(annotation.id) == annotation
+
+    def test_get_annotation_by_id_with_invalid_uuid(self, svc):
+        assert not svc.get_annotation_by_id("NOTVALID")
+
+    @pytest.fixture
+    def annotation(self, factories):
+        return factories.Annotation()
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return AnnotationReadService(db_session=db_session)
+
+
+class TestServiceFactory:
+    def test_it(self, pyramid_request, AnnotationReadService):
+        svc = service_factory(sentinel.context, pyramid_request)
+
+        AnnotationReadService.assert_called_once_with(db_session=pyramid_request.db)
+        assert svc == AnnotationReadService.return_value
+
+    @pytest.fixture
+    def AnnotationReadService(self, patch):
+        return patch("h.services.annotation_read.AnnotationReadService")

--- a/tests/h/services/search_index/_queue_test.py
+++ b/tests/h/services/search_index/_queue_test.py
@@ -393,7 +393,12 @@ class TestSync:
 
     @pytest.fixture
     def search_index(
-        self, es_client, pyramid_request, moderation_service, nipsa_service
+        self,
+        es_client,
+        pyramid_request,
+        moderation_service,
+        nipsa_service,
+        annotation_read_service,
     ):  # pylint:disable=unused-argument
         return SearchIndexService(
             pyramid_request,
@@ -401,6 +406,7 @@ class TestSync:
             session=pyramid_request.db,
             settings={},
             queue=queue,
+            annotation_read_service=annotation_read_service,
         )
 
     @pytest.fixture

--- a/tests/h/services/search_index/service_factory_test.py
+++ b/tests/h/services/search_index/service_factory_test.py
@@ -7,7 +7,13 @@ from h.services.search_index.service_factory import factory
 
 class TestFactory:
     def test_it(
-        self, pyramid_request, SearchIndexService, settings, BatchIndexer, Queue
+        self,
+        pyramid_request,
+        SearchIndexService,
+        settings,
+        BatchIndexer,
+        Queue,
+        annotation_read_service,
     ):
         result = factory(sentinel.context, pyramid_request)
 
@@ -25,6 +31,7 @@ class TestFactory:
             session=pyramid_request.db,
             settings=settings,
             queue=Queue.return_value,
+            annotation_read_service=annotation_read_service,
         )
         assert result == SearchIndexService.return_value
 

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -99,12 +99,13 @@ class TestPublishAnnotationEvent:
         return event
 
 
+@pytest.mark.usefixtures("annotation_read_service")
 class TestSendReplyNotifications:
     def test_it_sends_emails(
         self,
         event,
         pyramid_request,
-        storage,
+        annotation_read_service,
         reply,
         emails,
         mailer,
@@ -113,10 +114,10 @@ class TestSendReplyNotifications:
 
         # This is a pure plumbing test, checking everything is connected to
         # everything else as we expect
-        storage.fetch_annotation.assert_called_once_with(
-            pyramid_request.db, event.annotation_id
+        annotation_read_service.get_annotation_by_id.assert_called_once_with(
+            event.annotation_id
         )
-        annotation = storage.fetch_annotation.return_value
+        annotation = annotation_read_service.get_annotation_by_id.return_value
         reply.get_notification.assert_called_once_with(
             pyramid_request, annotation, event.action
         )
@@ -168,11 +169,6 @@ class TestSyncAnnotation:
             TransactionManager, instance=True, spec_set=True
         )
         return pyramid_request.tm
-
-
-@pytest.fixture(autouse=True)
-def storage(patch):
-    return patch("h.subscribers.storage")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/h/traversal/annotation_test.py
+++ b/tests/h/traversal/annotation_test.py
@@ -5,22 +5,25 @@ import pytest
 from h.traversal import AnnotationContext, AnnotationRoot
 
 
+@pytest.mark.usefixtures("annotation_read_service")
 class TestAnnotationRoot:
     def test_getting_by_subscript_returns_AnnotationContext(
-        self, root, pyramid_request, AnnotationContext, storage
+        self, root, AnnotationContext, annotation_read_service
     ):
         context = root[sentinel.annotation_id]
 
-        storage.fetch_annotation.assert_called_once_with(
-            pyramid_request.db, sentinel.annotation_id
+        annotation_read_service.get_annotation_by_id.assert_called_once_with(
+            sentinel.annotation_id
         )
-        AnnotationContext.assert_called_once_with(storage.fetch_annotation.return_value)
+        AnnotationContext.assert_called_once_with(
+            annotation_read_service.get_annotation_by_id.return_value
+        )
         assert context == AnnotationContext.return_value
 
     def test_getting_by_subscript_raises_KeyError_if_annotation_missing(
-        self, root, storage
+        self, root, annotation_read_service
     ):
-        storage.fetch_annotation.return_value = None
+        annotation_read_service.get_annotation_by_id.return_value = None
 
         with pytest.raises(KeyError):
             assert root[sentinel.annotation_id]
@@ -28,10 +31,6 @@ class TestAnnotationRoot:
     @pytest.fixture
     def root(self, pyramid_request):
         return AnnotationRoot(pyramid_request)
-
-    @pytest.fixture
-    def storage(self, patch):
-        return patch("h.traversal.annotation.storage")
 
     @pytest.fixture
     def AnnotationContext(self, patch):


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/h/issues/7932

## Testing notes

In H /  Via / ViaHTML / Client:

```shell
make services
make dev
```

In one tab:

 * Visit: http://localhost:9083/http://example.com/
 * Login as `devdata_user` / `pass`

In another private tab:

 * Visit: http://localhost:9083/http://example.com/
 * Login as `devdata_admin` / `pass`

### Websocket

 * Create an annotation in one tab
 * Switch to the other and see the websocket update icon
 * Click on it
 * The annotation should appear

### Notification reply

 * Remove `/mail/*` in your `h` directory
 * In the other tab reply to the annotation
 * Look in the `mail/` dir, it should have an `*.eml` file
 * There should be some details related to your reply

### Nearly anything which has a route on the annotation traversal

There are a bunch in routes which use the traversal, but flag is probably the easiest

 * In the admin tab flag an annotation
 * Reload the page
 * It should still be flagged
