### PR TITLE
Revert annotation.pk migration

### DIFF
--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -63,8 +63,6 @@ def init(engine, base=Base, should_create=False, should_drop=False, authority=No
         # extension.
         engine.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
         base.metadata.create_all(engine)
-        # Create sequences not used explicitly in a column here
-        engine.execute("CREATE SEQUENCE IF NOT EXISTS annotation_id_seq;")
 
     default_org = _maybe_create_default_organization(engine, authority)
     _maybe_create_world_group(engine, authority, default_org)

--- a/h/migrations/versions/77bc5b4f2205_revert_annotation_pk.py
+++ b/h/migrations/versions/77bc5b4f2205_revert_annotation_pk.py
@@ -1,0 +1,17 @@
+"""Revert creation of annotation.pk."""
+from alembic import op
+from sqlalchemy.schema import CreateSequence, DropSequence, Sequence
+
+revision = "77bc5b4f2205"
+down_revision = "5d1abac3c1a1"
+
+
+def upgrade():
+    op.execute(DropSequence(Sequence("annotation_id_seq")))
+    op.drop_constraint(op.f("uq__annotation__pk"), "annotation", type_="unique")
+    op.drop_column("annotation", "pk")
+
+
+def downgrade():
+    """No downgrade, check version f064c2b2e04a."""
+    pass


### PR DESCRIPTION
```
tox -e dev --run-command 'alembic upgrade head'

dev run-test-pre: PYTHONHASHSEED='3939729306'
dev run-test: commands[0] | alembic upgrade head
2023-09-19 15:29:36 3232810 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-19 15:29:36 3232810 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-19 15:29:36 3232810 alembic.runtime.migration [INFO] Running upgrade 5d1abac3c1a1 -> 77bc5b4f2205, Revert creation of annotation.pk.
```