### PR TITLE
Include the imported column on the reporting annotations table

### DIFF
--- a/h/data_tasks/report/create_from_scratch/03_annotations/01_create_table.sql
+++ b/h/data_tasks/report/create_from_scratch/03_annotations/01_create_table.sql
@@ -14,5 +14,6 @@ CREATE TABLE report.annotations (
     anchored BOOLEAN NOT NULL,
     size INT,
     parent_uuids UUID[],
-    tags TEXT[]
+    tags TEXT[],
+    imported BOOLEAN NOT NULL
 );

--- a/h/data_tasks/report/create_from_scratch/03_annotations/02_initial_fill.sql
+++ b/h/data_tasks/report/create_from_scratch/03_annotations/02_initial_fill.sql
@@ -12,7 +12,7 @@ INSERT INTO report.annotations (
     user_id, group_id, document_id, authority_id,
     created, updated,
     deleted, shared, anchored, size,
-    parent_uuids, tags
+    parent_uuids, tags, imported
 )
 SELECT
     annotation.id as uuid,
@@ -29,7 +29,8 @@ SELECT
     JSONB_ARRAY_LENGTH(target_selectors) <> 0 AS anchored,
     LENGTH(text) AS size,
     "references",
-    tags
+    tags,
+    coalesce(extra ->'extra'->>'source' = 'import', false)
 FROM annotation
 JOIN "user" users ON
     users.authority = SPLIT_PART(annotation.userid, '@', 2)

--- a/h/data_tasks/report/refresh/01_annotations_refresh.sql
+++ b/h/data_tasks/report/refresh/01_annotations_refresh.sql
@@ -18,7 +18,7 @@ INSERT INTO report.annotations (
     user_id, group_id, document_id, authority_id,
     created, updated,
     deleted, shared, anchored, size,
-    parent_uuids, tags
+    parent_uuids, tags, imported
 )
 SELECT
     annotation.id as uuid,
@@ -33,7 +33,8 @@ SELECT
     JSONB_ARRAY_LENGTH(target_selectors) <> 0 AS anchored,
     LENGTH(text) AS size,
     "references",
-    tags
+    tags,
+    coalesce(extra ->'extra'->>'source' = 'import', false)
 FROM annotation
 JOIN "user" users ON
     users.authority = SPLIT_PART(annotation.userid, '@', 2)


### PR DESCRIPTION
Exposes `imported` to the annotation table in the reporting schema