### PR TITLE
Handle deleted groups while updating the annotation slim table

### DIFF
--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -217,6 +217,13 @@ class AnnotationWriteService:
 
     def upsert_annotation_slim(self, annotation):
         self._db.flush()  # See the last model changes in the transaction
+
+        if not annotation.group:
+            # Due to the design of the old table this is possible for a short while
+            # when a user (and his groups) or a group is deleted.
+            # The AnnotationSlim records will get deleted by a cascade, no need to do anything here.
+            return
+
         moderated = self._db.scalar(
             select(
                 exists(

--- a/tests/unit/h/services/annotation_write_test.py
+++ b/tests/unit/h/services/annotation_write_test.py
@@ -232,6 +232,11 @@ class TestAnnotationWriteService:
 
         assert not annotation.is_hidden
 
+    def test_upsert_annotation_slim_with_deleted_group(self, annotation, svc):
+        annotation.groupid = "deleted group"
+
+        svc.upsert_annotation_slim(annotation)
+
     @pytest.fixture
     def create_data(self, factories):
         user = factories.User()


### PR DESCRIPTION
Fixes [this sentry exception](https://hypothesis.sentry.io/issues/4736156077/?alert_rule_id=7345746&alert_type=issue&project=37293&referrer=slack)

---
The process of deleting a group leaves the row in annotation pointing to a non existing group until the annotations itself is deleted.

The annotation slim uses FKs to other tables so that's not currently necessary. Skip any action on the upsert annotation slim method and let the CASCADE on the annotation table remove the existing slim rows if necessary.