### PR TITLE
Migration to create the annotation_metadata table

### DIFF
--- a/h/migrations/versions/34c8067db0ee_annotation_metatada.py
+++ b/h/migrations/versions/34c8067db0ee_annotation_metatada.py
@@ -1,0 +1,34 @@
+"""Create the annotation_metatada table."""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "34c8067db0ee"
+down_revision = "7418b43b64c3"
+
+
+def upgrade():
+    op.create_table(
+        "annotation_metadata",
+        sa.Column("annotation_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "data",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("jsonb('{}')"),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["annotation_id"],
+            ["annotation_slim.id"],
+            name=op.f("fk__annotation_metadata__annotation_id__annotation_slim"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("annotation_id", name=op.f("pk__annotation_metadata")),
+        sa.UniqueConstraint(
+            "annotation_id", name=op.f("uq__annotation_metadata__annotation_id")
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("annotation_metadata")


### PR DESCRIPTION
This was added, then reverted as we wanted to rule out any implication on the performance issues we were seeing in RDS.

We add it back here but relating to the new AnnotationSlim table.


This is not exactly a revert of https://github.com/hypothesis/h/pull/8158 as it's now adapted to use AnnotationSlim.

## Testing

```
tox -e dev --run-command 'alembic upgrade head'                   
dev run-test-pre: PYTHONHASHSEED='2144942792'
dev run-test: commands[0] | alembic upgrade head
2023-09-28 18:45:16 2273820 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-09-28 18:45:16 2273820 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-09-28 18:45:16 2273820 alembic.runtime.migration [INFO] Running upgrade 7418b43b64c3 -> 34c8067db0ee, Create the annotation_metatada table.

```