### PR TITLE
Simplify the user delete service and it's tests

### DIFF
--- a/h/cli/commands/user.py
+++ b/h/cli/commands/user.py
@@ -124,8 +124,7 @@ def delete(ctx, username, authority):
             f'no user with username "{username}" and authority "{authority}"'
         )
 
-    svc = request.find_service(name="user_delete")
-    svc.delete(user)
+    request.find_service(name="user_delete").delete_user(user)
     request.tm.commit()
 
     click.echo(f"User {username} deleted.", err=True)

--- a/h/services/user_delete.py
+++ b/h/services/user_delete.py
@@ -23,9 +23,9 @@ class UserDeleteService:
         """
 
         # Delete all annotations
-        annotations = self._db.query(Annotation).filter_by(userid=user.userid)
-        for annotation in annotations:
-            self._annotation_delete_service.delete(annotation)
+        self._annotation_delete_service.delete_annotations(
+            annotations=self._db.query(Annotation).filter_by(userid=user.userid).all()
+        )
 
         # Delete or remove our link to groups we've created
         for group, annotations_by_other_users in self._db.execute(

--- a/h/services/user_delete.py
+++ b/h/services/user_delete.py
@@ -1,4 +1,4 @@
-from h.models import Annotation, Group
+from h.models import Annotation, Group, User
 
 
 class UserDeleteService:
@@ -6,7 +6,7 @@ class UserDeleteService:
         self.request = request
         self._annotation_delete_service = annotation_delete_service
 
-    def delete(self, user):
+    def delete_user(self, user: User):
         """
         Delete a user with all their group memberships and annotations.
 

--- a/h/services/user_delete.py
+++ b/h/services/user_delete.py
@@ -22,59 +22,29 @@ class UserDeleteService:
         as creator but the group persists.
         """
 
-        created_groups = self._db.query(Group).filter(Group.creator == user)
-        groups_to_unassign_creator = self._groups_that_have_collaborators(
-            created_groups, user
-        )
-        groups_to_delete = list(set(created_groups) - set(groups_to_unassign_creator))
-
-        self._delete_annotations(user)
-        self._delete_groups(groups_to_delete)
-        self._unassign_groups_creator(groups_to_unassign_creator)
-        self._db.delete(user)
-
-    def _groups_that_have_collaborators(self, groups, user):
-        """
-        Return list of groups that have annotations from other users.
-
-        :param groups: List of group objects to evaluate.
-        :type groups: list[h.models.Group]
-        :param user: The user object and creator of the groups.
-        :type user: h.models.User
-
-        :returns: List of h.models.Group objects that contain annotations made by
-          other users.
-        """
-        group_ids = [g.pubid for g in groups]
-
-        # We check for non-empty `group_ids` before querying the DB to avoid an
-        # expensive SQL query if `in_` is given an empty list (see
-        # https://stackoverflow.com/questions/23523147/)
-        if not group_ids:
-            return []
-
-        query = (
-            self._db.query(Annotation.groupid)
-            .filter(Annotation.groupid.in_(group_ids), Annotation.userid != user.userid)
-            .group_by(Annotation.groupid)
-        )
-        groupids_with_other_user_anns = [pubid for (pubid,) in query.all()]
-
-        return [g for g in groups if g.pubid in groupids_with_other_user_anns]
-
-    def _delete_annotations(self, user):
+        # Delete all annotations
         annotations = self._db.query(Annotation).filter_by(userid=user.userid)
         for annotation in annotations:
             self._annotation_delete_service.delete(annotation)
 
-    def _delete_groups(self, groups):
-        for group in groups:
-            self._db.delete(group)
+        # Delete or remove our link to groups we've created
+        for group, annotations_by_other_users in self._db.execute(
+            sa.select([Group, sa.func.count(Annotation.id)])
+            .where(Group.creator == user)
+            .outerjoin(
+                Annotation,
+                sa.and_(
+                    Annotation.groupid == Group.pubid, Annotation.userid != user.userid
+                ),
+            )
+            .group_by(Group.id)
+        ):
+            if annotations_by_other_users:
+                group.creator = None
+            else:
+                self._db.delete(group)
 
-    @staticmethod
-    def _unassign_groups_creator(groups):
-        for group in groups:
-            group.creator = None
+        self._db.delete(user)
 
 
 def service_factory(_context, request):

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -134,7 +134,7 @@ def users_delete(request):
     user = _form_request_user(request)
     svc = request.find_service(name="user_delete")
 
-    svc.delete(user)
+    svc.delete_user(user)
     request.session.flash(
         f"Successfully deleted user {user.username} with authority {user.authority}"
         "success",

--- a/tests/h/cli/commands/user_test.py
+++ b/tests/h/cli/commands/user_test.py
@@ -200,7 +200,7 @@ class TestDeleteUserCommand:
         result = invoke_cli(user_cli.delete, [user.username])
 
         assert not result.exit_code
-        user_delete_service.delete.assert_called_once_with(user)
+        user_delete_service.delete_user.assert_called_once_with(user)
 
     def test_it_deletes_user_with_specific_authority(
         self, invoke_cli, user, user_delete_service
@@ -212,7 +212,7 @@ class TestDeleteUserCommand:
         )
 
         assert not result.exit_code
-        user_delete_service.delete.assert_called_once_with(user)
+        user_delete_service.delete_user.assert_called_once_with(user)
 
     def test_it_errors_when_user_could_not_be_found(
         self, invoke_cli, user_delete_service
@@ -220,7 +220,7 @@ class TestDeleteUserCommand:
         result = invoke_cli(user_cli.delete, ["bogus_username"])
 
         assert result.exit_code == 1
-        user_delete_service.delete.assert_not_called()
+        user_delete_service.delete_user.assert_not_called()
 
     def test_it_errors_when_user_with_specific_authority_could_not_be_found(
         self, invoke_cli, user, user_delete_service
@@ -228,7 +228,7 @@ class TestDeleteUserCommand:
         result = invoke_cli(user_cli.delete, ["--authority", "foo.com", user.username])
 
         assert result.exit_code == 1
-        user_delete_service.delete.assert_not_called()
+        user_delete_service.delete_user.assert_not_called()
 
     @pytest.fixture
     def user(self, factories):

--- a/tests/h/services/user_delete_test.py
+++ b/tests/h/services/user_delete_test.py
@@ -3,6 +3,7 @@ from unittest.mock import sentinel
 
 import pytest
 import sqlalchemy
+from h_matchers import Any
 
 from h.models import Annotation, Document
 from h.services.annotation_delete import AnnotationDeleteService
@@ -21,15 +22,12 @@ class TestDeleteUserService:
         self, svc, factories, annotation_delete_service
     ):
         user = factories.User(username="bob")
-        anns = [
-            factories.Annotation(userid=user.userid),
-            factories.Annotation(userid=user.userid),
-        ]
+        annotations = factories.Annotation.create_batch(2, userid=user.userid)
 
         svc.delete_user(user)
 
-        annotation_delete_service.delete.assert_has_calls(
-            [mock.call(anns[0]), mock.call(anns[1])], any_order=True
+        annotation_delete_service.delete_annotations.assert_called_once_with(
+            Any.iterable.containing(annotations).only()
         )
 
     def test_delete_deletes_user(self, svc, db_session, factories):

--- a/tests/h/services/user_delete_test.py
+++ b/tests/h/services/user_delete_test.py
@@ -13,7 +13,7 @@ class TestDeleteUserService:
     def test_delete_disassociate_group_memberships(self, factories, svc):
         user = factories.User()
 
-        svc.delete(user)
+        svc.delete_user(user)
 
         assert user.groups == []
 
@@ -26,7 +26,7 @@ class TestDeleteUserService:
             factories.Annotation(userid=user.userid),
         ]
 
-        svc.delete(user)
+        svc.delete_user(user)
 
         annotation_delete_service.delete.assert_has_calls(
             [mock.call(anns[0]), mock.call(anns[1])], any_order=True
@@ -35,7 +35,7 @@ class TestDeleteUserService:
     def test_delete_deletes_user(self, db_session, factories, svc):
         user = factories.User()
 
-        svc.delete(user)
+        svc.delete_user(user)
 
         assert user in db_session.deleted
 
@@ -46,7 +46,7 @@ class TestDeleteUserService:
         (group, creator, _, _, member_ann) = group_with_two_users
         db_session.delete(member_ann)
 
-        svc.delete(creator)
+        svc.delete_user(creator)
 
         assert sqlalchemy.inspect(group).was_deleted
 
@@ -56,7 +56,7 @@ class TestDeleteUserService:
         pyramid_request.db = db_session
         (group, creator, _, _, _) = group_with_two_users
 
-        svc.delete(creator)
+        svc.delete_user(creator)
 
         assert group.creator is None
 
@@ -66,7 +66,7 @@ class TestDeleteUserService:
         pyramid_request.db = db_session
         (group, _, member, _, _) = group_with_two_users
 
-        svc.delete(member)
+        svc.delete_user(member)
 
         assert group not in db_session.deleted
 

--- a/tests/h/services/user_delete_test.py
+++ b/tests/h/services/user_delete_test.py
@@ -1,111 +1,91 @@
-from unittest import mock
 from unittest.mock import sentinel
 
 import pytest
 import sqlalchemy
 from h_matchers import Any
 
-from h.models import Annotation, Document
-from h.services.annotation_delete import AnnotationDeleteService
+from h.models import GroupMembership
 from h.services.user_delete import UserDeleteService, service_factory
 
 
 class TestDeleteUserService:
-    def test_delete_disassociate_group_memberships(self, svc, factories):
-        user = factories.User()
-
-        svc.delete_user(user)
-
-        assert user.groups == []
-
-    def test_delete_deletes_annotations(
-        self, svc, factories, annotation_delete_service
+    def test_it(
+        self,
+        svc,
+        db_session,
+        annotation_delete_service,
+        user,
+        created_group,
+        joined_group,
+        user_annotations,
     ):
-        user = factories.User(username="bob")
-        annotations = factories.Annotation.create_batch(2, userid=user.userid)
-
         svc.delete_user(user)
 
+        # Check the user was deleted
+        assert user in db_session.deleted
+        # Check we delete this user's annotations
         annotation_delete_service.delete_annotations.assert_called_once_with(
-            Any.iterable.containing(annotations).only()
+            Any.iterable.containing(user_annotations).only()
+        )
+        # Check we delete groups we created, but not ones we joined
+        assert sqlalchemy.inspect(created_group).was_deleted
+        assert not sqlalchemy.inspect(joined_group).was_deleted
+        # Check we remove their group memberships
+        assert (
+            not db_session.query(GroupMembership)
+            .where(GroupMembership.user_id == user.id)
+            .all()
+        )
+        assert (
+            not db_session.query(GroupMembership)
+            .where(GroupMembership.group_id == created_group.id)
+            .all()
         )
 
-    def test_delete_deletes_user(self, svc, db_session, factories):
-        user = factories.User()
+    def test_it_doesnt_delete_groups_others_have_annotated_in(
+        self, svc, factories, user, member, created_group
+    ):
+        factories.Annotation(userid=member.userid, groupid=created_group.pubid)
 
         svc.delete_user(user)
 
-        assert user in db_session.deleted
+        # Check we don't delete groups which other people have annotated in
+        assert not sqlalchemy.inspect(created_group).was_deleted
+        # But that we are removed as the creator
+        assert not created_group.creator
 
-    def test_delete_user_removes_groups_if_no_collaborators(
-        self, svc, db_session, group_with_two_users
-    ):
-        (group, creator, _, _, member_ann) = group_with_two_users
-        db_session.delete(member_ann)
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User()
 
-        svc.delete_user(creator)
+    @pytest.fixture
+    def member(self, factories):
+        return factories.User()
 
-        assert sqlalchemy.inspect(group).was_deleted
+    @pytest.fixture
+    def created_group(self, factories, user, member):
+        return factories.Group(
+            authority=user.authority, creator=user, members=[user, member]
+        )
 
-    def test_creator_is_none_if_groups_have_collaborators(
-        self, svc, group_with_two_users
-    ):
-        (group, creator, _, _, _) = group_with_two_users
+    @pytest.fixture
+    def joined_group(self, factories, user, member):
+        return factories.Group(
+            authority=user.authority, creator=member, members=[user, member]
+        )
 
-        svc.delete_user(creator)
-
-        assert group.creator is None
-
-    def test_delete_user_removes_only_groups_created_by_user(
-        self, svc, db_session, group_with_two_users
-    ):
-        (group, _, member, _, _) = group_with_two_users
-
-        svc.delete_user(member)
-
-        assert group not in db_session.deleted
+    @pytest.fixture
+    def user_annotations(self, factories, user, created_group, joined_group):
+        return [
+            factories.Annotation(userid=user.userid, groupid=group.pubid)
+            for group in (created_group, joined_group)
+        ]
 
     @pytest.fixture
     def svc(self, db_session, annotation_delete_service):
         return UserDeleteService(
             db_session=db_session, annotation_delete_service=annotation_delete_service
         )
-
-
-@pytest.fixture
-def pyramid_request(pyramid_request):
-    pyramid_request.notify_after_commit = mock.Mock()
-    return pyramid_request
-
-
-@pytest.fixture
-def group_with_two_users(db_session, factories):
-    """Create a group with two members and an annotation created by each."""
-    creator = factories.User()
-    member = factories.User()
-
-    group = factories.Group(
-        authority=creator.authority, creator=creator, members=[creator, member]
-    )
-
-    doc = Document(web_uri="https://example.org")
-    creator_ann = Annotation(userid=creator.userid, groupid=group.pubid, document=doc)
-    member_ann = Annotation(userid=member.userid, groupid=group.pubid, document=doc)
-
-    db_session.add(creator_ann)
-    db_session.add(member_ann)
-    db_session.flush()
-
-    return (group, creator, member, creator_ann, member_ann)
-
-
-@pytest.fixture
-def annotation_delete_service(pyramid_config):
-    service = mock.create_autospec(
-        AnnotationDeleteService, spec_set=True, instance=True
-    )
-    pyramid_config.register_service(service, name="annotation_delete")
-    return service
 
 
 class TestServiceFactory:

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -212,7 +212,7 @@ def test_users_delete_deletes_user(user_service, user_delete_service, pyramid_re
 
     users_delete(pyramid_request)
 
-    user_delete_service.delete.assert_called_once_with(user)
+    user_delete_service.delete_user.assert_called_once_with(user)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Requires:

 * https://github.com/hypothesis/h/pull/8075
 * https://github.com/hypothesis/h/pull/8082

Refactor the user service to be smaller and normaller. This:

 * Adds test for the factory method
 * Keeps a DB session instead of the whole request object
 * Simplifies the code a lot
 * Simplifies the tests a bit
 * Moves to SQLAlchemy 2.0 friendly style

## Review notes

There should be no change in behavior, apart from being slightly faster.

The main change here is to replace a lot of Python code with SQL. Previously we were getting the list of groups created by the user, and then searching for those groups which have annotations in them by other users. After this we did a lot of list comprehensions and set manipulation to try and separate out two sets of groups:

 * Those which the user created, with no annotations by other people - These get deleted
 * Those which the user created, with annotations by other people - These get the creator set to `None`

In this version we look for the groups the user created and simultaneously count all the annotations by other users with an outer join all in SQL. We then take appropriate action depending on whether the count is 0 or not.

## If this works, why bother?

We are going to be letting the user trigger this code in the future ideally. I wanted to read this and understand what it did to make sure it was ready for to be used in this way.

I found the previous formulation long and confusing.

## Testing notes

This doesn't cover all the nitty gritty with different groups and memberships. Hopefully the unit tests do that, but we can kick the tires to make sure it's basically sound:

 * `make services devdata dev`
 * Visit: http://localhost:5000/login
 * Login as `devdata_admin` / `pass`
 * Visit: http://localhost:5000/admin/users
 * Search for `devdata_user`
 * Press "Delete user" and confirm
 * Nothing explodes!
 * Search for `devdata_user`. They should be gone
 * `make devdata` to reset