### PR TITLE
Handle `AnnotationSlim` records from `factories.Annotation`

### DIFF
--- a/h/models/annotation_slim.py
+++ b/h/models/annotation_slim.py
@@ -30,7 +30,9 @@ class AnnotationSlim(Base):
     )
     """The value of annotation.id, named here pubid following the convention of group.pubid"""
 
-    annotation = sa.orm.relationship("Annotation")
+    annotation = sa.orm.relationship(
+        "Annotation", backref=sa.orm.backref("slim", uselist=False)
+    )
 
     created = sa.Column(
         sa.DateTime,

--- a/tests/common/factories/annotation_moderation.py
+++ b/tests/common/factories/annotation_moderation.py
@@ -12,3 +12,8 @@ class AnnotationModeration(ModelFactory):
         sqlalchemy_session_persistence = "flush"
 
     annotation = factory.SubFactory(Annotation)
+
+    @factory.post_generation
+    def slim(self, create, extracted, **kwargs):  # pylint:disable=unused-argument
+        if self.annotation.slim:
+            self.annotation.slim.moderated = True

--- a/tests/h/services/bulk_annotation_test.py
+++ b/tests/h/services/bulk_annotation_test.py
@@ -28,9 +28,9 @@ class TestDateMatch:
         ),
     )
     def test_it(self, db_session, factories, spec, expected):
-        factories.Annotation(text="0", created="2000-01-01")
-        factories.Annotation(text="1", created="2001-01-01")
-        factories.Annotation(text="2", created="2002-01-01")
+        factories.Annotation(text="0", created="2000-01-01", slim__new=True)
+        factories.Annotation(text="1", created="2001-01-01", slim__new=True)
+        factories.Annotation(text="2", created="2002-01-01", slim__new=True)
 
         annotations = (
             db_session.execute(
@@ -57,7 +57,7 @@ class TestDateMatch:
 
 
 class TestBulkAnnotationService:
-    AUTHORITY = "my.authority"
+    AUTHORITY = "localhost"
 
     @pytest.mark.parametrize(
         "key,value,visible",
@@ -98,6 +98,7 @@ class TestBulkAnnotationService:
             shared=values["shared"],
             deleted=values["deleted"],
             updated=values["updated"],
+            slim__new=True,
         )
         if values["moderated"]:
             factories.AnnotationModeration(annotation=anno)
@@ -127,6 +128,7 @@ class TestBulkAnnotationService:
                 group=factories.Group(members=group_members),
                 shared=True,
                 deleted=False,
+                slim__new=True,
             )
             for group_members in (
                 # The first two annotations should match, because they are in


### PR DESCRIPTION
Create the adequate record for AnnotationSlim in the Annotation factory.

Only using this in the bulk API tests now. 

The motivation here is that follow up PR will just update the bulk query and the test will just work.

Using a parameter in the factory to make this optional as many test will need to be rewriting across the app as they don't create the users/groups/documents they implicilty rely on.