### PR TITLE
Accept a singular audience user for the bulk annotation API

### DIFF
--- a/h/services/bulk_api/annotation.py
+++ b/h/services/bulk_api/annotation.py
@@ -32,7 +32,7 @@ class BulkAnnotationService:
     def annotation_search(
         self,
         authority: str,
-        username: dict,
+        username: str,
         created: dict,
         limit=100000,
     ) -> List[BulkAnnotation]:

--- a/h/views/api/bulk/annotation.py
+++ b/h/views/api/bulk/annotation.py
@@ -40,7 +40,7 @@ def bulk_annotation(request):
             # Use the authority from the authenticated client to ensure the user
             # is limited to items they have permission to request
             authority=request.identity.auth_client.authority,
-            audience=query_filter["audience"],
+            username=query_filter["username"],
             created=query_filter["created"],
             limit=query_filter["limit"],
         )

--- a/h/views/api/bulk/annotation_schema.json
+++ b/h/views/api/bulk/annotation_schema.json
@@ -8,9 +8,7 @@
         {
             "filter": {
                 "limit": 2000,
-                "audience": {
-                    "username": ["3a022b6c146dfd9df4ea8662178eac"]
-                },
+                "username": "3a022b6c146dfd9df4ea8662178eac",
                 "created": {
                     "gt": "2018-11-13T20:20:39+00:00",
                     "lte": "2018-11-13T20:20:39+00:00"
@@ -33,28 +31,12 @@
             "type": "object",
             "properties": {
                 "limit": {"type": "integer", "minimum": 0, "maximum": 1000000},
-                "audience": {"$ref": "#/$defs/userFilter"},
+                "username": {"type": "string", "pattern": "^[a-z0-9]{30}$"},
                 "created": {"$ref": "#/$defs/dateFilter"}
             },
-            "required": ["limit", "audience", "created"],
+            "required": ["limit", "username", "created"],
             "additionalProperties": false
         },
-
-        "userFilter": {
-            "description": "A filter to specify the users you want",
-
-            "type": "object",
-            "properties": {
-                "username": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {"type": "string", "pattern": "^[a-z0-9]{30}$"}
-                }
-            },
-            "required": ["username"],
-            "additionalProperties": false
-        },
-
         "dateFilter": {
             "description": "A filter to apply on a date",
 

--- a/tests/functional/api/bulk/annotation_test.py
+++ b/tests/functional/api/bulk/annotation_test.py
@@ -40,7 +40,7 @@ class TestBulkAnnotation:
             {
                 "filter": {
                     "limit": 20,
-                    "audience": {"username": [user.username]},
+                    "username": user.username,
                     "created": {
                         "gt": "2018-11-12T20:20:39+00:00",
                         "lte": "2018-11-13T20:20:39+00:00",

--- a/tests/unit/h/services/bulk_api/annotation_test.py
+++ b/tests/unit/h/services/bulk_api/annotation_test.py
@@ -65,7 +65,7 @@ class TestBulkAnnotationService:
 
         annotations = svc.annotation_search(
             authority=self.AUTHORITY,
-            audience={"username": ["USERNAME"]},
+            username="USERNAME",
             created={"gt": "2020-01-01", "lte": "2022-01-01"},
         )
 
@@ -81,7 +81,7 @@ class TestBulkAnnotationService:
             assert not annotations
 
     def test_it_with_more_complex_grouping(self, svc, factories):
-        *viewers, author = factories.User.create_batch(3, authority=self.AUTHORITY)
+        viewer, author = factories.User.create_batch(2, authority=self.AUTHORITY)
 
         annotations = [
             factories.AnnotationSlim(
@@ -92,9 +92,9 @@ class TestBulkAnnotationService:
             )
             for group_members in (
                 # The first two annotations should match, because they are in
-                # groups the viewers are in
-                [author, viewers[0]],
-                [author, viewers[1]],
+                # groups the viewer is in
+                [author, viewer],
+                [author, viewer],
                 # This one is just noise and shouldn't match
                 [author],
             )
@@ -102,7 +102,7 @@ class TestBulkAnnotationService:
 
         matched_annos = svc.annotation_search(
             authority=self.AUTHORITY,
-            audience={"username": [viewer.username for viewer in viewers]},
+            username=viewer.username,
             created={"gt": "2020-01-01", "lte": "2099-01-01"},
         )
 

--- a/tests/unit/h/views/api/bulk/annotation_test.py
+++ b/tests/unit/h/views/api/bulk/annotation_test.py
@@ -43,7 +43,7 @@ class TestBulkAnnotation:
 
         bulk_annotation_service.annotation_search.assert_called_once_with(
             authority=pyramid_request.identity.auth_client.authority,
-            audience=valid_request["filter"]["audience"],
+            username=valid_request["filter"]["username"],
             limit=valid_request["filter"]["limit"],
             created=valid_request["filter"]["created"],
         )
@@ -82,7 +82,7 @@ class TestBulkAnnotation:
         pyramid_request.json = {
             "filter": {
                 "limit": 2000,
-                "audience": {"username": ["3a022b6c146dfd9df4ea8662178eac"]},
+                "username": "3a022b6c146dfd9df4ea8662178eac",
                 "created": {
                     "gt": "2018-11-13T20:20:39+00:00",
                     "lte": "2018-11-13T20:20:39+00:00",


### PR DESCRIPTION
Change the bulk annotation API to accept a single username string as the "audience" parameter, rather than a list of usernames.

Needs to be deployed at the same time as <https://github.com/hypothesis/lms/pull/5898> and not during the daily email digest generation time.

Once we've removed the unnecessary batching optimisation from the LMS app it'll only need to include one audience username per request to h's bulk annotation API, not a list of usernames. This enables us to simplify h's bulk annotation API code. It also results in a much more sensible API: an API that returns a list of annotations visible to a given user (e.g. in groups that user is in) makes sense. An API that returns all annotations visible to any user in a list of users is a bit weird, especially when you realise that some of the returned annotations may not be visible to some of the given audience users (e.g. may be in groups that some of the given audience users aren't in) but nothing in the API response indicates which annotations should be visible to which users.

Of course we can't actually merge this until we've merged the corresponding change to how LMS calls this API, and we'll have to coordinate deploying the two PRs.

Testing
=======

1. Log in to <https://hypothesis.instructure.com/> as `eng+canvasstudent@hypothes.is`, launch [localhost (make devdata) HTML Assignment](https://hypothesis.instructure.com/courses/125/assignments/873) and create some annotations

2. Make a bulk API request and see the response. For example using [httpie](https://httpie.io/):

   ```terminal
   $ http POST http://localhost:5000/api/bulk/annotation Authorization:'Basic ***' filter:='{"limit": 100000, "username": "3a022b6c146dfd9df4ea8662178eac", "created": {"gt": "2023-11-00T05:00:00+00:00", "lte": "2023-12-25T05:00:00+00:00"}}'
   ```

   Make sure the `gt` (greater than) and `lte` (less than or equal to) dates in your request cover the time when you created the annotation.

   The authorization token comes from taking [LMS's h API client ID and secret from devdata](https://github.com/hypothesis/devdata/blob/ad78af36ab56a3ae0fb0716261e9d5a1e88a28c4/lms/devdata.env#L27-L29), concatenating them with a `:`, and base64-encoding them. For some reason I found that I also had to replace the final character in the resulting token with a `=`:

   ```terminal
   $ echo 'f5a...761:45t...Tjo' | base64
   ```