### PR TITLE
Fix a bug with feeds being unable to parse user names

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,6 +12,6 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 98.44
+fail_under = 98.46
 
 skip_covered = True

--- a/h/feeds/atom.py
+++ b/h/feeds/atom.py
@@ -3,6 +3,7 @@ from pyramid import i18n
 
 import h.feeds.util
 from h import presenters, util
+from h.exceptions import InvalidUserId
 from h.util.datetime import utc_iso8601
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -20,7 +21,7 @@ def _feed_entry_from_annotation(annotation, annotation_url, annotation_api_url=N
     """
     try:
         name = util.user.split_user(annotation.userid)["username"]
-    except ValueError:
+    except InvalidUserId:
         name = annotation.userid
 
     entry = {

--- a/h/feeds/rss.py
+++ b/h/feeds/rss.py
@@ -6,6 +6,7 @@ from pyramid import i18n
 
 import h.feeds.util
 from h import presenters, util
+from h.exceptions import InvalidUserId
 
 _ = i18n.TranslationStringFactory(__package__)
 
@@ -35,7 +36,7 @@ def _feed_item_from_annotation(annotation, annotation_url):
     """
     try:
         name = util.user.split_user(annotation.userid)["username"]
-    except ValueError:
+    except InvalidUserId:
         name = annotation.userid
     return {
         "author": {"name": name},

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -91,15 +91,22 @@ def test_entry_id(util, factories):
     assert feed["entries"][0]["id"] == util.tag_uri_for_annotation.return_value
 
 
-def test_entry_author(factories):
+@pytest.mark.parametrize(
+    "userid,name",
+    (
+        ("acct:username@hypothes.is", "username"),
+        ("malformed", "malformed"),
+    ),
+)
+def test_entry_author(factories, userid, name):
     """The authors of entries should come from the annotation usernames."""
-    annotation = factories.Annotation(userid="acct:nobu@hypothes.is")
+    annotation = factories.Annotation(userid=userid)
 
     feed = atom.feed_from_annotations(
         [annotation], "atom_url", lambda _: "annotation url"
     )
 
-    assert feed["entries"][0]["author"]["name"] == "nobu"
+    assert feed["entries"][0]["author"]["name"] == name
 
 
 def test_entry_title(factories):

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -1,6 +1,8 @@
 import datetime
 from unittest import mock
 
+import pytest
+
 from h import models
 from h.feeds import rss
 
@@ -28,15 +30,22 @@ def _annotation(**kwargs):
     return models.Annotation(**args)
 
 
-def test_feed_from_annotations_item_author():
+@pytest.mark.parametrize(
+    "userid,name",
+    (
+        ("acct:username@hypothes.is", "username"),
+        ("malformed", "malformed"),
+    ),
+)
+def test_feed_from_annotations_item_author(userid, name):
     """Feed items should include the annotation's author."""
-    annotation = _annotation()
+    annotation = _annotation(userid=userid)
 
     feed = rss.feed_from_annotations(
         [annotation], _annotation_url(), mock.Mock(), "", "", ""
     )
 
-    assert feed["entries"][0]["author"] == {"name": "janebloggs"}
+    assert feed["entries"][0]["author"]["name"] == name
 
 
 def test_feed_annotations_pubDate():


### PR DESCRIPTION
If you do some code archeology you can see this is intended to catch invalid user ids, but the exception we raise has changed, and this code hasn't.

We had a coverage gap here which allowed the test to go un-noticed.

I can't spot anywhere else where we call `split_user` and try catch it with the wrong exception.

This was changed in:

 * https://github.com/hypothesis/h/pull/2635/commits/a2025ccac881ed4e8990c9e5ffa1a8241445ea4f
 * This is where we see `ValueError` does mean an invalid ID
 * It changed later and this code was left behind