### PR TITLE
Assert calls to service in any other in slim task

### DIFF
--- a/tests/unit/h/tasks/annotations_test.py
+++ b/tests/unit/h/tasks/annotations_test.py
@@ -19,7 +19,7 @@ class TestFillPKAndUserId:
         fill_annotation_slim(batch_size=10)
 
         annotation_write_service.upsert_annotation_slim.assert_has_calls(
-            [call(anno) for anno in annos]
+            [call(anno) for anno in annos], any_order=True
         )
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Recent change to the task returns rows with no particular order, adapt the tests to account for that.


Introduced in https://github.com/hypothesis/h/pull/8317