### PR TITLE
Revert the creation of the annotation_metadata table

### DIFF
--- a/h/migrations/versions/5d1abac3c1a1_revert_annotation_metadata.py
+++ b/h/migrations/versions/5d1abac3c1a1_revert_annotation_metadata.py
@@ -1,0 +1,15 @@
+"""Revert annotation_metadatai."""
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "5d1abac3c1a1"
+down_revision = "6df1c8c3e423"
+
+
+def upgrade():
+    op.drop_table("annotation_metadata")
+
+
+def downgrade():
+    """No downgrade, see orignal migration 5d1abac3c1a1."""
+    pass


### PR DESCRIPTION
```
tox -e dev --run-command 'alembic upgrade head'                                                                                         
dev run-test-pre: PYTHONHASHSEED='2951876878'                                         
dev run-test: commands[0] | alembic upgrade head                                                                                                                            
2023-09-19 15:19:40 3191578 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.                                                                                                                                                                                                                                                              
2023-09-19 15:19:40 3191578 alembic.runtime.migration [INFO] Will assume transactional DDL.                                                                                 
2023-09-19 15:19:40 3191578 alembic.runtime.migration [INFO] Running upgrade 6df1c8c3e423 -> 5d1abac3c1a1, Revert annotation_metadata.
```