### PR TITLE
Increase the timeout for data tasks to allow create from scratch to work

### DIFF
--- a/.github/workflows/data_tasks.yml
+++ b/.github/workflows/data_tasks.yml
@@ -53,7 +53,7 @@ jobs:
     with:
       App: ${{ github.event.repository.name }}
       Env: ${{ inputs.Environment }}
-      Timeout: 3600
+      Timeout: 7200
       Region: ${{ inputs.Region }}
       Command: 'newrelic-admin run-program python bin/run_data_task.py --config-file conf/app.ini --task ${{ inputs.Task }}'
     secrets: inherit


### PR DESCRIPTION
When we had 40M annotations the update took roughly 45 minutes. We now have 51M and we seem to have just nudged over the hour boundary we are allotted to run the create from scratch.

It's not clear how much longer we need.