### PR TITLE
Change the bulk annotation date filter to updated instead of created

### DIFF
--- a/h/services/bulk_annotation.py
+++ b/h/services/bulk_annotation.py
@@ -77,7 +77,7 @@ class BulkAnnotationService:
         self,
         authority: str,
         audience: dict,
-        updated: dict,
+        created: dict,
         limit=100000,
     ) -> List[BulkAnnotation]:
         """
@@ -86,7 +86,7 @@ class BulkAnnotationService:
         :param authority: The authority to search by
         :param audience: A specification of how to find the users. e.g.
             {"username": [...]}
-        :param updated: A specification of how to filter the updated date. e.g.
+        :param created: A specification of how to filter the created date. e.g.
             {"gt": "2019-01-20", "lte": "2019-01-21"}
         :param limit: A limit of results to generate
 
@@ -94,7 +94,7 @@ class BulkAnnotationService:
         """
 
         results = self._db.execute(
-            self._search_query(authority, audience=audience, updated=updated).limit(
+            self._search_query(authority, audience=audience, created=created).limit(
                 limit
             )
         )
@@ -107,7 +107,7 @@ class BulkAnnotationService:
         ]
 
     @classmethod
-    def _search_query(cls, authority, audience, updated) -> Select:
+    def _search_query(cls, authority, audience, created) -> Select:
         """Generate a query which can then be executed to find annotations."""
         return (
             sa.select([cls._AUTHOR.username, Group.authority_provided_id])
@@ -115,7 +115,7 @@ class BulkAnnotationService:
             .join(cls._AUTHOR, cls._AUTHOR.id == AnnotationSlim.user_id)
             .join(Group, Group.id == AnnotationSlim.group_id)
             .where(
-                date_match(AnnotationSlim.updated, updated),
+                date_match(AnnotationSlim.created, created),
                 AnnotationSlim.shared.is_(True),
                 AnnotationSlim.deleted.is_(False),
                 cls._AUTHOR.nipsa.is_(False),

--- a/h/views/api/bulk/annotation.py
+++ b/h/views/api/bulk/annotation.py
@@ -41,12 +41,12 @@ def bulk_annotation(request):
             # is limited to items they have permission to request
             authority=request.identity.auth_client.authority,
             audience=query_filter["audience"],
-            updated=query_filter["updated"],
+            created=query_filter["created"],
             limit=query_filter["limit"],
         )
 
     except BadDateFilter as err:
-        # We happen to know this is the updated field, because there's no other
+        # We happen to know this is the created field, because there's no other
         # but, it could easily be something else in the future
         raise ValidationError(str(err)) from err
 

--- a/h/views/api/bulk/annotation_schema.json
+++ b/h/views/api/bulk/annotation_schema.json
@@ -11,7 +11,7 @@
                 "audience": {
                     "username": ["3a022b6c146dfd9df4ea8662178eac"]
                 },
-                "updated": {
+                "created": {
                     "gt": "2018-11-13T20:20:39+00:00",
                     "lte": "2018-11-13T20:20:39+00:00"
                 }
@@ -34,9 +34,9 @@
             "properties": {
                 "limit": {"type": "integer", "minimum": 0, "maximum": 1000000},
                 "audience": {"$ref": "#/$defs/userFilter"},
-                "updated": {"$ref": "#/$defs/dateFilter"}
+                "created": {"$ref": "#/$defs/dateFilter"}
             },
-            "required": ["limit", "audience", "updated"],
+            "required": ["limit", "audience", "created"],
             "additionalProperties": false
         },
 

--- a/tests/functional/api/bulk/annotation_test.py
+++ b/tests/functional/api/bulk/annotation_test.py
@@ -30,7 +30,7 @@ class TestBulkAnnotation:
             group=group,
             shared=True,
             deleted=False,
-            updated="2018-11-13T20:20:39",
+            created="2018-11-13T20:20:39",
         )
 
         response = make_request(
@@ -38,7 +38,7 @@ class TestBulkAnnotation:
                 "filter": {
                     "limit": 20,
                     "audience": {"username": [user.username]},
-                    "updated": {
+                    "created": {
                         "gt": "2018-11-12T20:20:39+00:00",
                         "lte": "2018-11-13T20:20:39+00:00",
                     },

--- a/tests/h/services/bulk_annotation_test.py
+++ b/tests/h/services/bulk_annotation_test.py
@@ -67,10 +67,10 @@ class TestBulkAnnotationService:
             ("deleted", True, False),
             ("nipsad", True, False),
             ("moderated", True, False),
-            ("updated", "2020-01-01", False),
-            ("updated", "2020-01-02", True),
-            ("updated", "2022-01-01", True),
-            ("updated", "2022-01-02", False),
+            ("created", "2020-01-01", False),
+            ("created", "2020-01-02", True),
+            ("created", "2022-01-01", True),
+            ("created", "2022-01-02", False),
         ),
     )
     @pytest.mark.parametrize("username", ["USERNAME", "username", "user.name"])
@@ -82,7 +82,7 @@ class TestBulkAnnotationService:
             "deleted": False,
             "nipsad": False,
             "moderated": False,
-            "updated": "2021-01-01",
+            "created": "2021-01-01",
         }
         if key:
             values[key] = value
@@ -97,14 +97,14 @@ class TestBulkAnnotationService:
             group=group,
             shared=values["shared"],
             deleted=values["deleted"],
-            updated=values["updated"],
+            created=values["created"],
             moderated=values["moderated"],
         )
 
         annotations = svc.annotation_search(
             authority=self.AUTHORITY,
             audience={"username": ["USERNAME"]},
-            updated={"gt": "2020-01-01", "lte": "2022-01-01"},
+            created={"gt": "2020-01-01", "lte": "2022-01-01"},
         )
 
         if visible:
@@ -140,7 +140,7 @@ class TestBulkAnnotationService:
         matched_annos = svc.annotation_search(
             authority=self.AUTHORITY,
             audience={"username": [viewer.username for viewer in viewers]},
-            updated={"gt": "2020-01-01", "lte": "2099-01-01"},
+            created={"gt": "2020-01-01", "lte": "2099-01-01"},
         )
 
         # Only the first two annotations should match

--- a/tests/h/views/api/bulk/annotation_test.py
+++ b/tests/h/views/api/bulk/annotation_test.py
@@ -45,7 +45,7 @@ class TestBulkAnnotation:
             authority=pyramid_request.identity.auth_client.authority,
             audience=valid_request["filter"]["audience"],
             limit=valid_request["filter"]["limit"],
-            updated=valid_request["filter"]["updated"],
+            created=valid_request["filter"]["created"],
         )
 
         return_data = [
@@ -82,7 +82,7 @@ class TestBulkAnnotation:
             "filter": {
                 "limit": 2000,
                 "audience": {"username": ["3a022b6c146dfd9df4ea8662178eac"]},
-                "updated": {
+                "created": {
                     "gt": "2018-11-13T20:20:39+00:00",
                     "lte": "2018-11-13T20:20:39+00:00",
                 },


### PR DESCRIPTION
**This needs to be deployed together with the LMS side.**

The API it's only used during the early morning, so as long as we deploy them the same day it should be ok.


https://github.com/hypothesis/lms/pull/5774