### PR TITLE
Set logging level for h.streamer to INFO in production

### DIFF
--- a/conf/websocket-monolithic.ini
+++ b/conf/websocket-monolithic.ini
@@ -11,7 +11,7 @@ workers: 2
 worker_connections: 8192
 
 [loggers]
-keys = root, gunicorn.error
+keys = root, gunicorn.error, h.streamer
 
 [handlers]
 keys = console
@@ -27,6 +27,11 @@ handlers = console
 level = INFO
 handlers =
 qualname = gunicorn.error
+
+[logger_h.streamer]
+level = INFO
+handlers =
+qualname = h.streamer
 
 [handler_console]
 level = NOTSET

--- a/conf/websocket-separate.ini
+++ b/conf/websocket-separate.ini
@@ -12,7 +12,7 @@ workers: 2
 worker_connections: 8192
 
 [loggers]
-keys = root, gunicorn.error
+keys = root, gunicorn.error, h.streamer
 
 [handlers]
 keys = console
@@ -28,6 +28,11 @@ handlers = console
 level = INFO
 handlers =
 qualname = gunicorn.error
+
+[logger_h.streamer]
+level = INFO
+handlers =
+qualname = h.streamer
 
 [handler_console]
 level = NOTSET


### PR DESCRIPTION
This enables logging of debug mode messages when connecting to the WebSocket with `/ws?debug=1`.

This addresses an oversight in https://github.com/hypothesis/h/pull/8203.