### PR TITLE
Replace index on subscriptions.uri to use `lower`

### DIFF
--- a/h/migrations/versions/3081971a50fc_sub_uri_lower.py
+++ b/h/migrations/versions/3081971a50fc_sub_uri_lower.py
@@ -1,0 +1,26 @@
+"""Replace subscriptions index to be on lower(uri)."""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "3081971a50fc"
+down_revision = "0d101aa6b9a5"
+
+
+def upgrade():
+    op.drop_index("subs_uri_idx_subscriptions", table_name="subscriptions")
+    op.execute("COMMIT")  # For the concurrent index creation
+    op.create_index(
+        op.f("subs_uri_lower_idx_subscriptions"),
+        "subscriptions",
+        [sa.text("lower('uri')")],
+        postgresql_concurrently=True,
+        unique=False,
+    )
+
+
+def downgrade():
+    op.create_index(
+        "subs_uri_idx_subscriptions", "subscriptions", ["uri"], unique=False
+    )
+    op.drop_index("subs_uri_lower_idx_subscriptions", table_name="subscriptions")

--- a/h/models/subscriptions.py
+++ b/h/models/subscriptions.py
@@ -18,7 +18,9 @@ class Subscriptions(Base):
         REPLY = "reply"
 
     __tablename__ = "subscriptions"
-    __table_args__ = (sa.Index("subs_uri_idx_subscriptions", "uri"),)
+    __table_args__ = (
+        sa.Index("subs_uri_lower_idx_subscriptions", sa.func.lower("uri")),
+    )
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
 


### PR DESCRIPTION
Motivated by seeing this query show up in the top ones in RDS insights.


Queries made to this table always lower both side of the comparison making the existing index useless.

All queries seem to be made through this interface:

https://github.com/hypothesis/h/blob/sub-index-lower/h/services/subscription.py#L39



## Testing

```
tox -e dev --run-command 'alembic upgrade head'                                                                            
dev run-test-pre: PYTHONHASHSEED='3996407498'
dev run-test: commands[0] | alembic upgrade head
2023-09-28 13:47:02 1099831 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-28 13:47:02 1099831 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-28 13:47:02 1099831 alembic.runtime.migration [INFO] Running upgrade 0d101aa6b9a5 -> 3081971a50fc, Replace subscriptions index to be on lower(uri).
```
