### PR TITLE
Add a DB migration to make `Token.user_id` not nullable

### DIFF
--- a/h/migrations/versions/dad491955830_make_token_user_id_not_nullable.py
+++ b/h/migrations/versions/dad491955830_make_token_user_id_not_nullable.py
@@ -1,0 +1,14 @@
+"""Make token.user_id not nullable."""
+
+from alembic import op
+
+revision = "dad491955830"
+down_revision = "8e3417e3713b"
+
+
+def upgrade():
+    op.alter_column("token", "user_id", nullable=False)
+
+
+def downgrade():
+    op.alter_column("token", "user_id", nullable=True)


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h/pull/8516