### PR TITLE
Replace `storage.fetch_ordered_annotation` with an `AnnotationReadService` method

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,5 +12,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 98.26
+fail_under = 98.27
 skip_covered = True

--- a/h/services/annotation_read.py
+++ b/h/services/annotation_read.py
@@ -29,6 +29,7 @@ class AnnotationReadService:
     ) -> Iterable[Annotation]:
         """
         Get annotations in the same order as the provided ids.
+
         :param ids: the list of annotation ids
         :param eager_load: A list of annotation relationships to eager load
             like `Annotation.document`

--- a/h/services/annotation_read.py
+++ b/h/services/annotation_read.py
@@ -46,14 +46,12 @@ class AnnotationReadService:
 
     @staticmethod
     def _annotation_search_query(
-        ids: Optional[List[str]] = None, eager_load: Optional[List] = None
+        ids: List[str] = None, eager_load: Optional[List] = None
     ) -> Query:
         """Create a query for searching for annotations."""
 
         query = select(Annotation)
-
-        if ids:
-            query = query.where(Annotation.id.in_(ids))
+        query = query.where(Annotation.id.in_(ids))
 
         if eager_load:
             query = query.options(*(subqueryload(prop) for prop in eager_load))

--- a/h/services/annotation_read.py
+++ b/h/services/annotation_read.py
@@ -1,6 +1,7 @@
-from typing import Optional
+from typing import Iterable, List, Optional
 
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.orm import Query, Session, subqueryload
 
 from h.db.types import InvalidUUID
 from h.models import Annotation
@@ -22,6 +23,41 @@ class AnnotationReadService:
             return self._db.query(Annotation).get(id_)
         except InvalidUUID:
             return None
+
+    def get_annotations_by_id(
+        self, ids: List[str], eager_load: Optional[List] = None
+    ) -> Iterable[Annotation]:
+        """
+        Get annotations in the same order as the provided ids.
+        :param ids: the list of annotation ids
+        :param eager_load: A list of annotation relationships to eager load
+            like `Annotation.document`
+        """
+
+        if not ids:
+            return []
+
+        annotations = self._db.execute(
+            self._annotation_search_query(ids=ids, eager_load=eager_load)
+        ).scalars()
+
+        return sorted(annotations, key=lambda annotation: ids.index(annotation.id))
+
+    @staticmethod
+    def _annotation_search_query(
+        ids: Optional[List[str]] = None, eager_load: Optional[List] = None
+    ) -> Query:
+        """Create a query for searching for annotations."""
+
+        query = select(Annotation)
+
+        if ids:
+            query = query.where(Annotation.id.in_(ids))
+
+        if eager_load:
+            query = query.options(*(subqueryload(prop) for prop in eager_load))
+
+        return query
 
 
 def service_factory(_context, request) -> AnnotationReadService:

--- a/h/storage.py
+++ b/h/storage.py
@@ -30,41 +30,6 @@ from h.util.uri import normalize as normalize_uri
 _ = i18n.TranslationStringFactory(__package__)
 
 
-def fetch_ordered_annotations(session, ids, query_processor=None):
-    """
-    Fetch all annotations with the given ids and order them based on the list of ids.
-
-    The optional `query_processor` parameter allows for passing in a function
-    that can change the query before it is run, especially useful for
-    eager-loading certain data. The function will get the query as an argument
-    and has to return a query object again.
-
-    :param session: the database session
-    :type session: sqlalchemy.orm.session.Session
-
-    :param ids: the list of annotation ids
-    :type ids: list
-
-    :param query_processor: an optional function that takes the query and
-                            returns an updated query
-    :type query_processor: callable
-
-    :returns: the annotation, if found, or None.
-    :rtype: h.models.Annotation, NoneType
-    """
-    if not ids:
-        return []
-
-    ordering = {x: i for i, x in enumerate(ids)}
-
-    query = session.query(models.Annotation).filter(models.Annotation.id.in_(ids))
-    if query_processor:
-        query = query_processor(query)
-
-    anns = sorted(query, key=lambda a: ordering.get(a.id))
-    return anns
-
-
 def create_annotation(request, data):
     """
     Create an annotation from already-validated data.

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -389,12 +389,12 @@ class TestExecute:
             for bucket in timeframe.document_buckets.values():
                 presented_annotations.extend(bucket.presented_annotations)
 
-        for annotation in annotations:
-            for presented_annotation in presented_annotations:
-                if presented_annotation["annotation"].annotation == annotation:
-                    break
-            else:
-                assert False
+        assert set(annotations).intersection(
+            {
+                presented_anno["annotation"].annotation
+                for presented_anno in presented_annotations
+            }
+        )
 
     def test_it_returns_each_annotations_group(self, _fetch_groups, pyramid_request):
         result = execute(pyramid_request, MultiDict(), self.PAGE_SIZE)

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -5,7 +5,8 @@ from h_matchers import Any
 from pyramid.httpexceptions import HTTPFound
 from webob.multidict import MultiDict
 
-from h.activity.query import check_url, execute, extract, fetch_annotations
+from h.activity.query import check_url, execute, extract
+from h.models import Annotation
 
 
 class TestExtract:
@@ -190,7 +191,7 @@ class TestCheckURL:
 
 
 @pytest.mark.usefixtures(
-    "fetch_annotations",
+    "annotation_read_service",
     "_fetch_groups",
     "bucketing",
     "presenters",
@@ -353,20 +354,22 @@ class TestExecute:
         assert result.timeframes == []
 
     def test_it_fetches_the_annotations_from_the_database(
-        self, fetch_annotations, pyramid_request, search
+        self, annotation_read_service, pyramid_request, search
     ):
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
-        fetch_annotations.assert_called_once_with(
-            pyramid_request.db, search.run.return_value.annotation_ids
+        annotation_read_service.get_annotations_by_id.assert_called_once_with(
+            ids=search.run.return_value.annotation_ids, eager_load=[Annotation.document]
         )
 
     def test_it_buckets_the_annotations(
-        self, fetch_annotations, bucketing, pyramid_request
+        self, annotation_read_service, bucketing, pyramid_request
     ):
         result = execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
-        bucketing.bucket.assert_called_once_with(fetch_annotations.return_value)
+        bucketing.bucket.assert_called_once_with(
+            annotation_read_service.get_annotations_by_id.return_value
+        )
         assert result.timeframes == bucketing.bucket.return_value
 
     def test_it_fetches_the_groups_from_the_database(
@@ -461,10 +464,6 @@ class TestExecute:
         assert result.aggregations == mock.sentinel.aggregations
 
     @pytest.fixture
-    def fetch_annotations(self, patch):
-        return patch("h.activity.query.fetch_annotations")
-
-    @pytest.fixture
     def _fetch_groups(self, group_pubids, patch):
         _fetch_groups = patch("h.activity.query._fetch_groups")
         _fetch_groups.return_value = [mock.Mock(pubid=pubid) for pubid in group_pubids]
@@ -478,7 +477,6 @@ class TestExecute:
         Return a single flat list of all 20 annotations that will be
         distributed among the timeframes and document buckets that our mock
         bucketing.bucket() will return.
-
         """
         return [
             factories.Annotation.build(id="annotation_" + str(i), groupid=group_pubid)
@@ -525,7 +523,6 @@ class TestExecute:
         Return a single flat list of all 7 document buckets that will be
         distributed among the timeframes that our mock bucketing.bucket() will
         return.
-
         """
 
         def document_bucket(annotations):
@@ -552,7 +549,6 @@ class TestExecute:
 
         Return a single flat list of all 20 pubids of the groups of the
         annotations that our mock bucket() will return.
-
         """
         return ["group_" + str(i) for i in range(20)]
 
@@ -605,16 +601,6 @@ class TestExecute:
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         return pyramid_request
-
-
-class TestFetchAnnotations:
-    def test_it_returns_annotations_by_ids(self, db_session, factories):
-        annotations = factories.Annotation.create_batch(3)
-        ids = [a.id for a in annotations]
-
-        result = fetch_annotations(db_session, ids)
-
-        assert annotations == result
 
 
 @pytest.fixture

--- a/tests/h/services/annotation_read_test.py
+++ b/tests/h/services/annotation_read_test.py
@@ -1,7 +1,9 @@
 from unittest.mock import sentinel
 
 import pytest
+import sqlalchemy as sa
 
+from h.models import Annotation
 from h.services.annotation_read import AnnotationReadService, service_factory
 
 
@@ -11,6 +13,60 @@ class TestAnnotationReadService:
 
     def test_get_annotation_by_id_with_invalid_uuid(self, svc):
         assert not svc.get_annotation_by_id("NOTVALID")
+
+    @pytest.mark.parametrize("reverse", (True, False))
+    def test_get_annotations_by_id(self, svc, factories, reverse):
+        annotations = factories.Annotation.create_batch(3)
+        if reverse:
+            annotations = list(reversed(annotations))
+
+        results = svc.get_annotations_by_id(
+            [annotation.id for annotation in annotations]
+        )
+
+        assert results == annotations
+
+    def test_get_annotations_by_id_with_no_input(self, svc):
+        assert not svc.get_annotations_by_id(ids=[])
+
+    @pytest.mark.parametrize("attribute", ("document", "moderation", "group"))
+    def test_get_annotations_by_id_preloading(
+        self, svc, factories, db_session, query_counter, attribute
+    ):
+        annotation = factories.Annotation()
+
+        # Ensure SQLAlchemy forgets all about our annotation
+        db_session.flush()
+        db_session.expire(annotation)
+        svc.get_annotations_by_id(
+            [annotation.id],
+            eager_load=[
+                getattr(Annotation, attribute),
+                # Add another, so we see if we are constructing the list right
+                Annotation.group,
+            ],
+        )
+        query_counter.reset()
+
+        getattr(annotation, attribute)
+
+        # If we preloaded, we shouldn't execute any queries
+        assert not query_counter.count
+
+    @pytest.fixture
+    def query_counter(self, db_engine):
+        class QueryCounter:
+            count = 0
+
+            def __call__(self, *args, **kwargs):
+                self.count += 1
+
+            def reset(self):
+                self.count = 0
+
+        query_counter = QueryCounter()
+        sa.event.listen(db_engine, "before_cursor_execute", query_counter)
+        return query_counter
 
     @pytest.fixture
     def annotation(self, factories):

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -7,44 +7,12 @@ import sqlalchemy as sa
 from h_matchers import Any
 
 from h import storage
-from h.models.annotation import Annotation
 from h.models.document import Document, DocumentURI
 from h.schemas import ValidationError
 from h.security import Permission
 from h.traversal.group import GroupContext
 
 pytestmark = pytest.mark.usefixtures("search_index")
-
-
-class TestFetchOrderedAnnotations:
-    def test_it_returns_annotations_for_ids_in_the_same_order(
-        self, db_session, factories
-    ):
-        ann_1 = factories.Annotation(userid="luke")
-        ann_2 = factories.Annotation(userid="luke")
-
-        assert [ann_2, ann_1] == storage.fetch_ordered_annotations(
-            db_session, [ann_2.id, ann_1.id]
-        )
-        assert [ann_1, ann_2] == storage.fetch_ordered_annotations(
-            db_session, [ann_1.id, ann_2.id]
-        )
-
-    def test_it_allows_to_change_the_query(self, db_session, factories):
-        ann_1 = factories.Annotation(userid="luke")
-        ann_2 = factories.Annotation(userid="maria")
-
-        def only_maria(query):
-            return query.filter(Annotation.userid == "maria")
-
-        assert [ann_2] == storage.fetch_ordered_annotations(
-            db_session, [ann_2.id, ann_1.id], query_processor=only_maria
-        )
-
-    def test_it_handles_empty_ids(self):
-        results = storage.fetch_ordered_annotations(sentinel.db_session, ids=[])
-
-        assert results == []
 
 
 class TestExpandURI:

--- a/tests/h/views/feeds_test.py
+++ b/tests/h/views/feeds_test.py
@@ -1,103 +1,66 @@
-from unittest import mock
+from unittest.mock import sentinel
 
 import pytest
 
-from h.search.core import SearchResult
 from h.views.feeds import stream_atom, stream_rss
 
 
-@pytest.mark.usefixtures(
-    "fetch_ordered_annotations", "render_atom", "search_run", "routes"
-)
 class TestStreamAtom:
-    def test_renders_atom(self, pyramid_request, render_atom):
-        stream_atom(pyramid_request)
+    def test_it(self, render_atom, pyramid_request, annotation_read_service):
+        result = stream_atom(pyramid_request)
 
         render_atom.assert_called_once_with(
             request=pyramid_request,
-            annotations=mock.sentinel.fetched_annotations,
-            atom_url="http://example.com/thestream.atom",
-            html_url="http://example.com/thestream",
-            title="Some feed",
-            subtitle="It contains stuff",
+            annotations=annotation_read_service.get_annotations_by_id.return_value,
+            atom_url="http://example.com/stream_atom",
+            html_url="http://example.com/stream",
+            title=sentinel.feed_title,
+            subtitle=sentinel.feed_subtitle,
         )
-
-    def test_returns_rendered_atom(self, pyramid_request, render_atom):
-        result = stream_atom(pyramid_request)
 
         assert result == render_atom.return_value
 
+    @pytest.fixture
+    def render_atom(self, patch):
+        return patch("h.views.feeds.render_atom")
 
-@pytest.mark.usefixtures(
-    "fetch_ordered_annotations", "render_rss", "search_run", "routes"
-)
+
 class TestStreamRSS:
-    def test_renders_rss(self, pyramid_request, render_rss):
-        stream_rss(pyramid_request)
+    def test_it(self, render_rss, pyramid_request, annotation_read_service):
+        result = stream_rss(pyramid_request)
 
         render_rss.assert_called_once_with(
             request=pyramid_request,
-            annotations=mock.sentinel.fetched_annotations,
-            rss_url="http://example.com/thestream.rss",
-            html_url="http://example.com/thestream",
-            title="Some feed",
-            description="Stuff and things",
+            annotations=annotation_read_service.get_annotations_by_id.return_value,
+            rss_url="http://example.com/stream_rss",
+            html_url="http://example.com/stream",
+            title=sentinel.feed_title,
+            description=sentinel.feed_description,
         )
-
-    def test_returns_rendered_rss(self, pyramid_request, render_rss):
-        result = stream_rss(pyramid_request)
 
         assert result == render_rss.return_value
 
-
-@pytest.fixture
-def fetch_ordered_annotations(patch):
-    fetch_ordered_annotations = patch("h.views.feeds.fetch_ordered_annotations")
-    fetch_ordered_annotations.return_value = mock.sentinel.fetched_annotations
-    return fetch_ordered_annotations
+    @pytest.fixture
+    def render_rss(self, patch):
+        return patch("h.views.feeds.render_rss")
 
 
 @pytest.fixture
 def pyramid_settings(pyramid_settings):
-    settings = {}
-    settings.update(pyramid_settings)
-    settings.update(
-        {
-            "h.feed.title": "Some feed",
-            "h.feed.subtitle": "It contains stuff",
-            "h.feed.description": "Stuff and things",
-        }
-    )
-    return settings
+    pyramid_settings["h.feed.title"] = sentinel.feed_title
+    pyramid_settings["h.feed.subtitle"] = sentinel.feed_subtitle
+    pyramid_settings["h.feed.description"] = sentinel.feed_description
+
+    return pyramid_settings
 
 
-@pytest.fixture
-def render_atom(patch):
-    return patch("h.views.feeds.render_atom")
+@pytest.fixture(autouse=True)
+def Search(patch):
+    return patch("h.views.feeds.Search")
 
 
-@pytest.fixture
-def render_rss(patch):
-    return patch("h.views.feeds.render_rss")
-
-
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def routes(pyramid_config):
-    pyramid_config.add_route("stream_atom", "/thestream.atom")
-    pyramid_config.add_route("stream_rss", "/thestream.rss")
-    pyramid_config.add_route("stream", "/thestream")
-
-
-@pytest.fixture
-def search(patch):
-    return patch("h.views.feeds.search")
-
-
-@pytest.fixture
-def search_run(search):
-    result = SearchResult(
-        total=123, annotation_ids=["foo", "bar"], reply_ids=[], aggregations={}
-    )
-    search_run = search.Search.return_value.run
-    search_run.return_value = result
-    return search_run
+    pyramid_config.add_route("stream_atom", "/stream_atom")
+    pyramid_config.add_route("stream_rss", "/stream_rss")
+    pyramid_config.add_route("stream", "/stream")


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/h/issues/7932
 
Based on:

 * https://github.com/hypothesis/h/pull/7947

## Testing notes

 * Start H, the client, Via and ViaHTML
 * `make devdata`
 * Login to H: http://0.0.0.0:5000/login (devdata_user / pass)
 * Visit: http://localhost:9083/https://example.com/
 * Make an annotation with some text which is easy to spot

Checking search:

 * Visit: http://0.0.0.0:5000/users/devdata_user
 * Expand the annotation on example.com
 * You should see your annotation content
 
Checking annotation read JSON in the client:
 
 * Refresh the page: http://localhost:9083/https://example.com/
 * You should see the annotations show up
 * In the background we load: http://localhost:5000/api/search?limit=50&sort=created&order=asc&_separate_replies=false&group=__world__&uri=https%3A%2F%2Fexample.com%2F

Checking Atom and RSS feeds

 * Visit: http://0.0.0.0:5000/stream?q=
 * Visit: http://0.0.0.0:5000/stream.atom
 * Visit: http://0.0.0.0:5000/stream.rss
 * Your annotation should show up in each case