### PR TITLE
Filter candidate annotations by dates

### DIFF
--- a/h/tasks/annotations.py
+++ b/h/tasks/annotations.py
@@ -6,7 +6,7 @@ log = get_task_logger(__name__)
 
 
 @celery.task
-def fill_annotation_slim(batch_size=1000):
+def fill_annotation_slim(batch_size=1000, since="2012-01-01", until="2017-12-31"):
     """Task to fill the new AnnotationSlim table in batches."""
     # pylint:disable=no-member
 
@@ -15,7 +15,12 @@ def fill_annotation_slim(batch_size=1000):
     annotations = (
         celery.request.db.query(Annotation)
         .outerjoin(AnnotationSlim)
-        .where(AnnotationSlim.pubid.is_(None), Annotation.deleted.is_(False))
+        .where(
+            AnnotationSlim.pubid.is_(None),
+            Annotation.deleted.is_(False),
+            Annotation.created >= since,
+            Annotation.created <= until,
+        )
         .limit(batch_size)
     )
 

--- a/tests/unit/h/tasks/annotations_test.py
+++ b/tests/unit/h/tasks/annotations_test.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from unittest.mock import call
 
 import pytest
@@ -13,10 +14,14 @@ class TestFillPKAndUserId:
     USERNAME_2 = "USERNAME_2"
 
     def test_it(self, factories, annotation_write_service):
-        annos = factories.Annotation.create_batch(10)
+        now = datetime.now()
+        annos = factories.Annotation.create_batch(10, created=now)
         factories.Annotation.create_batch(10, deleted=True)
+        factories.Annotation.create_batch(10, created=now + timedelta(days=10))
 
-        fill_annotation_slim(batch_size=10)
+        fill_annotation_slim(
+            batch_size=10, since=now - timedelta(days=1), until=now + timedelta(days=1)
+        )
 
         annotation_write_service.upsert_annotation_slim.assert_has_calls(
             [call(anno) for anno in annos], any_order=True


### PR DESCRIPTION
This should limit the Annotation.id that need to be compared with AnnotationSlim.pubid making the query faster.

The default values here avoid having to sync the deploy with the h-periodic task.


Discussion over: https://hypothes-is.slack.com/archives/C0LUWQQJJ/p1699518328500679