### PR TITLE
Don't sync deleted annotations

### DIFF
--- a/h/tasks/annotations.py
+++ b/h/tasks/annotations.py
@@ -34,8 +34,8 @@ def sync_annotation_slim(limit):
     for job in jobs:
         # For each job, insert the row in annotation slim
         annotation_id = URLSafeUUID.hex_to_url_safe(job.kwargs["annotation_id"])
-        annotation = annotations_from_db.get(annotation_id)
-        anno_write_svc.upsert_annotation_slim(annotation)
+        if annotation := annotations_from_db.get(annotation_id):
+            anno_write_svc.upsert_annotation_slim(annotation)
 
     # Remove all jobs we've processed
     queue_svc.delete(jobs)


### PR DESCRIPTION
Don't try to sync annotations that are no longer in the DB. This situation can happen if between adding the job to sync an annotations and processing it the annotation itself is deleted.