### PR TITLE
Change the approach of the slim filling task

### DIFF
--- a/h/tasks/annotations.py
+++ b/h/tasks/annotations.py
@@ -1,7 +1,6 @@
-from sqlalchemy import func, insert
-
 from h.celery import celery, get_task_logger
-from h.models import Annotation, AnnotationModeration, AnnotationSlim, Group, User
+from h.models import Annotation, AnnotationSlim
+from h.services.annotation_write import AnnotationWriteService
 
 log = get_task_logger(__name__)
 
@@ -9,47 +8,18 @@ log = get_task_logger(__name__)
 @celery.task
 def fill_annotation_slim(batch_size=1000):
     """Task to fill the new AnnotationSlim table in batches."""
-    # pylint: disable=no-member
-    db = celery.request.db
+    # pylint:disable=no-member
+
+    anno_write_svc = celery.request.find_service(AnnotationWriteService)
 
     annotations = (
-        db.query(
-            Annotation.id.label("pubid"),
-            Annotation.created,
-            Annotation.updated,
-            Annotation.deleted,
-            Annotation.shared,
-            Annotation.document_id,
-            Group.id.label("group_id"),
-            User.id.label("user_id"),
-            AnnotationModeration.id.is_not(None).label("moderated"),
-        )
-        .join(Group, Group.pubid == Annotation.groupid)
-        .join(
-            User,
-            User.username
-            == func.split_part(func.split_part(Annotation.userid, "@", 1), ":", 2),
-        )
+        celery.request.db.query(Annotation)
         .outerjoin(AnnotationSlim)
-        .outerjoin(AnnotationModeration)
         .where(AnnotationSlim.id.is_(None))
         .order_by(Annotation.updated.desc())
         .limit(batch_size)
-    ).cte("annotations")
-
-    db.execute(
-        insert(AnnotationSlim).from_select(
-            [
-                annotations.c.pubid,
-                annotations.c.created,
-                annotations.c.updated,
-                annotations.c.deleted,
-                annotations.c.shared,
-                annotations.c.document_id,
-                annotations.c.group_id,
-                annotations.c.user_id,
-                annotations.c.moderated,
-            ],
-            annotations,
-        )
     )
+
+    for annotation in annotations:
+        log.info("Created AnnotationSlim record for: %s", annotation.id)
+        anno_write_svc.upsert_annotation_slim(annotation)

--- a/tests/h/tasks/annotations_test.py
+++ b/tests/h/tasks/annotations_test.py
@@ -1,6 +1,7 @@
+from unittest.mock import call
+
 import pytest
 
-from h.models import Annotation, AnnotationSlim
 from h.tasks.annotations import fill_annotation_slim
 
 
@@ -11,41 +12,17 @@ class TestFillPKAndUserId:
     USERNAME_1 = "USERNAME_1"
     USERNAME_2 = "USERNAME_2"
 
-    def test_it(self, factories, db_session):
-        author = factories.User(authority=self.AUTHORITY_1, username=self.USERNAME_1)
-
-        annos = factories.Annotation.create_batch(
-            10,
-            userid=author.userid,
-        )
-        factories.Annotation.create_batch(5)
+    def test_it(self, factories, annotation_write_service):
+        annos = factories.Annotation.create_batch(10)
 
         fill_annotation_slim(batch_size=10)
 
-        assert db_session.query(AnnotationSlim).count() == 10
-        assert (
-            db_session.query(Annotation)
-            .outerjoin(AnnotationSlim)
-            .filter(AnnotationSlim.id.is_(None))
-            .count()
-            == 5
+        annotation_write_service.upsert_annotation_slim.assert_has_calls(
+            [call(anno) for anno in reversed(annos)]
         )
 
-        # Refresh data for the annotations
-        _ = [db_session.refresh(anno) for anno in annos]
-
-        for anno in annos:
-            assert anno.slim.pubid == anno.id
-            assert anno.slim.created == anno.created
-            assert anno.slim.updated == anno.updated
-            assert anno.slim.deleted == anno.deleted
-            assert anno.slim.shared == anno.shared
-            assert anno.slim.document_id == anno.document_id
-            assert anno.slim.group_id == anno.group.id
-            assert anno.slim.user_id == author.id
-
     @pytest.fixture(autouse=True)
-    def celery(self, patch, db_session):
+    def celery(self, patch, pyramid_request):
         cel = patch("h.tasks.annotations.celery", autospec=False)
-        cel.request.db = db_session
+        cel.request = pyramid_request
         return cel


### PR DESCRIPTION
Query the candidate annotations and use the existing service method to create the new rows.



### Testing

- Make some annotations
- Remove the existing `_slim` rows 

`docker compose exec postgres psql -U postgres -c "truncate annotation_slim cascade"`


- Run the task, on `make shell`:


```
In [1]: from h.tasks.annotations import fill_annotation_slim
                                                                                     
In [2]: fill_annotation_slim.delay()  
```


- On the logs of `make dev`:


```
[2023-10-27 10:43:35,251: INFO/MainProcess] Task h.tasks.annotations.fill_annotation_slim[6d7457d3-afdf-4c05-b960-23ea1b0bbcf6] received
worker (stderr)      | [2023-10-27 10:43:35,297: INFO/ForkPoolWorker-16] h.tasks.annotations.fill_annotation_slim[6d7457d3-afdf-4c05-b960-23ea1b0bbcf6]: Created AnnotationSlim record for: _EY88nQBEe6sq5draWq-HQ
worker (stderr)      | [2023-10-27 10:43:35,337: INFO/ForkPoolWorker-16] h.tasks.annotations.fill_annotation_slim[6d7457d3-afdf-4c05-b960-23ea1b0bbcf6] Task h.tasks.annotations.fill_annotation_slim[6d7457d3-afdf-4c05-b960-23ea1b0bbcf6] succeeded in 0.08060170299722813s: None
```


- Running it again doesn't try to change the row that are already there

```
worker (stderr)      | [2023-10-27 10:43:48,762: INFO/MainProcess] Task h.tasks.annotations.fill_annotation_slim[54b06ec9-1af1-4d24-a1bf-942e6fe244f4] received
worker (stderr)      | [2023-10-27 10:43:48,769: INFO/ForkPoolWorker-16] h.tasks.annotations.fill_annotation_slim[54b06ec9-1af1-4d24-a1bf-942e6fe244f4] Task h.tasks.annotations.fill_annotation_slim[54b06ec9-1af1-4d24-a1bf-942e6fe244f4] succeeded in 0.004245407006237656s: None
```

