### PR TITLE
Create new unique index in document_uri

### DIFF
--- a/h/migrations/versions/8e04a443893d_document_uri_constraint.py
+++ b/h/migrations/versions/8e04a443893d_document_uri_constraint.py
@@ -1,0 +1,19 @@
+"""Unique document uri index with hash function."""
+
+from alembic import op
+
+revision = "8e04a443893d"
+down_revision = "8f5b6f8bbba8"
+
+
+def upgrade():
+    # CONCURRENTLY can't be used inside a transaction. Finish the current one.
+    op.execute("COMMIT")
+    # Create index for the constraint first, concurrently
+    op.execute(
+        """CREATE UNIQUE INDEX CONCURRENTLY ix__document_uri_unique ON document_uri (md5(claimant_normalized), md5(uri_normalized), type, content_type);"""
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX ix__document_uri_unique")

--- a/h/models/document/_uri.py
+++ b/h/models/document/_uri.py
@@ -12,13 +12,6 @@ log = logging.getLogger(__name__)
 
 class DocumentURI(Base, mixins.Timestamps):
     __tablename__ = "document_uri"
-    __table_args__ = (
-        sa.UniqueConstraint(
-            "claimant_normalized", "uri_normalized", "type", "content_type"
-        ),
-        sa.Index("ix__document_uri_document_id", "document_id"),
-        sa.Index("ix__document_uri_updated", "updated"),
-    )
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
 
@@ -38,6 +31,22 @@ class DocumentURI(Base, mixins.Timestamps):
     )
 
     document_id = sa.Column(sa.Integer, sa.ForeignKey("document.id"), nullable=False)
+
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "claimant_normalized", "uri_normalized", "type", "content_type"
+        ),
+        sa.Index(
+            "ix__document_uri_unique",
+            sa.func.md5(_claimant_normalized),
+            sa.func.md5(_uri_normalized),
+            "type",
+            "content_type",
+            unique=True,
+        ),
+        sa.Index("ix__document_uri_document_id", "document_id"),
+        sa.Index("ix__document_uri_updated", "updated"),
+    )
 
     @hybrid_property
     def claimant(self):

--- a/tests/unit/h/models/document/_uri_test.py
+++ b/tests/unit/h/models/document/_uri_test.py
@@ -43,6 +43,16 @@ class TestDocumentURI:
         with pytest.raises(sa.exc.IntegrityError):
             db_session.flush()
 
+    @pytest.mark.xfail(strict=True)
+    def test_unique_constraint_can_take_long_values(self, db_session):
+        document_uri = DocumentURI(
+            uri="http://example.com/" * 100000,
+            claimant="https://example.com" * 10000,
+            document=Document(),
+        )
+        db_session.add(document_uri)
+        db_session.commit()
+
     def test_you_cannot_add_duplicate_document_uris(self, db_session):
         # You can't add DocumentURI's with the same claimant, uri, type and
         # content_type, even if they have different documents.


### PR DESCRIPTION
Fixes: https://hypothesis.sentry.io/issues/4156465761/?project=37293&query=&referrer=issue-stream&statsPeriod=7d&stream_index=12

Helps with: https://github.com/hypothesis/h/issues/8498


The existing unique constraint fails with long URLs. The constraint also fails to be created on postgres dump/restores.

This commit doesn't remove the existing constraint yet but it adds a failing test about the size limitation on the constraint.


Next steps:

- Remove existing constraint
- Validate url length, there must be a limit for indexed columns. Not for the one created in this PR (which uses the md5 of the URLs) but for the indices used to query the table. We could pick a value around the longest URLs currently in the DB.