### PR TITLE
Tackle files with a single line of coverage missing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,6 +12,6 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 98.46
+fail_under = 98.59
 
 skip_covered = True

--- a/h/eventqueue.py
+++ b/h/eventqueue.py
@@ -67,5 +67,5 @@ class EventQueue:
         self.publish_all()
 
 
-def includeme(config):
+def includeme(config):  # pragma: nocover
     config.add_request_method(EventQueue, name="notify_after_commit", reify=True)

--- a/h/notification/__init__.py
+++ b/h/notification/__init__.py
@@ -1,2 +1,2 @@
-def includeme(config):
+def includeme(config):  # pragma: nocover
     config.include(".reply")

--- a/h/realtime.py
+++ b/h/realtime.py
@@ -142,5 +142,5 @@ def get_connection(settings, fail_fast=False):
     return kombu.Connection(conn, **kwargs)
 
 
-def includeme(config):
+def includeme(config):  # pragma: nocover
     config.add_request_method(Publisher, name="realtime", reify=True)

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -157,5 +157,8 @@ class Search:
     def _get_total_hits(response):
         total = response["hits"]["total"]
         if isinstance(total, int):
-            return total  # ES 6.x
-        return total["value"]  # ES 7.x
+            # ES 6.x
+            return total
+
+        # ES 7.x
+        return total["value"]  # pragma: nocover

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -126,7 +126,7 @@ class Sorter:
     @staticmethod
     def _parse_date(str_value):
         """
-        Convert a string to a float representing miliseconds since the epoch.
+        Convert a string to a float representing milliseconds since the epoch.
 
         Since the elasticsearch date parser is not run on search_after,
         the date must be converted to ms since the epoch as that is how
@@ -142,10 +142,6 @@ class Sorter:
         except ValueError:
             try:  # pylint: disable=too-many-try-statements
                 date = parse(str_value, default=DEFAULT_DATE)
-                # If timezone isn't specified assume it's utc.
-                if not date.tzinfo:
-                    date = date.replace(tzinfo=tz.tzutc())
-
                 return dt.timestamp(date) * 1000
 
             except ValueError:

--- a/h/services/document.py
+++ b/h/services/document.py
@@ -44,4 +44,4 @@ class DocumentService:
 
 
 def document_service_factory(_context, request):
-    return DocumentService(request.db)
+    return DocumentService(session=request.db)

--- a/h/util/view.py
+++ b/h/util/view.py
@@ -1,11 +1,4 @@
-import sys
-
 from pyramid.view import view_config
-
-
-# Test seam. Patching `sys.exc_info` directly causes problems with pytest.
-def _exc_info():
-    return sys.exc_info()
 
 
 def handle_exception(request, exception):  # pylint: disable=unused-argument

--- a/h/viewderivers.py
+++ b/h/viewderivers.py
@@ -37,5 +37,5 @@ def csp_protected_view(view, info):
 csp_protected_view.options = ("csp_insecure_optout",)
 
 
-def includeme(config):
+def includeme(config):  # pragma: nocover
     config.add_view_deriver(csp_protected_view)

--- a/h/viewpredicates.py
+++ b/h/viewpredicates.py
@@ -16,5 +16,5 @@ class FeaturePredicate:
         return request.feature(self.feature)
 
 
-def includeme(config):
+def includeme(config):  # pragma: nocover
     config.add_view_predicate("feature", FeaturePredicate)

--- a/h/views/__init__.py
+++ b/h/views/__init__.py
@@ -1,2 +1,2 @@
-def includeme(config):
+def includeme(config):  # pragma: nocover
     config.scan(__name__)

--- a/h/views/admin/__init__.py
+++ b/h/views/admin/__init__.py
@@ -1,2 +1,2 @@
-def includeme(config):
+def includeme(config):  # pragma: nocover
     config.scan(__name__)

--- a/h/views/api/__init__.py
+++ b/h/views/api/__init__.py
@@ -12,5 +12,5 @@ specifies a different version with a properly-formatted Accept header
 __all__ = ("API_VERSIONS", "API_VERSION_DEFAULT")
 
 
-def includeme(config):
+def includeme(config):  # pragma: nocover
     config.scan(__name__)

--- a/tests/h/models/activation_test.py
+++ b/tests/h/models/activation_test.py
@@ -1,12 +1,24 @@
 import re
 
-from h.models import Activation
+import pytest
+
+from h.models.activation import Activation
 
 
-def test_activation_has_asciinumeric_code(db_session):
-    act = Activation()
+class TestActivation:
+    def test_code(self, activation):
+        assert re.match(r"[A-Za-z0-9]{12}", activation.code)
 
-    db_session.add(act)
-    db_session.flush()
+    def test_get_by_code(self, activation, db_session):
+        result = Activation.get_by_code(db_session, code=activation.code)
 
-    assert re.match(r"[A-Za-z0-9]{12}", act.code)
+        assert result == activation
+
+    @pytest.fixture
+    def activation(self, db_session):
+        activation = Activation()
+
+        db_session.add(activation)
+        db_session.flush()
+
+        return activation

--- a/tests/h/models/annotation_moderation_test.py
+++ b/tests/h/models/annotation_moderation_test.py
@@ -1,0 +1,8 @@
+from h.models.annotation_moderation import AnnotationModeration
+
+
+class TestAnnotationModeration:
+    def test___repr__(self):
+        moderation = AnnotationModeration(annotation_id=123)
+
+        assert repr(moderation) == "<AnnotationModeration annotation_id=123>"

--- a/tests/h/models/auth_client_test.py
+++ b/tests/h/models/auth_client_test.py
@@ -31,6 +31,11 @@ class TestAuthClient:
         db_session.add(client)
         db_session.flush()
 
+    def test___repr__(self):
+        client = AuthClient(id=123)
+
+        assert repr(client) == "AuthClient(id=123)"
+
     @pytest.fixture
     def client(self, db_session):
         client = AuthClient(authority="example.com")

--- a/tests/h/models/blocklist_test.py
+++ b/tests/h/models/blocklist_test.py
@@ -19,3 +19,8 @@ class TestBlocklist:
             db_session.add(Blocklist(uri=block_uri))
 
         assert Blocklist.is_blocked(db_session, uri) == is_blocked
+
+    def test___repr__(self):
+        blocklist = Blocklist(uri="http://example.com")
+
+        assert repr(blocklist) == "http://example.com"

--- a/tests/h/models/flag_test.py
+++ b/tests/h/models/flag_test.py
@@ -1,0 +1,8 @@
+from h.models.flag import Flag
+
+
+class TestFlag:
+    def test___repr__(self):
+        flag = Flag(annotation_id=123, user_id=456)
+
+        assert repr(flag) == "<Flag annotation_id=123 user_id=456>"

--- a/tests/h/models/subscriptions_test.py
+++ b/tests/h/models/subscriptions_test.py
@@ -1,0 +1,13 @@
+from h.models.subscriptions import Subscriptions
+
+
+class TestSubscriptions:
+    def test___repr__(self):
+        subscription = Subscriptions(
+            uri="http://example.com", type=Subscriptions.Type.REPLY, active=True
+        )
+
+        assert (
+            repr(subscription)
+            == "<Subscription uri=http://example.com type=reply active=True>"
+        )

--- a/tests/h/schemas/base_test.py
+++ b/tests/h/schemas/base_test.py
@@ -48,6 +48,13 @@ class TestCSRFSchema:
 
 
 class TestJSONSchema:
+    def test_it_raises_for_unsupported_schema_versions(self):
+        class BadSchema(JSONSchema):
+            schema_version = 95
+
+        with pytest.raises(ValueError):
+            BadSchema()
+
     def test_it_returns_data_when_valid(self):
         data = {"foo": "baz", "bar": 123}
 

--- a/tests/h/schemas/forms/admin/organization_test.py
+++ b/tests/h/schemas/forms/admin/organization_test.py
@@ -8,7 +8,13 @@ pytestmark = pytest.mark.usefixtures("pyramid_config")
 
 
 class TestOrganizationSchema:
-    def test_it_allows_valid_data(self, org_data, bound_schema):
+    @pytest.mark.parametrize(
+        "logo",
+        ("<svg>foo</svg>", '<ns:svg xmlns:ns="http://example.com">foo</ns:svg>'),
+    )
+    def test_it_allows_valid_data(self, org_data, bound_schema, logo):
+        org_data["logo"] = logo
+
         bound_schema.deserialize(org_data)
 
     def test_it_raises_if_logo_is_too_long(self, org_data, bound_schema):

--- a/tests/h/services/developer_token_test.py
+++ b/tests/h/services/developer_token_test.py
@@ -13,6 +13,9 @@ class TestDeveloperTokenService:
     ):
         assert svc.fetch(userid) == developer_token
 
+    def test_fetch_returns_none_for_missing_userid(self, svc):
+        assert svc.fetch(None) is None
+
     def test_fetch_returns_none_for_missing_developer_token(self, svc, userid):
         assert svc.fetch(userid) is None
 

--- a/tests/h/services/group_create_test.py
+++ b/tests/h/services/group_create_test.py
@@ -218,17 +218,24 @@ class TestCreateOpenGroup:
 
         publish.assert_not_called()
 
-    def test_it_sets_scopes(self, svc, creator):
-        origins = ["https://biopub.org", "http://example.com", "https://wikipedia.com"]
-
+    @pytest.mark.parametrize(
+        "origins",
+        (["http://example.com", "http://example.org"], [], None),
+    )
+    def test_it_sets_scopes(self, svc, creator, origins):
         group = svc.create_open_group(
             name="test_group", userid=creator.userid, scopes=origins
         )
 
-        assert (
-            group.scopes
-            == Any.list.containing([GroupScopeWithOrigin(h) for h in origins]).only()
-        )
+        if origins:
+            assert (
+                group.scopes
+                == Any.list.containing(
+                    [GroupScopeWithOrigin(origin) for origin in origins]
+                ).only()
+            )
+        else:
+            assert group.scopes == []
 
     def test_it_always_creates_new_scopes(self, factories, svc, creator):
         # It always creates a new scope, even if a scope with the given origin
@@ -365,17 +372,24 @@ class TestCreateRestrictedGroup:
 
         publish.assert_called_once_with("group-join", group.pubid, creator.userid)
 
-    def test_it_sets_scopes(self, svc, creator):
-        origins = ["https://biopub.org", "http://example.com", "https://wikipedia.com"]
-
+    @pytest.mark.parametrize(
+        "origins",
+        (["http://example.com", "http://example.org"], [], None),
+    )
+    def test_it_sets_scopes(self, svc, creator, origins):
         group = svc.create_restricted_group(
             name="test_group", userid=creator.userid, scopes=origins
         )
 
-        assert (
-            group.scopes
-            == Any.list.containing([GroupScopeWithOrigin(h) for h in origins]).only()
-        )
+        if origins:
+            assert (
+                group.scopes
+                == Any.list.containing(
+                    [GroupScopeWithOrigin(origin) for origin in origins]
+                ).only()
+            )
+        else:
+            assert group.scopes == []
 
     def test_it_with_mismatched_authorities_raises_value_error(
         self, svc, origins, creator, factories

--- a/tests/h/services/group_list_test.py
+++ b/tests/h/services/group_list_test.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
@@ -213,6 +214,11 @@ class TestScopedGroups:
         svc.scoped_groups(default_authority, document_uri)
 
         group_scope_service.fetch_by_scope.assert_called_once_with(document_uri)
+
+    def test_it_returns_empty_list_if_no_document_url(self, svc):
+        results = svc.scoped_groups(sentinel.authority, document_uri=None)
+
+        assert results == []
 
     def test_it_returns_empty_list_if_no_matching_scopes(
         self, svc, default_authority, document_uri, group_scope_service

--- a/tests/h/services/subscription_test.py
+++ b/tests/h/services/subscription_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import sentinel
+from unittest.mock import patch, sentinel
 
 import pytest
 from h_matchers import Any
@@ -41,6 +41,16 @@ class TestSubscriptionService:
                 "active": True,
             }
         )
+
+    def test_get_all_subscriptions(self, svc):
+        with patch.object(svc, "get_subscription") as get_subscription:
+            subscriptions = svc.get_all_subscriptions(sentinel.user_id)
+
+            # Despite the name, there is only one subscription type
+            get_subscription.assert_called_once_with(
+                sentinel.user_id, Subscriptions.Type.REPLY
+            )
+            assert subscriptions == [get_subscription.return_value]
 
     def test_get_unsubscribe_token(self, svc, SignedSerializer):
         result = svc.get_unsubscribe_token(

--- a/tests/h/services/user_password_test.py
+++ b/tests/h/services/user_password_test.py
@@ -1,8 +1,10 @@
+from unittest.mock import sentinel
+
 import pytest
 from passlib.context import CryptContext
 
 from h.security import password_context
-from h.services.user_password import UserPasswordService
+from h.services.user_password import UserPasswordService, user_password_service_factory
 
 
 class TestUserPasswordService:
@@ -104,3 +106,15 @@ class TestUserPasswordService:
     @pytest.fixture
     def user(self, factories):
         return factories.User.build()
+
+
+class TestServiceFactory:
+    def test_it(self, UserPasswordService):
+        svc = user_password_service_factory(sentinel.context, sentinel.request)
+
+        UserPasswordService.assert_called_once_with()
+        assert svc == UserPasswordService.return_value
+
+    @pytest.fixture
+    def UserPasswordService(self, patch):
+        return patch("h.services.user_password.UserPasswordService")

--- a/tests/h/services/user_rename_test.py
+++ b/tests/h/services/user_rename_test.py
@@ -1,9 +1,10 @@
 from unittest import mock
+from unittest.mock import sentinel
 
 import pytest
 
 from h import models
-from h.services.user_rename import UserRenameError, UserRenameService
+from h.services.user_rename import UserRenameError, UserRenameService, service_factory
 
 
 class TestUserRenameService:
@@ -119,3 +120,17 @@ class TestUserRenameService:
         db_session.flush()
 
         return anns
+
+
+class TestServiceFactory:
+    def test_it(self, pyramid_request, search_index, UserRenameService):
+        svc = service_factory(sentinel.context, pyramid_request)
+
+        UserRenameService.assert_called_once_with(
+            session=pyramid_request.db, search_index=search_index
+        )
+        assert svc == UserRenameService.return_value
+
+    @pytest.fixture
+    def UserRenameService(self, patch):
+        return patch("h.services.user_rename.UserRenameService")

--- a/tests/h/util/markdown_render_test.py
+++ b/tests/h/util/markdown_render_test.py
@@ -69,6 +69,7 @@ class TestRender:
                 '<p><img src="/evil.jpg"></p>',
             ),
             ("<img src=\"javascript:alert('evil')\">", "<p><img></p>"),
+            (None, None),
         ],
     )
     def test_it_escapes_evil_html(self, text, expected):

--- a/tests/h/util/view_test.py
+++ b/tests/h/util/view_test.py
@@ -5,26 +5,11 @@ import pytest
 from h.util.view import handle_exception, json_view
 
 
-@pytest.mark.usefixtures("sys_exc_info")
 class TestHandleException:
     def test_sets_response_status_500(self, pyramid_request):
         handle_exception(pyramid_request, Mock())
 
         assert pyramid_request.response.status_int == 500
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        return pyramid_request
-
-    @pytest.fixture
-    def latest_exception(self):
-        return Exception("Last exception raised in thread")
-
-    @pytest.fixture
-    def sys_exc_info(self, patch, latest_exception):
-        sys_exc_info = patch("h.util.view._exc_info")
-        sys_exc_info.return_value = (type(latest_exception), latest_exception, None)
-        return sys_exc_info
 
 
 @pytest.mark.usefixtures("view_config")

--- a/tests/h/views/admin/documents_test.py
+++ b/tests/h/views/admin/documents_test.py
@@ -8,12 +8,14 @@ from h.views.admin.documents import DocumentsAdminViews
 
 
 class TestDocumentsAdminViews:
+    def test_get(self, views):
+        assert not views.get()
+
     def test_update_annotation_urls_schedules_update(
-        self, pyramid_request, move_annotations_by_url, flash
+        self, views, pyramid_request, move_annotations_by_url, flash
     ):
         mappings = {"https://example.com": {"url": "https://example.org"}}
         pyramid_request.POST["url_mappings"] = json.dumps(mappings)
-        views = DocumentsAdminViews(pyramid_request)
 
         views.update_annotation_urls()
 
@@ -22,10 +24,9 @@ class TestDocumentsAdminViews:
         flash.assert_called_once_with("URL migration started for 1 URL(s)", "success")
 
     def test_it_errors_if_json_does_not_parse(
-        self, pyramid_request, move_annotations_by_url, flash
+        self, views, pyramid_request, move_annotations_by_url, flash
     ):
         pyramid_request.POST["url_mappings"] = "not-json"
-        views = DocumentsAdminViews(pyramid_request)
 
         views.update_annotation_urls()
 
@@ -36,10 +37,9 @@ class TestDocumentsAdminViews:
         move_annotations_by_url.chunks.assert_not_called()
 
     def test_it_errors_if_validation_fails(
-        self, pyramid_request, move_annotations_by_url, flash
+        self, views, pyramid_request, move_annotations_by_url, flash
     ):
         pyramid_request.POST["url_mappings"] = json.dumps({"not-a-url": "foo"})
-        views = DocumentsAdminViews(pyramid_request)
 
         views.update_annotation_urls()
 
@@ -52,6 +52,10 @@ class TestDocumentsAdminViews:
     @pytest.fixture(autouse=True)
     def move_annotations_by_url(self, patch):
         return patch("h.views.admin.documents.move_annotations_by_url")
+
+    @pytest.fixture
+    def views(self, pyramid_request):
+        return DocumentsAdminViews(pyramid_request)
 
     @pytest.fixture
     def flash(self, pyramid_request):


### PR DESCRIPTION
Based on:

 * https://github.com/hypothesis/h/pull/8085

## What this PR tries to fix

This PR focuses on fixing coverage issues in files where there is only one line of coverage missing. When I tested these comprised about 1/3 of the outstanding files with coverage issues.

### Why these files?

The idea here is these should tend to be the easiest to fix, while reducing the number of files with coverage issues the most. This means you are more likely to be able to spot the thing you are looking for if these could all be fixed.

Doing all test coverage in `h` at once is a big ask (both to do and review) so we need some ways to break the task up, which are essentially arbitrary. You could do each of these as a separate PR, but nobody wants to look at that.

### What I didn't manage to fix and why:

`h/schemas/forms/accounts/login.py`

This is code which is called from a `colander.deferred` widget. I have no idea what that is or how to test it.

`h/activity/query.py`

The tests for this code are pretty wild and do that thing where every line of code gets it's own test instead of running the code once and saying what it's supposed to do.

In the middle of this we fixture out a piece of code which reads groups from the DB. I don't know why we do this, but this is where the issues come from.

I'm not sure where to start with this one, I think you'd want to refactor this to be less first. I suspect we've ended up mocking out this part as a way of making assertions, because so much around this is mocked out too.

## Testing notes

There really shouldn't be any change in behavior here. There is barely any change to the code outside of the tests. I think all bar the date change there are kind of trivially fine. You can try the date TZ issue yourself with code like this:

```python
from dateutil.parser import parse

from h.search.query import DEFAULT_DATE

# Can have no TZ, defaults to the 31st
date = parse("2001-01")
print(date)  # 2001-01-31 00:00:00
print(date.tzinfo)  # None

# Has a TZ, has been defaulted to the first
date = parse("2001-01", default=DEFAULT_DATE)
print(date)  # 2001-01-01 00:00:00+00:00
print(date.tzinfo)  # tzutc()
```

For the tests:

 * `make backend-tests`
 * `make coverage | grep -v "-" | grep -v ","`
 * You should see:

```shell
...
h/activity/query.py                             83      1     32      0  99.13%   194
h/schemas/forms/accounts/login.py               44      1      6      1  96.00%   90
...
```