### PR TITLE
Support annotation metadata in annotation PATCH-ing

### DIFF
--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -230,6 +230,8 @@ class UpdateAnnotationSchema:
                 new_appstruct.get("target_uri", self.existing_target_uri),
             )
 
+        new_appstruct["metadata"] = appstruct.pop("metadata", None)
+
         new_appstruct["extra"] = appstruct
 
         return new_appstruct

--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -110,6 +110,7 @@ class AnnotationWriteService:
         """
         initial_target_uri = annotation.target_uri
 
+        annotation_metadata = data.pop("metadata", None)
         self._update_annotation_values(annotation, data)
         if update_timestamp:
             annotation.updated = datetime.utcnow()
@@ -132,8 +133,10 @@ class AnnotationWriteService:
                 document.get("document_uri_dicts", {}),
                 updated=annotation.updated,
             )
-
         self.upsert_annotation_slim(annotation)
+
+        if annotation_metadata:
+            self._annotation_metadata_service.set(annotation, annotation_metadata)
 
         # The search index service by default does not reindex if the existing ES
         # entry's timestamp matches the DB timestamp. If we're not changing this

--- a/tests/h/services/annotation_write_test.py
+++ b/tests/h/services/annotation_write_test.py
@@ -150,6 +150,20 @@ class TestAnnotationWriteService:
         )
         assert result.updated == then
 
+    def test_update_annotation_with_metadata(
+        self, svc, annotation, annotation_metadata_service
+    ):
+        result = svc.update_annotation(
+            annotation,
+            {"metadata": sentinel.metadata},
+            update_timestamp=False,
+            reindex_tag="custom_tag",
+        )
+
+        annotation_metadata_service.set.assert_called_once_with(
+            result, sentinel.metadata
+        )
+
     def test__validate_group_with_no_group(self, svc, annotation):
         annotation.group = None
 


### PR DESCRIPTION
## Testing 

- Double check that editing an annotation still works as expected without any metadata

Create (if necessary) and edit an annotation in 
https://hypothesis.instructure.com/courses/125/assignments/873


- Note the annotation id an get the UUID version of it

The URL version is on the URL of the PATCH call to http://localhost:5000/api/annotations/ANNO_ID


- Convert the ID to one usable in postgres

```
In [1]: from h.db.types import URLSafeUUID

In [2]: import uuid

In [3]: print(uuid.UUID(URLSafeUUID.url_safe_to_hex("_a6x_lI4Ee6Eai9rFQaNEg")))
fdaeb1fe-5238-11ee-846a-2f6b15068d12
```

- Check the annotation in the DB

```
docker compose exec postgres psql -U postgres -c "select annotation.id, annotation.pk, annotation.user_id, text, data from annotation left outer join annotation_metadata on annotation_pk = annotation.pk where annotation.id::text = 'fdaeb1fe-5238-11ee-846a-2f6b15068d12';"
                  id                  | pk | user_id |         text         | data 
--------------------------------------+----+---------+----------------------+------
 fdaeb1fe-5238-11ee-846a-2f6b15068d12 |    |         | Test anno edited - 1 | 
(1 row)
```



- Copy the curl request from the LMS client call to H, the PATCH to http://localhost:5000/api/annotations/ANNO_ID


edit the --data-raw parameter to include metadata_jwe with the JWE generated above, eg:

`"metadata":  {"assignment_id": 1}`


- Check the anno in the DB

```
docker compose exec postgres psql -U postgres -c "select annotation.id, annotation.pk, annotation.user_id, text, data from annotation left outer join annotation_metadata on annotation_pk = annotation.pk where annotation.id::text = 'fdaeb1fe-5238-11ee-846a-2f6b15068d12';"
                  id                  |  pk  | user_id |         text         |             data              
--------------------------------------+------+---------+----------------------+-------------------------------
 fdaeb1fe-5238-11ee-846a-2f6b15068d12 | 3053 |       7 | Test anno edited - 3 | {"lms": {"assignment_id": 1}}
(1 row)
```

Now the annotation has metadata and the PK and user_id values.



- Curl again with other metadata and  check the DB again:

```
docker compose exec postgres psql -U postgres -c "select annotation.id, annotation.pk, annotation.user_id, text, data from annotation left outer join annotation_metadata on annotation_pk = annotation.pk where annotation.id::text = 'fdaeb1fe-5238-11ee-846a-2f6b15068d12';"
                  id                  |  pk  | user_id |         text         |              data              
--------------------------------------+------+---------+----------------------+--------------------------------
 fdaeb1fe-5238-11ee-846a-2f6b15068d12 | 3053 |       7 | Test anno edited - 3 | {"lms": {"other": "metadata"}}
(1 row)
```

The metadata has been replaced and the pk and user_id remain the same.

