### PR TITLE
Add a filter warning for pkg_resources deprecation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,8 @@ filterwarnings =
 
     # pkg_resources is calling its own deprecated function? Anyway I don't think the problem is with us.
     ignore:^Deprecated call to .pkg_resources\.declare_namespace\('.*'\).\.:DeprecationWarning:pkg_resources
+    # pkg_resources used in some of our dependencies
+    ignore:^pkg_resources is deprecated as an API$:DeprecationWarning:pkg_resources
 
     # Usage of deprecated method of urllib3 within the elasticsearch library
     ignore:^HTTPResponse.getheaders\(\) is deprecated and will be removed in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.$:DeprecationWarning:elasticsearch


### PR DESCRIPTION
Some of our dependencies use the deprecated pkg_resources API.

Ignoring the warning until they get updated.