### PR TITLE
Add DB migration to make `token.userid` nullable

### DIFF
--- a/h/migrations/versions/2127515df829_make_token_userid_nullable.py
+++ b/h/migrations/versions/2127515df829_make_token_userid_nullable.py
@@ -1,0 +1,14 @@
+"""Make token.userid nullable."""
+
+from alembic import op
+
+revision = "2127515df829"
+down_revision = "dad491955830"
+
+
+def upgrade():
+    op.alter_column("token", "userid", nullable=True)
+
+
+def downgrade():
+    op.alter_column("token", "userid", nullable=False)

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -22,7 +22,7 @@ class Token(Base, mixins.Timestamps):
 
     id = sqlalchemy.Column(sqlalchemy.Integer, autoincrement=True, primary_key=True)
 
-    userid = sqlalchemy.Column(sqlalchemy.UnicodeText(), nullable=False)
+    userid = sqlalchemy.Column(sqlalchemy.UnicodeText(), nullable=True)
 
     value = sqlalchemy.Column(sqlalchemy.UnicodeText(), nullable=False, unique=True)
 


### PR DESCRIPTION
This will allow models.Token.userid to be removed from the code.

Depends on https://github.com/hypothesis/h/pull/8517.
