### PR TITLE
Annotation table migrations (annotation.pk & annotation.user_id)

### DIFF
--- a/h/migrations/versions/8250dce465f2_annotation_user_id.py
+++ b/h/migrations/versions/8250dce465f2_annotation_user_id.py
@@ -1,0 +1,24 @@
+"""Add user_id to the annotation table."""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "8250dce465f2"
+down_revision = "f064c2b2e04a"
+
+
+def upgrade():
+    op.add_column("annotation", sa.Column("user_id", sa.Integer(), nullable=True))
+    op.create_index(
+        op.f("ix__annotation_user_id"), "annotation", ["user_id"], unique=False
+    )
+    op.create_foreign_key(
+        op.f("fk__annotation__user_id__user"), "annotation", "user", ["user_id"], ["id"]
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk__annotation__user_id__user"), "annotation", type_="foreignkey"
+    )
+    op.drop_index(op.f("ix__annotation_user_id"), table_name="annotation")
+    op.drop_column("annotation", "user_id")

--- a/h/migrations/versions/f064c2b2e04a_annotation_pk.py
+++ b/h/migrations/versions/f064c2b2e04a_annotation_pk.py
@@ -1,0 +1,19 @@
+"""Add pk to the annotation table."""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.schema import CreateSequence, DropSequence, Sequence
+
+revision = "f064c2b2e04a"
+down_revision = "7d39ade34b69"
+
+
+def upgrade():
+    op.execute(CreateSequence(Sequence("annotation_id_seq")))
+    op.add_column("annotation", sa.Column("pk", sa.Integer(), nullable=True))
+    op.create_unique_constraint(op.f("uq__annotation__pk"), "annotation", ["pk"])
+
+
+def downgrade():
+    op.drop_constraint(op.f("uq__annotation__pk"), "annotation", type_="unique")
+    op.drop_column("annotation", "pk")
+    op.execute(DropSequence(Sequence("annotation_id_seq")))

--- a/tox.ini
+++ b/tox.ini
@@ -83,6 +83,7 @@ setenv =
     dev: ENABLE_WEB = {env:ENABLE_WEB:true}
     dev: ENABLE_WEBSOCKET = {env:ENABLE_WEBSOCKET:true}
     dev: ENABLE_WORKER = {env:ENABLE_WORKER:true}
+    dev: ALEMBIC_CONFIG = {env:ALEMBIC_CONFIG:conf/alembic.ini}
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
     SQLALCHEMY_SILENCE_UBER_WARNING=1
 deps =


### PR DESCRIPTION
Generated from model changes over: https://github.com/hypothesis/h/pull/8131


## Testing

### Forward


```
tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='166551683'
dev run-test: commands[0] | alembic upgrade head
2023-08-30 15:47:25 3408177 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-08-30 15:47:25 3408177 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-08-30 15:47:25 3408177 alembic.runtime.migration [INFO] Running upgrade 7d39ade34b69 -> f064c2b2e04a, Add pk to the annotation table.
2023-08-30 15:47:27 3408177 alembic.runtime.migration [INFO] Running upgrade f064c2b2e04a -> 8250dce465f2, Add user_id to the annotation table.
```

### Backwards


```
tox -e dev --run-command 'alembic downgrade -2'
dev run-test-pre: PYTHONHASHSEED='2112297644'
dev run-test: commands[0] | alembic downgrade -2
2023-08-30 15:48:02 3410740 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-08-30 15:48:02 3410740 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-08-30 15:48:02 3410740 alembic.runtime.migration [INFO] Running downgrade 8250dce465f2 -> f064c2b2e04a, Add user_id to the annotation table.
2023-08-30 15:48:02 3410740 alembic.runtime.migration [INFO] Running downgrade f064c2b2e04a -> 7d39ade34b69, Add pk to the annotation table.
```