### PR TITLE
Note if WebSocket was terminated when logging messages sent out

### DIFF
--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -98,7 +98,7 @@ class WebSocket(_WebSocket):
 
     def send_json(self, payload):
         if self.debug:
-            log.info("Sending message %s", payload)
+            log.info("Sending message %s (terminated: %s)", payload, self.terminated)
         if not self.terminated:
             self.send(json.dumps(payload))
 


### PR DESCRIPTION
We are seeing cases where WS messages are received and `h.streamer.websocket.WebSocket.send_json` is called, but the reply is never received on the client. Log whether the connection was terminated, to rule that out as the reason.