### PR TITLE
Task to fill up the new annotation pk and user_id values

### DIFF
--- a/h/celery.py
+++ b/h/celery.py
@@ -74,6 +74,7 @@ celery.conf.update(
     # task's @app.task() arguments.
     task_time_limit=240,
     imports=(
+        "h.tasks.annotations",
         "h.tasks.cleanup",
         "h.tasks.indexer",
         "h.tasks.mailer",

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -63,6 +63,8 @@ def init(engine, base=Base, should_create=False, should_drop=False, authority=No
         # extension.
         engine.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
         base.metadata.create_all(engine)
+        # Create sequences not used explicitly in a column here
+        engine.execute("CREATE SEQUENCE IF NOT EXISTS annotation_id_seq;")
 
     default_org = _maybe_create_default_organization(engine, authority)
     _maybe_create_world_group(engine, authority, default_org)

--- a/h/tasks/annotations.py
+++ b/h/tasks/annotations.py
@@ -1,0 +1,38 @@
+from sqlalchemy import func, update
+
+from h.celery import celery, get_task_logger
+from h.models import Annotation, User
+
+log = get_task_logger(__name__)
+
+
+@celery.task
+def fill_pk_and_user_id(batch_size=1000):
+    """
+    Task to fill the new annotation.pk and annotation.user_id in batches.
+
+    Once most of the existing rows are done we'll make the code changes
+    to keep these up to date, make the column not nullable and remove this task.
+    """
+    # pylint: disable=no-member
+    db = celery.request.db
+
+    annotations = (
+        db.query(Annotation.id.label("annotation_id"), User.id.label("user_id"))
+        .join(
+            User,
+            User.username
+            == func.split_part(func.split_part(Annotation.userid, "@", 1), ":", 2),
+        )
+        .where(Annotation.pk.is_(None))
+        .order_by(Annotation.updated.asc())
+        .limit(batch_size)
+    ).cte("annotations")
+
+    db.execute(
+        update(Annotation)
+        .values(pk=Annotation.pk_sequence.next_value(), user_id=annotations.c.user_id)
+        .where(Annotation.id == annotations.c.annotation_id)
+        # just update the rows in the DB, we don't need to refresh the objects in the session
+        .execution_options(synchronize_session=False)
+    )

--- a/h/tasks/annotations.py
+++ b/h/tasks/annotations.py
@@ -26,6 +26,7 @@ def fill_pk_and_user_id(batch_size=1000):
         )
         .where(Annotation.pk.is_(None))
         .order_by(Annotation.updated.asc())
+        .with_for_update(skip_locked=True)
         .limit(batch_size)
     ).cte("annotations")
 

--- a/tests/h/tasks/annotations_test.py
+++ b/tests/h/tasks/annotations_test.py
@@ -1,0 +1,50 @@
+import pytest
+
+from h.models import Annotation
+from h.tasks.annotations import fill_pk_and_user_id
+
+
+class TestFillPKAndUserId:
+    AUTHORITY_1 = "AUTHORITY_1"
+    AUTHORITY_2 = "AUTHORITY_2"
+
+    USERNAME_1 = "USERNAME_1"
+    USERNAME_2 = "USERNAME_2"
+
+    def test_it(self, factories, db_session):
+        author_1 = factories.User(authority=self.AUTHORITY_1, username=self.USERNAME_1)
+        author_2 = factories.User(authority=self.AUTHORITY_2, username=self.USERNAME_2)
+
+        annos_1 = factories.Annotation.create_batch(
+            5,
+            userid=author_1.userid,
+        )
+        annos_2 = factories.Annotation.create_batch(
+            5,
+            userid=author_2.userid,
+        )
+        factories.Annotation.create_batch(
+            5,
+            userid=author_2.userid,
+        )
+
+        fill_pk_and_user_id(batch_size=10)
+
+        # Only one batch of 10 was processed, those have PKs now
+        assert (
+            db_session.query(Annotation).filter(Annotation.pk.is_not(None)).count()
+            == 10
+        )
+        assert db_session.query(Annotation).filter(Annotation.pk.is_(None)).count() == 5
+
+        # Refresh data for the annotations
+        _ = [db_session.refresh(anno) for anno in annos_1 + annos_2]
+        # user_id was updated with the right value
+        assert {anno.user_id for anno in annos_1} == {author_1.id}
+        assert {anno.user_id for anno in annos_2} == {author_2.id}
+
+    @pytest.fixture(autouse=True)
+    def celery(self, patch, db_session):
+        cel = patch("h.tasks.annotations.celery", autospec=False)
+        cel.request.db = db_session
+        return cel


### PR DESCRIPTION
Fill up the new annotation, the new pk with a value from the new sequence and, given that we are going to go over all rows anyway, take the opportunity to fill up the new `user_id` FK.


### Testing

- Make sure you are in the last version of the DB `tox -e dev --run-command 'alembic upgrade head'`

- Check the local annotations:

`docker compose exec postgres psql -U postgres -c "select id, pk, user_id from annotation order by updated asc limit 10"`

```                 id                  | pk | user_id 
--------------------------------------+----+---------
 f057ca22-4afe-11ee-9762-bbbdbc59f9ee |    |        
 b43188b0-48da-11ee-b8c7-1384f80c2902 |    |        
 9cd1f10a-48da-11ee-914c-93702ada8a92 |    |        
 75022b22-48c6-11ee-8eb5-1f0ef005b932 |    |        
 c71d19b6-45b6-11ee-9bf6-d7b735fdc34d |    |        
 35b3f2a4-45b3-11ee-9bf6-fbb4c8f399b4 |    |        
 90747dfe-45b2-11ee-9bf6-8f825f8c34c8 |    |        
 76b9ffb0-45b2-11ee-9bf6-cfc13962be76 |    |        
 f5d52cba-45ae-11ee-9bf6-5703e9a86c98 |    |        
 5baaa666-45ad-11ee-9bf6-53d59524d771 |    |        
(10 rows)
```

- In `make shell`, run the new task


```
from h.tasks.annotations import fill_pk_and_user_id
fill_pk_and_user_id.apply_async()
```


wait for the task to finish on `make dev` output:


```
[2023-09-04 16:56:59,221: INFO/ForkPoolWorker-16] h.tasks.annotations.fill_pk_and_user_id[ac1eeb3d-57bd-4222-bc2d-a8ae47421a7f] Task h.tasks.annotations.fill_pk_and_user_id[ac1eeb3d-57bd-4222-bc2d-a8ae47421a7f] succeeded in 12.00388038699748s: None
```


- Check the annotations again, the should have values in the new columns now:

```
docker compose exec postgres psql -U postgres -c "select id, pk, user_id from annotation order by updated asc limit 10" 
                  id                  | pk | user_id 
--------------------------------------+----+---------
 d56f6f26-2c59-11ee-ba2c-fff7b98eb96d |  1 |      53
 f300996a-2c5f-11ee-9c33-0242ac130002 |  5 |      53
 f3002656-2c5f-11ee-9c33-0242ac130002 |  4 |      53
 f30098b6-2c5f-11ee-9c33-0242ac130002 |  3 |      53
 f30099c4-2c5f-11ee-9c33-0242ac130002 |  2 |      53
 fc46cb2a-2c5f-11ee-9c33-0242ac130002 | 25 |      53
 fc45923c-2c5f-11ee-9c33-0242ac130002 | 24 |      53
 fc4595ac-2c5f-11ee-9c33-0242ac130002 | 23 |      53
 fc4593d6-2c5f-11ee-9c33-0242ac130002 | 22 |      53
 fc46c148-2c5f-11ee-9c33-0242ac130002 | 21 |      53
(10 rows)
```


