### PR TITLE
Add a DB migration to remove `token.userid`

### DIFF
--- a/h/migrations/versions/36459b033a54_remove_token_userid.py
+++ b/h/migrations/versions/36459b033a54_remove_token_userid.py
@@ -1,0 +1,14 @@
+"""Remove token.userid."""
+
+from alembic import op
+
+revision = "36459b033a54"
+down_revision = "2127515df829"
+
+
+def upgrade():
+    op.drop_column("token", "userid")
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h/pull/8522 and https://github.com/hypothesis/h/pull/8523.
