### PR TITLE
Add migration for annotation.pk

### DIFF
--- a/h/migrations/versions/f064c2b2e04a_annotation_pk.py
+++ b/h/migrations/versions/f064c2b2e04a_annotation_pk.py
@@ -1,0 +1,29 @@
+"""Add pk to the annotation table."""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.schema import CreateSequence, DropSequence, Sequence
+
+revision = "f064c2b2e04a"
+down_revision = "95825c951c08"
+
+
+def upgrade():
+    op.execute(CreateSequence(Sequence("annotation_id_seq")))
+    op.add_column("annotation", sa.Column("pk", sa.Integer(), nullable=True))
+
+    # CONCURRENTLY can't be used inside a transaction. Finish the current one.
+    op.execute("COMMIT")
+    # Create index for the constraint first, concurrently
+    op.execute(
+        """CREATE UNIQUE INDEX CONCURRENTLY ix__annotation__pk ON annotation (pk);"""
+    )
+    # Use the now existing index to create the constraint. It will be renamed in this process
+    op.execute(
+        """ALTER TABLE annotation ADD CONSTRAINT uq__annotation__pk UNIQUE USING INDEX ix__annotation__pk;"""
+    )
+
+
+def downgrade():
+    op.drop_constraint(op.f("uq__annotation__pk"), "annotation", type_="unique")
+    op.drop_column("annotation", "pk")
+    op.execute(DropSequence(Sequence("annotation_id_seq")))


### PR DESCRIPTION
Generated from model changes over: https://github.com/hypothesis/h/pull/8131 and tuned to include some raw SQL queries.

###  Testing

- Forward

`tox -e dev --run-command 'alembic upgrade head'`

```
dev run-test-pre: PYTHONHASHSEED='1306123296'
dev run-test: commands[0] | alembic upgrade head
2023-09-04 15:28:21 1015712 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-04 15:28:21 1015712 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-04 15:28:21 1015712 alembic.runtime.migration [INFO] Running upgrade 95825c951c08 -> f064c2b2e04a, Add pk to the annotation table.
```

- Backwards

```tox -e dev --run-command 'alembic downgrade -1'```

```
dev run-test-pre: PYTHONHASHSEED='2655395263'
dev run-test: commands[0] | alembic downgrade -1
2023-09-04 15:27:57 1013953 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-04 15:27:57 1013953 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-04 15:27:57 1013953 alembic.runtime.migration [INFO] Running downgrade f064c2b2e04a -> 95825c951c08, Add pk to the annotation table.
```
