### PR TITLE
Read `Token.user_id` instead of `Token.userid`

### DIFF
--- a/h/models/token.py
+++ b/h/models/token.py
@@ -2,6 +2,7 @@ import datetime
 
 import sqlalchemy
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Mapped
 
 from h.db import Base, mixins
 
@@ -55,6 +56,7 @@ class Token(Base, mixins.Timestamps):
         index=True,
         nullable=True,
     )
+    user: Mapped["User"] = sqlalchemy.orm.relationship(back_populates="tokens")
 
     #: The authclient which created the token.
     #: A NULL value means it is a developer token.

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -280,6 +280,8 @@ class User(Base):
     #: upgrading their passwords and setting this column to None.
     salt = sa.Column(sa.UnicodeText(), nullable=True)
 
+    tokens = sa.orm.relationship("Token", back_populates="user")
+
     @sa.orm.validates("email")
     def validate_email(self, _key, email):
         if email is None:

--- a/h/services/auth_token.py
+++ b/h/services/auth_token.py
@@ -17,7 +17,7 @@ class LongLivedToken:
 
     def __init__(self, token):
         self.expires = token.expires
-        self.userid = token.userid
+        self.userid = token.user.userid
 
         # Associates the userid with a given transaction/web request.
         newrelic.agent.add_custom_attribute("userid", self.userid)

--- a/h/services/developer_token.py
+++ b/h/services/developer_token.py
@@ -42,7 +42,7 @@ class DeveloperTokenService:
         """
         user = self.user_svc.fetch(userid)
         token = models.Token(
-            userid=user.userid, user_id=user.id, value=self._generate_token()
+            user=user, userid=user.userid, value=self._generate_token()
         )
         self.session.add(token)
         return token
@@ -68,9 +68,11 @@ class DeveloperTokenService:
         if userid is None:
             return None
 
+        user = self.user_svc.fetch(userid)
+
         return (
             self.session.query(models.Token)
-            .filter_by(userid=userid, authclient=None)
+            .filter_by(user=user, authclient=None)
             .order_by(models.Token.created.desc())
             .one_or_none()
         )

--- a/h/services/oauth/_validator.py
+++ b/h/services/oauth/_validator.py
@@ -30,9 +30,8 @@ class OAuthValidator(  # pylint: disable=too-many-public-methods, abstract-metho
     This implements the ``oauthlib.oauth2.RequestValidator`` interface.
     """
 
-    def __init__(self, session, user_svc):
+    def __init__(self, session):
         self.session = session
-        self.user_svc = user_svc
 
         self._cached_find_authz_code = lru_cache_in_transaction(self.session)(
             self._find_authz_code
@@ -223,8 +222,8 @@ class OAuthValidator(  # pylint: disable=too-many-public-methods, abstract-metho
         ]  # We don't want to render this in the response.
 
         oauth_token = models.Token(
+            user=request.user,
             userid=request.user.userid,
-            user_id=request.user.id,
             value=token["access_token"],
             refresh_token=token["refresh_token"],
             expires=expires,
@@ -321,7 +320,7 @@ class OAuthValidator(  # pylint: disable=too-many-public-methods, abstract-metho
         ):
             return False
 
-        request.user = self.user_svc.fetch(token.userid)
+        request.user = token.user
         return True
 
     def validate_response_type(

--- a/h/services/oauth/service.py
+++ b/h/services/oauth/service.py
@@ -143,7 +143,7 @@ def factory(_context, request):
     user_svc = request.find_service(name="user")
 
     return OAuthProviderService(
-        oauth_validator=OAuthValidator(session=request.db, user_svc=user_svc),
+        oauth_validator=OAuthValidator(session=request.db),
         user_svc=user_svc,
         domain=request.domain,
     )

--- a/h/services/user_delete.py
+++ b/h/services/user_delete.py
@@ -21,7 +21,7 @@ class UserDeleteService:
         in the group that have been made by other users, the user is unassigned
         as creator but the group persists.
         """
-        self._db.execute(sa.delete(Token).where(Token.userid == user.userid))
+        self._db.execute(sa.delete(Token).where(Token.user == user))
 
         # Delete all annotations
         self._annotation_delete_service.delete_annotations(

--- a/h/views/api/auth.py
+++ b/h/views/api/auth.py
@@ -270,7 +270,7 @@ def api_token_error(context, request):
 
 def _present_debug_token(token):
     data = {
-        "userid": token.userid,
+        "userid": token.user.userid,
         "expires_at": utc_iso8601(token.expires),
         "issued_at": utc_iso8601(token.created),
         "expired": token.expired,

--- a/tests/common/factories/token.py
+++ b/tests/common/factories/token.py
@@ -7,7 +7,8 @@ from h.services.developer_token import PREFIX as DEVELOPER_TOKEN_PREFIX
 from h.services.oauth import ACCESS_TOKEN_PREFIX, REFRESH_TOKEN_PREFIX
 
 from .auth_client import AuthClient
-from .base import FAKER, ModelFactory
+from .base import ModelFactory
+from .user import User
 
 
 class DeveloperToken(ModelFactory):
@@ -15,11 +16,8 @@ class DeveloperToken(ModelFactory):
         model = models.Token
         sqlalchemy_session_persistence = "flush"
 
-    userid = factory.LazyAttribute(
-        lambda _: (
-            "acct:" + FAKER.user_name() + "@example.com"  # pylint:disable=no-member
-        )
-    )
+    user = factory.SubFactory(User)
+    userid = factory.LazyAttribute(lambda developer_token: developer_token.user.userid)
     value = factory.LazyAttribute(
         lambda _: (DEVELOPER_TOKEN_PREFIX + security.token_urlsafe())
     )
@@ -30,11 +28,8 @@ class OAuth2Token(ModelFactory):
         model = models.Token
         sqlalchemy_session_persistence = "flush"
 
-    userid = factory.LazyAttribute(
-        lambda _: (
-            "acct:" + FAKER.user_name() + "@example.com"  # pylint:disable=no-member
-        )
-    )
+    user = factory.SubFactory(User)
+    userid = factory.LazyAttribute(lambda developer_token: developer_token.user.userid)
     value = factory.LazyAttribute(
         lambda _: (ACCESS_TOKEN_PREFIX + security.token_urlsafe())
     )

--- a/tests/functional/api/annotations_test.py
+++ b/tests/functional/api/annotations_test.py
@@ -272,7 +272,7 @@ def user_annotation(db_session, user, factories):
 
 @pytest.fixture
 def user_with_token(user, db_session, factories):
-    token = factories.DeveloperToken(userid=user.userid)
+    token = factories.DeveloperToken(user=user)
     db_session.add(token)
     db_session.commit()
     return (user, token)

--- a/tests/functional/api/conftest.py
+++ b/tests/functional/api/conftest.py
@@ -37,7 +37,7 @@ def auth_header_for_authority(db_session, factories):
 
 @pytest.fixture
 def token_auth_header(db_session, factories, user):
-    token = factories.DeveloperToken(userid=user.userid)
+    token = factories.DeveloperToken(user=user)
     db_session.add(token)
     db_session.commit()
 

--- a/tests/functional/api/errors_test.py
+++ b/tests/functional/api/errors_test.py
@@ -152,7 +152,7 @@ def append_auth_client(auth_client):
 @pytest.fixture
 def user_with_token(db_session, factories):
     user = factories.User()
-    token = factories.DeveloperToken(userid=user.userid)
+    token = factories.DeveloperToken(user=user)
     db_session.commit()
     return (user, token)
 

--- a/tests/functional/api/flags_test.py
+++ b/tests/functional/api/flags_test.py
@@ -78,7 +78,7 @@ def user(db_session, factories):
 
 @pytest.fixture
 def user_with_token(user, db_session, factories):
-    token = factories.DeveloperToken(userid=user.userid)
+    token = factories.DeveloperToken(user=user)
     db_session.add(token)
     db_session.commit()
     return (user, token)

--- a/tests/functional/api/groups/create_test.py
+++ b/tests/functional/api/groups/create_test.py
@@ -152,7 +152,7 @@ def auth_client_header(auth_client):
 @pytest.fixture
 def user_with_token(db_session, factories):
     user = factories.User()
-    token = factories.DeveloperToken(userid=user.userid)
+    token = factories.DeveloperToken(user=user)
     db_session.add(token)
     db_session.commit()
     return (user, token)

--- a/tests/functional/api/groups/members_test.py
+++ b/tests/functional/api/groups/members_test.py
@@ -258,7 +258,7 @@ def group_member(group, db_session, factories):
 
 @pytest.fixture
 def group_member_with_token(group_member, db_session, factories):
-    token = factories.DeveloperToken(userid=group_member.userid)
+    token = factories.DeveloperToken(user=group_member)
     db_session.add(token)
     db_session.commit()
     return (group_member, token)
@@ -267,7 +267,7 @@ def group_member_with_token(group_member, db_session, factories):
 @pytest.fixture
 def user_with_token(db_session, factories):
     user = factories.User()
-    token = factories.DeveloperToken(userid=user.userid)
+    token = factories.DeveloperToken(user=user)
     db_session.add(token)
     db_session.commit()
     return (user, token)

--- a/tests/functional/api/groups/read_test.py
+++ b/tests/functional/api/groups/read_test.py
@@ -176,7 +176,7 @@ def auth_client_header(auth_client):
 @pytest.fixture
 def user_with_token(db_session, factories):
     user = factories.User()
-    token = factories.DeveloperToken(userid=user.userid)
+    token = factories.DeveloperToken(user=user)
     db_session.add(token)
     db_session.commit()
     return (user, token)

--- a/tests/functional/api/groups/update_test.py
+++ b/tests/functional/api/groups/update_test.py
@@ -229,7 +229,7 @@ def first_party_group(db_session, factories, first_party_user):
 
 @pytest.fixture
 def user_with_token(db_session, factories, first_party_user):
-    token = factories.DeveloperToken(userid=first_party_user.userid)
+    token = factories.DeveloperToken(user=first_party_user)
     db_session.add(token)
     db_session.commit()
     return (first_party_user, token)

--- a/tests/functional/api/groups/upsert_test.py
+++ b/tests/functional/api/groups/upsert_test.py
@@ -254,7 +254,7 @@ def first_party_group(db_session, factories, first_party_user):
 
 @pytest.fixture
 def user_with_token(db_session, factories, first_party_user):
-    token = factories.DeveloperToken(userid=first_party_user.userid)
+    token = factories.DeveloperToken(user=first_party_user)
     db_session.add(token)
     db_session.commit()
     return (first_party_user, token)

--- a/tests/functional/api/moderation_test.py
+++ b/tests/functional/api/moderation_test.py
@@ -149,7 +149,7 @@ def private_group_annotation(group, db_session, factories, other_user):
 
 @pytest.fixture
 def user_with_token(user, db_session, factories):
-    token = factories.DeveloperToken(userid=user.userid)
+    token = factories.DeveloperToken(user=user)
     db_session.add(token)
     db_session.commit()
     return (user, token)

--- a/tests/functional/api/profile_test.py
+++ b/tests/functional/api/profile_test.py
@@ -155,7 +155,7 @@ def user(groups, db_session, factories):
 
 @pytest.fixture
 def user_with_token(user, db_session, factories):
-    token = factories.DeveloperToken(userid=user.userid)
+    token = factories.DeveloperToken(user=user)
     db_session.add(token)
     db_session.commit()
     return (user, token)
@@ -184,6 +184,6 @@ def open_group(auth_client, db_session, factories):
 
 @pytest.fixture
 def third_party_user_with_token(third_party_user, db_session, factories):
-    token = factories.DeveloperToken(userid=third_party_user.userid)
+    token = factories.DeveloperToken(user=third_party_user)
     db_session.commit()
     return (third_party_user, token)

--- a/tests/functional/moderation_test.py
+++ b/tests/functional/moderation_test.py
@@ -39,6 +39,6 @@ def moderator(db_session, factories):
 
 @pytest.fixture
 def moderator_with_token(moderator, db_session, factories):
-    token = factories.DeveloperToken(userid=moderator.userid)
+    token = factories.DeveloperToken(user=moderator)
     db_session.commit()
     return (moderator, token)

--- a/tests/unit/h/services/auth_token_test.py
+++ b/tests/unit/h/services/auth_token_test.py
@@ -17,7 +17,7 @@ class TestAuthTokenService:
         result = svc.validate(token_model.value)
 
         assert result.expires == token_model.expires
-        assert result.userid == token_model.userid
+        assert result.userid == token_model.user.userid
 
     def test_validate_caches_database_token(self, svc, factories, db_session):
         token_model = factories.DeveloperToken(expires=self.time(1))
@@ -103,9 +103,7 @@ class TestLongLivedToken:
         ),
     )
     def test_it(self, expires, is_valid, factories):
-        token = LongLivedToken(
-            factories.OAuth2Token(userid="acct:foo@example.com", expires=expires)
-        )
+        token = LongLivedToken(factories.OAuth2Token(expires=expires))
 
         assert token.is_valid() == is_valid
 

--- a/tests/unit/h/services/oauth/_validator_test.py
+++ b/tests/unit/h/services/oauth/_validator_test.py
@@ -384,7 +384,7 @@ class TestSaveBearerToken:
 
     def test_it_sets_userid(self, svc, token_payload, oauth_request):
         token = svc.save_bearer_token(token_payload, oauth_request)
-        assert token.userid == oauth_request.user.userid
+        assert token.user == oauth_request.user
 
     def test_it_sets_value(self, svc, token_payload, oauth_request):
         token = svc.save_bearer_token(token_payload, oauth_request)
@@ -638,14 +638,12 @@ class TestValidateRefreshToken:
         result = svc.validate_refresh_token(token.refresh_token, client, oauth_request)
         assert result is True
 
-    def test_sets_user_when_token_valid(
-        self, svc, client, oauth_request, token, user_service
-    ):
-        user_service.fetch.return_value = mock.Mock()
-
+    def test_sets_user_when_token_valid(self, svc, client, oauth_request, token):
         assert oauth_request.user is None
+
         svc.validate_refresh_token(token.refresh_token, client, oauth_request)
-        assert oauth_request.user == user_service.fetch.return_value
+
+        assert oauth_request.user == token.user
 
     @pytest.fixture
     def token(self, factories, client):
@@ -699,8 +697,8 @@ class TestValidateScopes:
 
 
 @pytest.fixture
-def svc(db_session, user_service):
-    return OAuthValidator(db_session, user_service)
+def svc(db_session):
+    return OAuthValidator(db_session)
 
 
 @pytest.fixture

--- a/tests/unit/h/services/oauth/service_test.py
+++ b/tests/unit/h/services/oauth/service_test.py
@@ -114,9 +114,7 @@ class TestOAuthProviderServiceFactory:
     ):
         service = factory(None, pyramid_request)
 
-        OAuthValidator.assert_called_once_with(
-            session=pyramid_request.db, user_svc=user_service
-        )
+        OAuthValidator.assert_called_once_with(session=pyramid_request.db)
         OAuthProviderService.assert_called_once_with(
             oauth_validator=OAuthValidator.return_value,
             user_svc=user_service,

--- a/tests/unit/h/services/user_delete_test.py
+++ b/tests/unit/h/services/user_delete_test.py
@@ -90,11 +90,11 @@ class TestDeleteUserService:
 
     @pytest.fixture
     def user_developer_token(self, user, factories):
-        return factories.DeveloperToken(userid=user.userid)
+        return factories.DeveloperToken(user=user)
 
     @pytest.fixture
     def user_oauth2_token(self, user, factories):
-        return factories.OAuth2Token(userid=user.userid)
+        return factories.OAuth2Token(user=user)
 
     @pytest.fixture
     def other_developer_token(self, factories):

--- a/tests/unit/h/services/user_rename_test.py
+++ b/tests/unit/h/services/user_rename_test.py
@@ -66,8 +66,8 @@ class TestUserRenameService:
         )
         assert not count
 
-    def test_rename_updates_tokens(self, service, user, db_session):
-        token = models.Token(userid=user.userid, value="foo")
+    def test_rename_updates_tokens(self, service, user, db_session, factories):
+        token = factories.DeveloperToken(user=user)
         db_session.add(token)
 
         service.rename(user, "panda")
@@ -76,6 +76,7 @@ class TestUserRenameService:
             db_session.query(models.Token).filter(models.Token.id == token.id).one()
         )
         assert updated_token.userid == user.userid
+        assert updated_token.user == user
 
     @pytest.mark.usefixtures("annotations")
     def test_rename_changes_the_users_annotations_userid(

--- a/tests/unit/h/views/api/auth_test.py
+++ b/tests/unit/h/views/api/auth_test.py
@@ -386,7 +386,7 @@ class TestDebugToken:
             "expired": oauth_token.expired,
             "expires_at": "2001-11-30T17:45:50.000000+00:00",
             "issued_at": "2000-10-16T15:51:59.000000+00:00",
-            "userid": oauth_token.userid,
+            "userid": oauth_token.user.userid,
         }
 
     def test_it_without_auth_client(self, pyramid_request, oauth_token):


### PR DESCRIPTION
Remove all **reads** of the `Token.userid` column, replacing them with reads of the new `Token.user_id` column instead.

This prepares the way for actually removing the `Token.userid` column.

For now the code does still need to **write** `Token.userid` because it's not nullable.
