### PR TITLE
Remove support for `fields` in the bulk annotation API

### DIFF
--- a/h/views/api/bulk/annotation_schema.json
+++ b/h/views/api/bulk/annotation_schema.json
@@ -15,31 +15,20 @@
                     "gt": "2018-11-13T20:20:39+00:00",
                     "lte": "2018-11-13T20:20:39+00:00"
                 }
-            },
-            "fields": ["author.username", "group.authority_provided_id"]
+            }
         }
     ],
 
     "properties": {
-        "fields": {"$ref": "#/$defs/fields"},
         "filter": {"$ref": "#/$defs/filter"}
     },
-    "required": ["filter", "fields"],
+    "required": ["filter"],
     "additionalProperties": false,
 
     "$defs": {
-        "fields": {
-            "title": "Fields",
-            "description": "A list of fields to include in the output",
-
-            "type": "array",
-            "items": {"type": "string"},
-            "enum": [["author.username", "group.authority_provided_id"]]
-        },
-
         "filter": {
             "title": "Filter query",
-            "description": "The fields to search for the annotations by",
+            "description": "The filters to search for the annotations by",
 
             "type": "object",
             "properties": {

--- a/h/views/api/bulk/annotation_schema.json
+++ b/h/views/api/bulk/annotation_schema.json
@@ -23,7 +23,7 @@
         "filter": {"$ref": "#/$defs/filter"}
     },
     "required": ["filter"],
-    "additionalProperties": false,
+    "additionalProperties": true,
 
     "$defs": {
         "filter": {


### PR DESCRIPTION
Removing support for specifying fields on the annotation bulk API.

This is a nice feature that the service provides, that the API hints at supporting but that we have code to disable/limit. 

We could support this in the future if needed but the current approach, IMO, adds additional complexity without any of the benefits of the feature.

In addition this was making adding new fields a bit more complex than necessary.


## Testing

Same as https://github.com/hypothesis/h/pull/8166