### PR TITLE
Temporarily pin Node to v20.5 in Docker to work around Babel issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build static frontend assets.
-FROM node:20-alpine as build
+FROM node:20.5-alpine as build
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
See https://github.com/babel/babel/issues/15927

Slack thread: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1693988638212529