### PR TITLE
Model for annotation metadata

### DIFF
--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -18,6 +18,7 @@ key to. So for convenience the test module can instead just do
 """
 from h.models.activation import Activation
 from h.models.annotation import Annotation
+from h.models.annotation_metadata import AnnotationMetadata
 from h.models.annotation_moderation import AnnotationModeration
 from h.models.annotation_slim import AnnotationSlim
 from h.models.auth_client import AuthClient

--- a/h/models/annotation_metadata.py
+++ b/h/models/annotation_metadata.py
@@ -1,0 +1,25 @@
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as pg
+from sqlalchemy.ext.mutable import MutableDict
+
+from h.db import Base
+
+
+class AnnotationMetadata(Base):
+    __tablename__ = "annotation_metadata"
+
+    annotation_id = sa.Column(
+        sa.Integer,
+        sa.ForeignKey("annotation_slim.id", ondelete="cascade"),
+        nullable=False,
+        unique=True,
+        primary_key=True,
+    )
+    """FK to annotation_slim.id"""
+
+    data = sa.Column(
+        MutableDict.as_mutable(pg.JSONB),
+        default=dict,
+        server_default=sa.func.jsonb("{}"),
+        nullable=True,
+    )


### PR DESCRIPTION
Migration over: https://github.com/hypothesis/h/pull/8222


Reverts the reverted, https://github.com/hypothesis/h/pull/8159. Again, like in the migration not exactly a git revert as we are adapting it here to the new AnnotationSlim.