### PR TITLE
Remove the order clause to find candidate annotations

### DIFF
--- a/h/tasks/annotations.py
+++ b/h/tasks/annotations.py
@@ -16,7 +16,6 @@ def fill_annotation_slim(batch_size=1000):
         celery.request.db.query(Annotation)
         .outerjoin(AnnotationSlim)
         .where(AnnotationSlim.pubid.is_(None), Annotation.deleted.is_(False))
-        .order_by(Annotation.updated.desc())
         .limit(batch_size)
     )
 

--- a/tests/unit/h/tasks/annotations_test.py
+++ b/tests/unit/h/tasks/annotations_test.py
@@ -19,7 +19,7 @@ class TestFillPKAndUserId:
         fill_annotation_slim(batch_size=10)
 
         annotation_write_service.upsert_annotation_slim.assert_has_calls(
-            [call(anno) for anno in reversed(annos)]
+            [call(anno) for anno in annos]
         )
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
The process to find missing annotations in the slim table is significantly.
slower when we order by `created`.

This change will mean that finishing all recent annotations will take longer but the overall process will be much faster.

We've also seen the behaviour where the first batch of day takes a long time and the rest are much faster. This is probably due to trying to load the `created` index in memory.