### PR TITLE
Change auto vacuum settings on big tables

### DIFF
--- a/h/migrations/versions/8b4b4fdef955_auto_vacuum_annotation.py
+++ b/h/migrations/versions/8b4b4fdef955_auto_vacuum_annotation.py
@@ -1,0 +1,30 @@
+"""Change auto-vacuum settings on big tables."""
+from alembic import op
+
+revision = "8b4b4fdef955"
+down_revision = "0de98307b3c0"
+
+BIG_TABLES = [
+    "annotation",
+    "annotation_slim",
+    "annotation_metadata",
+    "document",
+    "user",
+    "group",
+]
+
+
+def upgrade():
+    for table in BIG_TABLES:
+        # Set auto vacuum to kick in after 5% of dead tuples (vs total in the table) are detected
+        op.execute(
+            f'ALTER TABLE "{table}" SET (autovacuum_vacuum_scale_factor = 0.05);'
+        )
+
+
+def downgrade():
+    # Set it back to the default value
+    for table in BIG_TABLES:
+        op.execute(
+            f'ALTER TABLE "{table}" SET (autovacuum_vacuum_scale_factor = 0.20);'
+        )


### PR DESCRIPTION
For:

- #8279 


This should allow autovacuum to kick in for big tables where it has never run.


## Testing

#### Migration forward

```
tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='1796325260'
dev run-test: commands[0] | alembic upgrade head
2023-10-31 07:50:05 558985 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-10-31 07:50:05 558985 alembic.runtime.migration [INFO] Will assume transactional DDL.
2023-10-31 07:50:05 558985 alembic.runtime.migration [INFO] Running upgrade 0de98307b3c0 -> 8b4b4fdef955, Change auto-vacuum settings on big tables.
```

#### Query tables that have setting overridden:

```
select relname, reloptions, pg_namespace.nspname                                                                                                                                  
from pg_class
join pg_namespace on pg_namespace.oid = pg_class.relnamespace
where pg_namespace.nspname = 'public' and relkind = 'r' and reloptions is not null;
       relname       |              reloptions               | nspname 
---------------------+---------------------------------------+---------
 document            | {autovacuum_vacuum_scale_factor=0.05} | public
 annotation          | {autovacuum_vacuum_scale_factor=0.05} | public
 user                | {autovacuum_vacuum_scale_factor=0.05} | public
 group               | {autovacuum_vacuum_scale_factor=0.05} | public
 annotation_slim     | {autovacuum_vacuum_scale_factor=0.05} | public
 annotation_metadata | {autovacuum_vacuum_scale_factor=0.05} | public
(6 rows)
```


### Running migration backwards

```
tox -e dev --run-command 'alembic downgrade -1'
dev run-test-pre: PYTHONHASHSEED='3621830851'
dev run-test: commands[0] | alembic downgrade -1
2023-10-31 07:48:51 553912 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2023-10-31 07:48:51 553912 alembic.runtime.migration [INFO] Will assume transactional DDL.2023-10-31 07:48:51 553912 alembic.runtime.migration [INFO] Running downgrade 8b4b4fdef955 -> 0de98307b3c0, Change auto-vacuum settings on big tables.`

```