### PR TITLE
Add a CASCADE on delete for annotation_slim.document_id

### DIFF
--- a/h/migrations/versions/7418b43b64c3_anno_slim_document_cascade.py
+++ b/h/migrations/versions/7418b43b64c3_anno_slim_document_cascade.py
@@ -1,0 +1,36 @@
+"""Add CASCADE on deletion for annotation_slim.document_id."""
+from alembic import op
+
+revision = "7418b43b64c3"
+down_revision = "3081971a50fc"
+
+
+def upgrade():
+    op.drop_constraint(
+        "fk__annotation_slim__document_id__document",
+        "annotation_slim",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("fk__annotation_slim__document_id__document"),
+        "annotation_slim",
+        "document",
+        ["document_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk__annotation_slim__document_id__document"),
+        "annotation_slim",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk__annotation_slim__document_id__document",
+        "annotation_slim",
+        "document",
+        ["document_id"],
+        ["id"],
+    )

--- a/h/models/annotation_slim.py
+++ b/h/models/annotation_slim.py
@@ -69,7 +69,9 @@ class AnnotationSlim(Base):
         server_default=sa.sql.expression.false(),
     )
 
-    document_id = sa.Column(sa.Integer, sa.ForeignKey("document.id"), nullable=False)
+    document_id = sa.Column(
+        sa.Integer, sa.ForeignKey("document.id", ondelete="CASCADE"), nullable=False
+    )
     document = sa.orm.relationship("Document")
 
     user_id = sa.Column(


### PR DESCRIPTION
When documents are deleted during document merge this could be a problem.

Set a cascade on deletion.


## Testing

```
tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='1696399884'      
dev run-test: commands[0] | alembic upgrade head                                    
2023-09-28 16:08:10 1623114 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-28 16:08:10 1623114 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-28 16:08:10 1623114 alembic.runtime.migration [INFO] Running upgrade 3081971a50fc -> 7418b43b64c3, Add CASCADE on deletion for annotation_slim.document_id.
```