### PR TITLE
Migration to create the annotation_slim table

### DIFF
--- a/h/migrations/versions/15b5dc900ebb_annotation_slim.py
+++ b/h/migrations/versions/15b5dc900ebb_annotation_slim.py
@@ -1,0 +1,73 @@
+"""Create the annotation_slim table."""
+import sqlalchemy as sa
+from alembic import op
+
+import h
+
+revision = "15b5dc900ebb"
+down_revision = "77bc5b4f2205"
+
+
+def upgrade():
+    op.create_table(
+        "annotation_slim",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("pubid", h.db.types.URLSafeUUID(), nullable=False),
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "deleted", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+        sa.Column(
+            "moderated", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+        sa.Column(
+            "shared", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+        sa.Column("document_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("group_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["document_id"],
+            ["document.id"],
+            name=op.f("fk__annotation_slim__document_id__document"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["group_id"],
+            ["group.id"],
+            name=op.f("fk__annotation_slim__group_id__group"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["user.id"], name=op.f("fk__annotation_slim__user_id__user")
+        ),
+        sa.ForeignKeyConstraint(
+            ["pubid"],
+            ["annotation.id"],
+            name=op.f("fk__annotation_slim__pubid__annotation"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__annotation_slim")),
+        sa.UniqueConstraint("pubid", name=op.f("uq__annotation_slim__pubid")),
+    )
+    op.create_index(
+        op.f("ix__annotation_slim_created"),
+        "annotation_slim",
+        ["created"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix__annotation_slim_updated"),
+        "annotation_slim",
+        ["updated"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix__annotation_slim_updated"), table_name="annotation_slim")
+    op.drop_index(op.f("ix__annotation_slim_created"), table_name="annotation_slim")
+    op.drop_table("annotation_slim")


### PR DESCRIPTION
Model over: https://github.com/hypothesis/h/pull/8214


## Testing


```
tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='3732651211'
dev run-test: commands[0] | alembic upgrade head
2023-09-26 17:48:42 1329608 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-26 17:48:42 1329608 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-26 17:48:42 1329608 alembic.runtime.migration [INFO] Running upgrade 77bc5b4f2205 -> 15b5dc900ebb, Create the annotation_slim table.
```

```
tox -e dev --run-command 'alembic downgrade -1'
dev run-test-pre: PYTHONHASHSEED='3268345893'
dev run-test: commands[0] | alembic downgrade -1
2023-09-26 17:48:37 1329158 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-26 17:48:37 1329158 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-26 17:48:37 1329158 alembic.runtime.migration [INFO] Running downgrade 15b5dc900ebb -> 77bc5b4f2205, Create the annotation_slim table.
```

