### PR TITLE
Include filterwarning for pkg_resources deprecations in our dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,8 @@ filterwarnings =
     ignore:^Deprecated call to .pkg_resources\.declare_namespace\('.*'\).\.:DeprecationWarning:pkg_resources
     # pkg_resources used in some of our dependencies
     ignore:^pkg_resources is deprecated as an API$:DeprecationWarning:pkg_resources
+    ignore:^pkg_resources is deprecated as an API:DeprecationWarning:pyramid
+    ignore:^pkg_resources is deprecated as an API:DeprecationWarning:chameleon
 
     # Usage of deprecated method of urllib3 within the elasticsearch library
     ignore:^HTTPResponse.getheaders\(\) is deprecated and will be removed in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.$:DeprecationWarning:elasticsearch

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ filterwarnings =
     # See https://docs.python.org/3/library/warnings.html and
     # https://docs.pytest.org/en/latest/warnings.html
     ignore:^Use of \.\. or absolute path in a resource path is not allowed and will raise exceptions in a future release\.$:DeprecationWarning:pkg_resources
+    ignore:^Use of \.\. or absolute path in a resource path is not allowed and will raise exceptions in a future release\.$:DeprecationWarning:pyramid
     ignore:^the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses$:DeprecationWarning:newrelic.api.import_hook
     ignore:^The behavior of AcceptLanguageValidHeader\.__iter__ is currently maintained for backward compatibility, but will change in the future.$:DeprecationWarning:webob.acceptparse
 


### PR DESCRIPTION
We already had a filter for the usage of the deprecated function but this commit adds it for its usage in our dependencies

We'd have to wait for these to update and stop using this before being able to remove the new warning.