### PR TITLE
Revert "Add JWE decryption to security/encryption"

### DIFF
--- a/h/security/encryption.py
+++ b/h/security/encryption.py
@@ -1,10 +1,8 @@
 import base64
-import json
 import os
 
 from Cryptodome.Hash import SHA512
 from Cryptodome.Protocol.KDF import HKDF
-from jose import jwe
 from passlib.context import CryptContext
 
 DEFAULT_ENTROPY = 32
@@ -71,8 +69,3 @@ def token_urlsafe(nbytes=None):
         nbytes = DEFAULT_ENTROPY
     tok = os.urandom(nbytes)
     return base64.urlsafe_b64encode(tok).rstrip(b"=").decode("ascii")
-
-
-def decrypt_jwe_dict(secret: bytes, payload: str) -> dict:
-    """Decrypts the JWE payloads into a dictionary."""
-    return json.loads(jwe.decrypt(payload, secret.ljust(32)[:32]))

--- a/tests/h/security/encryption_test.py
+++ b/tests/h/security/encryption_test.py
@@ -6,12 +6,7 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from passlib.context import CryptContext
 
-from h.security.encryption import (
-    decrypt_jwe_dict,
-    derive_key,
-    password_context,
-    token_urlsafe,
-)
+from h.security.encryption import derive_key, password_context, token_urlsafe
 
 REASONABLE_INFO = st.text(alphabet=string.printable)
 REASONABLE_KEY_MATERIAL = st.binary(min_size=8, max_size=128)
@@ -157,24 +152,3 @@ def test_token_urlsafe_no_args():
 
     assert isinstance(tok, str)
     assert len(tok) > 32
-
-
-class TestDecryptDict:
-    def test_decrypt_dict(self, secret, jwe, json):
-        plain_text_dict = decrypt_jwe_dict(secret, "payload")
-
-        jwe.decrypt.assert_called_once_with("payload", secret.ljust(32))
-        json.loads.assert_called_once_with(jwe.decrypt.return_value)
-        assert plain_text_dict == json.loads.return_value
-
-    @pytest.fixture
-    def secret(self):
-        return b"VERY SECRET"
-
-    @pytest.fixture
-    def json(self, patch):
-        return patch("h.security.encryption.json")
-
-    @pytest.fixture
-    def jwe(self, patch):
-        return patch("h.security.encryption.jwe")


### PR DESCRIPTION
This reverts commit 9486204e56388f01171dde4d99d5703c4275ac4c.


We are no longer planning to use JWEs for the metadata, removing this.