### PR TITLE
Use h-testkit

### DIFF
--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -4,4 +4,5 @@ pytest
 factory-boy
 webtest
 pytest-reverse
+h-testkit
 -r prod.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -104,6 +104,8 @@ h-matchers==1.2.15
     # via -r requirements/prod.txt
 h-pyramid-sentry==1.2.4
     # via -r requirements/prod.txt
+h-testkit==1.0.0
+    # via -r requirements/functests.in
 hupper==1.12
     # via
     #   -r requirements/prod.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -171,6 +171,10 @@ h-pyramid-sentry==1.2.4
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+h-testkit==1.0.0
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 hupper==1.12
     # via
     #   -r requirements/functests.txt

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -7,4 +7,5 @@ pytest-xdist[psutil]
 freezegun
 factory-boy
 hypothesis
+h-testkit
 -r prod.txt

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -111,6 +111,8 @@ h-matchers==1.2.15
     # via -r requirements/prod.txt
 h-pyramid-sentry==1.2.4
     # via -r requirements/prod.txt
+h-testkit==1.0.0
+    # via -r requirements/tests.in
 hupper==1.12
     # via
     #   -r requirements/prod.txt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,5 @@
-from os import environ
-
 import pytest
-from sqlalchemy import create_engine, event
-from sqlalchemy.orm import sessionmaker
-
-
-@pytest.fixture(scope="session")
-def db_engine():
-    return create_engine(environ["DATABASE_URL"])
-
-
-@pytest.fixture(scope="session")
-def db_sessionfactory():
-    return sessionmaker()
+from sqlalchemy import event
 
 
 @pytest.fixture
@@ -20,20 +7,14 @@ def db_session(db_engine, db_sessionfactory):
     """
     Return the SQLAlchemy database session.
 
-    This returns a session that is wrapped in an external transaction that is
-    rolled back after each test, so tests can't make database changes that
-    affect later tests.  Even if the test (or the code under test) calls
-    session.commit() this won't touch the external transaction.
-
-    This is the same technique as used in SQLAlchemy's own CI.
-    Since h still uses SQLAlchemy 1.4 it uses the older, 1.4 version of the
-    technique:
+    h overrides the db_session fixture from h-testkit because h still uses
+    SQLAlchemy 1.4 so it has to use the older, 1.4 version of the SQLAlchemy
+    test suite technique:
 
     https://docs.sqlalchemy.org/en/14/orm/session_transaction.html#joining-a-session-into-an-external-transaction-such-as-for-test-suites
 
-    When h is upgraded to SQLAlchemy 2 we can upgrade this fixture to use the
-    newer, SQLAlchemy 2 version of the technique:
-    https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#joining-a-session-into-an-external-transaction-such-as-for-test-suites
+    When h is upgraded to SQLAlchemy 2 this fixture can be removed and it can
+    just use the one from h-testkit.
     """
     connection = db_engine.connect()
     transaction = connection.begin()

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -67,9 +67,9 @@ def with_clean_db(db_engine):
 
 
 @pytest.fixture
-def db_session(db_engine):
+def db_session(db_engine, db_sessionfactory):
     """Get a standalone database session for preparing database state."""
-    session = db.Session(bind=db_engine)
+    session = db_sessionfactory(bind=db_engine)
     yield session
     session.close()
 

--- a/tox.ini
+++ b/tox.ini
@@ -126,7 +126,7 @@ commands =
     functests: sh bin/create-testdb h_functests
     {tests,functests}: python3 -m h.scripts.init_db --delete --create
     tests: python -m pytest --cov --cov-report= --cov-fail-under=0 --numprocesses logical --dist loadgroup {posargs:tests/unit/}
-    functests: pytest {posargs:tests/functional/}
+    functests: python -m pytest {posargs:tests/functional/}
     docs: sphinx-autobuild -qT --open-browser -b dirhtml -d {envdir}/doctrees docs {envdir}/html
     checkdocs: sphinx-build -qTWn -b dirhtml -d {envdir}/doctrees docs {envdir}/html
     coverage: coverage combine


### PR DESCRIPTION
Instead of duplicating test fixtures.

Depends on https://github.com/hypothesis/cookiecutters/pull/165.

I might want to take a closer look at this one because h contains its own code for integrating factoryboy and sqlalchemy in a different way and it should be letting h-testkit do that now. Might want to straighten that out.