### PR TITLE
Prepare `rounded_corners` feature flag removal

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -18,7 +18,6 @@ FEATURES = {
     "client_user_profile": "Enable client-side user profile and preferences management",
     "export_annotations": "Allow users to export annotations",
     "import_annotations": "Allow users to import previously exported annotations",
-    "rounded_corners": "Enable rounded corners in UI components",
     "export_formats": "Allow users to select the format for their annotations export file",
 }
 
@@ -40,7 +39,9 @@ FEATURES = {
 #
 # 4. Finally, remove the feature from FEATURES_PENDING_REMOVAL.
 #
-FEATURES_PENDING_REMOVAL = {}
+FEATURES_PENDING_REMOVAL = {
+    "rounded_corners": "Enable rounded corners in UI components",
+}
 
 
 class Feature(Base):


### PR DESCRIPTION
The feature flag is no longer in use [by client](https://github.com/hypothesis/client/pull/5962).

I will create another PR to merge after this one has been deployed, which fully removes the feature.