### PR TITLE
Create annotation.created index

### DIFF
--- a/h/migrations/versions/95825c951c08_annotation_created_index.py
+++ b/h/migrations/versions/95825c951c08_annotation_created_index.py
@@ -1,0 +1,17 @@
+"""Create index on annotation.created."""
+from alembic import op
+
+revision = "95825c951c08"
+down_revision = "7d39ade34b69"
+
+
+def upgrade():
+    # CONCURRENTLY can't be used inside a transaction. Finish the current one.
+    op.execute("COMMIT")
+    op.execute(
+        """CREATE INDEX CONCURRENTLY IF NOT EXISTS ix__annotation_created ON "annotation" (created);"""
+    )
+
+
+def downgrade():
+    op.drop_index("ix__annotation_created", table_name="annotation")

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -25,6 +25,7 @@ class Annotation(Base):
         #   http://www.postgresql.org/docs/9.5/static/gin-intro.html
         #
         sa.Index("ix__annotation_tags", "tags", postgresql_using="gin"),
+        sa.Index("ix__annotation_created", "created"),
         sa.Index("ix__annotation_updated", "updated"),
         # This is a functional index on the *first* of the annotation's
         # references, pointing to the top-level annotation it refers to. We're

--- a/tox.ini
+++ b/tox.ini
@@ -83,6 +83,7 @@ setenv =
     dev: ENABLE_WEB = {env:ENABLE_WEB:true}
     dev: ENABLE_WEBSOCKET = {env:ENABLE_WEBSOCKET:true}
     dev: ENABLE_WORKER = {env:ENABLE_WORKER:true}
+    dev: ALEMBIC_CONFIG = {env:ALEMBIC_CONFIG:conf/alembic.ini}
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
     SQLALCHEMY_SILENCE_UBER_WARNING=1
 deps =


### PR DESCRIPTION
We have create this index manually on the prod DB, adding the migration and model changes for the Canadian server and our local environments.


### Testing


- Run the migration forwards


``` tox -e dev --run-command 'alembic upgrade head'```

```
2023-09-04 09:34:23 249521 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-04 09:34:23 249521 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-04 09:34:23 249521 alembic.runtime.migration [INFO] Running upgrade 7d39ade34b69 -> 95825c951c08, Create index on annotation.created
```

- Run it backwards with:


```tox -e dev --run-command 'alembic downgrade -1'```

```2023-09-04 09:34:54 251645 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-04 09:34:54 251645 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-04 09:34:54 251645 alembic.runtime.migration [INFO] Running downgrade 95825c951c08 -> 7d39ade34b69, Create index on annotation.created
```


- Create the index manually (to test the IF NOT EXIST part)


`docker compose exec postgres psql -U postgres -c "CREATE INDEX CONCURRENTLY ix__annotation_created ON annotation (created);"`


- Check the index is indeed there:

`docker compose exec postgres psql -U postgres -c "\d annotation"`


- Run the migration forward again 


``` tox -e dev --run-command 'alembic upgrade head'```



