### PR TITLE
Add missing `pytz` requirement

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -43,6 +43,7 @@ pyramid-retry
 pyramid-tm
 python-dateutil
 python-slugify < 8.1.0
+pytz
 rfc3339-validator  # Required for date-time format checking in jsonschema
 supervisor >= 4.0.0
 sqlparse

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -178,7 +178,9 @@ python-dateutil==2.8.2
 python-slugify==8.0.1
     # via -r requirements/requirements.in
 pytz==2021.3
-    # via celery
+    # via
+    #   -r requirements/requirements.in
+    #   celery
 repoze-sendmail==4.3
     # via pyramid-mailer
 rfc3339-validator==0.1.4


### PR DESCRIPTION
`pytz` is [used by `reset_password.py`](https://github.com/hypothesis/h/blob/f98179e4e4ca50142a06803cddc5c694eea0d5a4/h/schemas/forms/accounts/reset_password.py#L53) but we don't have a direct dependency on it, it's only in our `requirements.txt` file because `celery` depends on it, which means that if celery ever removes its `pytz` dependency our `reset_password.py` will break. Add `pytz` as a direct dependency to fix this.
