### PR TITLE
Fix migration error in `token` due to missing `userid` field

### DIFF
--- a/h/migrations/versions/8e3417e3713b_back_fill_the_token_user_id_column.py
+++ b/h/migrations/versions/8e3417e3713b_back_fill_the_token_user_id_column.py
@@ -4,16 +4,38 @@ import logging
 import re
 
 from alembic import op
-from sqlalchemy import select
+from sqlalchemy import Column, ForeignKey, Integer, UnicodeText, select
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-
-from h.models import Token, User
 
 revision = "8e3417e3713b"
 down_revision = "8fcdcefd8c6f"
 
 
 log = logging.getLogger(__name__)
+
+
+Base = declarative_base()
+
+
+class Token(Base):
+    __tablename__ = "token"
+
+    id = Column(Integer, primary_key=True)
+
+    # Legacy `userid` column.
+    userid = Column(UnicodeText())
+
+    # Replacement foreign key.
+    user_id = Column(Integer, ForeignKey("user.id"))
+
+
+class User(Base):
+    __tablename__ = "user"
+
+    id = Column(Integer, primary_key=True)
+    username = Column(UnicodeText(), nullable=False)
+    authority = Column(UnicodeText(), nullable=False)
 
 
 def split_userid(userid):


### PR DESCRIPTION
Replace imports from `h.models` with local ORM classes. The ORM classes in `h.models` assume the DB has the latest schema, which is not the case when running migrations. The new code matches how other migrations work.

Fixes https://github.com/hypothesis/h/issues/8541

**Testing:**

I ran `make db` and that initially failed with the error mentioned in #8541. After this change I was able to run `make db` and it successfully populated the `token.user_id` field in the DB.