### PR TITLE
Increase minimum password length to 8 characters

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -15,11 +15,10 @@ from h.models.user import (
 )
 from h.schemas import validators
 from h.schemas.base import CSRFSchema
+from h.schemas.forms.accounts.util import PASSWORD_MIN_LENGTH
 
 _ = i18n.TranslationString
 log = logging.getLogger(__name__)
-
-PASSWORD_MIN_LENGTH = 2  # FIXME: this is ridiculous
 
 
 @lru_cache(maxsize=None)

--- a/h/schemas/forms/accounts/util.py
+++ b/h/schemas/forms/accounts/util.py
@@ -3,7 +3,7 @@ import deform
 
 from h.schemas import validators
 
-PASSWORD_MIN_LENGTH = 2  # FIXME: this is ridiculous
+PASSWORD_MIN_LENGTH = 8
 
 
 def new_password_node(**kwargs):

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -79,7 +79,7 @@ class TestRegisterSchema:
 
         with pytest.raises(colander.Invalid) as exc:
             schema.deserialize({"password": "a"})
-        assert exc.value.asdict()["password"] == ("Must be 2 characters or more.")
+        assert exc.value.asdict()["password"] == ("Must be 8 characters or more.")
 
     def test_it_is_invalid_when_username_too_short(self, pyramid_request, user_model):
         schema = schemas.RegisterSchema().bind(request=pyramid_request)
@@ -273,8 +273,8 @@ class TestPasswordChangeSchema:
         with pytest.raises(colander.Invalid) as exc:
             schema.deserialize(
                 {
-                    "new_password": "wibble",
-                    "new_password_confirm": "wibble!",
+                    "new_password": "foo-bar-baz",
+                    "new_password_confirm": "foo-bar-buzz",
                     "password": "flibble",
                 }
             )
@@ -292,8 +292,8 @@ class TestPasswordChangeSchema:
         with pytest.raises(colander.Invalid) as exc:
             schema.deserialize(
                 {
-                    "new_password": "wibble",
-                    "new_password_confirm": "wibble",
+                    "new_password": "foo-bar-baz",
+                    "new_password_confirm": "foo-bar-baz",
                     "password": "flibble",
                 }
             )

--- a/tests/h/schemas/forms/accounts/reset_password_test.py
+++ b/tests/h/schemas/forms/accounts/reset_password_test.py
@@ -12,9 +12,9 @@ from h.schemas.forms.accounts import ResetPasswordSchema
 @pytest.mark.usefixtures("pyramid_config")
 class TestResetPasswordSchemaDeserialize:
     def test_it_is_valid_with_a_long_password(self, schema):
-        # Yeah... our minimum password length is 2 chars. See
+        # Yeah... our minimum password length is 8 chars. See
         # `h.schema.forms.accounts.util`
-        schema.deserialize({"user": "*any*", "password": "aa"})
+        schema.deserialize({"user": "*any*", "password": "new-password"})
 
     @pytest.mark.parametrize("password", ("", "a"))
     def test_it_is_invalid_with_password_too_short(self, schema, password):
@@ -25,7 +25,7 @@ class TestResetPasswordSchemaDeserialize:
 
     def test_it_is_invalid_with_a_null_user(self, schema):
         with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({"user": colander.null, "password": "*any*"})
+            schema.deserialize({"user": colander.null, "password": "new-password"})
 
         assert "user" in exc.value.asdict()
 
@@ -33,7 +33,7 @@ class TestResetPasswordSchemaDeserialize:
         models.User.get_by_username.return_value = None
 
         with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({"user": "encoded_token", "password": "*any*"})
+            schema.deserialize({"user": "encoded_token", "password": "new-password"})
 
         assert "user" in exc.value.asdict()
 
@@ -41,7 +41,7 @@ class TestResetPasswordSchemaDeserialize:
         serializer.loads.side_effect = BadData("Invalid token")
 
         with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({"user": "INVALID_TOKEN", "password": "*any*"})
+            schema.deserialize({"user": "INVALID_TOKEN", "password": "new-password"})
 
         assert "user" in exc.value.asdict()
         assert "Wrong reset code." in exc.value.asdict()["user"]
@@ -50,7 +50,7 @@ class TestResetPasswordSchemaDeserialize:
         serializer.loads.side_effect = SignatureExpired("Token has expired")
 
         with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({"user": "encoded_token", "password": "*any*"})
+            schema.deserialize({"user": "encoded_token", "password": "new-password"})
 
         serializer.loads.assert_called_once_with(
             "encoded_token", max_age=72 * 3600, return_timestamp=True
@@ -74,7 +74,9 @@ class TestResetPasswordSchemaDeserialize:
     ):
         user.password_updated = password_updated
 
-        appstruct = schema.deserialize({"user": "encoded_token", "password": "secret"})
+        appstruct = schema.deserialize(
+            {"user": "encoded_token", "password": "new-password"}
+        )
 
         models.User.get_by_username.assert_called_once_with(
             pyramid_csrf_request.db,
@@ -89,7 +91,7 @@ class TestResetPasswordSchemaDeserialize:
         user.password_updated = datetime.now() + timedelta(days=1)
 
         with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({"user": "EXPIRED_TOKEN", "password": "*any*"})
+            schema.deserialize({"user": "EXPIRED_TOKEN", "password": "new-password"})
 
         assert "user" in exc.value.asdict()
         assert "This reset code has already been used." in exc.value.asdict()["user"]


### PR DESCRIPTION
Increase the minimum password length from 2 characters to 8. This affects newly created passwords, for new or existing accounts, but not existing logins.

Fixes https://github.com/hypothesis/product-backlog/issues/1523

**Testing:**

1. If you have already created an account with a password that has < 8 chars, try to log in. This should still work.
2. Try to change your password to something shorter than 8 chars. This should fail.
3. Try to create a new account with an initial password shorter than 8 chars. This should fail.