### PR TITLE
Remove no-longer-needed Heroku support

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -3,11 +3,6 @@ import os
 if 'GUNICORN_TIMEOUT' in os.environ:
     timeout = int(os.environ['GUNICORN_TIMEOUT'])
 
-# Smart detect heroku stack and assume a trusted proxy.
-# This is a convenience that should hopefully not be too surprising.
-if 'heroku' in os.environ.get('LD_LIBRARY_PATH', ''):
-    forwarded_allow_ips = '*'
-
 if 'H_GUNICORN_CERTFILE' in os.environ:
     certfile = os.environ['H_GUNICORN_CERTFILE']
 


### PR DESCRIPTION
This originates from:

https://github.com/hypothesis/h/commit/bd6948423a88970200b006316ae6430c0af4e93a

It looks like it was added in order to support Dokku, which was a
service that we used to use to deploy development branches of h to
temporary servers for testing (and apparently these temporary servers
ran on Heroku?).

We haven't used Dokku or Heroku for years.
