### PR TITLE
Add a CASCADE on delete for annotation_slim.group_id

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,6 +12,6 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 98.59
+fail_under = 98.58
 
 skip_covered = True

--- a/h/migrations/versions/0d101aa6b9a5_anno_slim_group_cascade.py
+++ b/h/migrations/versions/0d101aa6b9a5_anno_slim_group_cascade.py
@@ -1,0 +1,34 @@
+"""Add CASCADE on deletion for annotation_slim.group."""
+from alembic import op
+
+revision = "0d101aa6b9a5"
+down_revision = "28a982795769"
+
+
+def upgrade():
+    op.drop_constraint(
+        "fk__annotation_slim__group_id__group", "annotation_slim", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        op.f("fk__annotation_slim__group_id__group"),
+        "annotation_slim",
+        "group",
+        ["group_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk__annotation_slim__group_id__group"),
+        "annotation_slim",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk__annotation_slim__group_id__group",
+        "annotation_slim",
+        "group",
+        ["group_id"],
+        ["id"],
+    )

--- a/h/models/annotation_slim.py
+++ b/h/models/annotation_slim.py
@@ -77,5 +77,7 @@ class AnnotationSlim(Base):
     )
     user = sa.orm.relationship("User")
 
-    group_id = sa.Column(sa.Integer, sa.ForeignKey("group.id"), nullable=False)
+    group_id = sa.Column(
+        sa.Integer, sa.ForeignKey("group.id", ondelete="CASCADE"), nullable=False
+    )
     group = sa.orm.relationship("Group")


### PR DESCRIPTION
Same behaviour for the annotation table: https://github.com/hypothesis/h/blob/anno-slim-group-cascade/h/services/group_delete.py#L27


## Testing

```
tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='447296010'
dev run-test: commands[0] | alembic upgrade head
2023-09-28 13:42:42 1080020 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-28 13:42:42 1080020 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-28 13:42:42 1080020 alembic.runtime.migration [INFO] Running upgrade 28a982795769 -> 0d101aa6b9a5, Add CASCADE on deletion for annotation_slim.group.
```