### PR TITLE
Add indices to group and user FK in annotation_slim and user_group

### DIFF
--- a/h/migrations/versions/7bcd729defec_fk_indexes.py
+++ b/h/migrations/versions/7bcd729defec_fk_indexes.py
@@ -1,0 +1,37 @@
+"""Create FK indexes for user and groups."""
+from alembic import op
+
+revision = "7bcd729defec"
+down_revision = "8b4b4fdef955"
+
+
+def upgrade():
+    # Creating a concurrent index does not work inside a transaction
+    op.execute("COMMIT")
+    op.create_index(
+        op.f("ix__annotation_slim_group_id"),
+        "annotation_slim",
+        ["group_id"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+    op.create_index(
+        op.f("ix__annotation_slim_user_id"),
+        "annotation_slim",
+        ["user_id"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+    op.create_index(
+        op.f("ix__user_group_group_id"),
+        "user_group",
+        ["group_id"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix__user_group_group_id"), table_name="user_group")
+    op.drop_index(op.f("ix__annotation_slim_user_id"), table_name="annotation_slim")
+    op.drop_index(op.f("ix__annotation_slim_group_id"), table_name="annotation_slim")

--- a/h/models/annotation_slim.py
+++ b/h/models/annotation_slim.py
@@ -77,11 +77,17 @@ class AnnotationSlim(Base):
     document = sa.orm.relationship("Document")
 
     user_id = sa.Column(
-        sa.Integer, sa.ForeignKey("user.id", ondelete="CASCADE"), nullable=False
+        sa.Integer,
+        sa.ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     user = sa.orm.relationship("User")
 
     group_id = sa.Column(
-        sa.Integer, sa.ForeignKey("group.id", ondelete="CASCADE"), nullable=False
+        sa.Integer,
+        sa.ForeignKey("group.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     group = sa.orm.relationship("Group")

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -41,7 +41,7 @@ class GroupMembership(Base):
     id = sa.Column("id", sa.Integer, autoincrement=True, primary_key=True)
     user_id = sa.Column("user_id", sa.Integer, sa.ForeignKey("user.id"), nullable=False)
     group_id = sa.Column(
-        "group_id", sa.Integer, sa.ForeignKey("group.id"), nullable=False
+        "group_id", sa.Integer, sa.ForeignKey("group.id"), nullable=False, index=True
     )
 
 


### PR DESCRIPTION
While this columns do have FK constrains the don't have indices making the cascades deletions for for example groups very slow.


---

Current stats from a group deletion:


```
explain analyze delete from "group" where id = 13747334;
                                                       QUERY PLAN                                                        
-------------------------------------------------------------------------------------------------------------------------
 Delete on "group"  (cost=0.42..8.44 rows=1 width=6) (actual time=0.035..0.038 rows=0 loops=1)
   ->  Index Scan using pk__group on "group"  (cost=0.42..8.44 rows=1 width=6) (actual time=0.024..0.026 rows=1 loops=1)
         Index Cond: (id = 13747334)
 Planning Time: 0.082 ms
 Trigger for constraint fk__annotation_slim__group_id__group: time=3025.936 calls=1
 Trigger for constraint fk__groupscope__group_id__group: time=0.206 calls=1
 Trigger for constraint fk__user_group__group_id__group: time=232.864 calls=1
 Execution Time: 3259.073 ms
(8 rows)
```

check the time for the constraint on fk__annotation_slim__group_id__group  and fk__user_group__group_id__group


---

Testing

`tox -e dev --run-command 'alembic upgrade head'`

```
2024-01-22 16:31:41 3057442 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2024-01-22 16:31:41 3057442 alembic.runtime.migration [INFO] Will assume transactional DDL.2024-01-22 16:31:41 3057442 alembic.runtime.migration [INFO] Running upgrade 8b4b4fdef955 -> 7bcd729defec, Create FK indexes for user and groups.
```


