### PR TITLE
Use pipe instead of slash as profile menu item separator

### DIFF
--- a/h/static/styles/components/_tabs.scss
+++ b/h/static/styles/components/_tabs.scss
@@ -12,7 +12,7 @@
   font-size: typography.$title-font-size;
 
   &:not(:last-of-type)::after {
-    content: " / ";
+    content: " | ";
   }
 
   .is-active {


### PR DESCRIPTION
Some weeks ago it was brought to our attention that the account profile menu looks like a breadcrumb, because it uses slashes (`/`) as menu item separators.

![image](https://github.com/hypothesis/h/assets/2719332/4777714e-e01a-4bf9-ab06-44e7fbd0136f)

We need to get a proper design in place, and potentially align it with the component styles we have in other frontend apps (client, lms, via, etc), but until that can happen, using pipes (`|`) to separate items is a very simplistic way to solve the confusion.

![image](https://github.com/hypothesis/h/assets/2719332/92414c92-c7a9-4a1c-960b-bffc04964c14)

This PR only changes the separator character as a naive and short-term solution.
