### PR TITLE
Validate selector suffix/prefix is valid unicode

### DIFF
--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -305,10 +305,19 @@ def _target_selectors(targets):
     """
     # Any targets other than the first in the list are discarded.
     # Any fields of the target other than 'selector' are discarded.
+    selectors = []
     if targets and "selector" in targets[0]:
-        return targets[0]["selector"]
+        selectors = targets[0]["selector"]
 
-    return []
+    for target_selector in selectors:
+        for field in ["suffix", "prefix"]:
+            if value := target_selector.get(field):
+                if not is_valid_unicode(value):
+                    raise ValidationError(
+                        f"{field}: " + _(f"'{field}' must be valid unicode")
+                    )
+
+    return selectors
 
 
 class SearchParamsSchema(colander.Schema):
@@ -480,3 +489,12 @@ class SearchParamsSchema(colander.Schema):
             except ValueError:
                 return False
         return True
+
+
+def is_valid_unicode(value: str):
+    try:
+        value.encode()
+    except UnicodeEncodeError:
+        return False
+
+    return True

--- a/tests/unit/h/schemas/annotation_test.py
+++ b/tests/unit/h/schemas/annotation_test.py
@@ -65,7 +65,7 @@ class TestCreateUpdateAnnotationSchema:
                 "references": ["foo", "bar"],
                 "tags": ["foo", "bar"],
                 "target": [
-                    {"selector": [{"type": "foo"}]},
+                    {"selector": [{"type": "foo", "suffix": "selector suffix"}]},
                     {"selector": [{"type": "bar"}]},
                 ],
                 "text": "foo",
@@ -248,6 +248,43 @@ class TestCreateUpdateAnnotationSchema:
             {"type": "FooSelector"},
             {"type": "BarSelector"},
         ]
+
+    @pytest.mark.parametrize(
+        "payload,expected",
+        [
+            (
+                {
+                    "target": [
+                        {
+                            "selector": [
+                                {"type": "FooSelector", "suffix": "Invalid \ud835"}
+                            ],
+                        }
+                    ]
+                },
+                "suffix: 'suffix' must be valid unicode",
+            ),
+            (
+                {
+                    "target": [
+                        {
+                            "selector": [
+                                {"type": "FooSelector", "prefix": "Invalid \ud835"}
+                            ],
+                        }
+                    ]
+                },
+                "prefix: 'prefix' must be valid unicode",
+            ),
+        ],
+    )
+    def test_it_validates_invalid_unicode(
+        self, pyramid_request, validate, payload, expected
+    ):
+        with pytest.raises(ValidationError) as exc:
+            validate(pyramid_request, payload)
+
+        assert str(exc.value) == expected
 
     def test_it_extracts_document_uris_from_the_document(
         self, pyramid_request, document_claims, validate


### PR DESCRIPTION
While we'd want all fields in the request to be valid unicode we've found that in practice `suffix` often enough isn't.


Fixes: https://hypothesis.sentry.io/issues/4510606178/?project=37293&query=&referrer=issue-stream&statsPeriod=7d&stream_index=1


For the actual invalid payloads sent by the client: https://github.com/hypothesis/client/issues/5028