### PR TITLE
Remove `Token.userid` from the Python code

### DIFF
--- a/h/models/token.py
+++ b/h/models/token.py
@@ -23,8 +23,6 @@ class Token(Base, mixins.Timestamps):
 
     id = sqlalchemy.Column(sqlalchemy.Integer, autoincrement=True, primary_key=True)
 
-    userid = sqlalchemy.Column(sqlalchemy.UnicodeText(), nullable=True)
-
     value = sqlalchemy.Column(sqlalchemy.UnicodeText(), nullable=False, unique=True)
 
     #: A timestamp after which this token will no longer be considered valid.

--- a/h/services/developer_token.py
+++ b/h/services/developer_token.py
@@ -41,9 +41,7 @@ class DeveloperTokenService:
         :rtype: h.models.Token
         """
         user = self.user_svc.fetch(userid)
-        token = models.Token(
-            user=user, userid=user.userid, value=self._generate_token()
-        )
+        token = models.Token(user=user, value=self._generate_token())
         self.session.add(token)
         return token
 

--- a/h/services/oauth/_validator.py
+++ b/h/services/oauth/_validator.py
@@ -223,7 +223,6 @@ class OAuthValidator(  # pylint: disable=too-many-public-methods, abstract-metho
 
         oauth_token = models.Token(
             user=request.user,
-            userid=request.user.userid,
             value=token["access_token"],
             refresh_token=token["refresh_token"],
             expires=expires,

--- a/h/services/user_rename.py
+++ b/h/services/user_rename.py
@@ -51,10 +51,6 @@ class UserRenameService:
         # https://michael.merickel.org/projects/pyramid_auth_demo/auth_vs_auth.html
         self._purge_auth_tickets(user)
 
-        # For OAuth tokens, only the token's value is stored by clients, so we
-        # can just update the userid.
-        self._update_tokens(old_userid, new_userid)
-
         self._change_annotations(old_userid, new_userid)
         tasks.job_queue.add_annotations_from_user.delay(
             "sync_annotation",
@@ -67,11 +63,6 @@ class UserRenameService:
         self.session.query(models.AuthTicket).filter(
             models.AuthTicket.user_id == user.id
         ).delete()
-
-    def _update_tokens(self, old_userid, new_userid):
-        self.session.query(models.Token).filter(
-            models.Token.userid == old_userid
-        ).update({"userid": new_userid}, synchronize_session="fetch")
 
     def _change_annotations(self, old_userid, new_userid):
         annotations = self._fetch_annotations(old_userid)

--- a/tests/common/factories/token.py
+++ b/tests/common/factories/token.py
@@ -17,7 +17,6 @@ class DeveloperToken(ModelFactory):
         sqlalchemy_session_persistence = "flush"
 
     user = factory.SubFactory(User)
-    userid = factory.LazyAttribute(lambda developer_token: developer_token.user.userid)
     value = factory.LazyAttribute(
         lambda _: (DEVELOPER_TOKEN_PREFIX + security.token_urlsafe())
     )
@@ -29,7 +28,6 @@ class OAuth2Token(ModelFactory):
         sqlalchemy_session_persistence = "flush"
 
     user = factory.SubFactory(User)
-    userid = factory.LazyAttribute(lambda developer_token: developer_token.user.userid)
     value = factory.LazyAttribute(
         lambda _: (ACCESS_TOKEN_PREFIX + security.token_urlsafe())
     )

--- a/tests/unit/h/services/developer_token_test.py
+++ b/tests/unit/h/services/developer_token_test.py
@@ -40,9 +40,7 @@ class TestDeveloperTokenService:
 
         user_service.fetch.assert_called_once_with(user.userid)
         assert db_session.query(models.Token).all() == [
-            Any.instance_of(models.Token).with_attrs(
-                {"userid": user.userid, "user": user}
-            )
+            Any.instance_of(models.Token).with_attrs({"user": user})
         ]
 
     def test_create_returns_new_developer_token_for_userid(
@@ -54,7 +52,6 @@ class TestDeveloperTokenService:
 
         token = svc.create(user.userid)
 
-        assert token.userid == user.userid
         assert token.user == user
         assert token.value == "6879-secure-token"
         assert token.expires is None

--- a/tests/unit/h/services/user_rename_test.py
+++ b/tests/unit/h/services/user_rename_test.py
@@ -75,7 +75,6 @@ class TestUserRenameService:
         updated_token = (
             db_session.query(models.Token).filter(models.Token.id == token.id).one()
         )
-        assert updated_token.userid == user.userid
         assert updated_token.user == user
 
     @pytest.mark.usefixtures("annotations")


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h/pull/8521 and https://github.com/hypothesis/h/pull/8523.

This paves the way for removing it from existing DBs with a migration.
