### PR TITLE
Use the job queue to fill the annotation slim table

### DIFF
--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -82,7 +82,10 @@ class AnnotationWriteService:
             self._annotation_metadata_service.set(annotation, annotation_metadata)
 
         self._queue_service.add_by_id(
-            annotation.id, tag="storage.create_annotation", schedule_in=60
+            name=JobQueueService.JobName.SYNC_ANNOTATION,
+            annotation_id=annotation.id,
+            tag="storage.create_annotation",
+            schedule_in=60,
         )
 
         return annotation
@@ -142,7 +145,8 @@ class AnnotationWriteService:
         # entry's timestamp matches the DB timestamp. If we're not changing this
         # timestamp, we need to force reindexing.
         self._queue_service.add_by_id(
-            annotation.id,
+            name=JobQueueService.JobName.SYNC_ANNOTATION,
+            annotation_id=annotation.id,
             tag=reindex_tag,
             schedule_in=60,
             force=not update_timestamp,

--- a/h/services/job_queue.py
+++ b/h/services/job_queue.py
@@ -17,6 +17,7 @@ class Priority:
 class JobQueueService:
     class JobName(str, Enum):
         SYNC_ANNOTATION = "sync_annotation"
+        ANNOTATION_SLIM = "annotation_slim"
 
     def __init__(self, db):
         self._db = db

--- a/h/services/search_index.py
+++ b/h/services/search_index.py
@@ -9,6 +9,7 @@ from h.models import Annotation
 from h.presenters import AnnotationSearchIndexPresenter
 from h.search.index import BatchIndexer
 from h.services.annotation_read import AnnotationReadService
+from h.services.job_queue import JobQueueService
 
 
 class Result:
@@ -163,7 +164,9 @@ class SearchIndexService:
           job on the queue to be re-checked and removed the next time the
           method runs.
         """
-        jobs = self._queue_service.get(name="sync_annotation", limit=limit)
+        jobs = self._queue_service.get(
+            name=JobQueueService.JobName.SYNC_ANNOTATION, limit=limit
+        )
 
         if not jobs:
             return {}

--- a/h/tasks/job_queue.py
+++ b/h/tasks/job_queue.py
@@ -7,21 +7,21 @@ log = get_task_logger(__name__)
 
 
 @celery.task
-def add_annotations_between_times(start_time, end_time, tag):
+def add_annotations_between_times(name, start_time, end_time, tag):
     celery.request.find_service(name="queue_service").add_between_times(
-        start_time, end_time, tag
+        name, start_time, end_time, tag
     )
 
 
 @celery.task
-def add_annotations_from_user(userid, tag, force=False, schedule_in=None):
+def add_annotations_from_user(name, userid, tag, force=False, schedule_in=None):
     celery.request.find_service(name="queue_service").add_by_user(
-        userid, tag, force=force, schedule_in=schedule_in
+        name, userid, tag, force=force, schedule_in=schedule_in
     )
 
 
 @celery.task
-def add_annotations_from_group(groupid, tag, force=False, schedule_in=None):
+def add_annotations_from_group(name, groupid, tag, force=False, schedule_in=None):
     celery.request.find_service(name="queue_service").add_by_group(
-        groupid, tag, force=force, schedule_in=schedule_in
+        name, groupid, tag, force=force, schedule_in=schedule_in
     )

--- a/h/templates/admin/search.html.jinja2
+++ b/h/templates/admin/search.html.jinja2
@@ -12,6 +12,13 @@
     <div class="panel-body">
       <form method="POST">
         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+        <div>
+            <select name="name">
+                <option value="sync_annotation">Reindex</option>
+                <option value="annotation_slim">Annotation slim</option>
+            </select>
+        </div>
+
         {{ caller() }}
         <div class="form-group">
           <input type="submit" class="btn btn-default" name="{{ action }}" value="Reindex">

--- a/h/templates/admin/search.html.jinja2
+++ b/h/templates/admin/search.html.jinja2
@@ -13,15 +13,14 @@
       <form method="POST">
         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <div>
-            <select name="name">
+            Job type: <select name="name">
                 <option value="sync_annotation">Reindex</option>
                 <option value="annotation_slim">Annotation slim</option>
             </select>
         </div>
-
         {{ caller() }}
         <div class="form-group">
-          <input type="submit" class="btn btn-default" name="{{ action }}" value="Reindex">
+          <input type="submit" class="btn btn-default" name="{{ action }}" value="Process">
         </div>
       </form>
     </div>
@@ -31,14 +30,12 @@
 {% macro force_checkbox(name) %}
   <div class="form-group form-check">
     <input class="form-check-input" type="checkbox" checked id="{{ name }}" name="{{ name }}">
-    <label class="form-check-label" for="{{ name }}">Force <small class="text-muted">(Reindex all matching annotations even if they're already up to date in Elasticsearch.)</small></label>
+    <label class="form-check-label" for="{{ name }}">Force <small class="text-muted">(Process all matching annotations even if they're already up to date in Elasticsearch.)</small></label>
   </div>
 {% endmacro %}
 
 {% block content %}
-  <p>This is the search index admin page.</p>
-
-  {% call reindex_form(heading="Reindex all annotations between two dates", action="reindex_date") %}
+  {% call reindex_form(heading="Process all annotations between two dates", action="reindex_date") %}
     <div class="form-group">
       <label for="start">Start date</label>
       <input required type="datetime-local" class="form-control" name="start" id="start">
@@ -50,7 +47,7 @@
     </div>
   {% endcall %}
 
-  {% call reindex_form(heading="Reindex all annotations by a user", action="reindex_user") %}
+  {% call reindex_form(heading="Process all annotations by a user", action="reindex_user") %}
     <div class="form-group">
       <label for="username">Username</label>
       <input required class="form-control" name="username" id="username">
@@ -59,7 +56,7 @@
     {{ force_checkbox("reindex_user_force") }}
   {% endcall %}
 
-  {% call reindex_form(heading="Reindex all annotations in a group", action="reindex_group") %}
+  {% call reindex_form(heading="Process all annotations in a group", action="reindex_group") %}
     <div class="form-group">
       <label for="groupid">Group ID</label>
       <input required class="form-control" name="groupid" id="groupid">

--- a/h/views/admin/search.py
+++ b/h/views/admin/search.py
@@ -4,7 +4,6 @@ from pyramid.view import view_config, view_defaults
 
 from h import models, tasks
 from h.security import Permission
-from h.services.job_queue import JobQueueService
 
 
 class NotFoundError(Exception):
@@ -38,7 +37,7 @@ class SearchAdminViews:
         end_time = isoparse(self.request.params["end"].strip())
 
         tasks.job_queue.add_annotations_between_times.delay(
-            JobQueueService.JobName.SYNC_ANNOTATION,
+            self.request.params["name"],
             start_time,
             end_time,
             tag="reindex_date",
@@ -64,7 +63,7 @@ class SearchAdminViews:
             raise NotFoundError(f"User {username} not found")
 
         tasks.job_queue.add_annotations_from_user.delay(
-            JobQueueService.JobName.SYNC_ANNOTATION,
+            self.request.params["name"],
             user.userid,
             tag="reindex_user",
             force=force,
@@ -88,7 +87,7 @@ class SearchAdminViews:
             raise NotFoundError(f"Group {groupid} not found")
 
         tasks.job_queue.add_annotations_from_group.delay(
-            JobQueueService.JobName.SYNC_ANNOTATION,
+            self.request.params["name"],
             groupid,
             tag="reindex_group",
             force=force,

--- a/h/views/admin/search.py
+++ b/h/views/admin/search.py
@@ -4,6 +4,7 @@ from pyramid.view import view_config, view_defaults
 
 from h import models, tasks
 from h.security import Permission
+from h.services.job_queue import JobQueueService
 
 
 class NotFoundError(Exception):
@@ -37,7 +38,10 @@ class SearchAdminViews:
         end_time = isoparse(self.request.params["end"].strip())
 
         tasks.job_queue.add_annotations_between_times.delay(
-            start_time, end_time, tag="reindex_date"
+            JobQueueService.JobName.SYNC_ANNOTATION,
+            start_time,
+            end_time,
+            tag="reindex_date",
         )
         return self._notify_reindexing_started(
             f"Began reindexing from {start_time} to {end_time}"
@@ -60,7 +64,10 @@ class SearchAdminViews:
             raise NotFoundError(f"User {username} not found")
 
         tasks.job_queue.add_annotations_from_user.delay(
-            user.userid, tag="reindex_user", force=force
+            JobQueueService.JobName.SYNC_ANNOTATION,
+            user.userid,
+            tag="reindex_user",
+            force=force,
         )
         return self._notify_reindexing_started(
             f"Began reindexing annotations by {user.userid}"
@@ -81,7 +88,10 @@ class SearchAdminViews:
             raise NotFoundError(f"Group {groupid} not found")
 
         tasks.job_queue.add_annotations_from_group.delay(
-            groupid, tag="reindex_group", force=force
+            JobQueueService.JobName.SYNC_ANNOTATION,
+            groupid,
+            tag="reindex_group",
+            force=force,
         )
         return self._notify_reindexing_started(
             f"Began reindexing annotations in group {groupid} ({group.name})"

--- a/tests/unit/h/tasks/job_queue_test.py
+++ b/tests/unit/h/tasks/job_queue_test.py
@@ -9,17 +9,18 @@ from h.tasks import job_queue
 class TestAddAnnotationsBetweenTimes:
     def test_it(self, queue_service):
         job_queue.add_annotations_between_times(
-            sentinel.start_time, sentinel.end_time, sentinel.tag
+            sentinel.name, sentinel.start_time, sentinel.end_time, sentinel.tag
         )
 
         queue_service.add_between_times.assert_called_once_with(
-            sentinel.start_time, sentinel.end_time, sentinel.tag
+            sentinel.name, sentinel.start_time, sentinel.end_time, sentinel.tag
         )
 
 
 class TestAddAnnotationsFromUser:
     def test_it(self, queue_service):
         job_queue.add_annotations_from_user(
+            sentinel.name,
             sentinel.userid,
             sentinel.tag,
             force=sentinel.force,
@@ -27,6 +28,7 @@ class TestAddAnnotationsFromUser:
         )
 
         queue_service.add_by_user.assert_called_once_with(
+            sentinel.name,
             sentinel.userid,
             sentinel.tag,
             force=sentinel.force,
@@ -37,6 +39,7 @@ class TestAddAnnotationsFromUser:
 class TestAddAnnotationsFromGroup:
     def test_it(self, queue_service):
         job_queue.add_annotations_from_group(
+            sentinel.name,
             sentinel.groupid,
             sentinel.tag,
             force=sentinel.force,
@@ -44,6 +47,7 @@ class TestAddAnnotationsFromGroup:
         )
 
         queue_service.add_by_group.assert_called_once_with(
+            sentinel.name,
             sentinel.groupid,
             sentinel.tag,
             force=sentinel.force,

--- a/tests/unit/h/views/admin/search_test.py
+++ b/tests/unit/h/views/admin/search_test.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 from h.services.group import GroupService
+from h.services.job_queue import JobQueueService
 from h.views.admin.search import NotFoundError, SearchAdminViews
 
 
@@ -20,6 +21,7 @@ class TestSearchAdminViews:
         views.reindex_date()
 
         tasks.job_queue.add_annotations_between_times.delay.assert_called_once_with(
+            JobQueueService.JobName.SYNC_ANNOTATION,
             datetime.datetime(year=2020, month=9, day=9),
             datetime.datetime(year=2020, month=9, day=11),
             tag="reindex_date",
@@ -40,7 +42,10 @@ class TestSearchAdminViews:
         views.reindex_user()
 
         tasks.job_queue.add_annotations_from_user.delay.assert_called_once_with(
-            user.userid, tag="reindex_user", force=force
+            JobQueueService.JobName.SYNC_ANNOTATION,
+            user.userid,
+            tag="reindex_user",
+            force=force,
         )
 
         assert pyramid_request.session.peek_flash("success") == [
@@ -67,7 +72,10 @@ class TestSearchAdminViews:
 
         group_service.fetch_by_pubid.assert_called_with(group.pubid)
         tasks.job_queue.add_annotations_from_group.delay.assert_called_once_with(
-            group.pubid, tag="reindex_group", force=force
+            JobQueueService.JobName.SYNC_ANNOTATION,
+            group.pubid,
+            tag="reindex_group",
+            force=force,
         )
 
         assert pyramid_request.session.peek_flash("success") == [

--- a/tests/unit/h/views/admin/search_test.py
+++ b/tests/unit/h/views/admin/search_test.py
@@ -16,6 +16,7 @@ class TestSearchAdminViews:
         pyramid_request.params = {
             "start": "2020-09-09",
             "end": "2020-09-11",
+            "name": "sync_annotation",
         }
 
         views.reindex_date()
@@ -35,7 +36,10 @@ class TestSearchAdminViews:
         self, views, pyramid_request, tasks, factories, force
     ):
         user = factories.User(username="johnsmith")
-        pyramid_request.params = {"username": "johnsmith"}
+        pyramid_request.params = {
+            "username": "johnsmith",
+            "name": "sync_annotation",
+        }
         if force:
             pyramid_request.params["reindex_user_force"] = "on"
 
@@ -53,7 +57,7 @@ class TestSearchAdminViews:
         ]
 
     def test_reindex_user_errors_if_user_not_found(self, views, pyramid_request):
-        pyramid_request.params = {"username": "johnsmith"}
+        pyramid_request.params = {"username": "johnsmith", "name": "sync_annotation"}
 
         with pytest.raises(NotFoundError, match="User johnsmith not found"):
             views.reindex_user()
@@ -63,7 +67,7 @@ class TestSearchAdminViews:
         self, views, pyramid_request, tasks, factories, group_service, force
     ):
         group = factories.Group(pubid="abc123")
-        pyramid_request.params = {"groupid": "abc123"}
+        pyramid_request.params = {"groupid": "abc123", "name": "sync_annotation"}
         if force:
             pyramid_request.params["reindex_group_force"] = "on"
         group_service.fetch_by_pubid.return_value = group
@@ -85,7 +89,7 @@ class TestSearchAdminViews:
     def test_reindex_group_errors_if_group_not_found(
         self, views, pyramid_request, group_service
     ):
-        pyramid_request.params = {"groupid": "def456"}
+        pyramid_request.params = {"groupid": "def456", "name": "sync_annotation"}
         group_service.fetch_by_pubid.return_value = None
 
         with pytest.raises(NotFoundError, match="Group def456 not found"):


### PR DESCRIPTION
There's not an immediate need to fill the slim table but this is useful to

- Having it for all past rows will be handy "at some point". The sooner we do it the better.

- This is a good test for being able to reprocess past annotations for whatever purpose. We've done some refactoring around this to make it more obvious.


This PR does:

- Add a new `name` explicitly parameter to pick the right job to add/take from the queue
- Process a new type of job to fill up the sync annotation.


It doesn't however:

- Deal with the `force` parameter that's not used in the new task. There was a suggesting about introducing something like job_kwargs which I reckon makes sense but I leaved out of this PR.
- Rename everything in the admin pages about "search" / "index" / "reindex" to talk about annotations and queues. That should be easy enough once we pick the right language.




### Testing

- Make one annotation, for example in https://hypothesis.instructure.com/courses/125/assignments/1833

- Remove existing slim rows ```docker compose exec postgres psql -U postgres -c "truncate annotation_slim cascade"```


- In http://localhost:5000/admin/search

Use for example the date option, pick "Annotation slim" in job type 

- Query for the jobs created in the DB `docker compose exec postgres psql -U postgres -c "select kwargs, name from job"`


- Process the jobs, in `make shell`

```
from h.tasks.annotations import sync_annotation_slim
sync_annotation_slim.delay(100)
```


- THe slim rows should be there now:

```docker compose exec postgres psql -U postgres -c "select pubid from annotation_slim"```