### PR TITLE
Configure gunicorn's max_request and and max_request_jitter

### DIFF
--- a/conf/gunicorn-dev.conf.py
+++ b/conf/gunicorn-dev.conf.py
@@ -7,8 +7,12 @@ reload_extra_files = "h/templates"
 timeout = 0
 
 
-if 'H_GUNICORN_CERTFILE' in environ:
-    certfile = environ['H_GUNICORN_CERTFILE']
+max_requests = 100
+max_requests_jitter = 10
 
-if 'H_GUNICORN_KEYFILE' in environ:
-    keyfile = environ['H_GUNICORN_KEYFILE']
+
+if "H_GUNICORN_CERTFILE" in environ:
+    certfile = environ["H_GUNICORN_CERTFILE"]
+
+if "H_GUNICORN_KEYFILE" in environ:
+    keyfile = environ["H_GUNICORN_KEYFILE"]

--- a/conf/gunicorn.conf.py
+++ b/conf/gunicorn.conf.py
@@ -4,3 +4,6 @@ from os import environ
 bind = "unix:/tmp/gunicorn-web.sock"
 worker_tmp_dir = "/dev/shm"
 workers = environ["WEB_NUM_WORKERS"]
+
+max_requests = 1_000_000
+max_requests_jitter = 250_000


### PR DESCRIPTION
Automatically restarting workers should alleviate any issues from memory leaks.

Setting the values also on the local config so we see them happening locally to.



Restarting looks like:

```
2024-02-07 11:26:59,659 [2621756] [gunicorn.error:INFO] Autorestarting worker after current request.
2024-02-07 11:26:59,702 [2621756] [gunicorn.error:INFO] Worker exiting (pid: 2621756)
2024-02-07 11:27:00,195 [2623354] [gunicorn.error:INFO] Booting worker with pid: 2623354
````
