### PR TITLE
Revert migration adding annotation.user_id

### DIFF
--- a/h/migrations/versions/6df1c8c3e423_revert_annotation_user_id.py
+++ b/h/migrations/versions/6df1c8c3e423_revert_annotation_user_id.py
@@ -1,0 +1,18 @@
+"""Revert annotation.user_id."""
+from alembic import op
+
+revision = "6df1c8c3e423"
+down_revision = "076ac6c7a8e0"
+
+
+def upgrade():
+    op.drop_index("ix__annotation_user_id", table_name="annotation")
+    op.drop_constraint(
+        "fk__annotation__user_id__user", "annotation", type_="foreignkey"
+    )
+    op.drop_column("annotation", "user_id")
+
+
+def downgrade():
+    """No downgrade, see the upgrade for migration 8250dce465f2."""
+    pass


### PR DESCRIPTION
Investigating performance problems in H's DB. Trying to rule this table changes as the direct cause.


## Testing

```
tox -e dev --run-command 'alembic upgrade head'                                                                                      
                                                                                     
dev run-test-pre: PYTHONHASHSEED='1279886815'                                        
dev run-test: commands[0] | alembic upgrade head                                     
2023-09-19 14:24:16 2974043 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.                                                                                  
2023-09-19 14:24:16 2974043 alembic.runtime.migration [INFO] Will assume transactional DDL.                                                                                
2023-09-19 14:24:16 2974043 alembic.runtime.migration [INFO] Running upgrade 076ac6c7a8e0 -> 6df1c8c3e423, Revert annotation.user_id.             
```