### PR TITLE
Keep Annotation and AnnotationSlim in sync

### DIFF
--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -42,6 +42,7 @@ __all__ = (
     "Activation",
     "Annotation",
     "AnnotationModeration",
+    "AnnotationSlim",
     "AuthClient",
     "AuthTicket",
     "AuthzCode",

--- a/h/models/annotation_slim.py
+++ b/h/models/annotation_slim.py
@@ -30,6 +30,8 @@ class AnnotationSlim(Base):
     )
     """The value of annotation.id, named here pubid following the convention of group.pubid"""
 
+    annotation = sa.orm.relationship("Annotation")
+
     created = sa.Column(
         sa.DateTime,
         default=datetime.datetime.utcnow,
@@ -68,5 +70,10 @@ class AnnotationSlim(Base):
     )
 
     document_id = sa.Column(sa.Integer, sa.ForeignKey("document.id"), nullable=False)
+    document = sa.orm.relationship("Document")
+
     user_id = sa.Column(sa.Integer, sa.ForeignKey("user.id"), nullable=False)
+    user = sa.orm.relationship("User")
+
     group_id = sa.Column(sa.Integer, sa.ForeignKey("group.id"), nullable=False)
+    group = sa.orm.relationship("Group")

--- a/h/services/annotation_delete.py
+++ b/h/services/annotation_delete.py
@@ -1,11 +1,14 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from h.events import AnnotationEvent
+from h.models import Annotation, AnnotationSlim
+from h.services.annotation_write import AnnotationWriteService
 
 
 class AnnotationDeleteService:
-    def __init__(self, request):
+    def __init__(self, request, annotation_write):
         self.request = request
+        self.annotation_write = annotation_write
 
     def delete(self, annotation):
         """
@@ -16,6 +19,8 @@ class AnnotationDeleteService:
         """
         annotation.updated = datetime.utcnow()
         annotation.deleted = True
+
+        self.annotation_write.upsert_annotation_slim(annotation)
 
         event = AnnotationEvent(self.request, annotation.id, "delete")
         self.request.notify_after_commit(event)
@@ -30,6 +35,25 @@ class AnnotationDeleteService:
         for ann in annotations:
             self.delete(ann)
 
+    def bulk_delete(self):
+        """
+        Remove annotations marked as deleted from the database.
+
+        Deletes all annotations flagged as deleted more than 10 minutes ago. This
+        buffer period should ensure that this task doesn't delete annotations
+        deleted just before the task runs, which haven't yet been processed by the
+        streamer.
+        """
+        cutoff = datetime.utcnow() - timedelta(minutes=10)
+        self.request.db.query(AnnotationSlim).filter_by(deleted=True).filter(
+            AnnotationSlim.updated < cutoff
+        ).delete()
+        self.request.db.query(Annotation).filter_by(deleted=True).filter(
+            Annotation.updated < cutoff
+        ).delete()
+
 
 def annotation_delete_service_factory(_context, request):
-    return AnnotationDeleteService(request)
+    return AnnotationDeleteService(
+        request, request.find_service(AnnotationWriteService)
+    )

--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 from collections.abc import Callable
+from datetime import datetime
 
 from sqlalchemy import exists, select
 from sqlalchemy.dialects.postgresql import insert

--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Callable
+from collections.abc import Callable
 
 from sqlalchemy import exists, select
 from sqlalchemy.dialects.postgresql import insert

--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -143,6 +143,18 @@ class AnnotationWriteService:
         return annotation
 
     @staticmethod
+    def change_document(db, old_document_ids, new_document):
+        """Update the annotations that pointed to any of `old_document_ids` to point to `new_document` instead."""
+        db.query(Annotation).filter(
+            Annotation.document_id.in_(old_document_ids)
+        ).update({Annotation.document_id: new_document.id}, synchronize_session="fetch")
+        db.query(AnnotationSlim).filter(
+            AnnotationSlim.document_id.in_(old_document_ids)
+        ).update(
+            {AnnotationSlim.document_id: new_document.id}, synchronize_session="fetch"
+        )
+
+    @staticmethod
     def _update_annotation_values(annotation: Annotation, data: dict):
         for key, value in data.items():
             # Don't set complex things

--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Callable
 
 from sqlalchemy import exists, select
 from sqlalchemy.dialects.postgresql import insert
@@ -23,7 +24,7 @@ class AnnotationWriteService:
     def __init__(
         self,
         db_session: Session,
-        has_permission: callable,
+        has_permission: Callable,
         search_index_service: SearchIndexService,
         annotation_read_service: AnnotationReadService,
     ):
@@ -180,6 +181,15 @@ class AnnotationWriteService:
                 "group scope: "
                 + _("Annotations for this target URI are not allowed in this group")
             )
+
+    def hide(self, annotation):
+        """Hides  an annotation marking it it as "moderated"."""
+        if not annotation.is_hidden:
+            annotation.moderation = AnnotationModeration()
+
+    def unhide(self, annotation):
+        """Remove the moderation status of an annotation."""
+        annotation.moderation = None
 
     def upsert_annotation_slim(self, annotation):
         moderated = self._db.scalar(

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -1,8 +1,8 @@
 from pyramid.httpexceptions import HTTPNoContent
 
 from h import events
-from h.models import AnnotationModeration
 from h.security import Permission
+from h.services import AnnotationWriteService
 from h.views.api.config import api_config
 
 
@@ -15,10 +15,7 @@ from h.views.api.config import api_config
     permission=Permission.Annotation.MODERATE,
 )
 def create(context, request):
-    annotation = context.annotation
-
-    if not annotation.is_hidden:
-        annotation.moderation = AnnotationModeration()
+    request.find_service(AnnotationWriteService).hide(context.annotation)
 
     event = events.AnnotationEvent(request, context.annotation.id, "update")
     request.notify_after_commit(event)
@@ -35,7 +32,7 @@ def create(context, request):
     permission=Permission.Annotation.MODERATE,
 )
 def delete(context, request):
-    context.annotation.moderation = None
+    request.find_service(AnnotationWriteService).unhide(context.annotation)
 
     event = events.AnnotationEvent(request, context.annotation.id, "update")
     request.notify_after_commit(event)

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -3,6 +3,7 @@
 from tests.common.factories.activation import Activation
 from tests.common.factories.annotation import Annotation
 from tests.common.factories.annotation_moderation import AnnotationModeration
+from tests.common.factories.annotation_slim import AnnotationSlim
 from tests.common.factories.auth_client import AuthClient, ConfidentialAuthClient
 from tests.common.factories.auth_ticket import AuthTicket
 from tests.common.factories.authz_code import AuthzCode

--- a/tests/common/factories/annotation_slim.py
+++ b/tests/common/factories/annotation_slim.py
@@ -1,0 +1,19 @@
+import factory
+
+from h import models
+
+from .annotation import Annotation
+from .base import ModelFactory
+from .document import Document
+from .group import Group
+from .user import User
+
+
+class AnnotationSlim(ModelFactory):
+    class Meta:
+        model = models.AnnotationSlim
+
+    annotation = factory.SubFactory(Annotation)
+    user = factory.SubFactory(User)
+    group = factory.SubFactory(Group)
+    document = factory.SubFactory(Document)

--- a/tests/functional/api/moderation_test.py
+++ b/tests/functional/api/moderation_test.py
@@ -109,6 +109,13 @@ def user(db_session, factories):
 
 
 @pytest.fixture
+def other_user(db_session, factories):
+    user = factories.User()
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
 def group(user, db_session, factories):
     group = factories.Group(creator=user)
     db_session.commit()
@@ -123,18 +130,18 @@ def world_annotation(user, db_session, factories):
 
 
 @pytest.fixture
-def group_annotation(group, db_session, factories):
+def group_annotation(group, db_session, factories, other_user):
     ann = factories.Annotation(
-        userid="acct:someone@example.com", groupid=group.pubid, shared=True
+        userid=other_user.userid, groupid=group.pubid, shared=True
     )
     db_session.commit()
     return ann
 
 
 @pytest.fixture
-def private_group_annotation(group, db_session, factories):
+def private_group_annotation(group, db_session, factories, other_user):
     ann = factories.Annotation(
-        userid="acct:someone@example.com", groupid=group.pubid, shared=False
+        userid=other_user.userid, groupid=group.pubid, shared=False
     )
     db_session.commit()
     return ann

--- a/tests/h/services/annotation_delete_test.py
+++ b/tests/h/services/annotation_delete_test.py
@@ -1,8 +1,10 @@
+from datetime import datetime, timedelta
 from unittest import mock
 
 import pytest
 
 from h.events import AnnotationEvent
+from h.models import Annotation, AnnotationSlim
 from h.services.annotation_delete import annotation_delete_service_factory
 
 
@@ -39,14 +41,57 @@ class TestAnnotationDeleteService:
 
         assert svc.delete.mock_calls == [mock.call(anns[0]), mock.call(anns[1])]
 
+    @pytest.mark.parametrize(
+        "deleted,mins_ago,purged",
+        [
+            # Deleted more than 10 minutes ago... should be purged.
+            (True, 30, True),
+            (True, 3600, True),
+            # Deleted less than 10 minutes ago... should NOT be purged.
+            (True, -30, False),  # annotation from the future! wooOOOooo!
+            (True, 0, False),
+            (True, 1, False),
+            (True, 9, False),
+            # Not deleted... should NOT be purged.
+            (False, -30, False),
+            (False, 0, False),
+            (False, 1, False),
+            (False, 9, False),
+            (False, 30, False),
+            (False, 3600, False),
+        ],
+    )
+    def test_bulk_delete(self, db_session, svc, factories, deleted, mins_ago, purged):
+        updated = datetime.utcnow() - timedelta(minutes=mins_ago)
+        annotation = factories.Annotation(deleted=deleted, updated=updated)
+        annotation_slim = factories.AnnotationSlim(
+            deleted=deleted, updated=updated, annotation=annotation
+        )
+        db_session.add(annotation)
+        db_session.add(annotation_slim)
+
+        svc.bulk_delete()
+
+        if purged:
+            assert not db_session.query(Annotation).count()
+            assert not db_session.query(AnnotationSlim).count()
+        else:
+            assert db_session.query(Annotation).count() == 1
+            assert db_session.query(AnnotationSlim).count() == 1
+
+    @pytest.fixture
+    def datetime(self, patch):
+        return patch("h.services.annotation_delete.datetime")
+
 
 @pytest.fixture
 def annotation(factories):
     return lambda factories=factories: factories.Annotation()
 
 
+# pylint:disable=unused-argument
 @pytest.fixture
-def svc(db_session, pyramid_request):
+def svc(db_session, pyramid_request, annotation_write_service):
     pyramid_request.db = db_session
     return annotation_delete_service_factory({}, pyramid_request)
 
@@ -55,8 +100,3 @@ def svc(db_session, pyramid_request):
 def pyramid_request(pyramid_request):
     pyramid_request.notify_after_commit = mock.Mock()
     return pyramid_request
-
-
-@pytest.fixture
-def datetime(patch):
-    return patch("h.services.annotation_delete.datetime")

--- a/tests/h/services/annotation_write_test.py
+++ b/tests/h/services/annotation_write_test.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch, sentinel
 import pytest
 from h_matchers import Any
 
-from h.models import Annotation, AnnotationSlim, User
+from h.models import Annotation, AnnotationModeration, AnnotationSlim, User
 from h.schemas import ValidationError
 from h.security import Permission
 from h.services.annotation_write import AnnotationWriteService, service_factory
@@ -178,6 +178,23 @@ class TestAnnotationWriteService:
                 svc._validate_group(annotation)  # pylint: disable=protected-access
         else:
             svc._validate_group(annotation)  # pylint: disable=protected-access
+
+    def test_hide_hides_the_annotation(self, annotation, svc):
+        annotation.moderation = None
+
+        svc.hide(annotation)
+
+        assert annotation.is_hidden
+
+    def test_hide_does_not_modify_an_already_hidden_annotation(self, annotation, svc):
+        moderation = AnnotationModeration()
+        annotation.moderation = moderation
+
+        svc.hide(annotation)
+
+        assert annotation.is_hidden
+        # It's the same one not a new one
+        assert annotation.moderation == moderation
 
     @pytest.fixture
     def create_data(self, factories):


### PR DESCRIPTION
Handles actions happening for now on. We don't address the historical annotation backlog here yet.



# Testing

- In `main` create a few annotations as `devdata_user` in http://localhost:5000/docs/help

I'm creating ones with the following bodies:

`Existing to edit`
`Existing to delete`
(In a new group), invite another user (eg devdata_staff) and as that second user:  `To moderate` 


- Now switch to this branch `annotation-slim-sync`

- Make sure you are in the latest migration:

```tox -e dev --run-command 'alembic upgrade head'```



- New annotations

use the text `new in Slim` and query for the new row in Slim


```
docker compose exec postgres psql -U postgres -c "select annotation_slim.* from annotation_slim join annotation on annotation.id = annotation_slim.pubid 
 where text = 'new in slim';"
 id |                pubid                 |          created           |          updated           | deleted | moderated | shared | document_id | user_id | group_id 
----+--------------------------------------+----------------------------+----------------------------+---------+-----------+--------+-------------+---------+----------
 11 | 051948b0-5d1e-11ee-912b-7bdf8501a5d8 | 2023-09-27 10:10:01.061613 | 2023-09-27 10:10:01.061613 | f       | f         | t      |           4 |       3 |        1
(1 row)

```



- Edit existing annotations

edit `Existing to Edit` to something like `existing to edit`, query on slim


```
docker compose exec postgres psql -U postgres -c "select annotation_slim.* from annotation_slim join annotation on annotation.id = annotation_slim.pubid
 where text = 'existing to edit';"
 id |                pubid                 |          created           |          updated           | deleted | moderated | shared | document_id | user_id | group_id 
----+--------------------------------------+----------------------------+----------------------------+---------+-----------+--------+-------------+---------+----------
 12 | 777cd16c-5d1c-11ee-92c5-ef26cdd88cf5 | 2023-09-27 09:58:54.006171 | 2023-09-27 10:14:31.658583 | f       | f         | t      |           4 |       3 |        1

```



- Deleting annotation


Delete `Existing to Delete`, query and check the value of `deleted`:


```
docker compose exec postgres psql -U postgres -c "select annotation_slim.* from annotation_slim join annotation on annotation.id = annotation_slim.pubid                                         
 where text = 'Existing to Delete';"                                                                            
 id |                pubid                 |          created           |          updated           | deleted | moderated | shared | document_id | user_id | group_id 
----+--------------------------------------+----------------------------+----------------------------+---------+-----------+--------+-------------+---------+----------
 13 | 7d107534-5d1c-11ee-92c5-134e9390a00a | 2023-09-27 09:59:03.348593 | 2023-09-27 10:15:33.709161 | t       | f         | t      |           4 |       3 |        1
(1 row)
```



- Moderate annotation

Flag and moderate the annotation in a group


```
docker compose exec postgres psql -U postgres -c "select annotation_slim.* from annotation_slim join annotation on annotation.id = annotation_slim.pubid
 where text = 'To moderate';"
 id |                pubid                 |          created           |          updated           | deleted | moderated | shared | document_id | user_id | group_id 
----+--------------------------------------+----------------------------+----------------------------+---------+-----------+--------+-------------+---------+----------
 15 | 96faf022-5d22-11ee-9408-8f44fcebb3b2 | 2023-09-27 10:42:43.813067 | 2023-09-27 10:42:43.813067 | f       | t         | t      |           4 |       2 |      428
```

Unhide it after:

```
docker compose exec postgres psql -U postgres -c "select annotation_slim.* from annotation_slim join annotation on annotation.id = annotation_slim.pubid
 where text = 'To moderate';"
 id |                pubid                 |          created           |          updated           | deleted | moderated | shared | document_id | user_id | group_id 
----+--------------------------------------+----------------------------+----------------------------+---------+-----------+--------+-------------+---------+----------
 15 | 96faf022-5d22-11ee-9408-8f44fcebb3b2 | 2023-09-27 10:42:43.813067 | 2023-09-27 10:42:43.813067 | f       | f         | t      |           4 |       2 |      428
(1 row)
```




