### PR TITLE
Don't use `newrelic-admin` for the WebSocket

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -21,7 +21,7 @@ stderr_events_enabled=true
 autostart = %(ENV_ENABLE_WEB)s
 
 [program:websocket]
-command=newrelic-admin run-program gunicorn --paste conf/websocket.ini --config conf/gunicorn-websocket.conf.py
+command=gunicorn --paste conf/websocket.ini --config conf/gunicorn-websocket.conf.py
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true
@@ -29,7 +29,7 @@ stderr_events_enabled=true
 autostart = %(ENV_ENABLE_WEBSOCKET)s
 
 [program:websocket-monolithic]
-command=newrelic-admin run-program gunicorn --paste conf/websocket-monolithic.ini --config conf/gunicorn-websocket-monolithic.conf.py
+command=gunicorn --paste conf/websocket-monolithic.ini --config conf/gunicorn-websocket-monolithic.conf.py
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true


### PR DESCRIPTION
https://github.com/hypothesis/h/pull/8386/ changed the WebSocket command
in `supervisord.conf` to be prefixed by `newrelic-admin run-program ...`
which it wasn't before. I suspect that might have broken the WebSocket.
If I'm right, this will hopefully fix it.

Slack thread: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1704201384991689?thread_ts=1704200985.822419&cid=C4K6M7P5E
