### PR TITLE
Order by created now that we have an index

### DIFF
--- a/h/tasks/annotations.py
+++ b/h/tasks/annotations.py
@@ -25,7 +25,7 @@ def fill_pk_and_user_id(batch_size=1000):
             == func.split_part(func.split_part(Annotation.userid, "@", 1), ":", 2),
         )
         .where(Annotation.pk.is_(None))
-        .order_by(Annotation.updated.asc())
+        .order_by(Annotation.created.asc())
         .with_for_update(skip_locked=True)
         .limit(batch_size)
     ).cte("annotations")


### PR DESCRIPTION
The only reason to sort by updated was because the index on created didn't exist before. Use created now.