### PR TITLE
Remove support for back-ported SSL changes

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -15,14 +15,6 @@ if 'H_GUNICORN_KEYFILE' in os.environ:
     keyfile = os.environ['H_GUNICORN_KEYFILE']
 
 
-def post_fork(server, worker):
-    # Support back-ported SSL changes on Debian / Ubuntu
-    import _ssl
-    import gevent.hub
-    if hasattr(_ssl, 'SSLContext') and not hasattr(_ssl, '_sslwrap'):
-        gevent.hub.PYGTE279 = True
-
-
 def when_ready(server):
     name = server.proc_name
     if name == 'web' and 'WEB_NUM_WORKERS' in os.environ:


### PR DESCRIPTION
Remove support for "back-ported SSL changes on Debian / Ubuntu". I don't
know what setting `gevent.hub.PYGTE279` ever did, it seems to originate
from this commit but the commit message doesn't explain anything:

https://github.com/hypothesis/h/commit/c3c99186549e6ecdae54e6743aa90b9baae78cca

Grepping the gevent source code `PYGTE279` doesn't appear to do anything
anymore, so I'm betting we can get away with getting rid of this.

Slack thread:

https://hypothes-is.slack.com/archives/C0LUWQQJJ/p1704217024563879?thread_ts=1704205428.543429&cid=C0LUWQQJJ
