### PR TITLE
Explicitly declare all no coverage areas

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ omit =
     h/debug.py
     h/migrations/*
     h/cli/*
+    h/__main__.py
 
 [report]
 show_missing = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -13,6 +13,6 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 98.58
+fail_under = 100
 
 skip_covered = True

--- a/h/_version.py
+++ b/h/_version.py
@@ -43,7 +43,7 @@ def git_version():
     return pep440_version(date, ref, dirty)
 
 
-def git_archive_version():
+def git_archive_version():  # pragma: no cover
     ref = VERSION_GIT_REF
     date = datetime.datetime.fromtimestamp(int(VERSION_GIT_DATE))
     return pep440_version(date, ref)
@@ -54,7 +54,7 @@ def pep440_version(date, ref, dirty=False):
     return f"{date.strftime('%Y%m%d')}+g{ref}{'.dirty' if dirty else ''}"
 
 
-def get_version():
+def get_version():  # pragma: no cover
     """Fetch the current application version."""
     # First we try to retrieve the current application version from git.
     try:

--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -33,7 +33,7 @@ def get_user(request):
     return user
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     # Add a `request.user` property.
     #
     # N.B. we use `property=True` and not `reify=True` here because it is

--- a/h/accounts/events.py
+++ b/h/accounts/events.py
@@ -1,5 +1,5 @@
 class ActivationEvent:
-    def __init__(self, request, user):
+    def __init__(self, request, user):  # pragma: no cover
         self.request = request
         self.user = user
 

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -30,7 +30,7 @@ def get_blacklist():
     try:  # pylint: disable=too-many-try-statements
         with codecs.open("h/accounts/blacklist", encoding="utf-8") as handle:
             blacklist = handle.readlines()
-    except (IOError, ValueError):
+    except (IOError, ValueError):  # pragma: no cover
         log.exception("unable to load blacklist")
         blacklist = []
     return set(line.strip().lower() for line in blacklist)
@@ -49,7 +49,7 @@ def unique_username(node, value):
     """Colander validator that ensures the username does not exist."""
     request = node.bindings["request"]
     user = models.User.get_by_username(request.db, value, request.default_authority)
-    if user:
+    if user:  # pragma: no cover
         msg = _("This username is already taken.")
         raise colander.Invalid(node, msg)
 
@@ -210,7 +210,7 @@ class PasswordChangeSchema(CSRFSchema):
         hide_until_form_active=True,
     )
 
-    def validator(self, node, value):
+    def validator(self, node, value):  # pragma: no cover
         super().validator(node, value)
         exc = colander.Invalid(node)
         request = node.bindings["request"]
@@ -236,5 +236,5 @@ class NotificationsSchema(CSRFSchema):
     )
 
 
-def includeme(_config):
+def includeme(_config):  # pragma: no cover
     pass

--- a/h/activity/bucketing.py
+++ b/h/activity/bucketing.py
@@ -121,7 +121,7 @@ class Timeframe:
         """
         return annotation.updated >= self.cutoff_time
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return f'{self.__class__} "{self.label}" with {len(self.document_buckets)} document buckets'
 
 
@@ -178,5 +178,5 @@ def bucket(annotations):
     return timeframes
 
 
-def utcnow():
+def utcnow():  # pragma: no cover
     return datetime.datetime.utcnow()

--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -190,7 +190,7 @@ def _execute_search(request, query, page_size):
 
 
 @newrelic.agent.function_trace()
-def _fetch_groups(session, pubids):
+def _fetch_groups(session, pubids):  # pragma: no cover
     return session.query(Group).filter(Group.pubid.in_(pubids))
 
 

--- a/h/app.py
+++ b/h/app.py
@@ -14,11 +14,11 @@ from h.views.client import DEFAULT_CLIENT_URL
 log = logging.getLogger(__name__)
 
 
-def in_debug_mode(request):
+def in_debug_mode(request):  # pragma: no cover
     return asbool(request.registry.settings.get("pyramid.debug_all"))
 
 
-def create_app(_global_config, **settings):
+def create_app(_global_config, **settings):  # pragma: no cover
     """
     Create the h WSGI application.
 
@@ -29,7 +29,7 @@ def create_app(_global_config, **settings):
     return config.make_wsgi_app()
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     config.scan("h.subscribers")
 
     config.add_tween("h.tweens.conditional_http_tween_factory", under=EXCVIEW)
@@ -125,7 +125,7 @@ def _configure_mailer(config):
     config.registry.settings.setdefault(
         "mail.default_sender", '"Annotation Daemon" <no-reply@localhost>'
     )
-    if asbool(config.registry.settings.get("h.debug")):
+    if asbool(config.registry.settings.get("h.debug")):  # pragma: no cover
         config.include("pyramid_mailer.debug")
     else:
         config.include("pyramid_mailer")
@@ -144,5 +144,5 @@ def _configure_csp(config):
         # including on /docs/help.
         "style-src": ["'self'", "fonts.googleapis.com", client_host, "'unsafe-inline'"],
     }
-    if "csp.report_uri" in settings:
+    if "csp.report_uri" in settings:  # pragma: no cover
         settings["csp"]["report-uri"] = [settings["csp.report_uri"]]

--- a/h/assets.py
+++ b/h/assets.py
@@ -5,7 +5,7 @@ from h_assets import Environment, assets_view
 from pyramid.settings import asbool
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     auto_reload = asbool(config.registry.settings.get("h.reload_assets", False))
     h_files = importlib_resources.files("h")
 

--- a/h/celery.py
+++ b/h/celery.py
@@ -143,7 +143,7 @@ def report_failure(sender, task_id, args, kwargs, einfo, **_kwargs):
     )
 
 
-def start(argv, bootstrap):
+def start(argv, bootstrap):  # pragma: no cover
     """Run the Celery CLI."""
     # We attach the bootstrap function directly to the Celery application
     # instance, and it's then used in the worker bootstrap subscriber above.

--- a/h/config.py
+++ b/h/config.py
@@ -24,9 +24,9 @@ DEFAULT_SALT = (
 
 
 def configure(environ=None, settings=None):  # pylint: disable=too-many-statements
-    if environ is None:
+    if environ is None:  # pragma: no cover
         environ = os.environ
-    if settings is None:
+    if settings is None:  # pragma: no cover
         settings = {}
     settings_manager = SettingsManager(settings, environ)
     # Configuration for external components
@@ -122,7 +122,9 @@ def configure(environ=None, settings=None):  # pylint: disable=too-many-statemen
     # Debug/development settings
     settings_manager.set("debug_query", "DEBUG_QUERY")
 
-    if "MANDRILL_USERNAME" in environ and "MANDRILL_APIKEY" in environ:
+    if (
+        "MANDRILL_USERNAME" in environ and "MANDRILL_APIKEY" in environ
+    ):  # pragma: no cover
         settings_manager.set("mail.username", "MANDRILL_USERNAME")
         settings_manager.set("mail.password", "MANDRILL_APIKEY")
         settings_manager.set(
@@ -135,7 +137,7 @@ def configure(environ=None, settings=None):  # pylint: disable=too-many-statemen
     settings = settings_manager.settings
 
     # Set up SQLAlchemy debug logging
-    if "debug_query" in settings:
+    if "debug_query" in settings:  # pragma: no cover
         level = logging.INFO
         if settings["debug_query"] == "trace":
             level = logging.DEBUG

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -51,14 +51,14 @@ def init(engine, base=Base, should_create=False, should_drop=False, authority=No
     # Import models package to populate the metadata
     import h.models  # pylint: disable=unused-import
 
-    if should_drop:
+    if should_drop:  # pragma: no cover
         # SQLAlchemy doesn't know about the report schema, and will end up
         # trying to drop tables without cascade that have dependent tables
         # in the report schema and failing. Clear it out first.
         engine.execute("DROP SCHEMA IF EXISTS report CASCADE")
         base.metadata.reflect(engine)
         base.metadata.drop_all(engine)
-    if should_create:
+    if should_create:  # pragma: no cover
         # In order to be able to generate UUIDs, we load the uuid-ossp
         # extension.
         engine.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
@@ -68,12 +68,12 @@ def init(engine, base=Base, should_create=False, should_drop=False, authority=No
     _maybe_create_world_group(engine, authority, default_org)
 
 
-def make_engine(settings):
+def make_engine(settings):  # pragma: no cover
     """Construct a sqlalchemy engine from the passed ``settings``."""
     return sqlalchemy.create_engine(settings["sqlalchemy.url"])
 
 
-def _session(request):
+def _session(request):  # pragma: no cover
     engine = request.registry["sqlalchemy.engine"]
     session = Session(bind=engine)
 
@@ -147,7 +147,7 @@ def _maybe_create_world_group(engine, authority, default_org):
 
     session = Session(bind=engine)
     world_group = session.query(models.Group).filter_by(pubid="__world__").one_or_none()
-    if world_group is None:
+    if world_group is None:  # pragma: no cover
         world_group = models.Group(
             name="Public",
             authority=authority,
@@ -163,7 +163,7 @@ def _maybe_create_world_group(engine, authority, default_org):
     session.close()
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     # Create the SQLAlchemy engine and save a reference in the app registry.
     engine = make_engine(config.registry.settings)
     config.registry["sqlalchemy.engine"] = engine

--- a/h/db/types.py
+++ b/h/db/types.py
@@ -144,7 +144,7 @@ class AnnotationSelectorJSONB(types.TypeDecorator):  # pylint:disable=abstract-m
         return _transform_quote_selector(value, _unescape_null_byte)
 
 
-def _transform_quote_selector(selectors, transform_func):
+def _transform_quote_selector(selectors, transform_func):  # pragma: no cover
     if selectors is None:
         return None
 
@@ -170,13 +170,13 @@ def _transform_quote_selector(selectors, transform_func):
 
 def _escape_null_byte(string):
     if string is None:
-        return string
+        return string  # pragma: no cover
 
     return string.replace("\u0000", "\\u0000")
 
 
 def _unescape_null_byte(string):
     if string is None:
-        return string
+        return string  # pragma: no cover
 
     return string.replace("\\u0000", "\u0000")

--- a/h/feeds/render.py
+++ b/h/feeds/render.py
@@ -28,11 +28,11 @@ def render_atom(  # pylint:disable=too-many-arguments
 
     """
 
-    def annotation_url(annotation):
+    def annotation_url(annotation):  # pragma: no cover
         """Return the HTML permalink URL for the given annotation."""
         return request.route_url("annotation", id=annotation.id)
 
-    def annotation_api_url(annotation):
+    def annotation_api_url(annotation):  # pragma: no cover
         """Return the JSON API URL for the given annotation."""
         return request.route_url("api.annotation", id=annotation.id)
 
@@ -78,7 +78,7 @@ def render_rss(  # pylint:disable=too-many-arguments
 
     """
 
-    def annotation_url(annotation):
+    def annotation_url(annotation):  # pragma: no cover
         """Return the HTML permalink URL for the given annotation."""
         return request.route_url("annotation", id=annotation.id)
 

--- a/h/form.py
+++ b/h/form.py
@@ -125,7 +125,7 @@ def handle_form_submission(request, form, on_success, on_failure):
         if result is None:
             result = httpexceptions.HTTPFound(location=request.url)
 
-        if not request.is_xhr:
+        if not request.is_xhr:  # pragma: no cover
             request.session.flash(_("Success. We've saved your changes."), "success")
 
     return to_xhr_response(request, result, form)

--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -41,7 +41,7 @@ def reindex(session, es, request):
         if errored:
             log.debug("failed to index %d annotations, retrying...", len(errored))
             errored = indexer.index(errored)
-            if errored:
+            if errored:  # pragma: no cover
                 log.warning("failed to index %d annotations: %r", len(errored), errored)
 
         log.info("making new index %s current", new_index)

--- a/h/links.py
+++ b/h/links.py
@@ -40,7 +40,7 @@ def incontext_link(request, annotation):
         # We can't use urljoin here, because if it detects the second argument
         # is a URL it will discard the base URL, breaking the link entirely.
         link += "/" + uri[uri.index("://") + 3 :]
-    elif uri.startswith("urn:x-pdf:") and annotation.document:
+    elif uri.startswith("urn:x-pdf:") and annotation.document:  # pragma: no cover
         for docuri in annotation.document.document_uris:
             uri = docuri.uri
             if uri.startswith(("http://", "https://")):
@@ -58,7 +58,7 @@ def jsonld_id_link(request, annotation):
     return request.route_url("annotation", id=annotation.id)
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     # Add an annotation link generator for the `annotation` view -- this adds a
     # named link called "html" to API rendered views of annotations. See
     # :py:mod:`h.presenters` for details.

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -113,8 +113,8 @@ class Feature(Base):
         known = set(FEATURES) | set(FEATURES_PENDING_REMOVAL)
         unknown_flags = session.query(cls).filter(sa.not_(cls.name.in_(known)))
         count = unknown_flags.delete(synchronize_session=False)
-        if count > 0:
+        if count > 0:  # pragma: no cover
             log.info("removed %d old/unknown feature flags from database", count)
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return "<Feature {f.name} everyone={f.everyone}>".format(f=self)

--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -98,7 +98,7 @@ def get_notification(
     # the reply, and dealing with the possibility that we have no document
     # metadata.
     if reply.document is None:
-        return None
+        return None  # pragma: no cover
 
     # Bail if there is no active 'reply' subscription for the user being
     # replied to.
@@ -112,5 +112,5 @@ def get_notification(
     return Notification(reply, reply_user, parent, parent_user, reply.document)
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     config.scan(__name__)

--- a/h/paginator.py
+++ b/h/paginator.py
@@ -120,7 +120,7 @@ def paginate_query(wrapped=None, page_size=PAGE_SIZE):
     context and the current request. This decorator does not support view
     functions which accept only a single argument.
     """
-    if wrapped is None:
+    if wrapped is None:  # pragma: no cover
 
         def decorator(wrap):
             return paginate_query(wrap, page_size=page_size)

--- a/h/presenters/annotation_jsonld.py
+++ b/h/presenters/annotation_jsonld.py
@@ -37,7 +37,7 @@ class AnnotationJSONLDPresenter:
                 "format": "text/markdown",
             }
         ]
-        if self.annotation.tags:
+        if self.annotation.tags:  # pragma: no cover
             for tag in self.annotation.tags:
                 bodies.append(
                     {"type": "TextualBody", "value": tag, "purpose": "tagging"}

--- a/h/presenters/document_html.py
+++ b/h/presenters/document_html.py
@@ -184,7 +184,7 @@ class DocumentHTMLPresenter:
         return web_uri
 
 
-def _format_document_link(href, title, link_text, host_or_filename):
+def _format_document_link(href, title, link_text, host_or_filename):  # pragma: no cover
     """
     Return a document link for the given components.
 

--- a/h/presenters/document_json.py
+++ b/h/presenters/document_json.py
@@ -8,7 +8,7 @@ class DocumentJSONPresenter:
 
         document_dict = {}
         title = self.document.title
-        if title:
+        if title:  # pragma: no cover
             document_dict["title"] = [title]
 
         return document_dict

--- a/h/renderers.py
+++ b/h/renderers.py
@@ -39,6 +39,6 @@ class SVGRenderer:
         return value
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     config.add_renderer(name="json_sorted", factory=json_sorted_factory)
     config.add_renderer(name="svg", factory=SVGRenderer)

--- a/h/schemas/forms/accounts/login.py
+++ b/h/schemas/forms/accounts/login.py
@@ -81,7 +81,7 @@ class LoginSchema(CSRFSchema):
         }
 
 
-def _should_autofocus_username(kwargs):
+def _should_autofocus_username(kwargs):  # pragma: no cover
     """Return True if the username widget should be autofocused."""
     if LoginSchema.default_values(kwargs["request"]).get("username"):
         # The username widget is going to be pre-filled, so don't autofocus it.

--- a/h/schemas/forms/accounts/reset_password.py
+++ b/h/schemas/forms/accounts/reset_password.py
@@ -13,7 +13,7 @@ _ = i18n.TranslationString
 class ResetCode(colander.SchemaType):
     """Schema type transforming a reset code to a user and back."""
 
-    def serialize(self, node, appstruct):
+    def serialize(self, node, appstruct):  # pragma: no cover
         if appstruct is colander.null:
             return colander.null
         if not isinstance(appstruct, models.User):

--- a/h/schemas/validators.py
+++ b/h/schemas/validators.py
@@ -3,14 +3,14 @@
 import colander
 
 
-class Email(colander.Email):
+class Email(colander.Email):  # pragma: no cover
     def __init__(self, *args, **kwargs):
         if "msg" not in kwargs:
             kwargs["msg"] = "Invalid email address."
         super().__init__(*args, **kwargs)
 
 
-class Length(colander.Length):
+class Length(colander.Length):  # pragma: no cover
     def __init__(self, *args, **kwargs):
         if "min_err" not in kwargs:
             kwargs["min_err"] = "Must be ${min} characters or more."

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -25,7 +25,7 @@ __all__ = (
 )
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     settings = config.registry.settings
 
     kwargs = {}

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -225,7 +225,7 @@ def _update_index_analysis(conn, name, analysis):
     """Attempt to update the index analysis settings."""
     settings = conn.indices.get_settings(index=name)
     existing = settings[name]["settings"]["index"].get("analysis", {})
-    if existing != analysis:
+    if existing != analysis:  # pragma: no cover
         try:  # pylint: disable=too-many-try-statements
             conn.indices.close(index=name)
             conn.indices.put_settings(index=name, body={"analysis": analysis})

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -79,7 +79,7 @@ class BatchIndexer:
             "_index": self._target_index,
             "_id": annotation.id,
         }
-        if self.es_client.server_version < Version("7.0.0"):
+        if self.es_client.server_version < Version("7.0.0"):  # pragma: no cover
             operation["_type"] = self.es_client.mapping_type
 
         data = presenters.AnnotationSearchIndexPresenter(

--- a/h/services/oauth/_jwt_grant_token.py
+++ b/h/services/oauth/_jwt_grant_token.py
@@ -80,7 +80,7 @@ class VerifiedJWTGrantToken(JWTGrantToken):
             raise InvalidGrantError("Invalid grant token signature.") from err
         except jwt.exceptions.InvalidAlgorithmError as err:
             raise InvalidGrantError("Invalid grant token signature algorithm.") from err
-        except jwt.MissingRequiredClaimError as err:
+        except jwt.MissingRequiredClaimError as err:  # pragma: no cover
             if err.claim == "aud":
                 raise MissingJWTGrantTokenClaimError("aud", "audience") from err
 
@@ -91,7 +91,7 @@ class VerifiedJWTGrantToken(JWTGrantToken):
             raise InvalidGrantError("Grant token is not yet valid.") from err
         except jwt.ExpiredSignatureError as err:
             raise InvalidGrantError("Grant token is expired.") from err
-        except jwt.InvalidIssuedAtError as err:
+        except jwt.InvalidIssuedAtError as err:  # pragma: no cover
             raise InvalidGrantError(
                 "Grant token issue time (iat) is in the future."
             ) from err

--- a/h/services/oauth/_validator.py
+++ b/h/services/oauth/_validator.py
@@ -362,7 +362,7 @@ class OAuthValidator(  # pylint: disable=too-many-public-methods, abstract-metho
         except StatementError:
             return None
 
-    def _find_refresh_token(self, value):
+    def _find_refresh_token(self, value):  # pragma: no cover
         if value is None:
             return None
 
@@ -376,7 +376,7 @@ class OAuthValidator(  # pylint: disable=too-many-public-methods, abstract-metho
     def _find_token(self, value):
         """Retrieve a token without knowing which kind it is."""
 
-        if value is None:
+        if value is None:  # pragma: no cover
             return None
 
         return (

--- a/h/services/oauth/service.py
+++ b/h/services/oauth/service.py
@@ -95,7 +95,7 @@ class OAuthProviderService(AuthorizationEndpoint, RevocationEndpoint, TokenEndpo
         if request.token:
             token = self.oauth_validator.find_token(request.token)
 
-            if token:
+            if token:  # pragma: no cover
                 request.client_id = token.authclient.id
 
         # Mark this request as a revocation request so we can know _not_

--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -242,10 +242,10 @@ class Queue:
             Job.name == "sync_annotation", Job.expires_at >= now
         )
 
-        if hide_scheduled:
+        if hide_scheduled:  # pragma: no cover
             query = query.filter(Job.scheduled_at < now)
 
-        if tags:
+        if tags:  # pragma: no cover
             query = query.filter(Job.tag.in_(tags))
 
         return query

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -89,7 +89,7 @@ class UserService:
         :returns: a list with the found user instances
         :rtype: list of h.models.User
         """
-        if not userids:
+        if not userids:  # pragma: no cover
             return []
 
         cache_keys = {}
@@ -99,7 +99,7 @@ class UserService:
 
             try:
                 cache_keys[key] = userid
-            except ValueError:
+            except ValueError:  # pragma: no cover
                 continue
 
         userid_tuples = set(cache_keys.keys())
@@ -170,7 +170,7 @@ class UserService:
             keys = ", ".join(sorted(invalid_keys))
             raise TypeError(f"settings with keys {keys} are not allowed")
 
-        if "show_sidebar_tutorial" in kwargs:
+        if "show_sidebar_tutorial" in kwargs:  # pragma: no cover
             user.sidebar_tutorial_dismissed = not kwargs["show_sidebar_tutorial"]
 
 

--- a/h/session.py
+++ b/h/session.py
@@ -55,7 +55,7 @@ def user_info(user):
     return {"user_info": {"display_name": user.display_name}}
 
 
-def pop_flash(request):
+def pop_flash(request):  # pragma: no cover
     return {
         k: request.session.pop_flash(k) for k in ["error", "info", "warning", "success"]
     }
@@ -94,7 +94,7 @@ def _user_preferences(user):
     return preferences
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     settings = config.registry.settings
 
     # By default, derive_key generates a 64-byte (512 bit) secret, which is the

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -33,7 +33,7 @@ def process_messages(settings, routing_key, work_queue, raise_error=True):
         message = Message(topic=routing_key, payload=payload)
         try:
             work_queue.put(message, timeout=0.1)
-        except Full:
+        except Full:  # pragma: no cover
             log.warning(
                 "Streamer work queue full! Unable to queue message from "
                 "h.realtime having waited 0.1s: giving up."

--- a/h/streamer/streamer.py
+++ b/h/streamer/streamer.py
@@ -33,7 +33,7 @@ class UnknownMessageType(Exception):
 
 
 @subscriber(ApplicationCreated)
-def start(event):
+def start(event):  # pragma: no cover
     """
     Start some greenlets to process the incoming data from the message queue.
 
@@ -84,7 +84,7 @@ def process_work_queue(registry, queue):
                 raise UnknownMessageType(repr(msg))
 
 
-def supervise(greenlets):
+def supervise(greenlets):  # pragma: no cover
     try:
         gevent.joinall(greenlets, raise_error=True)
     except (KeyboardInterrupt, SystemExit):

--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -22,7 +22,7 @@ def websocket_view(request):
 
 
 @notfound_view_config(renderer="json")
-def notfound(_exc, request):
+def notfound(_exc, request):  # pragma: no cover
     request.response.status_code = 404
     return {
         "ok": False,
@@ -32,7 +32,7 @@ def notfound(_exc, request):
 
 
 @forbidden_view_config(renderer="json")
-def forbidden(_exc, request):
+def forbidden(_exc, request):  # pragma: no cover
     request.response.status_code = 403
     return {
         "ok": False,
@@ -43,7 +43,7 @@ def forbidden(_exc, request):
 
 
 @view_config(context=HandshakeError, renderer="json")
-def error_badhandshake(_exc, request):
+def error_badhandshake(_exc, request):  # pragma: no cover
     request.response.status_code = 400
     return {
         "ok": False,
@@ -53,7 +53,7 @@ def error_badhandshake(_exc, request):
 
 
 @view_config(context=Exception, renderer="json")
-def error(_context, request):
+def error(_context, request):  # pragma: no cover
     request.response.status_code = 500
 
     return {

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -82,7 +82,7 @@ class WebSocket(_WebSocket):
 
         try:
             self._work_queue.put(Message(socket=self, payload=payload), timeout=0.1)
-        except Full:
+        except Full:  # pragma: no cover
             log.warning(
                 "Streamer work queue full! Unable to queue message from "
                 "WebSocket client having waited 0.1s: giving up."
@@ -117,14 +117,14 @@ def handle_message(message, session=None):
     It may also passed a database session which *must* be used for any
     communication with the database.
     """
-    if message.socket.debug:
+    if message.socket.debug:  # pragma: no cover
         log.info("Handling message %s", message.payload)
 
     payload = message.payload
     type_ = payload.get("type")
 
     # FIXME: This code is here to tolerate old and deprecated message formats.
-    if type_ is None:
+    if type_ is None:  # pragma: no cover
         if "messageType" in payload and payload["messageType"] == "client_id":
             type_ = "client_id"
         if "filter" in payload:

--- a/h/streamer/worker.py
+++ b/h/streamer/worker.py
@@ -55,7 +55,7 @@ class WebSocketWSGIHandler(PyWSGIHandler):
     usual.
     """
 
-    def finalize_headers(self):
+    def finalize_headers(self):  # pragma: no cover
         if self.environ.get("HTTP_UPGRADE", "").lower() == "websocket":
             # Middleware may yield from the empty upgrade
             # response, confusing this method into sending "Transfer-Encoding:
@@ -70,7 +70,7 @@ class WebSocketWSGIHandler(PyWSGIHandler):
 
         super().finalize_headers()
 
-    def run_application(self):
+    def run_application(self):  # pragma: no cover
         upgrade_header = self.environ.get("HTTP_UPGRADE", "").lower()
         if upgrade_header:
             # Build and start the HTTP response
@@ -103,11 +103,11 @@ class GEventWebSocketPool(Pool):
     server is shutdown.
     """
 
-    def track(self, websocket):
+    def track(self, websocket):  # pragma: no cover
         log.debug("managing websocket %s", format_addresses(websocket))
         return self.spawn(websocket.run)
 
-    def clear(self):
+    def clear(self):  # pragma: no cover
         log.info("terminating server and all connected websockets")
         for greenlet in list(self):
             try:  # pylint:disable=too-many-try-statements
@@ -136,7 +136,7 @@ class WSGIServer(PyWSGIServer):
     # it
     instances = weakref.WeakSet()
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # pragma: no cover
         super().__init__(*args, **kwargs)
         self.pool = GEventWebSocketPool()
 
@@ -144,7 +144,7 @@ class WSGIServer(PyWSGIServer):
         self.connection_pool = kwargs.get("spawn")
         self.instances.add(self)
 
-    def stop(self, *args, **kwargs):
+    def stop(self, *args, **kwargs):  # pragma: no cover
         self.pool.clear()
         super().stop(*args, **kwargs)
         self.instances.remove(self)
@@ -154,7 +154,7 @@ class Worker(GeventPyWSGIWorker):
     server_class = WSGIServer
     wsgi_handler = WebSocketWSGIHandler
 
-    def patch(self):
+    def patch(self):  # pragma: no cover
         psycogreen.gevent.patch_psycopg()
         self.log.info("Made psycopg green")
 

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -84,6 +84,6 @@ def send_reply_notifications(event):
 
         try:
             mailer.send.delay(*send_params)
-        except OperationalError as err:
+        except OperationalError as err:  # pragma: no cover
             # We could not connect to rabbit! So carry on
             report_exception(err)

--- a/h/tasks/mailer.py
+++ b/h/tasks/mailer.py
@@ -34,11 +34,11 @@ def send(self, recipients, subject, body, html=None):
         subject=subject, recipients=recipients, body=body, html=html
     )
     mailer = pyramid_mailer.get_mailer(celery.request)
-    if celery.request.debug:
+    if celery.request.debug:  # pragma: no cover
         log.info("emailing in debug mode: check the `mail/' directory")
     try:
         mailer.send_immediately(email)
-    except smtplib.SMTPRecipientsRefused as exc:
+    except smtplib.SMTPRecipientsRefused as exc:  # pragma: no cover
         log.warning(
             "Recipient was refused when trying to send an email. Does the user have an invalid email address?",
             exc_info=exc,

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 resolver = DottedNameResolver(None)
 
 
-def conditional_http_tween_factory(handler, registry):
+def conditional_http_tween_factory(handler, registry):  # pragma: no cover
     """Set up conditional response handling for some requests."""
 
     def conditional_http_tween(request):
@@ -38,7 +38,7 @@ def conditional_http_tween_factory(handler, registry):
             isinstance(response.app_iter, Sequence) and len(response.app_iter) == 1
         )
         cacheable = request.method in {"GET", "HEAD"} and response.status_code == 200
-        if have_buffered_response and cacheable:
+        if have_buffered_response and cacheable:  # pragma: no cover
             response.conditional_response = True
             response.md5_etag()
 
@@ -47,7 +47,7 @@ def conditional_http_tween_factory(handler, registry):
     return conditional_http_tween
 
 
-def invalid_path_tween_factory(handler, registry):
+def invalid_path_tween_factory(handler, registry):  # pragma: no cover
     def invalid_path_tween(request):
         # Due to a bug in WebOb accessing request.path (or request.path_info
         # etc) will raise UnicodeDecodeError if the requested path doesn't

--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -31,7 +31,7 @@ def parse_scope_from_url(url):
 
 def _parse_path(url):
     """Return the path component of a URL string."""
-    if url is None:
+    if url is None:  # pragma: no cover# pragma: no cover
         return None
     parsed = urlsplit(url)
     return parsed.path
@@ -49,7 +49,7 @@ def parse_origin(url):
     :rtype: str or None
     """
 
-    if url is None:
+    if url is None:  # pragma: no cover
         return None
 
     parsed = urlsplit(url)

--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -191,7 +191,7 @@ def origin(url):
 def _normalize_scheme(uri):
     scheme = uri.scheme
 
-    if scheme in URL_SCHEMES:
+    if scheme in URL_SCHEMES:  # pragma: no cover
         scheme = "httpx"
 
     return scheme

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -34,7 +34,7 @@ _ = i18n.TranslationString
 
 # A little helper to ensure that session data is returned in every ajax
 # response payload.
-def ajax_payload(request, data):
+def ajax_payload(request, data):  # pragma: no cover
     payload = {"flash": session.pop_flash(request), "model": session.model(request)}
     payload.update(data)
     return payload
@@ -62,20 +62,20 @@ def bad_csrf_token_html(_context, request):
 
 
 @json_view(context=BadCSRFToken)
-def bad_csrf_token_json(_context, request):
+def bad_csrf_token_json(_context, request):  # pragma: no cover
     request.response.status_code = 403
     reason = _("Session is invalid. Please try again.")
     return {"status": "failure", "reason": reason, "model": session.model(request)}
 
 
 @json_view(context=accounts.JSONError)
-def error_json(error, request):
+def error_json(error, request):  # pragma: no cover
     request.response.status_code = 400
     return {"status": "failure", "reason": str(error)}
 
 
 @json_view(context=deform.ValidationFailure)
-def error_validation(error, request):
+def error_validation(error, request):  # pragma: no cover
     request.response.status_code = 400
     return ajax_payload(request, {"status": "failure", "errors": error.error.asdict()})
 
@@ -173,7 +173,7 @@ class ForgotPasswordController:
         self.form = request.create_form(self.schema, buttons=(_("Reset"),))
 
     @view_config(request_method="GET")
-    def get(self):
+    def get(self):  # pragma: no cover
         """Render the forgot password page, including the form."""
         self._redirect_if_logged_in()
 
@@ -262,7 +262,7 @@ class ResetController:
             appstruct = self.form.validate(self.request.POST.items())
         except deform.ValidationFailure:
             # If the code is valid, hide the field.
-            if not self.form["user"].error:
+            if not self.form["user"].error:  # pragma: no cover
                 self.form.set_widgets({"user": deform.widget.HiddenWidget()})
             return {"form": self.form.render()}
 
@@ -277,7 +277,7 @@ class ResetController:
         )
 
     def _redirect_if_logged_in(self):
-        if self.request.authenticated_userid is not None:
+        if self.request.authenticated_userid is not None:  # pragma: no cover
             raise httpexceptions.HTTPFound(self.request.route_path("index"))
 
     def _reset_password(self, user, password):
@@ -619,7 +619,7 @@ class DeveloperController:
     request_method="GET",
     renderer="h:templates/accounts/claim_account_legacy.html.jinja2",
 )
-def claim_account_legacy(_request):
+def claim_account_legacy(_request):  # pragma: no cover
     """Render a page explaining that claim links are no longer valid."""
     return {}
 
@@ -627,7 +627,7 @@ def claim_account_legacy(_request):
 @view_config(
     route_name="dismiss_sidebar_tutorial", request_method="POST", renderer="json"
 )
-def dismiss_sidebar_tutorial(request):
+def dismiss_sidebar_tutorial(request):  # pragma: no cover
     if request.authenticated_userid is None:
         raise accounts.JSONError()
 

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -34,7 +34,7 @@ class SearchController:
         self.parsed_query_params = query.extract(self.request)
 
     @view_config(request_method="GET")
-    def search(self):
+    def search(self):  # pragma: no cover
         # Make a copy of the query params to be consumed by search.
         query_params = self.parsed_query_params.copy()
 
@@ -172,7 +172,7 @@ class GroupSearchController(SearchController):
             "share_subtitle": _("Share group"),
             "share_msg": _("Sharing the link lets people view this group:"),
         }
-        if self.group.organization:
+        if self.group.organization:  # pragma: no cover
             result["group"]["organization"] = OrganizationJSONPresenter(
                 self.group.organization, self.request
             ).asdict(summary=True)
@@ -359,7 +359,7 @@ class UserSearchController(SearchController):
         result["opts"] = {"search_username": self.user.username}
         result["more_info"] = "more_info" in self.request.params
 
-        def domain(user):
+        def domain(user):  # pragma: no cover
             if not user.uri:
                 return None
             return urlparse(user.uri).netloc
@@ -480,7 +480,7 @@ def _redirect_to_user_or_group_search(request, params):
             slug=request.matchdict["slug"],
             _query=params,
         )
-    elif request.matched_route.name == "activity.user_search":
+    elif request.matched_route.name == "activity.user_search":  # pragma: no cover
         location = request.route_url(
             "activity.user_search",
             username=request.matchdict["username"],

--- a/h/views/admin/features.py
+++ b/h/views/admin/features.py
@@ -27,7 +27,7 @@ def features_index(request):
     permission=Permission.AdminPage.HIGH_RISK,
     require_csrf=True,
 )
-def features_save(request):
+def features_save(request):  # pragma: no cover
     for feat in models.Feature.all(request.db):
         for attr in ["everyone", "first_party", "admins", "staff"]:
             val = request.POST.get(f"{feat.name}[{attr}]")
@@ -120,7 +120,7 @@ def cohorts_edit_add(request):
     cohort_id = request.matchdict["id"]
 
     member = models.User.get_by_username(request.db, member_name, member_authority)
-    if member is None:
+    if member is None:  # pragma: no cover
         request.session.flash(
             _(
                 # pylint:disable=consider-using-f-string
@@ -154,7 +154,7 @@ def cohorts_edit_remove(request):
     member = request.db.query(models.User).filter_by(userid=member_userid).first()
     try:
         cohort.members.remove(member)
-    except ValueError:
+    except ValueError:  # pragma: no cover
         request.session.flash(
             _(
                 # pylint:disable=consider-using-f-string

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -83,7 +83,7 @@ class GroupCreateViews:  # pylint: disable=too-many-instance-attributes
             }
 
             type_ = appstruct["group_type"]
-            if type_ not in ["open", "restricted"]:
+            if type_ not in ["open", "restricted"]:  # pragma: no cover
                 raise ValueError(f"Unsupported group type {type_}")
 
             group = create_fns[type_](
@@ -238,7 +238,7 @@ class GroupEditViews:  # pylint: disable=too-many-instance-attributes
         }
 
 
-def _userid(username, authority):
+def _userid(username, authority):  # pragma: no cover
     return models.User(username=username, authority=authority).userid
 
 

--- a/h/views/admin/nipsa.py
+++ b/h/views/admin/nipsa.py
@@ -74,6 +74,6 @@ def nipsa_remove(request):
 
 
 @view_config(context=UserNotFoundError)
-def user_not_found(exc, request):
+def user_not_found(exc, request):  # pragma: no cover
     request.session.flash(str(exc), "error")
     return httpexceptions.HTTPFound(location=request.route_path("admin.nipsa"))

--- a/h/views/admin/search.py
+++ b/h/views/admin/search.py
@@ -11,7 +11,7 @@ class NotFoundError(Exception):
 
 
 @view_config(context=NotFoundError)
-def not_found(exc, request):
+def not_found(exc, request):  # pragma: no cover
     request.session.flash(str(exc), "error")
     return HTTPFound(location=request.route_url("admin.search"))
 

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -90,7 +90,7 @@ def users_activate(request):
     permission=Permission.AdminPage.LOW_RISK,
     require_csrf=True,
 )
-def users_rename(request):
+def users_rename(request):  # pragma: no cover
     user = _form_request_user(request)
 
     old_username = user.username
@@ -144,7 +144,7 @@ def users_delete(request):
 
 
 @view_config(context=UserNotFoundError)
-def user_not_found(exc, request):
+def user_not_found(exc, request):  # pragma: no cover
     request.session.flash(jinja2.Markup(_(exc.message)), "error")
     return httpexceptions.HTTPFound(location=request.route_path("admin.users"))
 

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -170,7 +170,7 @@ class OAuthAuthorizeController:
 
         try:
             return HTTPFound(location=headers["Location"])
-        except KeyError as err:
+        except KeyError as err:  # pragma: no cover
             client_id = self.request.params.get("client_id")
             raise RuntimeError(
                 f'created authorisation code for client "{client_id}" but got no redirect location'

--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -117,7 +117,7 @@ def api_config(versions, link_name=None, description=None, **settings):
             **settings
         )
 
-    def wrapper(wrapped):
+    def wrapper(wrapped):  # pragma: no cover
         info = venusian.attach(wrapped, callback, category="pyramid")
 
         # Support use as a class method decorator.

--- a/h/views/api/errors.py
+++ b/h/views/api/errors.py
@@ -43,7 +43,7 @@ def api_notfound(context, request):
 @view_config(
     context=OAuthAuthorizeError, renderer="h:templates/oauth/error.html.jinja2"
 )
-def oauth_error(context, request):
+def oauth_error(context, request):  # pragma: no cover
     """Handle an expected/deliberately thrown OAuth exception."""
     request.response.status_code = context.status_code
     return {"detail": context.detail}
@@ -57,15 +57,14 @@ def api_error(context, request):
 
 
 @json_view(context=JSONAPIError, path_info="/api/bulk", decorator=cors_policy)
-def bulk_api_error(context, request):
+def bulk_api_error(context, request):  # pragma: no cover
     """Handle JSONAPIErrors produced by the Bulk API."""
-
     request.response.status_code = context.http_status
     return context.as_dict()
 
 
 @json_view(context=Exception, path_info="/api/", decorator=cors_policy)
-def json_error(context, request):
+def json_error(context, request):  # pragma: no cover
     """Handle an unexpected exception in an API view."""
     handle_exception(request, exception=context)
     message = _(

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -65,7 +65,7 @@ def sidebar_app(request, extra=None):
         "rpcAllowedOrigins": settings.get("h.client_rpc_allowed_origins"),
     }
 
-    if sentry_public_dsn:
+    if sentry_public_dsn:  # pragma: no cover
         # `h.sentry_environment` primarily refers to h's Sentry environment,
         # but it also matches the client environment for the embed (dev, qa, prod).
         sentry_environment = settings.get("h.sentry_environment")
@@ -78,7 +78,7 @@ def sidebar_app(request, extra=None):
         "client_url": _client_url(request),
     }
 
-    if extra is not None:
+    if extra is not None:  # pragma: no cover
         ctx.update(extra)
 
     # Add CSP headers to prevent scripts or styles from unexpected locations

--- a/h/views/home.py
+++ b/h/views/home.py
@@ -5,7 +5,7 @@ from pyramid.view import view_config
 
 
 @view_config(route_name="via_redirect", request_method="GET")
-def via_redirect(_context, request):
+def via_redirect(_context, request):  # pragma: no cover
     url = request.params.get("url")
 
     if url is None:

--- a/h/views/main.py
+++ b/h/views/main.py
@@ -55,7 +55,7 @@ def annotation_page(context, request):
 
 
 @view_config(route_name="robots", http_cache=(86400, {"public": True}))
-def robots(_context, request):
+def robots(_context, request):  # pragma: no cover
     return response.FileResponse(
         "h/static/robots.txt", request=request, content_type="text/plain"
     )
@@ -89,7 +89,7 @@ def stream(_context, request):
 
 
 @view_config(route_name="stream.tag_query")
-def stream_tag_redirect(request):
+def stream_tag_redirect(request):  # pragma: no cover
     query = {"q": f"tag:{request.matchdict['tag']}"}
     location = request.route_url("stream", _query=query)
     raise httpexceptions.HTTPFound(location=location)

--- a/tests/h/services/annotation_write_test.py
+++ b/tests/h/services/annotation_write_test.py
@@ -196,6 +196,14 @@ class TestAnnotationWriteService:
         # It's the same one not a new one
         assert annotation.moderation == moderation
 
+    def test_unhide(self, annotation, svc):
+        moderation = AnnotationModeration()
+        annotation.moderation = moderation
+
+        svc.unhide(annotation)
+
+        assert not annotation.is_hidden
+
     @pytest.fixture
     def create_data(self, factories):
         user = factories.User()


### PR DESCRIPTION
We have coverage gap of around 2% in the unit tests. Marking the gaps
explicitly allows us to set the required coverage to 100% so no need
code adds new gaps and eventually tackle the existing gaps as we modify refactor
around these areas.


Just blindly adding no-covers. Not stopping to fix even what it feels like low hanging fruit. I reckon this is more mergeable right away like this.

There's one exception to that, a gap in coverage I recently introduced in AnnotationWriteService, fixed that one now that's impossible to miss.
