### PR TITLE
Add JWE decryption to security.encryption

### DIFF
--- a/h/security/encryption.py
+++ b/h/security/encryption.py
@@ -1,8 +1,10 @@
 import base64
+import json
 import os
 
 from Cryptodome.Hash import SHA512
 from Cryptodome.Protocol.KDF import HKDF
+from jose import jwe
 from passlib.context import CryptContext
 
 DEFAULT_ENTROPY = 32
@@ -69,3 +71,8 @@ def token_urlsafe(nbytes=None):
         nbytes = DEFAULT_ENTROPY
     tok = os.urandom(nbytes)
     return base64.urlsafe_b64encode(tok).rstrip(b"=").decode("ascii")
+
+
+def decrypt_jwe_dict(secret: bytes, payload: str) -> dict:
+    """Decrypts the JWE payloads into a dictionary."""
+    return json.loads(jwe.decrypt(payload, secret.ljust(32)[:32]))

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -41,7 +41,9 @@ certifi==2023.7.22
     #   -r requirements/requirements.txt
     #   sentry-sdk
 cffi==1.15.1
-    # via -r requirements/requirements.txt
+    # via
+    #   -r requirements/requirements.txt
+    #   cryptography
 chameleon==3.8.1
     # via
     #   -r requirements/requirements.txt
@@ -70,6 +72,10 @@ colander==1.8.2
     # via
     #   -r requirements/requirements.txt
     #   deform
+cryptography==41.0.3
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 data-tasks==0.0.3
     # via -r requirements/requirements.txt
 decorator==5.0.7
@@ -78,6 +84,10 @@ decorator==5.0.7
     #   ipython
 deform==2.0.15
     # via -r requirements/requirements.txt
+ecdsa==0.18.0
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 elasticsearch==6.8.2
     # via
     #   -r requirements/requirements.txt
@@ -237,6 +247,11 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.1
     # via stack-data
+pyasn1==0.5.0
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
+    #   rsa
 pycparser==2.20
     # via
     #   -r requirements/requirements.txt
@@ -281,6 +296,8 @@ python-dateutil==2.8.2
     #   celery
     #   elasticsearch-dsl
     #   faker
+python-jose[cryptography]==3.3.0
+    # via -r requirements/requirements.txt
 python-slugify==8.0.1
     # via -r requirements/requirements.txt
 pytz==2023.3
@@ -302,6 +319,10 @@ rpds-py==0.9.2
     #   -r requirements/requirements.txt
     #   jsonschema
     #   referencing
+rsa==4.9
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 sentry-sdk==1.17.0
     # via
     #   -r requirements/requirements.txt
@@ -312,6 +333,7 @@ six==1.15.0
     #   asttokens
     #   bleach
     #   click-repl
+    #   ecdsa
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -39,7 +39,9 @@ certifi==2023.7.22
     #   -r requirements/requirements.txt
     #   sentry-sdk
 cffi==1.15.1
-    # via -r requirements/requirements.txt
+    # via
+    #   -r requirements/requirements.txt
+    #   cryptography
 chameleon==3.8.1
     # via
     #   -r requirements/requirements.txt
@@ -68,10 +70,18 @@ colander==1.8.2
     # via
     #   -r requirements/requirements.txt
     #   deform
+cryptography==41.0.3
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 data-tasks==0.0.3
     # via -r requirements/requirements.txt
 deform==2.0.15
     # via -r requirements/requirements.txt
+ecdsa==0.18.0
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 elasticsearch==6.8.2
     # via
     #   -r requirements/requirements.txt
@@ -213,6 +223,11 @@ psycopg2==2.9.7
     # via
     #   -r requirements/requirements.txt
     #   data-tasks
+pyasn1==0.5.0
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
+    #   rsa
 pycparser==2.20
     # via
     #   -r requirements/requirements.txt
@@ -261,6 +276,8 @@ python-dateutil==2.8.2
     #   celery
     #   elasticsearch-dsl
     #   faker
+python-jose[cryptography]==3.3.0
+    # via -r requirements/requirements.txt
 python-slugify==8.0.1
     # via -r requirements/requirements.txt
 pytz==2023.3
@@ -282,6 +299,10 @@ rpds-py==0.9.2
     #   -r requirements/requirements.txt
     #   jsonschema
     #   referencing
+rsa==4.9
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 sentry-sdk==1.17.0
     # via
     #   -r requirements/requirements.txt
@@ -291,6 +312,7 @@ six==1.15.0
     #   -r requirements/requirements.txt
     #   bleach
     #   click-repl
+    #   ecdsa
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -63,6 +63,7 @@ cffi==1.15.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+    #   cryptography
 chameleon==3.8.1
     # via
     #   -r requirements/functests.txt
@@ -99,6 +100,11 @@ colander==1.8.2
     #   deform
 coverage==7.3.0
     # via -r requirements/tests.txt
+cryptography==41.0.3
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   python-jose
 data-tasks==0.0.3
     # via
     #   -r requirements/functests.txt
@@ -109,6 +115,11 @@ deform==2.0.15
     #   -r requirements/tests.txt
 dill==0.3.4
     # via pylint
+ecdsa==0.18.0
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   python-jose
 elasticsearch==6.8.2
     # via
     #   -r requirements/functests.txt
@@ -329,6 +340,12 @@ psycopg2==2.9.7
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   data-tasks
+pyasn1==0.5.0
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   python-jose
+    #   rsa
 pycodestyle==2.11.0
     # via -r requirements/lint.in
 pycparser==2.20
@@ -407,6 +424,10 @@ python-dateutil==2.8.2
     #   celery
     #   elasticsearch-dsl
     #   faker
+python-jose[cryptography]==3.3.0
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 python-slugify==8.0.1
     # via
     #   -r requirements/functests.txt
@@ -437,6 +458,11 @@ rpds-py==0.9.2
     #   -r requirements/tests.txt
     #   jsonschema
     #   referencing
+rsa==4.9
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   python-jose
 sentry-sdk==1.17.0
     # via
     #   -r requirements/functests.txt
@@ -448,6 +474,7 @@ six==1.15.0
     #   -r requirements/tests.txt
     #   bleach
     #   click-repl
+    #   ecdsa
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -7,6 +7,7 @@ data_tasks
 pyramid-sanity
 
 # 3rd-party packages
+python-jose[cryptography]
 PyJWT
 SQLAlchemy >= 1.1.4
 alembic

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -29,7 +29,9 @@ certifi==2023.7.22
     #   -r requirements/requirements.in
     #   sentry-sdk
 cffi==1.15.1
-    # via -r requirements/requirements.in
+    # via
+    #   -r requirements/requirements.in
+    #   cryptography
 chameleon==3.8.1
     # via deform
 click==8.1.7
@@ -47,10 +49,14 @@ click-repl==0.2.0
     # via celery
 colander==1.8.2
     # via deform
+cryptography==41.0.3
+    # via python-jose
 data-tasks==0.0.3
     # via -r requirements/requirements.in
 deform==2.0.15
     # via -r requirements/requirements.in
+ecdsa==0.18.0
+    # via python-jose
 elasticsearch==6.8.2
     # via
     #   -r requirements/requirements.in
@@ -149,6 +155,10 @@ psycopg2==2.9.7
     # via
     #   -r requirements/requirements.in
     #   data-tasks
+pyasn1==0.5.0
+    # via
+    #   python-jose
+    #   rsa
 pycparser==2.20
     # via cffi
 pycryptodomex==3.18.0
@@ -188,6 +198,8 @@ python-dateutil==2.8.2
     #   -r requirements/requirements.in
     #   celery
     #   elasticsearch-dsl
+python-jose[cryptography]==3.3.0
+    # via -r requirements/requirements.in
 python-slugify==8.0.1
     # via -r requirements/requirements.in
 pytz==2023.3
@@ -205,12 +217,15 @@ rpds-py==0.9.2
     # via
     #   jsonschema
     #   referencing
+rsa==4.9
+    # via python-jose
 sentry-sdk==1.17.0
     # via h-pyramid-sentry
 six==1.15.0
     # via
     #   bleach
     #   click-repl
+    #   ecdsa
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -38,7 +38,9 @@ certifi==2023.7.22
     #   -r requirements/requirements.txt
     #   sentry-sdk
 cffi==1.15.1
-    # via -r requirements/requirements.txt
+    # via
+    #   -r requirements/requirements.txt
+    #   cryptography
 chameleon==3.8.1
     # via
     #   -r requirements/requirements.txt
@@ -69,10 +71,18 @@ colander==1.8.2
     #   deform
 coverage==7.3.0
     # via -r requirements/tests.in
+cryptography==41.0.3
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 data-tasks==0.0.3
     # via -r requirements/requirements.txt
 deform==2.0.15
     # via -r requirements/requirements.txt
+ecdsa==0.18.0
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 elasticsearch==6.8.2
     # via
     #   -r requirements/requirements.txt
@@ -218,6 +228,11 @@ psycopg2==2.9.7
     # via
     #   -r requirements/requirements.txt
     #   data-tasks
+pyasn1==0.5.0
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
+    #   rsa
 pycparser==2.20
     # via
     #   -r requirements/requirements.txt
@@ -262,6 +277,8 @@ python-dateutil==2.8.2
     #   celery
     #   elasticsearch-dsl
     #   faker
+python-jose[cryptography]==3.3.0
+    # via -r requirements/requirements.txt
 python-slugify==8.0.1
     # via -r requirements/requirements.txt
 pytz==2023.3
@@ -283,6 +300,10 @@ rpds-py==0.9.2
     #   -r requirements/requirements.txt
     #   jsonschema
     #   referencing
+rsa==4.9
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 sentry-sdk==1.17.0
     # via
     #   -r requirements/requirements.txt
@@ -292,6 +313,7 @@ six==1.15.0
     #   -r requirements/requirements.txt
     #   bleach
     #   click-repl
+    #   ecdsa
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator


### PR DESCRIPTION
Not yet used but planned for the LMS metadata in annotations feature.


The JWE will be generated in the LMS side by: https://github.com/hypothesis/lms/pull/5675


Implementation copied from https://github.com/hypothesis/h-vialib/blob/main/src/h_vialib/secure/encryption.py