### PR TITLE
Add capability to enable a feature flag for first-party users only

### DIFF
--- a/h/migrations/versions/7d39ade34b69_add_feature_first_party.py
+++ b/h/migrations/versions/7d39ade34b69_add_feature_first_party.py
@@ -1,0 +1,22 @@
+"""Add feature.first_party column."""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "7d39ade34b69"
+down_revision = "be612e693243"
+
+
+def upgrade():
+    op.add_column(
+        "feature",
+        sa.Column(
+            "first_party",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.sql.expression.false(),
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("feature", "first_party")

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -55,6 +55,14 @@ class Feature(Base):
         server_default=sa.sql.expression.false(),
     )
 
+    # Is the feature enabled for first-party users?
+    first_party = sa.Column(
+        sa.Boolean,
+        nullable=False,
+        default=False,
+        server_default=sa.sql.expression.false(),
+    )
+
     # Is the feature enabled for admins?
     admins = sa.Column(
         sa.Boolean,

--- a/h/templates/admin/features.html.jinja2
+++ b/h/templates/admin/features.html.jinja2
@@ -23,6 +23,7 @@
           <tr>
             <th></th>
             <th>Everyone</th>
+            <th>First party</th>
             <th>Admins</th>
             <th>Staff</th>
             <th>Cohorts</th>
@@ -38,6 +39,12 @@
                 type="checkbox"
                 name="{{ feat.name }}[everyone]"
                 {% if feat.everyone %}checked{% endif %}>
+            </td>
+            <td>
+              <input
+                type="checkbox"
+                name="{{ feat.name }}[first_party]"
+                {% if feat.first_party %}checked{% endif %}>
             </td>
             <td>
               <input

--- a/h/views/admin/features.py
+++ b/h/views/admin/features.py
@@ -29,7 +29,7 @@ def features_index(request):
 )
 def features_save(request):
     for feat in models.Feature.all(request.db):
-        for attr in ["everyone", "admins", "staff"]:
+        for attr in ["everyone", "first_party", "admins", "staff"]:
             val = request.POST.get(f"{feat.name}[{attr}]")
             if val == "on":
                 setattr(feat, attr, True)

--- a/tests/h/services/feature_test.py
+++ b/tests/h/services/feature_test.py
@@ -64,6 +64,15 @@ class TestFeatureService:
 
         assert svc.enabled("on-for-everyone") is True
 
+    def test_enabled_if_first_party(self, db_session, factories):
+        user = factories.User(authority="foobar.com")
+        third_party_user = factories.User(authority="othersite.com")
+        svc = FeatureService(session=db_session, default_authority=user.authority)
+
+        assert svc.enabled("on-for-first-party") is False
+        assert svc.enabled("on-for-first-party", user) is True
+        assert svc.enabled("on-for-first-party", third_party_user) is False
+
     def test_enabled_false_when_admins_true_no_user(self, db_session):
         svc = FeatureService(session=db_session)
 
@@ -132,6 +141,7 @@ class TestFeatureService:
             "foo": False,
             "bar": False,
             "on-for-everyone": True,
+            "on-for-first-party": False,
             "on-for-staff": False,
             "on-for-admins": False,
             "on-for-cohort": False,
@@ -147,6 +157,7 @@ class TestFeatureService:
             "foo": False,
             "bar": False,
             "on-for-everyone": True,
+            "on-for-first-party": False,
             "on-for-staff": True,
             "on-for-admins": False,
             "on-for-cohort": False,
@@ -159,6 +170,7 @@ class TestFeatureService:
             factories.Feature(name="foo"),
             factories.Feature(name="bar"),
             factories.Feature(name="on-for-everyone", everyone=True),
+            factories.Feature(name="on-for-first-party", first_party=True),
             factories.Feature(name="on-for-staff", staff=True),
             factories.Feature(name="on-for-admins", admins=True),
             factories.Feature(name="on-for-cohort", cohorts=[cohort]),

--- a/tests/h/views/admin/features_test.py
+++ b/tests/h/views/admin/features_test.py
@@ -45,13 +45,22 @@ def test_features_save_sets_attributes_when_checkboxes_on(Feature, pyramid_reque
     Feature.all.return_value = [feature_foo, feature_bar]
     pyramid_request.POST = {
         "foo[everyone]": "on",
+        "foo[first_party]": "on",
         "foo[staff]": "on",
         "bar[admins]": "on",
     }
 
     features_save(pyramid_request)
 
-    assert feature_foo.everyone is feature_foo.staff is feature_bar.admins is True
+    expected_true = {
+        (feature_foo, "everyone"),
+        (feature_foo, "first_party"),
+        (feature_foo, "staff"),
+        (feature_bar, "admins"),
+    }
+    for feature in [feature_foo, feature_bar]:
+        for group in ["everyone", "first_party", "staff", "admins"]:
+            assert getattr(feature, group) is ((feature, group) in expected_true)
 
 
 @features_save_fixtures


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/h/pull/8014.**

This is like the existing "Everyone" option, but only applies for users whose authority is the default authority for the H server (aka. "first party" users).

This will enable us to roll out certain features more gradually, by turning them on first for regular Hypothesis users and then LMS users (and other third parties).

When a user is logged-out, they are considered "not first party". A consequence of this is that feature flags that are on for first-party users will only activate when the user logs in.

----

**Testing:**

1. Check out this branch
2. Run `make db` to run the DB migration (standalone PR for migration: https://github.com/hypothesis/h/pull/8014)
3. Go to http://localhost:5000/admin/features and turn the `html_side_by_side` feature flag on for first party users
4. Go to http://localhost:3000/document/burns or some other HTML page with the client embedded and log in. You should see in the `/api/profile` response that the `html_side_by_side` flag is on
5. Go to an LMS HTML assignment and you will see that the `html_side_by_side` flag is off