### PR TITLE
Fix select() no longer accepts varied constructor arguments

### DIFF
--- a/h/services/bulk_api/annotation.py
+++ b/h/services/bulk_api/annotation.py
@@ -67,11 +67,9 @@ class BulkAnnotationService:
         """Generate a query which can then be executed to find annotations."""
         return (
             sa.select(
-                [
-                    cls._AUTHOR.username,
-                    Group.authority_provided_id,
-                    sa.func.coalesce(AnnotationMetadata.data, "{}").label("metadata"),
-                ]
+                cls._AUTHOR.username,
+                Group.authority_provided_id,
+                sa.func.coalesce(AnnotationMetadata.data, "{}").label("metadata"),
             )
             .select_from(AnnotationSlim)
             .join(cls._AUTHOR, cls._AUTHOR.id == AnnotationSlim.user_id)

--- a/h/services/search_index/_queue.py
+++ b/h/services/search_index/_queue.py
@@ -62,15 +62,13 @@ class Queue:
         query = Job.__table__.insert().from_select(
             [Job.name, Job.scheduled_at, Job.priority, Job.tag, Job.kwargs],
             select(
-                [
-                    literal_column("'sync_annotation'"),
-                    literal_column(f"'{schedule_at}'"),
-                    literal_column(str(priority)),
-                    literal_column(repr(tag)),
-                    func.jsonb_build_object(
-                        "annotation_id", Annotation.id, "force", bool(force)
-                    ),
-                ]
+                literal_column("'sync_annotation'"),
+                literal_column(f"'{schedule_at}'"),
+                literal_column(str(priority)),
+                literal_column(repr(tag)),
+                func.jsonb_build_object(
+                    "annotation_id", Annotation.id, "force", bool(force)
+                ),
             ).where(where_clause),
         )
 

--- a/h/services/user_delete.py
+++ b/h/services/user_delete.py
@@ -29,7 +29,7 @@ class UserDeleteService:
 
         # Delete or remove our link to groups we've created
         for group, annotations_by_other_users in self._db.execute(
-            sa.select([Group, sa.func.count(Annotation.id)])
+            sa.select(Group, sa.func.count(Annotation.id))
             .where(Group.creator == user)
             .outerjoin(
                 Annotation,


### PR DESCRIPTION
Fix select() no longer accepts varied constructor arguments, columns are passed positionally

https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-core-usage


This style works in both 1.4 and 2.0 making the upgrade easier.