### PR TITLE
Validate tag length and set a limit of 1000

### DIFF
--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -87,7 +87,7 @@ class AnnotationSchema(JSONSchema):
                 "required": ["read"],
             },
             "references": {"type": "array", "items": {"type": "string"}},
-            "tags": {"type": "array", "items": {"type": "string"}},
+            "tags": {"type": "array", "items": {"type": "string", "maxLength": 1000}},
             "target": {
                 "type": "array",
                 "items": {

--- a/tests/unit/h/schemas/annotation_test.py
+++ b/tests/unit/h/schemas/annotation_test.py
@@ -143,6 +143,7 @@ class TestCreateUpdateAnnotationSchema:
             ),
             ({"references": False}, "references: False is not of type 'array'"),
             ({"references": [False]}, "references.0: False is not of type 'string'"),
+            ({"tags": ["tag" * 1000]}, f"tags.0: '{'tag' * 1000}' is too long"),
             ({"tags": False}, "tags: False is not of type 'array'"),
             ({"tags": [False]}, "tags.0: False is not of type 'string'"),
             ({"target": False}, "target: False is not of type 'array'"),


### PR DESCRIPTION
Start validating tag length, first with a very big limit that would prevent any problems at the storaged layer.

This value should be reduced to a more sane and practical limit once the client itself presents a message while validating these.


Created https://github.com/hypothesis/client/issues/6211 to keep track of the client side validation.