### PR TITLE
Remove the Staging (WebSocket) environment from the GitHub Actions workflows

### DIFF
--- a/.cookiecutter/includes/.github/workflows/environments.json
+++ b/.cookiecutter/includes/.github/workflows/environments.json
@@ -6,15 +6,8 @@
     "elasticbeanstalk_application": "h",
     "elasticbeanstalk_environment": "staging"
   },
-  "staging_websocket": {
-    "github_environment_name": "Staging (WebSocket)",
-    "github_environment_url": "https://staging.hypothes.is/docs/help",
-    "aws_region": "us-west-1",
-    "elasticbeanstalk_application": "h-websocket",
-    "elasticbeanstalk_environment": "staging"
-  },
   "production": {
-    "needs": ["staging", "staging_websocket"],
+    "needs": ["staging"],
     "github_environment_name": "Production",
     "github_environment_url": "https://hypothes.is/search",
     "aws_region": "us-west-1",
@@ -22,7 +15,7 @@
     "elasticbeanstalk_environment": "prod"
   },
   "production_websocket": {
-    "needs": ["staging", "staging_websocket"],
+    "needs": ["staging"],
     "github_environment_name": "Production (WebSocket)",
     "github_environment_url": "https://hypothes.is/docs/help",
     "aws_region": "us-west-1",
@@ -30,7 +23,7 @@
     "elasticbeanstalk_environment": "prod"
   },
   "production_canada": {
-    "needs": ["staging", "staging_websocket"],
+    "needs": ["staging"],
     "github_environment_name": "Production (Canada)",
     "github_environment_url": "https://ca.hypothes.is/search",
     "aws_region": "ca-central-1",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,22 +51,9 @@ jobs:
       elasticbeanstalk_environment: staging
       docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
     secrets: inherit
-  staging_websocket:
-    name: Staging (WebSocket)
-    needs: [docker_hub]
-    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
-    with:
-      operation: deploy
-      github_environment_name: Staging (WebSocket)
-      github_environment_url: https://staging.hypothes.is/docs/help
-      aws_region: us-west-1
-      elasticbeanstalk_application: h-websocket
-      elasticbeanstalk_environment: staging
-      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
-    secrets: inherit
   production:
     name: Production
-    needs: [docker_hub, staging, staging_websocket]
+    needs: [docker_hub, staging]
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
       operation: deploy
@@ -79,7 +66,7 @@ jobs:
     secrets: inherit
   production_websocket:
     name: Production (WebSocket)
-    needs: [docker_hub, staging, staging_websocket]
+    needs: [docker_hub, staging]
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
       operation: deploy
@@ -92,7 +79,7 @@ jobs:
     secrets: inherit
   production_canada:
     name: Production (Canada)
-    needs: [docker_hub, staging, staging_websocket]
+    needs: [docker_hub, staging]
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
       operation: deploy

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -8,9 +8,6 @@ on:
       staging:
         type: boolean
         description: Redeploy Staging
-      staging_websocket:
-        type: boolean
-        description: Redeploy Staging (WebSocket)
       production:
         type: boolean
         description: Redeploy Production
@@ -31,18 +28,6 @@ jobs:
       github_environment_url: https://staging.hypothes.is/search
       aws_region: us-west-1
       elasticbeanstalk_application: h
-      elasticbeanstalk_environment: staging
-    secrets: inherit
-  staging_websocket:
-    name: Staging (WebSocket)
-    if: inputs.staging_websocket
-    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
-    with:
-      operation: redeploy
-      github_environment_name: Staging (WebSocket)
-      github_environment_url: https://staging.hypothes.is/docs/help
-      aws_region: us-west-1
-      elasticbeanstalk_application: h-websocket
       elasticbeanstalk_environment: staging
     secrets: inherit
   production:


### PR DESCRIPTION
This is disrupting work too much because deploying to this environment is very unreliable. Having a staging environment for the WebSocket is not as important as being able to reliably deploy to h as a whole.

https://hypothes-is.slack.com/archives/C4K6M7P5E/p1707996566884949?thread_ts=1707994171.411589&cid=C4K6M7P5E
