### PR TITLE
Revert "Revert "Fix the bulk annotation API username normalization""

### DIFF
--- a/h/models/user.py
+++ b/h/models/user.py
@@ -42,6 +42,12 @@ class UsernameComparator(Comparator):  # pylint: disable=abstract-method
             **kwargs,
         )
 
+    def in_(self, other):
+        # Normalize the RHS usernames in python
+        usernames = [username.lower().replace(".", "") for username in other]
+        # And compare them to the normalized LHS in postgres
+        return _normalise_username(self.__clause_element__()).in_(usernames)
+
 
 class UserIDComparator(Comparator):  # pylint: disable=abstract-method
     """

--- a/h/services/bulk_annotation.py
+++ b/h/services/bulk_annotation.py
@@ -150,12 +150,7 @@ class BulkAnnotationService:
             .join(GroupMembership, GroupMembership.group_id == Group.id)
             .join(cls._AUDIENCE, GroupMembership.user_id == cls._AUDIENCE.id)
             .where(
-                cls._AUDIENCE._username.in_(  # pylint:disable=protected-access
-                    [
-                        username.lower().replace(".", "")
-                        for username in audience["username"]
-                    ]
-                ),
+                cls._AUDIENCE.username.in_(audience["username"]),
                 cls._AUDIENCE.authority == authority,
             )
         )

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -30,16 +30,10 @@ class TestUserIDComparator:
 class TestUserModelDataConstraints:
     """Unit tests for :py:module:`h.models.User` data integrity constraints."""
 
-    def test_cannot_create_dot_variant_of_user(self, db_session):
-        fred = User(
-            authority="example.com", username="fredbloggs", email="fred@example.com"
+    def test_cannot_create_dot_variant_of_user(self, db_session, fred):
+        db_session.add(
+            User(authority=fred.authority, username="fred.bloggs", email=fred.email)
         )
-        fred2 = User(
-            authority="example.com", username="fred.bloggs", email="fred@example.org"
-        )
-
-        db_session.add(fred)
-        db_session.add(fred2)
         with pytest.raises(exc.IntegrityError):
             db_session.flush()
 
@@ -56,47 +50,25 @@ class TestUserModelDataConstraints:
         with pytest.raises(exc.IntegrityError):
             db_session.flush()
 
-    def test_filtering_by_username_matches_dot_variant_of_user(self, db_session):
-        fred = User(
-            authority="example.com", username="fredbloggs", email="fred@example.com"
-        )
-        db_session.add(fred)
-        db_session.flush()
-
+    def test_filtering_by_username_matches_dot_variant_of_user(self, db_session, fred):
         result = db_session.query(User).filter_by(username="fred.bloggs").one()
 
         assert result == fred
 
     def test_filtering_by_username_matches_dot_variant_of_user_using_in(
-        self, db_session
+        self, db_session, fred
     ):
-        fred = User(
-            authority="example.com", username="fredbloggs", email="fred@example.com"
-        )
-        db_session.add(fred)
-        db_session.flush()
-
         result = db_session.query(User).filter(User.username.in_(["Fred.bloggs"])).one()
 
         assert result == fred
 
-    def test_filtering_by_username_matches_case_variant_of_user(self, db_session):
-        fred = User(
-            authority="example.com", username="fredbloggs", email="fred@example.com"
-        )
-        db_session.add(fred)
-        db_session.flush()
-
+    def test_filtering_by_username_matches_case_variant_of_user(self, db_session, fred):
         result = db_session.query(User).filter_by(username="FredBloggs").one()
 
         assert result == fred
 
-    def test_userid_derived_from_username_and_authority(self):
-        fred = User(
-            authority="example.net", username="fredbloggs", email="fred@example.com"
-        )
-
-        assert fred.userid == "acct:fredbloggs@example.net"
+    def test_userid_derived_from_username_and_authority(self, fred):
+        assert fred.userid == "acct:fredbloggs@example.com"
 
     def test_cannot_create_user_with_too_short_username(self):
         with pytest.raises(ValueError):
@@ -144,15 +116,9 @@ class TestUserModelDataConstraints:
 
 
 class TestUserModelUserId:
-    def test_userid_equals_query(self, db_session):
-        fred = User(
-            authority="example.net", username="fredbloggs", email="fred@example.com"
-        )
-        db_session.add(fred)
-        db_session.flush()
-
+    def test_userid_equals_query(self, db_session, fred):
         result = (
-            db_session.query(User).filter_by(userid="acct:fredbloggs@example.net").one()
+            db_session.query(User).filter_by(userid="acct:fredbloggs@example.com").one()
         )
 
         assert result == fred
@@ -161,18 +127,15 @@ class TestUserModelUserId:
         # This is to ensure that we don't expose the InvalidUserId that could
         # potentially be thrown by split_user.
 
-        result = db_session.query(User).filter_by(userid="fredbloggsexample.net").all()
+        result = db_session.query(User).filter_by(userid="fredbloggsexample.com").all()
 
         assert result == []
 
-    def test_userid_in_query(self, db_session):
-        fred = User(
-            authority="example.net", username="fredbloggs", email="fred@example.net"
-        )
+    def test_userid_in_query(self, db_session, fred):
         alice = User(
             authority="foobar.com", username="alicewrites", email="alice@foobar.com"
         )
-        db_session.add_all([fred, alice])
+        db_session.add(alice)
         db_session.flush()
 
         result = (
@@ -180,7 +143,7 @@ class TestUserModelUserId:
             .filter(
                 User.userid.in_(  # pylint:disable=no-member
                     [
-                        "acct:fredbloggs@example.net",
+                        "acct:fredbloggs@example.com",
                         "acct:alicewrites@foobar.com",
                         "acct:missing@bla.org",
                     ]
@@ -193,21 +156,14 @@ class TestUserModelUserId:
         assert fred in result
         assert alice in result
 
-    def test_userid_in_query_with_invalid_userid_mixed_in(self, db_session):
+    def test_userid_in_query_with_invalid_userid_mixed_in(self, db_session, fred):
         # This is to ensure that we don't expose the InvalidUserId that could
         # potentially be thrown by split_user.
-
-        fred = User(
-            authority="example.net", username="fredbloggs", email="fred@example.com"
-        )
-        db_session.add(fred)
-        db_session.flush()
-
         result = (
             db_session.query(User)
             .filter(
                 # pylint:disable=no-member
-                User.userid.in_(["acct:fredbloggs@example.net", "invalid"])
+                User.userid.in_(["acct:fredbloggs@example.com", "invalid"])
             )
             .all()
         )
@@ -357,3 +313,12 @@ class TestUserGetByUsername:
         }
         db_session.flush()
         return users
+
+
+@pytest.fixture
+def fred(db_session):
+    fred = User(authority="example.com", username="fredbloggs", email="fred@email.com")
+
+    db_session.add(fred)
+    db_session.flush()
+    return fred

--- a/tests/h/services/bulk_annotation_test.py
+++ b/tests/h/services/bulk_annotation_test.py
@@ -73,7 +73,10 @@ class TestBulkAnnotationService:
             ("updated", "2022-01-02", False),
         ),
     )
-    def test_it_with_single_annotation(self, svc, factories, key, value, visible):
+    @pytest.mark.parametrize("username", ["USERNAME", "username", "user.name"])
+    def test_it_with_single_annotation(
+        self, svc, factories, key, value, visible, username
+    ):
         values = {
             "shared": True,
             "deleted": False,
@@ -85,7 +88,9 @@ class TestBulkAnnotationService:
             values[key] = value
 
         viewer = factories.User(authority=self.AUTHORITY)
-        author = factories.User(authority=self.AUTHORITY, nipsa=values["nipsad"])
+        author = factories.User(
+            authority=self.AUTHORITY, nipsa=values["nipsad"], username=username
+        )
         group = factories.Group(members=[author, viewer])
         anno = factories.Annotation(
             userid=author.userid,
@@ -99,7 +104,7 @@ class TestBulkAnnotationService:
 
         annotations = svc.annotation_search(
             authority=self.AUTHORITY,
-            audience={"username": [viewer.username]},
+            audience={"username": ["USERNAME"]},
             updated={"gt": "2020-01-01", "lte": "2022-01-01"},
         )
 


### PR DESCRIPTION
Reverts hypothesis/h#8186. I don't think that #8178 was responsible for the issues we've been seeing (we continued to have issues after reverting the PR), and in fact I think it did successfully make the bulk annotation API's DB query much cheaper by getting it to use the `ix__user__userid` index. Slack thread: <https://hypothes-is.slack.com/archives/C0LUWQQJJ/p1695213050272079?thread_ts=1695029990.159129&cid=C0LUWQQJJ>