### PR TITLE
Remove `GUNICORN_TIMEOUT`

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,7 +1,5 @@
 import os
 
-if 'GUNICORN_TIMEOUT' in os.environ:
-    timeout = int(os.environ['GUNICORN_TIMEOUT'])
 
 if 'H_GUNICORN_CERTFILE' in os.environ:
     certfile = os.environ['H_GUNICORN_CERTFILE']


### PR DESCRIPTION
Remove support for the `GUNICORN_TIMEOUT` envvar (a custom envvar that
sets Gunicorn's `timeout` setting).

The `GUNICORN_TIMEOUT` envvar originates from this commit, but there's
unfortunately no PR and the commit message doesn't explain anything:

https://github.com/hypothesis/h/commit/e0ef80815fbfd49ffaec91c6aceba4af46202bf7

Searching Slack didn't reveal anything about this change either.

Gunicorn's `timeout` setting defaults to `30`:
https://docs.gunicorn.org/en/stable/settings.html#timeout

We currently have `GUNICORN_TIMEOUT` set to `20` in Production,
Production (WebSocket), QA and QA (WebSocket). It's set to `30` in
Production (Canada).

If we do want to change Gunicorn's `timeout` setting and we want to be
able to change it differently in different environments (so we can't
just hard-code a `timeout` value in our Gunicorn config file in git) we
can just do this by setting the `GUNICORN_CMD_ARGS` envvar:

    GUNICORN_CMD_ARGS = "--timeout 20"

There's no need to add our own envvar for this.

However, I don't see any reason why we should change Gunicorn's
`timeout` from its default `30` to `20`. So I think we can get away with
just removing the `GUNICORN_TIMEOUT` envvar and not adding
`GUNICORN_CMD_ARGS`.

We should set a reminder to remove the `GUNICORN_TIMEOUT` envvar from
all environments a few days after deploying this.
