### PR TITLE
Add DB migration to delete orphaned tokens

### DIFF
--- a/h/migrations/versions/8fcdcefd8c6f_delete_orphaned_api_tokens.py
+++ b/h/migrations/versions/8fcdcefd8c6f_delete_orphaned_api_tokens.py
@@ -1,0 +1,56 @@
+"""Delete orphaned API tokens."""
+
+import logging
+
+from alembic import op
+from sqlalchemy import Column, Integer, UnicodeText, and_, delete, func, select
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+revision = "8fcdcefd8c6f"
+down_revision = "8e04a443893d"
+
+
+log = logging.getLogger(__name__)
+
+
+Base = declarative_base()
+Session = sessionmaker()
+
+
+class User(Base):
+    __tablename__ = "user"
+    id = Column(Integer, primary_key=True)
+    username = Column(UnicodeText)
+    authority = Column(UnicodeText)
+
+
+class Token(Base):
+    __tablename__ = "token"
+    id = Column(Integer, primary_key=True)
+    userid = Column(UnicodeText())
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+
+    userids = session.scalars(
+        select(Token.userid)
+        .outerjoin(
+            User,
+            and_(
+                User.username
+                == func.substring(func.split_part(Token.userid, "@", 1), 6),
+                User.authority == func.split_part(Token.userid, "@", 2),
+            ),
+        )
+        .where(User.id.is_(None))
+        .distinct()
+    ).all()
+
+    op.execute(delete(Token).where(Token.userid.in_(userids)))
+    log.info(f"Deleted %d orphaned tokens", len(userids))
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
This should be merged after https://github.com/hypothesis/h/pull/8510 (which will make sure that we don't orphan any more tokens).

Checking what the SQLAlchemy query evaluates to:

```python
$ make shell
>>> from sqlalchemy import select, and_, func
>>> str(
...     select(m.Token.userid)
...     .outerjoin(
...         m.User,
...         and_(
...             m.User._username
...             == func.substring(func.split_part(m.Token.userid, "@", 1), 6),
...             m.User.authority == func.split_part(m.Token.userid, "@", 2),
...         )
...     )
...     .where(m.User.id.is_(None))
...     .distinct()
... )
'SELECT DISTINCT token.userid \nFROM token LEFT OUTER JOIN "user" ON "user".username = substring(split_part(token.userid, :split_part_1, :split_part_2), :substring_1) AND "user".authority = split_part(token.userid, :split_part_3, :split_part_4) \nWHERE "user".id IS NULL'
```

### Testing

1. Log in as `devdata_user`, go to <http://localhost:5000/account/developer>, and generate a token
2. Log out, log back in as `devdata_admin`, go to <http://localhost:5000/account/developer>, and generate a token, then go to <http://localhost:5000/admin/users> and delete `devdata_user`

At this point you should have two rows in the `token` table in your DB: one belonging to `devdata_admin` and one orphaned row belonging to `devdata_user`.

If you now run:

```terminal
$ make db args='upgrade +1'
```

you should see `Deleted 1 orphaned tokens` and the `devdata_user` token should be deleted from your DB.