### PR TITLE
Add `--redirect_uri` and `--grant-type` arguments to the `bin/hypothesis authclient add` command

### DIFF
--- a/h/cli/commands/authclient.py
+++ b/h/cli/commands/authclient.py
@@ -36,7 +36,9 @@ def authclient():
     help="An allowable grant type"
 )
 @click.pass_context
-def add(ctx, name, authority, type_, redirect_uri, grant_type):
+def add(
+    ctx, name, authority, type_, redirect_uri, grant_type
+):  # pylint:disable=too-many-arguments
     """Create a new OAuth client."""
     request = ctx.obj["bootstrap"]()
 

--- a/h/cli/commands/authclient.py
+++ b/h/cli/commands/authclient.py
@@ -27,13 +27,13 @@ def authclient():
 @click.option(
     "--redirect-uri",
     prompt=False,
-    help="URI for browser redirect after authorization. Required if grant type is 'authorization_code'"
+    help="URI for browser redirect after authorization. Required if grant type is 'authorization_code'",
 )
 @click.option(
     "--grant-type",
     type=click.Choice(GrantType.__members__),
     prompt=False,
-    help="An allowable grant type"
+    help="An allowable grant type",
 )
 @click.pass_context
 def add(

--- a/h/cli/commands/authclient.py
+++ b/h/cli/commands/authclient.py
@@ -1,6 +1,7 @@
 import click
 
 from h import models
+from h.models.auth_client import GrantType
 from h.security import token_urlsafe
 
 
@@ -23,14 +24,27 @@ def authclient():
     prompt=True,
     help="The OAuth client type (public, or confidential)",
 )
+@click.option(
+    "--redirect-uri",
+    prompt=False,
+    help="URI for browser redirect after authorization. Required if grant type is 'authorization_code'"
+)
+@click.option(
+    "--grant-type",
+    type=click.Choice(GrantType.__members__),
+    prompt=False,
+    help="An allowable grant type"
+)
 @click.pass_context
-def add(ctx, name, authority, type_):
+def add(ctx, name, authority, type_, redirect_uri, grant_type):
     """Create a new OAuth client."""
     request = ctx.obj["bootstrap"]()
 
     client = models.AuthClient(name=name, authority=authority)
     if type_ == "confidential":
         client.secret = token_urlsafe()
+    client.redirect_uri = redirect_uri
+    client.grant_type = grant_type
     request.db.add(client)
     request.db.flush()
 

--- a/tests/h/cli/commands/authclient_test.py
+++ b/tests/h/cli/commands/authclient_test.py
@@ -48,6 +48,23 @@ class TestAddCommand:
         )
         assert expected_id_and_secret in output
 
+    def test_it_creates_an_authclient_with_grant_type(self, cli, cliconfig, db_session):
+        result = cli.invoke(
+            authclient_cli.add,
+            ["--name", "AuthCode", "--authority", "example.org", "--type", "public",
+             "--grant-type", "authorization_code",
+             "--redirect-uri", "http://localhost:5000/app.html"], obj=cliconfig)
+        
+        assert not result.exit_code
+
+        authclient = (
+            db_session.query(models.AuthClient)
+            .filter(models.AuthClient.authority == "example.org")
+            .first()
+        )
+        assert authclient.grant_type.value == "authorization_code"
+        assert authclient.redirect_uri == "http://localhost:5000/app.html"
+
     def _add_authclient(self, cli, cliconfig, db_session, type_):
         result = cli.invoke(
             authclient_cli.add,

--- a/tests/h/cli/commands/authclient_test.py
+++ b/tests/h/cli/commands/authclient_test.py
@@ -51,10 +51,21 @@ class TestAddCommand:
     def test_it_creates_an_authclient_with_grant_type(self, cli, cliconfig, db_session):
         result = cli.invoke(
             authclient_cli.add,
-            ["--name", "AuthCode", "--authority", "example.org", "--type", "public",
-             "--grant-type", "authorization_code",
-             "--redirect-uri", "http://localhost:5000/app.html"], obj=cliconfig)
-        
+            [
+                "--name",
+                "AuthCode",
+                "--authority",
+                "example.org",
+                "--type",
+                "public",
+                "--grant-type",
+                "authorization_code",
+                "--redirect-uri",
+                "http://localhost:5000/app.html",
+            ],
+            obj=cliconfig,
+        )
+
         assert not result.exit_code
 
         authclient = (


### PR DESCRIPTION
Addresses #7009, adding functionality to the cli tool that otherwise would only be possible in the web interface. Useful for scripting addition of an authclient (e.g., for provisioning
or testing).

This is the same as #7297 rebased against current main. That PR was closed (multiple times) as `stale` without review by anyone on the main development team (see also issue #7572)