### PR TITLE
Add a CASCADE on delete for annotation_slim.user_id

### DIFF
--- a/h/migrations/versions/28a982795769_anno_slim_user_cascade.py
+++ b/h/migrations/versions/28a982795769_anno_slim_user_cascade.py
@@ -1,0 +1,34 @@
+"""Add CASCADE on deletion for annotation_slim.user."""
+from alembic import op
+
+revision = "28a982795769"
+down_revision = "15b5dc900ebb"
+
+
+def upgrade():
+    op.drop_constraint(
+        "fk__annotation_slim__user_id__user", "annotation_slim", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        op.f("fk__annotation_slim__user_id__user"),
+        "annotation_slim",
+        "user",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk__annotation_slim__user_id__user"),
+        "annotation_slim",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk__annotation_slim__user_id__user",
+        "annotation_slim",
+        "user",
+        ["user_id"],
+        ["id"],
+    )

--- a/h/models/annotation_slim.py
+++ b/h/models/annotation_slim.py
@@ -72,7 +72,9 @@ class AnnotationSlim(Base):
     document_id = sa.Column(sa.Integer, sa.ForeignKey("document.id"), nullable=False)
     document = sa.orm.relationship("Document")
 
-    user_id = sa.Column(sa.Integer, sa.ForeignKey("user.id"), nullable=False)
+    user_id = sa.Column(
+        sa.Integer, sa.ForeignKey("user.id", ondelete="CASCADE"), nullable=False
+    )
     user = sa.orm.relationship("User")
 
     group_id = sa.Column(sa.Integer, sa.ForeignKey("group.id"), nullable=False)


### PR DESCRIPTION
This will be equivalent to the behaviour in annotation, see:

https://github.com/hypothesis/h/blob/anno-slim-user-cascade/h/services/user_delete.py#L26



## Testing

```
tox -e dev --run-command 'alembic upgrade head'                                        
dev run-test-pre: PYTHONHASHSEED='3129793428'
dev run-test: commands[0] | alembic upgrade head
2023-09-28 13:36:05 1052117 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-28 13:36:05 1052117 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-28 13:36:05 1052117 alembic.runtime.migration [INFO] Running upgrade 15b5dc900ebb -> 28a982795769, Add CASCADE on deletion for annotation_slim.user.
```