### PR TITLE
Skip DB init flaky tests

### DIFF
--- a/tests/h/cli/commands/init_test.py
+++ b/tests/h/cli/commands/init_test.py
@@ -7,9 +7,10 @@ from h.cli.commands import init as init_cli
 
 @pytest.mark.usefixtures("alembic_config", "alembic_stamp", "db", "search")
 class TestInitCommand:
+    @pytest.mark.skip(reason="We've been seeing flaky behavior on CI")
     def test_initialises_database(
         self, cli, cliconfig, db, db_engine, pyramid_settings
-    ):
+    ):  # pragma: no cover
         db.make_engine.return_value = db_engine
         pyramid_settings["h.authority"] = "foobar.org"
 


### PR DESCRIPTION
This is adding a lot of noise in slack.

Seems to fail in often on the run on main. I never seen it fail on the test on PRs, :thinking: .

https://hypothes-is.slack.com/archives/C4K6M7P5E/p1698050035184479?thread_ts=1698024462.432369&cid=C4K6M7P5E
https://hypothes-is.slack.com/archives/C4K6M7P5E/p1698369897340069