### PR TITLE
Create index on job

### DIFF
--- a/h/migrations/versions/aeda42d241b3_job_table_index.py
+++ b/h/migrations/versions/aeda42d241b3_job_table_index.py
@@ -1,0 +1,22 @@
+"""Add index to the job table."""
+
+from alembic import op
+
+revision = "aeda42d241b3"
+down_revision = "7bcd729defec"
+
+
+def upgrade():
+    # CONCURRENTLY can't be used inside a transaction. Finish the current one.
+    op.execute("COMMIT")
+    op.create_index(
+        "ix__job_priority_enqueued_at",
+        "job",
+        ["priority", "enqueued_at"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade():
+    op.drop_index("ix__job_priority_enqueued_at", table_name="job")

--- a/h/models/job.py
+++ b/h/models/job.py
@@ -28,7 +28,16 @@ This home-grown job queue differs from our Celery task queue in a few ways:
    that really need Postgres transactionality should use this custom job queue.
 """
 
-from sqlalchemy import Column, DateTime, Integer, Sequence, UnicodeText, func, text
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Index,
+    Integer,
+    Sequence,
+    UnicodeText,
+    func,
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 
 from h.db import Base
@@ -38,6 +47,8 @@ class Job(Base):
     """A job in the job queue."""
 
     __tablename__ = "job"
+
+    __table_args__ = (Index("ix__job_priority_enqueued_at", "priority", "enqueued_at"),)
 
     id = Column(Integer, Sequence("job_id_seq", cycle=True), primary_key=True)
     name = Column(UnicodeText, nullable=False)


### PR DESCRIPTION
Index priority and enqueued_at, these are the columns we use to sort by all queries to this table.


All queries sorted by that here: https://github.com/hypothesis/h/blob/job-index/h/services/job_queue.py#L33


We might need more indices but no need to add them all in one PR/migration. We can see the effect after deploying each of them this way too.

