### PR TITLE
Remove distinct clause in the groups subquery for the bulk API

### DIFF
--- a/h/services/bulk_api/annotation.py
+++ b/h/services/bulk_api/annotation.py
@@ -92,7 +92,6 @@ class BulkAnnotationService:
     def _audience_groups_subquery(cls, authority, username):
         return (
             sa.select(Group.id)
-            .distinct()
             .join(GroupMembership, GroupMembership.group_id == Group.id)
             .join(cls._AUDIENCE, GroupMembership.user_id == cls._AUDIENCE.id)
             .where(


### PR DESCRIPTION
The DISTINCT clause doesn't have any semantic effect as is being used on a `ID in ( SUBQUERY)` context.

The clause does however have a big performance impact as it forces the query planner to sort the results.

Compare perfomance with the two resulting queries:

- [With distinct](https://report.hypothes.is/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJleHBsYWluIGFuYWx5emUgIFNFTEVDVCBhdXRob3IudXNlcm5hbWUsIFwiZ3JvdXBcIi5hdXRob3JpdHlfcHJvdmlkZWRfaWQsIGNvYWxlc2NlKGFubm90YXRpb25fbWV0YWRhdGEuZGF0YSwgJ3t9JykgQVMgbWV0YWRhdGEgXG5GUk9NIGFubm90YXRpb25fc2xpbSBKT0lOIFwidXNlclwiIEFTIGF1dGhvciBPTiBhdXRob3IuaWQgPSBhbm5vdGF0aW9uX3NsaW0udXNlcl9pZCBcbkpPSU4gXCJncm91cFwiIE9OIFwiZ3JvdXBcIi5pZCA9IGFubm90YXRpb25fc2xpbS5ncm91cF9pZCBcbkxFRlQgT1VURVIgSk9JTiBhbm5vdGF0aW9uX21ldGFkYXRhIE9OIGFubm90YXRpb25fc2xpbS5pZCA9IGFubm90YXRpb25fbWV0YWRhdGEuYW5ub3RhdGlvbl9pZCBcbldIRVJFIGFubm90YXRpb25fc2xpbS5jcmVhdGVkID4gJzIwMjMtMTItMTRUMDU6MDA6MDArMDA6MDAnIEFORCBhbm5vdGF0aW9uX3NsaW0uY3JlYXRlZCA8PSAnMjAyMy0xMi0xNVQwNTowMDowMCswMDowMCcgQU5EIGFubm90YXRpb25fc2xpbS5zaGFyZWQgSVMgdHJ1ZSBBTkQgYW5ub3RhdGlvbl9zbGltLmRlbGV0ZWQgSVMgZmFsc2UgQU5EIGF1dGhvci5uaXBzYSBJUyBmYWxzZSBBTkQgYW5ub3RhdGlvbl9zbGltLm1vZGVyYXRlZCBJUyBmYWxzZSBcbkFORCBcImdyb3VwXCIuaWQgSU4gKFNFTEVDVCAgZGlzdGluY3QgXCJncm91cFwiLmlkIFxuRlJPTSBcImdyb3VwXCIgSk9JTiB1c2VyX2dyb3VwIE9OIHVzZXJfZ3JvdXAuZ3JvdXBfaWQgPSBcImdyb3VwXCIuaWQgSk9JTiBcInVzZXJcIiBBUyBhdWRpZW5jZSBPTiB1c2VyX2dyb3VwLnVzZXJfaWQgPSBhdWRpZW5jZS5pZCBcbldIRVJFIGxvd2VyKHJlcGxhY2UoYXVkaWVuY2UudXNlcm5hbWUsICcuJywgJycpKSA9IGxvd2VyKHJlcGxhY2UoJ2M4ZTA3MDE4NmM3ZWQ0NjRlNWUwYmE3Nzc3YzZhOCcsICcuJywgJycpKSBBTkQgYXVkaWVuY2UuYXV0aG9yaXR5ID0gJ2xtcy5oeXBvdGhlcy5pcycpIFxuTElNSVQgMTAwMDAwIiwidGVtcGxhdGUtdGFncyI6e319LCJkYXRhYmFzZSI6Mn0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=)

`Execution Time: 11505.118 ms`

- [Without it ](https://report.hypothes.is/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJleHBsYWluIGFuYWx5emUgIFNFTEVDVCBhdXRob3IudXNlcm5hbWUsIFwiZ3JvdXBcIi5hdXRob3JpdHlfcHJvdmlkZWRfaWQsIGNvYWxlc2NlKGFubm90YXRpb25fbWV0YWRhdGEuZGF0YSwgJ3t9JykgQVMgbWV0YWRhdGEgXG5GUk9NIGFubm90YXRpb25fc2xpbSBKT0lOIFwidXNlclwiIEFTIGF1dGhvciBPTiBhdXRob3IuaWQgPSBhbm5vdGF0aW9uX3NsaW0udXNlcl9pZCBcbkpPSU4gXCJncm91cFwiIE9OIFwiZ3JvdXBcIi5pZCA9IGFubm90YXRpb25fc2xpbS5ncm91cF9pZCBcbkxFRlQgT1VURVIgSk9JTiBhbm5vdGF0aW9uX21ldGFkYXRhIE9OIGFubm90YXRpb25fc2xpbS5pZCA9IGFubm90YXRpb25fbWV0YWRhdGEuYW5ub3RhdGlvbl9pZCBcbldIRVJFIGFubm90YXRpb25fc2xpbS5jcmVhdGVkID4gJzIwMjMtMTItMTRUMDU6MDA6MDArMDA6MDAnIEFORCBhbm5vdGF0aW9uX3NsaW0uY3JlYXRlZCA8PSAnMjAyMy0xMi0xNVQwNTowMDowMCswMDowMCcgQU5EIGFubm90YXRpb25fc2xpbS5zaGFyZWQgSVMgdHJ1ZSBBTkQgYW5ub3RhdGlvbl9zbGltLmRlbGV0ZWQgSVMgZmFsc2UgQU5EIGF1dGhvci5uaXBzYSBJUyBmYWxzZSBBTkQgYW5ub3RhdGlvbl9zbGltLm1vZGVyYXRlZCBJUyBmYWxzZSBcbkFORCBcImdyb3VwXCIuaWQgSU4gKFNFTEVDVCAgIFwiZ3JvdXBcIi5pZCBcbkZST00gXCJncm91cFwiIEpPSU4gdXNlcl9ncm91cCBPTiB1c2VyX2dyb3VwLmdyb3VwX2lkID0gXCJncm91cFwiLmlkIEpPSU4gXCJ1c2VyXCIgQVMgYXVkaWVuY2UgT04gdXNlcl9ncm91cC51c2VyX2lkID0gYXVkaWVuY2UuaWQgXG5XSEVSRSBsb3dlcihyZXBsYWNlKGF1ZGllbmNlLnVzZXJuYW1lLCAnLicsICcnKSkgPSBsb3dlcihyZXBsYWNlKCdjOGUwNzAxODZjN2VkNDY0ZTVlMGJhNzc3N2M2YTgnLCAnLicsICcnKSkgQU5EIGF1ZGllbmNlLmF1dGhvcml0eSA9ICdsbXMuaHlwb3RoZXMuaXMnKSBcbkxJTUlUIDEwMDAwMCIsInRlbXBsYXRlLXRhZ3MiOnt9fSwiZGF0YWJhc2UiOjJ9LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319)

`Execution Time: 38.680 ms`



As a sanity check I tweaked the query to return results and being able to compare them:

- [With DISTINCT](https://report.hypothes.is/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1QgYXV0aG9yLnVzZXJuYW1lLCBcImdyb3VwXCIuYXV0aG9yaXR5X3Byb3ZpZGVkX2lkLCBjb2FsZXNjZShhbm5vdGF0aW9uX21ldGFkYXRhLmRhdGEsICd7fScpIEFTIG1ldGFkYXRhIFxuRlJPTSBhbm5vdGF0aW9uX3NsaW0gSk9JTiBcInVzZXJcIiBBUyBhdXRob3IgT04gYXV0aG9yLmlkID0gYW5ub3RhdGlvbl9zbGltLnVzZXJfaWQgXG5KT0lOIFwiZ3JvdXBcIiBPTiBcImdyb3VwXCIuaWQgPSBhbm5vdGF0aW9uX3NsaW0uZ3JvdXBfaWQgXG5MRUZUIE9VVEVSIEpPSU4gYW5ub3RhdGlvbl9tZXRhZGF0YSBPTiBhbm5vdGF0aW9uX3NsaW0uaWQgPSBhbm5vdGF0aW9uX21ldGFkYXRhLmFubm90YXRpb25faWQgXG5XSEVSRSBhbm5vdGF0aW9uX3NsaW0uY3JlYXRlZCA-ICcyMDIzLTEwLTE2VDA1OjAwOjAwKzAwOjAwJyBBTkQgYW5ub3RhdGlvbl9zbGltLmNyZWF0ZWQgPD0gJzIwMjMtMTAtMTdUMDU6MDA6MDArMDA6MDAnIEFORCBhbm5vdGF0aW9uX3NsaW0uc2hhcmVkIElTIHRydWUgQU5EIGFubm90YXRpb25fc2xpbS5kZWxldGVkIElTIGZhbHNlIEFORCBhdXRob3Iubmlwc2EgSVMgZmFsc2UgQU5EIGFubm90YXRpb25fc2xpbS5tb2RlcmF0ZWQgSVMgZmFsc2UgXG5BTkQgXCJncm91cFwiLmlkIElOIChTRUxFQ1QgIGRpc3RpbmN0IFwiZ3JvdXBcIi5pZCBcbkZST00gXCJncm91cFwiIEpPSU4gdXNlcl9ncm91cCBPTiB1c2VyX2dyb3VwLmdyb3VwX2lkID0gXCJncm91cFwiLmlkIEpPSU4gXCJ1c2VyXCIgQVMgYXVkaWVuY2UgT04gdXNlcl9ncm91cC51c2VyX2lkID0gYXVkaWVuY2UuaWQgXG5XSEVSRSBsb3dlcihyZXBsYWNlKGF1ZGllbmNlLnVzZXJuYW1lLCAnLicsICcnKSkgPSBsb3dlcihyZXBsYWNlKCdjOGUwNzAxODZjN2VkNDY0ZTVlMGJhNzc3N2M2YTgnLCAnLicsICcnKSkgQU5EIGF1ZGllbmNlLmF1dGhvcml0eSA9ICdsbXMuaHlwb3RoZXMuaXMnKSBcbkxJTUlUIDEwMDAwMCIsInRlbXBsYXRlLXRhZ3MiOnt9fSwiZGF0YWJhc2UiOjJ9LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319)
- [Without DISTINCT](https://report.hypothes.is/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiIgU0VMRUNUIGF1dGhvci51c2VybmFtZSwgXCJncm91cFwiLmF1dGhvcml0eV9wcm92aWRlZF9pZCwgY29hbGVzY2UoYW5ub3RhdGlvbl9tZXRhZGF0YS5kYXRhLCAne30nKSBBUyBtZXRhZGF0YVxuRlJPTSBhbm5vdGF0aW9uX3NsaW0gSk9JTiBcInVzZXJcIiBBUyBhdXRob3IgT04gYXV0aG9yLmlkID0gYW5ub3RhdGlvbl9zbGltLnVzZXJfaWQgXG5KT0lOIFwiZ3JvdXBcIiBPTiBcImdyb3VwXCIuaWQgPSBhbm5vdGF0aW9uX3NsaW0uZ3JvdXBfaWQgXG5MRUZUIE9VVEVSIEpPSU4gYW5ub3RhdGlvbl9tZXRhZGF0YSBPTiBhbm5vdGF0aW9uX3NsaW0uaWQgPSBhbm5vdGF0aW9uX21ldGFkYXRhLmFubm90YXRpb25faWQgXG5XSEVSRSBhbm5vdGF0aW9uX3NsaW0uY3JlYXRlZCA-ICcyMDIzLTEwLTE2VDA1OjAwOjAwKzAwOjAwJyBBTkQgYW5ub3RhdGlvbl9zbGltLmNyZWF0ZWQgPD0gJzIwMjMtMTAtMTdUMDU6MDA6MDArMDA6MDAnIEFORCBhbm5vdGF0aW9uX3NsaW0uc2hhcmVkIElTIHRydWUgQU5EIGFubm90YXRpb25fc2xpbS5kZWxldGVkIElTIGZhbHNlIEFORCBhdXRob3Iubmlwc2EgSVMgZmFsc2UgQU5EIGFubm90YXRpb25fc2xpbS5tb2RlcmF0ZWQgSVMgZmFsc2UgXG5BTkQgXCJncm91cFwiLmlkIElOIChTRUxFQ1QgICBcImdyb3VwXCIuaWQgXG5GUk9NIFwiZ3JvdXBcIiBKT0lOIHVzZXJfZ3JvdXAgT04gdXNlcl9ncm91cC5ncm91cF9pZCA9IFwiZ3JvdXBcIi5pZCBKT0lOIFwidXNlclwiIEFTIGF1ZGllbmNlIE9OIHVzZXJfZ3JvdXAudXNlcl9pZCA9IGF1ZGllbmNlLmlkIFxuV0hFUkUgbG93ZXIocmVwbGFjZShhdWRpZW5jZS51c2VybmFtZSwgJy4nLCAnJykpID0gbG93ZXIocmVwbGFjZSgnYzhlMDcwMTg2YzdlZDQ2NGU1ZTBiYTc3NzdjNmE4JywgJy4nLCAnJykpIEFORCBhdWRpZW5jZS5hdXRob3JpdHkgPSAnbG1zLmh5cG90aGVzLmlzJykgXG5MSU1JVCAxMDAwMDAiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjoyfSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsidGFibGUuY29sdW1uX3dpZHRocyI6WzM4NCw1ODldfX0=)

Yes, this look like duplicates in both queries but that's because we are not returning the annotation ID, each row here represent one annotation.