### PR TITLE
Create index on lower(user.email)

### DIFF
--- a/h/migrations/versions/0de98307b3c0_email_index.py
+++ b/h/migrations/versions/0de98307b3c0_email_index.py
@@ -1,0 +1,20 @@
+"""Add "user" index for email."""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0de98307b3c0"
+down_revision = "34c8067db0ee"
+
+
+def upgrade():
+    op.execute("COMMIT")  # For the concurrent index creation
+    op.create_index(
+        op.f("ix__user__email"),
+        "user",
+        [sa.text("lower('email')")],
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix__user__email"), "user")

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -143,6 +143,7 @@ class User(Base):
             sa.Index(
                 "ix__user__nipsa", cls.nipsa, postgresql_where=cls.nipsa.is_(True)
             ),
+            sa.Index("ix__user__email", sa.func.lower("email")),
         )
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)


### PR DESCRIPTION
This is often used a lookup, for example on login and it's currently requiring a full sequential table scan.

This type of queries are not the slowest but we do it often enough that it appears in the most time consuming ones: https://one.newrelic.com/nr1-core/apm-features/databases/MTM4NTI4M3xBUE18QVBQTElDQVRJT058MjI2ODg2MzE?account=1385283&duration=604800000&state=5e0e0841-93c8-dbb4-ab12-2ac41d47b76c


## Testing

### Forwards


`tox -e dev --run-command 'alembic upgrade head'`    

```dev run-test-pre: PYTHONHASHSEED='255206574'
dev run-test: commands[0] | alembic upgrade head
2023-10-23 16:04:17 3215305 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-10-23 16:04:17 3215305 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-10-23 16:04:17 3215305 alembic.runtime.migration [INFO] Running upgrade 34c8067db0ee -> 0de98307b3c0, Add "user" index for email.```



### Backwards

`tox -e dev --run-command 'alembic downgrade -1'`    

```dev run-test-pre: PYTHONHASHSEED='3098158456'
dev run-test: commands[0] | alembic downgrade -1
2023-10-23 16:04:05 3214343 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-10-23 16:04:05 3214343 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-10-23 16:04:05 3214343 alembic.runtime.migration [INFO] Running downgrade 0de98307b3c0 -> 34c8067db0ee, Add "user" index for email.```
