### PR TITLE
Fix some flakey tests

### DIFF
--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -4,7 +4,7 @@ import os
 import alembic.command
 import alembic.config
 import click
-import sqlalchemy
+from sqlalchemy.exc import ProgrammingError
 
 from h import db, search
 
@@ -32,7 +32,7 @@ def _init_db(settings):
     # alembic, and we shouldn't call `db.init`.
     try:
         engine.execute("select 1 from alembic_version")
-    except sqlalchemy.exc.ProgrammingError:
+    except ProgrammingError:
         log.info("initializing database")
         db.init(engine, should_create=True, authority=settings["h.authority"])
 

--- a/tests/unit/h/cli/commands/init_test.py
+++ b/tests/unit/h/cli/commands/init_test.py
@@ -1,92 +1,124 @@
-from unittest import mock
+import logging
+from unittest.mock import sentinel
 
 import pytest
+from sqlalchemy.exc import ProgrammingError
 
-from h.cli.commands import init as init_cli
+from h.cli.commands.init import init
 
 
-@pytest.mark.usefixtures("alembic_config", "alembic_stamp", "db", "search")
 class TestInitCommand:
-    @pytest.mark.skip(reason="We've been seeing flaky behavior on CI")
-    def test_initialises_database(
-        self, cli, cliconfig, db, db_engine, pyramid_settings
-    ):  # pragma: no cover
-        db.make_engine.return_value = db_engine
-        pyramid_settings["h.authority"] = "foobar.org"
+    def test_it_overrides_the_elasticsearch_client_timeout(self, cli, ctx, os):
+        result = cli.invoke(init, obj=ctx)
 
-        result = cli.invoke(init_cli.init, obj=cliconfig)
+        assert os.environ["ELASTICSEARCH_CLIENT_TIMEOUT"] == "30"
+        assert not result.exit_code
 
-        db.make_engine.assert_called_once_with(pyramid_settings)
+    def test_it_initializes_the_db(
+        self, alembic, caplog, cli, ctx, db, db_engine, pyramid_request
+    ):
+        caplog.set_level(logging.INFO)
+        db_engine.execute.side_effect = ProgrammingError(
+            sentinel.statement, sentinel.params, sentinel.orig
+        )
+
+        result = cli.invoke(init, obj=ctx)
+
+        db.make_engine.assert_called_once_with(pyramid_request.registry.settings)
+        db_engine.execute.assert_called_once_with("select 1 from alembic_version")
+        assert (
+            "h.cli.commands.init",
+            logging.INFO,
+            "initializing database",
+        ) in caplog.record_tuples
         db.init.assert_called_once_with(
-            db_engine, should_create=True, authority="foobar.org"
+            db_engine,
+            should_create=True,
+            authority=pyramid_request.registry.settings["h.authority"],
+        )
+        alembic.config.Config.assert_called_once_with("conf/alembic.ini")
+        alembic.command.stamp.assert_called_once_with(
+            alembic.config.Config.return_value, "head"
         )
         assert not result.exit_code
 
-    def test_skips_database_init_if_alembic_managed(
-        self, request, cli, cliconfig, db, db_engine
+    def test_it_skips_initializing_the_db_if_its_already_initialized(
+        self, alembic, caplog, cli, ctx, db
     ):
-        db.make_engine.return_value = db_engine
-        db_engine.execute("CREATE TABLE alembic_version (version_num VARCHAR(32));")
+        caplog.set_level(logging.INFO)
 
-        @request.addfinalizer
-        def _cleanup():
-            db_engine.execute("DROP TABLE alembic_version;")
+        result = cli.invoke(init, obj=ctx)
 
-        result = cli.invoke(init_cli.init, obj=cliconfig)
-
-        assert not db.init.called
+        db.init.assert_not_called()
+        alembic.command.stamp.assert_not_called()
+        assert (
+            "h.cli.commands.init",
+            logging.INFO,
+            "detected alembic_version table, skipping db initialization",
+        ) in caplog.record_tuples
         assert not result.exit_code
 
-    def test_stamps_alembic_version(
-        self,
-        alembic_config,
-        alembic_stamp,
-        cli,
-        cliconfig,
-        db,
-        db_engine,
-        pyramid_settings,
+    @pytest.mark.parametrize(
+        "settings,check_icu_plugin",
+        [
+            ({"es.check_icu_plugin": True}, True),
+            ({"es.check_icu_plugin": False}, False),
+            ({}, True),
+        ],
+    )
+    def test_it_initializes_elasticsearch(
+        self, caplog, cli, ctx, search, pyramid_request, settings, check_icu_plugin
     ):
-        db.make_engine.return_value = db_engine
-        Config = alembic_config.Config
-        pyramid_settings["h.authority"] = "foobar.org"
+        caplog.set_level(logging.INFO)
+        pyramid_request.registry.settings.update(settings)
 
-        result = cli.invoke(init_cli.init, obj=cliconfig)
+        result = cli.invoke(init, obj=ctx)
 
-        Config.assert_called_once_with("conf/alembic.ini")
-        alembic_stamp.assert_called_once_with(Config.return_value, "head")
-        assert not result.exit_code
-
-    def test_initialises_search(self, cli, cliconfig, search, pyramid_settings):
-        pyramid_settings["es.check_icu_plugin"] = False
-        es_client = search.get_client.return_value
-        result = cli.invoke(init_cli.init, obj=cliconfig)
-
-        search.get_client.assert_called_once_with(pyramid_settings)
-        search.init.assert_any_call(es_client, pyramid_settings["es.check_icu_plugin"])
+        search.get_client.assert_called_once_with(pyramid_request.registry.settings)
+        assert (
+            "h.cli.commands.init",
+            logging.INFO,
+            "initializing ES6 search index",
+        ) in caplog.record_tuples
+        search.init.assert_called_once_with(
+            search.get_client.return_value, check_icu_plugin=check_icu_plugin
+        )
         assert not result.exit_code
 
 
-@pytest.fixture
-def cliconfig(pyramid_request):
-    return {"bootstrap": mock.Mock(return_value=pyramid_request)}
+@pytest.fixture(autouse=True)
+def os(patch):
+    os = patch("h.cli.commands.init.os")
+    os.environ = {}
+    return os
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
+def alembic(patch):
+    return patch("h.cli.commands.init.alembic")
+
+
+@pytest.fixture(autouse=True)
 def db(patch):
     return patch("h.cli.commands.init.db")
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def search(patch):
     return patch("h.cli.commands.init.search")
 
 
-@pytest.fixture
-def alembic_config(patch):
-    return patch("h.cli.commands.init.alembic.config")
+@pytest.fixture(autouse=True)
+def pyramid_settings(pyramid_settings):
+    pyramid_settings["h.authority"] = sentinel.h_authority
+    return pyramid_settings
 
 
 @pytest.fixture
-def alembic_stamp(patch):
-    return patch("h.cli.commands.init.alembic.command.stamp")
+def ctx(pyramid_request):
+    return {"bootstrap": lambda: pyramid_request}
+
+
+@pytest.fixture
+def db_engine(db):
+    return db.make_engine.return_value


### PR DESCRIPTION
Multiple tests in `cli/commands/init_test.py` have been intermittently
failing on CI, and I've managed to reproduce the failure once locally as
well.

I don't know what exactly is causing these tests to fail but the tests
do some non-standard things that I don't like the looks of:

* There are patch fixtures for several of `cli.py`'s imports but these
  aren't `autouse` fixtures, so individual tests might fail to activate
  some of the fixtures. `autouse` also affects the timing of fixture
  execution.

  When using patch to isolate a module-under-test from other modules
  that it imports, our standard approach is module-level autouse
  fixtures.

* It reaches into `alembic` to patch things: `cli.py` imports `alembic`
  and then the tests patch `cli.py::alembic.config` and
  `cli.py::alembic.stamp`. This is a bad idea: it's hard to predict what
  the effect will be of reaching into the innards of a third-party
  library like alembic and patching parts of it after we've imported it.

  Our normal approach would be to patch the entirety of
  `cli.py::alembic`.

* The tests themselves are running commands like
  `CREATE TABLE  ...` and `DROP TABLE ...` on the real DB.

I don't know why these tests have been intermittently failing, but the
above are exactly the sorts of things that would create a hard-to-find
intermittent test failure.

I've replaced all this with more standard tests that use our normal
approach to patching and that avoid using the real DB in these tests.

Hopefully that will fix whatever has been causing the test failures.
