### PR TITLE
Create a table of annotation types collected by day

### DIFF
--- a/h/data_tasks/report/create_from_scratch/04_annotation_group_counts/01_create_view.sql
+++ b/h/data_tasks/report/create_from_scratch/04_annotation_group_counts/01_create_view.sql
@@ -3,7 +3,7 @@ DROP MATERIALIZED VIEW IF EXISTS report.annotation_group_counts CASCADE;
 CREATE MATERIALIZED VIEW report.annotation_group_counts AS (
     SELECT
         -- Cast to a date as it's 4 bytes instead of 8
-        DATE_TRUNC('week', created)::date AS created_week,
+        DATE_TRUNC('week', created)::DATE AS created_week,
         authority_id,
         group_id,
         COUNT(1)::INTEGER AS count,

--- a/h/data_tasks/report/create_from_scratch/04_annotation_group_counts/02_initial_fill.sql
+++ b/h/data_tasks/report/create_from_scratch/04_annotation_group_counts/02_initial_fill.sql
@@ -6,5 +6,6 @@ REFRESH MATERIALIZED VIEW report.annotation_group_counts;
 ANALYSE report.annotation_group_counts;
 
 -- A unique index is mandatory for concurrent updates used in the refresh
-CREATE UNIQUE INDEX annotation_group_counts_created_week_authority_id_group_id_idx ON report.annotation_group_counts (authority_id, created_week, group_id);
+CREATE UNIQUE INDEX annotation_group_counts_created_week_authority_id_group_id_idx
+    ON report.annotation_group_counts (authority_id, created_week, group_id);
 CREATE INDEX annotation_group_counts_created_week_idx ON report.annotation_group_counts USING BRIN (created_week);

--- a/h/data_tasks/report/create_from_scratch/07_annotation_type_group_counts/01_create_view.sql
+++ b/h/data_tasks/report/create_from_scratch/07_annotation_type_group_counts/01_create_view.sql
@@ -1,0 +1,50 @@
+DROP MATERIALIZED VIEW IF EXISTS report.annotation_type_group_counts CASCADE;
+
+CREATE TYPE report.annotation_sub_type AS ENUM (
+    -- This is not a good name for a sub-type of an annotation, we should
+    -- change this
+    'annotation',
+    -- Other primary types of annotation
+    'reply', 'highlight', 'page_note'
+);
+
+-- There are various indicators of different sub-types of annotation, only
+-- certain combinations should happen together. This table shows all
+-- combinations and how we will interpret them.
+
+-- This table is in the same order as the CASE statement below.
+
+-- |----------|--------------|-----------|------------|-----------|
+-- | Is Root? | Is Anchored? | Has text? | Sub-Type   | Expected? |
+-- |----------|--------------|-----------|------------|-----------|
+-- | False    | True         | True      | Reply      | No!       |
+-- | False    | True         | False     | Reply      | No!       |
+-- | False    | False        | True      | Reply      | Yes       |
+-- | False    | False        | False     | Reply      | No!       |
+-- | True     | False        | True      | Page-note  | Yes       |
+-- | True     | False        | False     | Page-note  | No!       |
+-- | True     | True         | False     | Highlight  | Yes       |
+-- | True     | True         | True      | Annotation | Yes       |
+-- |----------|--------------|-----------|------------|-----------|
+
+CREATE MATERIALIZED VIEW report.annotation_type_group_counts AS (
+    SELECT
+        authority_id,
+        group_id,
+        -- Cast to a date as it's 4 bytes instead of 8
+        DATE_TRUNC('day', created)::DATE AS created_day,
+        CASE
+            WHEN ARRAY_LENGTH(parent_uuids, 1) IS NOT NULL
+                THEN 'reply'::report.annotation_sub_type
+            WHEN anchored = false
+                THEN 'page_note'::report.annotation_sub_type
+            WHEN size = 0
+                THEN 'highlight'::report.annotation_sub_type
+            ELSE 'annotation'::report.annotation_sub_type
+        END AS sub_type,
+        shared,
+        COUNT(1) AS count
+    FROM report.annotations
+    GROUP BY created_day, authority_id, group_id, sub_type, shared
+    ORDER BY created_day, authority_id, group_id, count DESC
+) WITH NO DATA;

--- a/h/data_tasks/report/create_from_scratch/07_annotation_type_group_counts/01_create_view.sql
+++ b/h/data_tasks/report/create_from_scratch/07_annotation_type_group_counts/01_create_view.sql
@@ -32,7 +32,7 @@ CREATE MATERIALIZED VIEW report.annotation_type_group_counts AS (
         authority_id,
         group_id,
         -- Cast to a date as it's 4 bytes instead of 8
-        DATE_TRUNC('day', created)::DATE AS created_day,
+        DATE_TRUNC('week', created)::DATE AS created_week,
         CASE
             WHEN ARRAY_LENGTH(parent_uuids, 1) IS NOT NULL
                 THEN 'reply'::report.annotation_sub_type
@@ -45,6 +45,6 @@ CREATE MATERIALIZED VIEW report.annotation_type_group_counts AS (
         shared,
         COUNT(1) AS count
     FROM report.annotations
-    GROUP BY created_day, authority_id, group_id, sub_type, shared
-    ORDER BY created_day, authority_id, group_id, count DESC
+    GROUP BY created_week, authority_id, group_id, sub_type, shared
+    ORDER BY created_week, authority_id, group_id, count DESC
 ) WITH NO DATA;

--- a/h/data_tasks/report/create_from_scratch/07_annotation_type_group_counts/02_initial_fill.sql
+++ b/h/data_tasks/report/create_from_scratch/07_annotation_type_group_counts/02_initial_fill.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS report.annotation_type_group_counts_created_day_authority_id_idx;
+
+REFRESH MATERIALIZED VIEW report.annotation_type_group_counts;
+
+ANALYSE report.annotation_type_group_counts;
+
+-- A unique index is mandatory for concurrent updates used in the refresh
+CREATE UNIQUE INDEX annotation_type_group_counts_created_day_authority_id_idx
+    ON report.annotation_type_group_counts (created_day, authority_id, group_id, sub_type, shared);

--- a/h/data_tasks/report/create_from_scratch/07_annotation_type_group_counts/02_initial_fill.sql
+++ b/h/data_tasks/report/create_from_scratch/07_annotation_type_group_counts/02_initial_fill.sql
@@ -1,9 +1,9 @@
-DROP INDEX IF EXISTS report.annotation_type_group_counts_created_day_authority_id_idx;
+DROP INDEX IF EXISTS report.annotation_type_group_counts_created_week_authority_id_idx;
 
 REFRESH MATERIALIZED VIEW report.annotation_type_group_counts;
 
 ANALYSE report.annotation_type_group_counts;
 
 -- A unique index is mandatory for concurrent updates used in the refresh
-CREATE UNIQUE INDEX annotation_type_group_counts_created_day_authority_id_idx
-    ON report.annotation_type_group_counts (created_day, authority_id, group_id, sub_type, shared);
+CREATE UNIQUE INDEX annotation_type_group_counts_created_week_authority_id_idx
+    ON report.annotation_type_group_counts (created_week, authority_id, group_id, sub_type, shared);

--- a/h/data_tasks/report/create_from_scratch/99_grant_permissions/01_grant_schema.jinja2.sql
+++ b/h/data_tasks/report/create_from_scratch/99_grant_permissions/01_grant_schema.jinja2.sql
@@ -22,6 +22,7 @@
 
     GRANT SELECT ON report.authorities TO "{{fdw_user}}";
     GRANT SELECT ON report.annotation_group_counts TO "{{fdw_user}}";
+    GRANT SELECT ON report.annotation_type_group_counts TO "{{fdw_user}}";
     GRANT SELECT ON report.annotation_user_counts TO "{{fdw_user}}";
     GRANT SELECT ON report.authority_activity TO "{{fdw_user}}";
 {% endfor %}

--- a/h/data_tasks/report/refresh/02_materialized_views.sql
+++ b/h/data_tasks/report/refresh/02_materialized_views.sql
@@ -6,3 +6,6 @@ ANALYSE report.annotation_user_counts;
 
 REFRESH MATERIALIZED VIEW CONCURRENTLY report.authority_activity;
 ANALYSE report.authority_activity;
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY report.annotation_type_group_counts;
+ANALYSE report.annotation_type_group_counts;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/231

This is intended to be used to create further aggregations which roll up by different time scales. 

Day has been chosen as some users have expressed a requirement for daily info. I'm not sure if we will need it, but it would be good to see if we can. There are 747,723 rows in the other group count table, which is at a weekly level, so we would expect around 5.2M rows here.

## Follow up

There is some unfortunate overlap with the existing annotation group count table. We should at a minimum:

 * Try and base that table off of this one
 * Collect annotation related things into a folder
 * See if we can shift downstream tables to use this and remove the old one

## Testing notes

 * Usual type of affair for testing reporting
 * Start many things
 * Make some annotations
 * Run the create from scratch and refresh
