### PR TITLE
Add debug mode for WebSocket connections

### DIFF
--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -1,3 +1,4 @@
+from pyramid.settings import asbool
 from pyramid.view import forbidden_view_config, notfound_view_config, view_config
 from ws4py.exc import HandshakeError
 from ws4py.server.wsgiutils import WebSocketWSGIApplication
@@ -10,7 +11,7 @@ def websocket_view(request):
     # Provide environment which the WebSocket handler can use...
     request.environ.update(
         {
-            "h.ws.debug": bool(request.params.get("debug")),
+            "h.ws.debug": asbool(request.params.get("debug")),
             "h.ws.streamer_work_queue": streamer.WORK_QUEUE,
             "h.ws.identity": request.identity,
         }

--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -10,6 +10,7 @@ def websocket_view(request):
     # Provide environment which the WebSocket handler can use...
     request.environ.update(
         {
+            "h.ws.debug": bool(request.params.get("debug")),
             "h.ws.streamer_work_queue": streamer.WORK_QUEUE,
             "h.ws.identity": request.identity,
         }

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -46,6 +46,9 @@ class WebSocket(_WebSocket):
     query = None
     identity = None
 
+    debug = False
+    """Enable debug logging for this connection."""
+
     def __init__(self, sock, protocols=None, extensions=None, environ=None):
         super().__init__(
             sock,
@@ -55,6 +58,7 @@ class WebSocket(_WebSocket):
             heartbeat_freq=30.0,
         )
 
+        self.debug = environ["h.ws.debug"]
         self.identity = environ["h.ws.identity"]
 
         self._work_queue = environ["h.ws.streamer_work_queue"]
@@ -65,11 +69,17 @@ class WebSocket(_WebSocket):
         return instance
 
     def received_message(self, message):
+        if self.debug:
+            log.info("Received message %s", message)
+
         try:
             payload = json.loads(message.data)
         except ValueError:
+            if self.debug:
+                log.warning("Failed to parse message %s", message)
             self.close(reason="invalid message format")
             return
+
         try:
             self._work_queue.put(Message(socket=self, payload=payload), timeout=0.1)
         except Full:
@@ -79,12 +89,16 @@ class WebSocket(_WebSocket):
             )
 
     def closed(self, code, reason=None):
+        if self.debug:
+            log.info("Closed connection code=%s reason=%s", code, reason)
         try:
             self.instances.remove(self)
         except KeyError:
             pass
 
     def send_json(self, payload):
+        if self.debug:
+            log.info("Sending message %s", payload)
         if not self.terminated:
             self.send(json.dumps(payload))
 
@@ -103,6 +117,9 @@ def handle_message(message, session=None):
     It may also passed a database session which *must* be used for any
     communication with the database.
     """
+    if message.socket.debug:
+        log.info("Handling message %s", message.payload)
+
     payload = message.payload
     type_ = payload.get("type")
 

--- a/tests/h/streamer/views_test.py
+++ b/tests/h/streamer/views_test.py
@@ -19,6 +19,15 @@ class TestWebsocketView:
             pyramid_request.environ["h.ws.streamer_work_queue"] == streamer.WORK_QUEUE
         )
 
+    def test_debug_mode_is_disabled_by_default(self, pyramid_request):
+        views.websocket_view(pyramid_request)
+        assert pyramid_request.environ["h.ws.debug"] is False
+
+    def test_enable_debug_mode(self, pyramid_request):
+        pyramid_request.params["debug"] = "1"
+        views.websocket_view(pyramid_request)
+        assert pyramid_request.environ["h.ws.debug"] is True
+
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.get_response = lambda _: None


### PR DESCRIPTION
Add an option to enable debug mode for an individual connection by adding a `debug=1` query param when connecting to the WebSocket server. When debug mode is enabled for a connection, the WS server will log messages received, responses sent and connections closed.

This should help us debug a problem where the production WebSocket server is unreliable when connecting through Cloudflare.

Part of https://github.com/hypothesis/h/issues/8183.

---

**Testing:**

1. Install [websocat](https://github.com/vi/websocat)
2. Start the h dev server
3. Connect the the WS server in debug mode and send a test "whoami" message. You should get a "whoyouare" response back.

```sh
$ websocat 'ws://127.0.0.1:5001/ws?debug=1'
{"type":"whoami", "id": 1}
{"type": "whoyouare", "userid": null, "ok": true, "reply_to": 1}
```
4. Close the connection

In the h dev server logs,  you should see log messages for each step:

```
websocket (stderr)   | 2023-09-21 11:15:10,825 [28323] [h.streamer.websocket:INFO] Received message {"type":"whoami", "id": 1}
websocket (stderr)   | 2023-09-21 11:15:10,873 [28323] [h.streamer.websocket:INFO] Handling message {'type': 'whoami', 'id': 1}
websocket (stderr)   | 2023-09-21 11:15:10,873 [28323] [h.streamer.websocket:INFO] Sending message {'type': 'whoyouare', 'userid': None, 'ok': True, 'reply_to': 1}
websocket (stderr)   | 2023-09-21 11:15:49,891 [28323] [h.streamer.websocket:INFO] Closed connection code=1006 reason=Going away
```