### PR TITLE
Increase nginx rate limit for API and asset requests to 4/sec

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -33,9 +33,9 @@ http {
 
   # 1m stands for 1 megabyte so the zone can store ~8k users.
   limit_req_zone $limit_per_user zone=badge_user_limit:1m rate=1r/s;
-  limit_req_zone $limit_per_user zone=assets_user_limit:1m rate=1r/s;
-  limit_req_zone $limit_per_user zone=create_ann_user_limit:1m rate=1r/s;
-  limit_req_zone $limit_per_user zone=user_limit:1m rate=1r/s;
+  limit_req_zone $limit_per_user zone=assets_user_limit:1m rate=20r/s;
+  limit_req_zone $limit_per_user zone=create_ann_user_limit:1m rate=4r/s;
+  limit_req_zone $limit_per_user zone=user_limit:1m rate=4r/s;
   limit_req_status 429;
 
   # We set fail_timeout=0 so that the upstream isn't marked as down if a single
@@ -102,12 +102,9 @@ http {
         proxy_pass http://web;
       }
 
-      # The /assets rate limit is chosen so that the user
-      # can refresh the web page with the most asset links
-      # on it a few times in succession without hitting the
-      # limit.
+      # Static assets.
       location /assets {
-        limit_req zone=assets_user_limit burst=139 nodelay;
+        limit_req zone=assets_user_limit burst=20 nodelay;
 
         proxy_pass http://web;
       }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -32,12 +32,10 @@ http {
   }
 
   # 1m stands for 1 megabyte so the zone can store ~8k users.
-  # User's typically don't go over 1rps including bots so set the
-  # generic rate limit of all endpoints to 1rps.
-  limit_req_zone $limit_per_user zone=badge_user_1rps_limit:1m rate=1r/s;
-  limit_req_zone $limit_per_user zone=assets_user_1rps_limit:1m rate=1r/s;
-  limit_req_zone $limit_per_user zone=create_ann_user_1rps_limit:1m rate=1r/s;
-  limit_req_zone $limit_per_user zone=user_1rps_limit:1m rate=1r/s;
+  limit_req_zone $limit_per_user zone=badge_user_limit:1m rate=1r/s;
+  limit_req_zone $limit_per_user zone=assets_user_limit:1m rate=1r/s;
+  limit_req_zone $limit_per_user zone=create_ann_user_limit:1m rate=1r/s;
+  limit_req_zone $limit_per_user zone=user_limit:1m rate=1r/s;
   limit_req_status 429;
 
   # We set fail_timeout=0 so that the upstream isn't marked as down if a single
@@ -98,7 +96,7 @@ http {
       # load from any single user, and take advantage of latency
       # not being critical.
       location /api/badge {
-        limit_req zone=badge_user_1rps_limit burst=15;
+        limit_req zone=badge_user_limit burst=15;
         error_page 429 @api_error_429;
 
         proxy_pass http://web;
@@ -109,7 +107,7 @@ http {
       # on it a few times in succession without hitting the
       # limit.
       location /assets {
-        limit_req zone=assets_user_1rps_limit burst=139 nodelay;
+        limit_req zone=assets_user_limit burst=139 nodelay;
 
         proxy_pass http://web;
       }
@@ -118,14 +116,14 @@ http {
       # reasonable usage while preventing a single user from
       # causing service disruption.
       location =/api/annotations {
-        limit_req zone=create_ann_user_1rps_limit burst=8;
+        limit_req zone=create_ann_user_limit burst=8;
         error_page 429 @api_error_429;
 
         proxy_pass http://web;
       }
 
       location /api {
-        limit_req zone=user_1rps_limit burst=44 nodelay;
+        limit_req zone=user_limit burst=44 nodelay;
         error_page 429 @api_error_429;
 
         proxy_pass http://web;
@@ -133,7 +131,7 @@ http {
 
       # An overall rate limit was chosen to allow reasonable usage while
       # preventing a single user from causing service disruption.
-      limit_req zone=user_1rps_limit burst=44 nodelay;
+      limit_req zone=user_limit burst=44 nodelay;
     }
   }
 


### PR DESCRIPTION
The original values were chosen very conservatively, but we think this has had
the effect of slowing down bulk annotation operations (eg. via the client's
Import feature [1]) unnecessarily.

The new value for API requests has been chosen based on the 95th percentile
response times of the `GET /api/search` and `POST /api/annotations` endpoints,
which are two endpoints that are both heavily used and expensive. The thinking
is that as long as the significant majority of requests are processed faster
than this, we'll avoid a backlog.

The new value for asset requests was chosen in a similar way, but is much higher
because asset requests are much faster at the 95th percentile.

[1] https://github.com/hypothesis/client/issues/5741#issuecomment-1699245104
