### PR TITLE
Set `Secure` flag on session cookies in production

### DIFF
--- a/h/services/auth_cookie.py
+++ b/h/services/auth_cookie.py
@@ -116,9 +116,9 @@ def factory(_context, request):
         secret=request.registry.settings["h_auth_cookie_secret"],
         salt="authsanity",
         cookie_name="auth",
-        secure=False,
         max_age=30 * 24 * 3600,  # 30 days
         httponly=True,
+        secure=request.scheme == "https",
     )
 
     return AuthCookieService(

--- a/h/session.py
+++ b/h/session.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 from pyramid.csrf import SessionCSRFStoragePolicy
 from pyramid.session import JSONSerializer, SignedCookieSessionFactory
 
@@ -96,6 +98,7 @@ def _user_preferences(user):
 
 def includeme(config):  # pragma: no cover
     settings = config.registry.settings
+    secure = urlparse(settings.get("h.app_url")).scheme == "https"
 
     # By default, derive_key generates a 64-byte (512 bit) secret, which is the
     # correct length for SHA512-based HMAC as specified by the `hashalg`.
@@ -105,8 +108,9 @@ def includeme(config):  # pragma: no cover
         ),
         hashalg="sha512",
         httponly=True,
-        timeout=3600,
+        secure=secure,
         serializer=JSONSerializer(),
+        timeout=3600,
     )
     config.set_session_factory(factory)
     config.set_csrf_storage_policy(SessionCSRFStoragePolicy())

--- a/tests/h/services/auth_cookie_test.py
+++ b/tests/h/services/auth_cookie_test.py
@@ -148,7 +148,7 @@ class TestFactory:
             secret=pyramid_request.registry.settings["h_auth_cookie_secret"],
             salt="authsanity",
             cookie_name="auth",
-            secure=False,
+            secure=True,
             max_age=2592000,
             httponly=True,
         )
@@ -167,3 +167,8 @@ class TestFactory:
     @pytest.fixture
     def AuthCookieService(self, patch):
         return patch("h.services.auth_cookie.AuthCookieService")
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.scheme = "https"  # Simulate production environment
+        return pyramid_request


### PR DESCRIPTION
When generating cookies, set the secure flag if the application's URL scheme is HTTPS, which is the case in all production environments but not during local development.

This protects the confidentiality of cookies in the event that a plain HTTP URL pointing to h is encountered by the browser. Note that all the links we generate and all the pages we serve should always be over HTTPS.

Fixes https://github.com/hypothesis/product-backlog/issues/1524

**Testing:**

To test, check out this branch and apply the following diff:

```diff
diff --git a/h/services/auth_cookie.py b/h/services/auth_cookie.py
index 63cdd71aa..8fc818d60 100644
--- a/h/services/auth_cookie.py
+++ b/h/services/auth_cookie.py
@@ -118,7 +118,7 @@ def factory(_context, request):
         cookie_name="auth",
         max_age=30 * 24 * 3600,  # 30 days
         httponly=True,
-        secure=request.scheme == "https",
+        secure=request.scheme == "http",
     )
 
     return AuthCookieService(
diff --git a/h/session.py b/h/session.py
index 9b86a67be..c8bb69ee4 100644
--- a/h/session.py
+++ b/h/session.py
@@ -98,7 +98,7 @@ def _user_preferences(user):
 
 def includeme(config):  # pragma: no cover
     settings = config.registry.settings
-    secure = urlparse(settings.get("h.app_url")).scheme == "https"
+    secure = urlparse(settings.get("h.app_url")).scheme == "http"
 
     # By default, derive_key generates a 64-byte (512 bit) secret, which is the
     # correct length for SHA512-based HMAC as specified by the `hashalg`.
```

1. Go to http://localhost:5000/search in Chrome and log in
2. Inspect cookies in the Application => Cookies section of developer tools. Notice that the "Secure" flag is unchecked 
3. Delete cookies and reload the page, then sign in again
4. See that the cookies now have the `Secure` flag next to them

Even though you are actually visiting the site over HTTP in development, secure cookies still work because Chrome treats localhost as HTTPS.