### PR TITLE
Remove old unique constraint on document_uri

### DIFF
--- a/h/migrations/versions/63e2559e0339_remove_duplicate_constraint.py
+++ b/h/migrations/versions/63e2559e0339_remove_duplicate_constraint.py
@@ -1,0 +1,20 @@
+"""Remove duplicate constraint on document_uri."""
+
+from alembic import op
+
+revision = "63e2559e0339"
+down_revision = "9e47da806421"
+
+
+def upgrade():
+    op.drop_constraint(
+        "uq__document_uri__claimant_normalized", "document_uri", type_="unique"
+    )
+
+
+def downgrade():
+    op.create_unique_constraint(
+        "uq__document_uri__claimant_normalized",
+        "document_uri",
+        ["claimant_normalized", "uri_normalized", "type", "content_type"],
+    )

--- a/h/models/document/_uri.py
+++ b/h/models/document/_uri.py
@@ -33,9 +33,6 @@ class DocumentURI(Base, mixins.Timestamps):
     document_id = sa.Column(sa.Integer, sa.ForeignKey("document.id"), nullable=False)
 
     __table_args__ = (
-        sa.UniqueConstraint(
-            "claimant_normalized", "uri_normalized", "type", "content_type"
-        ),
         sa.Index(
             "ix__document_uri_unique",
             sa.func.md5(_claimant_normalized),

--- a/tests/unit/h/models/document/_uri_test.py
+++ b/tests/unit/h/models/document/_uri_test.py
@@ -43,10 +43,9 @@ class TestDocumentURI:
         with pytest.raises(sa.exc.IntegrityError):
             db_session.flush()
 
-    @pytest.mark.xfail(strict=True)
     def test_unique_constraint_can_take_long_values(self, db_session):
         document_uri = DocumentURI(
-            uri="http://example.com/" * 100000,
+            uri="http://example.com/" * 10000,
             claimant="https://example.com" * 10000,
             document=Document(),
         )


### PR DESCRIPTION
After adding another constraint based on the md5 hash of the uris remove
the original constraint based on the raw values.