### PR TITLE
Migration for annotation metadata

### DIFF
--- a/h/migrations/versions/076ac6c7a8e0_annotation_metadata.py
+++ b/h/migrations/versions/076ac6c7a8e0_annotation_metadata.py
@@ -1,0 +1,35 @@
+"""Add the annotation metadata table."""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "076ac6c7a8e0"
+down_revision = "8250dce465f2"
+
+
+def upgrade():
+    op.create_table(
+        "annotation_metadata",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("annotation_pk", sa.Integer(), nullable=False),
+        sa.Column(
+            "data",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("jsonb('{}')"),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["annotation_pk"],
+            ["annotation.pk"],
+            name=op.f("fk__annotation_metadata__annotation_pk__annotation"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__annotation_metadata")),
+        sa.UniqueConstraint(
+            "annotation_pk", name=op.f("uq__annotation_metadata__annotation_pk")
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("annotation_metadata")


### PR DESCRIPTION
Model changes over:

- https://github.com/hypothesis/h/pull/8159


### Forwards

```
tox -e dev --run-command 'alembic upgrade head'

2023-09-05 12:33:02 2616403 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-05 12:33:02 2616403 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-05 12:33:02 2616403 alembic.runtime.migration [INFO] Running upgrade 8250dce465f2 -> 076ac6c7a8e0, Add the annotation metadata table.
```


### Check the table

```
docker compose exec postgres psql -U postgres -c "\d annotation_metadata"

                                Table "public.annotation_metadata"
    Column     |  Type   | Collation | Nullable |                     Default                     
---------------+---------+-----------+----------+-------------------------------------------------
 id            | integer |           | not null | nextval('annotation_metadata_id_seq'::regclass)
 annotation_pk | integer |           | not null | 
 metadata      | jsonb   |           |          | '{}'::jsonb
Indexes:
    "pk__annotation_metadata" PRIMARY KEY, btree (id)
    "uq__annotation_metadata__annotation_pk" UNIQUE CONSTRAINT, btree (annotation_pk)
Foreign-key constraints:
    "fk__annotation_metadata__annotation_pk__annotation" FOREIGN KEY (annotation_pk) REFERENCES annotation(pk) ON DELETE CASCADE

```



### Backwards

```
tox -e dev --run-command 'alembic downgrade -1'

2023-09-05 12:32:11 2613039 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-05 12:32:11 2613039 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-05 12:32:11 2613039 alembic.runtime.migration [INFO] Running downgrade 076ac6c7a8e0 -> 8250dce465f2, Add the annotation metadata table.
```
