### PR TITLE
Rename `TEST_DATABASE_URL` to just `DATABASE_URL`

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -25,7 +25,7 @@ TEST_SETTINGS = {
     "pyramid.debug_all": False,
     "secret_key": "notasecret",
     "sqlalchemy.url": os.environ.get(
-        "TEST_DATABASE_URL", "postgresql://postgres@localhost/htest"
+        "DATABASE_URL", "postgresql://postgres@localhost/htest"
     ),
 }
 

--- a/tests/unit/h/conftest.py
+++ b/tests/unit/h/conftest.py
@@ -20,8 +20,8 @@ from tests.common.fixtures.elasticsearch import *  # pylint:disable=wildcard-imp
 from tests.common.fixtures.services import *  # pylint:disable=wildcard-import,unused-wildcard-import
 
 TEST_AUTHORITY = "example.com"
-TEST_DATABASE_URL = database_url(
-    os.environ.get("TEST_DATABASE_URL", "postgresql://postgres@localhost/htest")
+DATABASE_URL = database_url(
+    os.environ.get("DATABASE_URL", "postgresql://postgres@localhost/htest")
 )
 
 Session = sessionmaker()
@@ -73,7 +73,7 @@ def cli():
 @pytest.fixture(scope="session")
 def db_engine(tmp_path_factory):
     """Set up the database connection and create tables."""
-    engine = sqlalchemy.create_engine(TEST_DATABASE_URL)
+    engine = sqlalchemy.create_engine(DATABASE_URL)
 
     shared_tmpdir = tmp_path_factory.getbasetemp().parent
     done_file = shared_tmpdir / "db_initialized.done"
@@ -229,4 +229,4 @@ def pyramid_csrf_request(pyramid_request):
 @pytest.fixture
 def pyramid_settings():
     """Return the default app settings."""
-    return {"sqlalchemy.url": TEST_DATABASE_URL}
+    return {"sqlalchemy.url": DATABASE_URL}

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ passenv =
     dev: NODE_ENV
     dev: PROXY_AUTH
 
-    {tests,functests}: TEST_DATABASE_URL
+    {tests,functests}: DATABASE_URL
     {tests,functests}: ELASTICSEARCH_URL
     {tests,functests}: PYTEST_ADDOPTS
     functests: BROKER_URL


### PR DESCRIPTION
This is gonna make it easier to clean things up and apply the
cookiecutter to h in future commits.
