### PR TITLE
Make `JWE_SECRET_LMS` a Pyramid setting

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -131,6 +131,8 @@ def configure(environ=None, settings=None):  # pylint: disable=too-many-statemen
         settings_manager.set("mail.port", "MANDRILL_PORT", default=587)
         settings_manager.set("mail.tls", "MANDRILL_TLS", default=True)
 
+    settings_manager.set("jwe_secret_lms", "JWE_SECRET_LMS")
+
     # Get resolved settings.
     settings = settings_manager.settings
 

--- a/h/services/annotation_metadata.py
+++ b/h/services/annotation_metadata.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert
@@ -10,9 +9,9 @@ from h.security import decrypt_jwe_dict
 
 
 class AnnotationMetadataService:
-    def __init__(self, db: Session):
+    def __init__(self, db: Session, secret: str):
         self._db = db
-        self._secret = os.environ.get("JWE_SECRET_LMS")
+        self._secret = secret
 
     def set_annotation_metadata_from_jwe(self, annotation: Annotation, jwe: str):
         """
@@ -46,4 +45,7 @@ class AnnotationMetadataService:
 
 
 def factory(_context, request) -> AnnotationMetadataService:
-    return AnnotationMetadataService(db=request.db)
+    return AnnotationMetadataService(
+        db=request.db,
+        secret=request.registry.settings["jwe_secret_lms"],
+    )

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -27,6 +27,7 @@ TEST_SETTINGS = {
     "sqlalchemy.url": os.environ.get(
         "TEST_DATABASE_URL", "postgresql://postgres@localhost/htest"
     ),
+    "jwe_secret_lms": "TEST_JWE_SECRET_LMS",
 }
 
 TEST_ENVIRONMENT = {

--- a/tests/h/services/annotation_metadata_test.py
+++ b/tests/h/services/annotation_metadata_test.py
@@ -15,7 +15,7 @@ class TestAnnotationMetadataService:
 
         svc.set_annotation_metadata_from_jwe(anno, sentinel.jwe)
 
-        decrypt_jwe_dict.assert_called_once_with("secret", sentinel.jwe)
+        decrypt_jwe_dict.assert_called_once_with("TEST_JWE_SECRET_LMS", sentinel.jwe)
         anno_metadata = (
             db_session.query(AnnotationMetadata)
             .filter_by(annotation_id=anno_slim.id)
@@ -29,6 +29,8 @@ class TestAnnotationMetadataService:
         assert anno_metadata.data == {"new": "data"}
 
     def test_factory(self, pyramid_request):
+        pyramid_request.registry.settings["jwe_secret_lms"] = "TEST_JWE_SECRET_LMS"
+
         svc = factory(sentinel.context, pyramid_request)
 
         assert isinstance(svc, AnnotationMetadataService)
@@ -40,8 +42,4 @@ class TestAnnotationMetadataService:
     @pytest.fixture
     def svc(self, db_session, pyramid_request):
         pyramid_request.db = db_session
-        return AnnotationMetadataService(db_session)
-
-    @pytest.fixture(autouse=True)
-    def environ(self, monkeypatch):
-        monkeypatch.setenv("JWE_SECRET_LMS", "secret")
+        return AnnotationMetadataService(db_session, secret="TEST_JWE_SECRET_LMS")


### PR DESCRIPTION
Instead of `AnnotationMetadataService` reading `os.environ` directly.

This is consistent with how we do other envvars/settings (across all
apps, not just h) and it's nice for services not to read `os.environ`.
