### PR TITLE
Refactor the CLI user script tests to use fixtures normally

### DIFF
--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -28,6 +28,7 @@ from h.services.search_index._queue import Queue
 from h.services.subscription import SubscriptionService
 from h.services.url_migration import URLMigrationService
 from h.services.user import UserService
+from h.services.user_delete import UserDeleteService
 from h.services.user_password import UserPasswordService
 from h.services.user_signup import UserSignupService
 from h.services.user_unique import UserUniqueService
@@ -59,6 +60,7 @@ __all__ = (
     "search_index",
     "subscription_service",
     "url_migration_service",
+    "user_delete_service",
     "user_password_service",
     "user_service",
     "user_password_service",
@@ -218,6 +220,11 @@ def subscription_service(mock_service):
 @pytest.fixture
 def url_migration_service(mock_service):
     return mock_service(URLMigrationService, name="url_migration")
+
+
+@pytest.fixture
+def user_delete_service(mock_service):
+    return mock_service(UserDeleteService, name="user_delete")
 
 
 @pytest.fixture

--- a/tests/h/cli/commands/user_test.py
+++ b/tests/h/cli/commands/user_test.py
@@ -2,8 +2,8 @@ from unittest import mock
 
 import pytest
 
-from h import models
 from h.cli.commands import user as user_cli
+from h.models import User
 
 
 class TestAddCommand:
@@ -63,7 +63,7 @@ class TestAdminCommand:
 
         assert not result.exit_code
 
-        user = db_session.query(models.User).get(non_admin_user.id)
+        user = db_session.query(User).get(non_admin_user.id)
         assert user.admin
 
     def test_it_adds_admin_by_default(self, invoke_cli, non_admin_user, db_session):
@@ -71,7 +71,7 @@ class TestAdminCommand:
 
         assert not result.exit_code
 
-        user = db_session.query(models.User).get(non_admin_user.id)
+        user = db_session.query(User).get(non_admin_user.id)
         assert user.admin
 
     def test_it_adds_admin_with_specific_authority(
@@ -86,7 +86,7 @@ class TestAdminCommand:
 
         assert not result.exit_code
 
-        user = db_session.query(models.User).get(non_admin_user.id)
+        user = db_session.query(User).get(non_admin_user.id)
         assert user.admin
 
     def test_it_removes_admin(self, invoke_cli, admin_user, db_session):
@@ -94,7 +94,7 @@ class TestAdminCommand:
 
         assert not result.exit_code
 
-        user = db_session.query(models.User).get(admin_user.id)
+        user = db_session.query(User).get(admin_user.id)
         assert not user.admin
 
     def test_it_removes_admin_with_specific_authority(
@@ -108,7 +108,7 @@ class TestAdminCommand:
 
         assert not result.exit_code
 
-        user = db_session.query(models.User).get(admin_user.id)
+        user = db_session.query(User).get(admin_user.id)
         assert not user.admin
 
     def test_it_errors_when_user_could_not_be_found(
@@ -117,7 +117,7 @@ class TestAdminCommand:
         result = invoke_cli(user_cli.admin, [f"bogus_{non_admin_user.username}"])
 
         assert result.exit_code == 1
-        user = db_session.query(models.User).get(non_admin_user.id)
+        user = db_session.query(User).get(non_admin_user.id)
         assert not user.admin
 
     def test_it_errors_when_user_with_specific_authority_could_not_be_found(
@@ -128,7 +128,7 @@ class TestAdminCommand:
         )
 
         assert result.exit_code == 1
-        user = db_session.query(models.User).get(non_admin_user.id)
+        user = db_session.query(User).get(non_admin_user.id)
         assert not user.admin
 
     @pytest.fixture
@@ -148,7 +148,7 @@ class TestPasswordCommand:
 
         assert not result.exit_code
 
-        user = db_session.query(models.User).get(user.id)
+        user = db_session.query(User).get(user.id)
         user_password_service.update_password.assert_called_once_with(user, "newpass")
 
     def test_it_changes_password_with_specific_authority(
@@ -164,7 +164,7 @@ class TestPasswordCommand:
 
         assert not result.exit_code
 
-        user = db_session.query(models.User).get(user.id)
+        user = db_session.query(User).get(user.id)
         user_password_service.update_password.assert_called_once_with(user, "newpass")
 
     def test_it_errors_when_user_could_not_be_found(

--- a/tests/h/cli/commands/user_test.py
+++ b/tests/h/cli/commands/user_test.py
@@ -7,10 +7,8 @@ from h.cli.commands import user as user_cli
 
 
 class TestAddCommand:
-    def test_it_adds_user_with_default_authority(
-        self, cli, cliconfig, user_signup_service
-    ):
-        result = cli.invoke(
+    def test_it_adds_user_with_default_authority(self, invoke_cli, user_signup_service):
+        result = invoke_cli(
             user_cli.add,
             [
                 "--username",
@@ -20,7 +18,6 @@ class TestAddCommand:
                 "--password",
                 "admin",
             ],
-            obj=cliconfig,
         )
 
         assert not result.exit_code
@@ -33,9 +30,9 @@ class TestAddCommand:
         )
 
     def test_it_adds_user_with_specific_authority(
-        self, cli, cliconfig, user_signup_service
+        self, invoke_cli, user_signup_service
     ):
-        result = cli.invoke(
+        result = invoke_cli(
             user_cli.add,
             [
                 "--username",
@@ -47,7 +44,6 @@ class TestAddCommand:
                 "--authority",
                 "publisher.org",
             ],
-            obj=cliconfig,
         )
 
         assert not result.exit_code
@@ -62,18 +58,16 @@ class TestAddCommand:
 
 
 class TestAdminCommand:
-    def test_it_adds_admin(self, cli, cliconfig, non_admin_user, db_session):
-        result = cli.invoke(
-            user_cli.admin, ["--on", non_admin_user.username], obj=cliconfig
-        )
+    def test_it_adds_admin(self, invoke_cli, non_admin_user, db_session):
+        result = invoke_cli(user_cli.admin, ["--on", non_admin_user.username])
 
         assert not result.exit_code
 
         user = db_session.query(models.User).get(non_admin_user.id)
         assert user.admin
 
-    def test_it_adds_admin_by_default(self, cli, cliconfig, non_admin_user, db_session):
-        result = cli.invoke(user_cli.admin, [non_admin_user.username], obj=cliconfig)
+    def test_it_adds_admin_by_default(self, invoke_cli, non_admin_user, db_session):
+        result = invoke_cli(user_cli.admin, [non_admin_user.username])
 
         assert not result.exit_code
 
@@ -81,15 +75,13 @@ class TestAdminCommand:
         assert user.admin
 
     def test_it_adds_admin_with_specific_authority(
-        self, cli, cliconfig, non_admin_user, db_session
+        self, invoke_cli, non_admin_user, db_session
     ):
         non_admin_user.authority = "partner.org"
         db_session.flush()
 
-        result = cli.invoke(
-            user_cli.admin,
-            ["--authority", "partner.org", non_admin_user.username],
-            obj=cliconfig,
+        result = invoke_cli(
+            user_cli.admin, ["--authority", "partner.org", non_admin_user.username]
         )
 
         assert not result.exit_code
@@ -97,10 +89,8 @@ class TestAdminCommand:
         user = db_session.query(models.User).get(non_admin_user.id)
         assert user.admin
 
-    def test_it_removes_admin(self, cli, cliconfig, admin_user, db_session):
-        result = cli.invoke(
-            user_cli.admin, ["--off", admin_user.username], obj=cliconfig
-        )
+    def test_it_removes_admin(self, invoke_cli, admin_user, db_session):
+        result = invoke_cli(user_cli.admin, ["--off", admin_user.username])
 
         assert not result.exit_code
 
@@ -108,14 +98,12 @@ class TestAdminCommand:
         assert not user.admin
 
     def test_it_removes_admin_with_specific_authority(
-        self, cli, cliconfig, admin_user, db_session
+        self, invoke_cli, admin_user, db_session
     ):
         admin_user.authority = "partner.org"
 
-        result = cli.invoke(
-            user_cli.admin,
-            ["--off", "--authority", "partner.org", admin_user.username],
-            obj=cliconfig,
+        result = invoke_cli(
+            user_cli.admin, ["--off", "--authority", "partner.org", admin_user.username]
         )
 
         assert not result.exit_code
@@ -124,23 +112,19 @@ class TestAdminCommand:
         assert not user.admin
 
     def test_it_errors_when_user_could_not_be_found(
-        self, cli, cliconfig, non_admin_user, db_session
+        self, invoke_cli, non_admin_user, db_session
     ):
-        result = cli.invoke(
-            user_cli.admin, [f"bogus_{non_admin_user.username}"], obj=cliconfig
-        )
+        result = invoke_cli(user_cli.admin, [f"bogus_{non_admin_user.username}"])
 
         assert result.exit_code == 1
         user = db_session.query(models.User).get(non_admin_user.id)
         assert not user.admin
 
     def test_it_errors_when_user_with_specific_authority_could_not_be_found(
-        self, cli, cliconfig, non_admin_user, db_session
+        self, invoke_cli, non_admin_user, db_session
     ):
-        result = cli.invoke(
-            user_cli.admin,
-            ["--authority", "foo.com", non_admin_user.username],
-            obj=cliconfig,
+        result = invoke_cli(
+            user_cli.admin, ["--authority", "foo.com", non_admin_user.username]
         )
 
         assert result.exit_code == 1
@@ -158,11 +142,9 @@ class TestAdminCommand:
 
 class TestPasswordCommand:
     def test_it_changes_password(
-        self, cli, cliconfig, user, db_session, user_password_service
+        self, invoke_cli, user, db_session, user_password_service
     ):
-        result = cli.invoke(
-            user_cli.password, [user.username, "--password", "newpass"], obj=cliconfig
-        )
+        result = invoke_cli(user_cli.password, [user.username, "--password", "newpass"])
 
         assert not result.exit_code
 
@@ -170,15 +152,14 @@ class TestPasswordCommand:
         user_password_service.update_password.assert_called_once_with(user, "newpass")
 
     def test_it_changes_password_with_specific_authority(
-        self, cli, cliconfig, user, db_session, user_password_service
+        self, invoke_cli, user, db_session, user_password_service
     ):
         user.authority = "partner.org"
         db_session.flush()
 
-        result = cli.invoke(
+        result = invoke_cli(
             user_cli.password,
             ["--authority", "partner.org", user.username, "--password", "newpass"],
-            obj=cliconfig,
         )
 
         assert not result.exit_code
@@ -187,12 +168,10 @@ class TestPasswordCommand:
         user_password_service.update_password.assert_called_once_with(user, "newpass")
 
     def test_it_errors_when_user_could_not_be_found(
-        self, cli, cliconfig, user_password_service
+        self, invoke_cli, user_password_service
     ):
-        result = cli.invoke(
-            user_cli.password,
-            ["bogus_username", "--password", "newpass"],
-            obj=cliconfig,
+        result = invoke_cli(
+            user_cli.password, ["bogus_username", "--password", "newpass"]
         )
 
         assert result.exit_code == 1
@@ -200,12 +179,11 @@ class TestPasswordCommand:
         user_password_service.update_password.assert_not_called()
 
     def test_it_errors_when_user_with_specific_authority_could_not_be_found(
-        self, cli, cliconfig, user, user_password_service
+        self, invoke_cli, user, user_password_service
     ):
-        result = cli.invoke(
+        result = invoke_cli(
             user_cli.password,
             ["--authority", "foo.com", user.username, "--password", "newpass"],
-            obj=cliconfig,
         )
 
         assert result.exit_code == 1
@@ -218,40 +196,36 @@ class TestPasswordCommand:
 
 
 class TestDeleteUserCommand:
-    def test_it_deletes_user(self, cli, cliconfig, user, user_delete_service):
-        result = cli.invoke(user_cli.delete, [user.username], obj=cliconfig)
+    def test_it_deletes_user(self, invoke_cli, user, user_delete_service):
+        result = invoke_cli(user_cli.delete, [user.username])
 
         assert not result.exit_code
         user_delete_service.delete.assert_called_once_with(user)
 
     def test_it_deletes_user_with_specific_authority(
-        self, cli, cliconfig, user, user_delete_service
+        self, invoke_cli, user, user_delete_service
     ):
         user.authority = "partner.org"
 
-        result = cli.invoke(
-            user_cli.delete,
-            ["--authority", "partner.org", user.username],
-            obj=cliconfig,
+        result = invoke_cli(
+            user_cli.delete, ["--authority", "partner.org", user.username]
         )
 
         assert not result.exit_code
         user_delete_service.delete.assert_called_once_with(user)
 
     def test_it_errors_when_user_could_not_be_found(
-        self, cli, cliconfig, user_delete_service
+        self, invoke_cli, user_delete_service
     ):
-        result = cli.invoke(user_cli.delete, ["bogus_username"], obj=cliconfig)
+        result = invoke_cli(user_cli.delete, ["bogus_username"])
 
         assert result.exit_code == 1
         user_delete_service.delete.assert_not_called()
 
     def test_it_errors_when_user_with_specific_authority_could_not_be_found(
-        self, cli, cliconfig, user, user_delete_service
+        self, invoke_cli, user, user_delete_service
     ):
-        result = cli.invoke(
-            user_cli.delete, ["--authority", "foo.com", user.username], obj=cliconfig
-        )
+        result = invoke_cli(user_cli.delete, ["--authority", "foo.com", user.username])
 
         assert result.exit_code == 1
         user_delete_service.delete.assert_not_called()
@@ -262,6 +236,12 @@ class TestDeleteUserCommand:
 
 
 @pytest.fixture
-def cliconfig(pyramid_config, pyramid_request):  # pylint:disable=unused-argument
+def invoke_cli(cli, pyramid_request):
     pyramid_request.tm = mock.Mock()
-    return {"bootstrap": mock.Mock(return_value=pyramid_request)}
+
+    def invoke_cli(method, args):
+        return cli.invoke(
+            method, args, obj={"bootstrap": mock.Mock(return_value=pyramid_request)}
+        )
+
+    return invoke_cli


### PR DESCRIPTION
Based on:

 * https://github.com/hypothesis/h/pull/8075

This is preparation for a change which modifies the name of the function. There are two major changes here:

 * Use service fixtures normally (which makes the next PR easier)
 * Use a caller pattern fixture to remove persistent duplication (I just couldn't bear it)

## Review notes

This looks like a lot of changes, but it's really the same changes again and again. Once you get the rhythm you'll see.

## Testing notes

None really. The script itself doesn't change, just the tests, which should still run and pass.