### PR TITLE
Create an annotation summary table which summaries counts by various facets

### DIFF
--- a/h/data_tasks/report/create_from_scratch/08_annotation_counts/01_create_view.sql
+++ b/h/data_tasks/report/create_from_scratch/08_annotation_counts/01_create_view.sql
@@ -1,0 +1,55 @@
+-- This is a summary table which re-interprets the annotations data in terms of
+-- weekly counts split by a number of facets:
+--
+--  * Authority
+--  * Group
+--  * User
+--  * Annotation sub-type
+--  * Annotation shared status
+--
+-- This is intended to speed up a variety of summary queries over the table and
+-- make queries about the sub-type easy.
+
+DROP MATERIALIZED VIEW IF EXISTS report.annotation_counts CASCADE;
+
+-- There are various indicators of different sub-types of annotation, only
+-- certain combinations should happen together. This table shows all
+-- combinations and how we will interpret them.
+
+-- This table is in the same order as the CASE statement below.
+
+-- |----------|--------------|-----------|------------|-----------|
+-- | Is Root? | Is Anchored? | Has text? | Sub-Type   | Expected? |
+-- |----------|--------------|-----------|------------|-----------|
+-- | False    | True         | True      | Reply      | No!       |
+-- | False    | True         | False     | Reply      | No!       |
+-- | False    | False        | True      | Reply      | Yes       |
+-- | False    | False        | False     | Reply      | No!       |
+-- | True     | False        | True      | Page-note  | Yes       |
+-- | True     | False        | False     | Page-note  | No!       |
+-- | True     | True         | False     | Highlight  | Yes       |
+-- | True     | True         | True      | Annotation | Yes       |
+-- |----------|--------------|-----------|------------|-----------|
+
+CREATE MATERIALIZED VIEW report.annotation_counts AS (
+    SELECT
+        authority_id,
+        group_id,
+        user_id,
+        -- Cast to a date as it's 4 bytes instead of 8
+        DATE_TRUNC('week', created)::DATE AS created_week,
+        CASE
+            WHEN ARRAY_LENGTH(parent_uuids, 1) IS NOT NULL
+                THEN 'reply'::report.annotation_sub_type
+            WHEN anchored = false
+                THEN 'page_note'::report.annotation_sub_type
+            WHEN size = 0
+                THEN 'highlight'::report.annotation_sub_type
+            ELSE 'annotation'::report.annotation_sub_type
+        END AS sub_type,
+        shared,
+        COUNT(1) AS count
+    FROM report.annotations
+    GROUP BY created_week, authority_id, group_id, user_id, sub_type, shared
+    ORDER BY created_week, authority_id, group_id, user_id, count DESC
+) WITH NO DATA;

--- a/h/data_tasks/report/create_from_scratch/08_annotation_counts/02_initial_fill.sql
+++ b/h/data_tasks/report/create_from_scratch/08_annotation_counts/02_initial_fill.sql
@@ -1,0 +1,11 @@
+DROP INDEX IF EXISTS report.annotation_counts_created_week_authority_id_idx;
+
+REFRESH MATERIALIZED VIEW report.annotation_counts;
+
+ANALYSE report.annotation_counts;
+
+-- A unique index is mandatory for concurrent updates used in the refresh
+CREATE UNIQUE INDEX annotation_counts_created_week_authority_id_idx
+    ON report.annotation_counts (
+        created_week, authority_id, group_id, user_id, sub_type, shared
+    );

--- a/h/data_tasks/report/create_from_scratch/99_grant_permissions/01_grant_schema.jinja2.sql
+++ b/h/data_tasks/report/create_from_scratch/99_grant_permissions/01_grant_schema.jinja2.sql
@@ -22,6 +22,7 @@
 
     GRANT SELECT ON report.authorities TO "{{fdw_user}}";
     GRANT SELECT ON report.annotation_group_counts TO "{{fdw_user}}";
+    GRANT SELECT ON report.annotation_counts TO "{{fdw_user}}";
     GRANT SELECT ON report.annotation_type_group_counts TO "{{fdw_user}}";
     GRANT SELECT ON report.annotation_user_counts TO "{{fdw_user}}";
     GRANT SELECT ON report.authority_activity TO "{{fdw_user}}";

--- a/h/data_tasks/report/fast_recreate/08_annotation_counts
+++ b/h/data_tasks/report/fast_recreate/08_annotation_counts
@@ -1,0 +1,1 @@
+../create_from_scratch/08_annotation_counts/

--- a/h/data_tasks/report/refresh/02_materialized_views.sql
+++ b/h/data_tasks/report/refresh/02_materialized_views.sql
@@ -9,3 +9,6 @@ ANALYSE report.authority_activity;
 
 REFRESH MATERIALIZED VIEW CONCURRENTLY report.annotation_type_group_counts;
 ANALYSE report.annotation_type_group_counts;
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY report.annotation_counts;
+ANALYSE report.annotation_counts;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/235

The main value add here is the addition of the annotation sub-type, and splitting by more facets than before.

## History

This greatly duplicates a number of other tables we have, and is the result of requirements becoming clearer over time. Basically we want to count everything in combination with everything else pretty much.

We probably want to come back round and try and refactor all the other tables out which could be derived from this table.

I was hoping we could not do this, by using more specific tables, but we have a requirement to show counts by:

* Group
* Role (requires user id from H)
* ~Shared / Annotation sub-type~ - This requirement has been removed for now, but I think it's going to come back. We might as well try the single table which contains all of these things

## Testing notes

 * Start all the things and make some annotations (make a mixture of types)
 * Follow the `h` bits only from:
 * https://stackoverflowteams.com/c/hypothesis/questions/513