### PR TITLE
Tweak fill query to filter on pubid instad of id

### DIFF
--- a/h/tasks/annotations.py
+++ b/h/tasks/annotations.py
@@ -15,7 +15,7 @@ def fill_annotation_slim(batch_size=1000):
     annotations = (
         celery.request.db.query(Annotation)
         .outerjoin(AnnotationSlim)
-        .where(AnnotationSlim.id.is_(None))
+        .where(AnnotationSlim.pubid.is_(None))
         .order_by(Annotation.updated.desc())
         .limit(batch_size)
     )


### PR DESCRIPTION
This small change has a very big impact on the performance of the query


## Performance 

(in the read replica)

[metabase query, pubid is null](https://report.hypothes.is/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJleHBsYWluIGFuYWx5emUgXG5zZWxlY3QgKiBmcm9tIGFubm90YXRpb25cbmxlZnQgb3V0ZXIgam9pbiBhbm5vdGF0aW9uX3NsaW0gb24gYW5ub3RhdGlvbl9zbGltLnB1YmlkID0gYW5ub3RhdGlvbi5pZFxud2hlcmUgYW5ub3RhdGlvbl9zbGltLnB1YmlkIGlzIG51bGxcbm9yZGVyIGJ5IGFubm90YXRpb24udXBkYXRlZCBkZXNjXG5saW1pdCAxMDAwIiwidGVtcGxhdGUtdGFncyI6e319LCJkYXRhYmFzZSI6Mn0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=)

```
explain analyze 
select * from annotation
left outer join annotation_slim on annotation_slim.pubid = annotation.id
where annotation_slim.pubid is null
order by annotation.updated desc
limit 1000
```

```Execution Time: 8142.644 ms```



vs, the original version:


[metabase query, id is null](https://report.hypothes.is/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJleHBsYWluIGFuYWx5emUgXG5zZWxlY3QgKiBmcm9tIGFubm90YXRpb25cbmxlZnQgb3V0ZXIgam9pbiBhbm5vdGF0aW9uX3NsaW0gb24gYW5ub3RhdGlvbl9zbGltLnB1YmlkID0gYW5ub3RhdGlvbi5pZFxud2hlcmUgYW5ub3RhdGlvbl9zbGltLmlkIGlzIG51bGxcbm9yZGVyIGJ5IGFubm90YXRpb24udXBkYXRlZCBkZXNjXG5saW1pdCAxMDAwIiwidGVtcGxhdGUtdGFncyI6e319LCJkYXRhYmFzZSI6Mn0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=
)


```
explain analyze 
select * from annotation
left outer join annotation_slim on annotation_slim.pubid = annotation.id
where annotation_slim.id is null
order by annotation.updated desc
limit 1000
```

```ERROR: canceling statement due to conflict with recovery Detail: User query might have needed to see row versions that must be removed.```





