### PR TITLE
Exclude delete annotations from sync task

### DIFF
--- a/h/tasks/annotations.py
+++ b/h/tasks/annotations.py
@@ -15,7 +15,7 @@ def fill_annotation_slim(batch_size=1000):
     annotations = (
         celery.request.db.query(Annotation)
         .outerjoin(AnnotationSlim)
-        .where(AnnotationSlim.pubid.is_(None))
+        .where(AnnotationSlim.pubid.is_(None), Annotation.deleted.is_(False))
         .order_by(Annotation.updated.desc())
         .limit(batch_size)
     )

--- a/tests/h/tasks/annotations_test.py
+++ b/tests/h/tasks/annotations_test.py
@@ -14,6 +14,7 @@ class TestFillPKAndUserId:
 
     def test_it(self, factories, annotation_write_service):
         annos = factories.Annotation.create_batch(10)
+        factories.Annotation.create_batch(10, deleted=True)
 
         fill_annotation_slim(batch_size=10)
 


### PR DESCRIPTION
Deleted annotations are marked first as `deleted` and then actually deleted from the DB.

While they are in that deleted=True state the might have some missing relationships, see:

https://hypothesis.sentry.io/issues/4586240338/?alert_rule_id=7345746&alert_type=issue&notification_uuid=467604ec-df5e-42d5-907f-a63cba0e5729&project=37293&referrer=slack


Exclude them explicitly to avoid any issues.