### PR TITLE
Revert "Remove the Staging (WebSocket) environment from the GitHub Actions workflows"

### DIFF
--- a/.cookiecutter/includes/.github/workflows/environments.json
+++ b/.cookiecutter/includes/.github/workflows/environments.json
@@ -6,8 +6,15 @@
     "elasticbeanstalk_application": "h",
     "elasticbeanstalk_environment": "staging"
   },
+  "staging_websocket": {
+    "github_environment_name": "Staging (WebSocket)",
+    "github_environment_url": "https://staging.hypothes.is/docs/help",
+    "aws_region": "us-west-1",
+    "elasticbeanstalk_application": "h-websocket",
+    "elasticbeanstalk_environment": "staging"
+  },
   "production": {
-    "needs": ["staging"],
+    "needs": ["staging", "staging_websocket"],
     "github_environment_name": "Production",
     "github_environment_url": "https://hypothes.is/search",
     "aws_region": "us-west-1",
@@ -15,7 +22,7 @@
     "elasticbeanstalk_environment": "prod"
   },
   "production_websocket": {
-    "needs": ["staging"],
+    "needs": ["staging", "staging_websocket"],
     "github_environment_name": "Production (WebSocket)",
     "github_environment_url": "https://hypothes.is/docs/help",
     "aws_region": "us-west-1",
@@ -23,7 +30,7 @@
     "elasticbeanstalk_environment": "prod"
   },
   "production_canada": {
-    "needs": ["staging"],
+    "needs": ["staging", "staging_websocket"],
     "github_environment_name": "Production (Canada)",
     "github_environment_url": "https://ca.hypothes.is/search",
     "aws_region": "ca-central-1",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,9 +51,22 @@ jobs:
       elasticbeanstalk_environment: staging
       docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
     secrets: inherit
+  staging_websocket:
+    name: Staging (WebSocket)
+    needs: [docker_hub]
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: deploy
+      github_environment_name: Staging (WebSocket)
+      github_environment_url: https://staging.hypothes.is/docs/help
+      aws_region: us-west-1
+      elasticbeanstalk_application: h-websocket
+      elasticbeanstalk_environment: staging
+      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
+    secrets: inherit
   production:
     name: Production
-    needs: [docker_hub, staging]
+    needs: [docker_hub, staging, staging_websocket]
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
       operation: deploy
@@ -66,7 +79,7 @@ jobs:
     secrets: inherit
   production_websocket:
     name: Production (WebSocket)
-    needs: [docker_hub, staging]
+    needs: [docker_hub, staging, staging_websocket]
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
       operation: deploy
@@ -79,7 +92,7 @@ jobs:
     secrets: inherit
   production_canada:
     name: Production (Canada)
-    needs: [docker_hub, staging]
+    needs: [docker_hub, staging, staging_websocket]
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
       operation: deploy

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -8,6 +8,9 @@ on:
       staging:
         type: boolean
         description: Redeploy Staging
+      staging_websocket:
+        type: boolean
+        description: Redeploy Staging (WebSocket)
       production:
         type: boolean
         description: Redeploy Production
@@ -28,6 +31,18 @@ jobs:
       github_environment_url: https://staging.hypothes.is/search
       aws_region: us-west-1
       elasticbeanstalk_application: h
+      elasticbeanstalk_environment: staging
+    secrets: inherit
+  staging_websocket:
+    name: Staging (WebSocket)
+    if: inputs.staging_websocket
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: redeploy
+      github_environment_name: Staging (WebSocket)
+      github_environment_url: https://staging.hypothes.is/docs/help
+      aws_region: us-west-1
+      elasticbeanstalk_application: h-websocket
       elasticbeanstalk_environment: staging
     secrets: inherit
   production:


### PR DESCRIPTION
The problem with h-websocket deployments to staging being unreliable was resolved by changing the deployment mode from `Rolling` to `RollingWithAdditionalBatch` in Elastic Beanstalk.

To recap: The failures were caused by `systemctl stop nginx.service` jobs failing during deployment, if there was an open long-lived connection to that nginx server. Changing the deployment mode to `RollingWithAdditionalBatch` works around the problem by causing deployments to be done on a new instance. This takes longer (~4m instead of ~1m) but at least it works.

Slack threads for context:
- [Discussion of initial issue](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1707994171411589)
- [Follow-up investigation from me](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1708443606801559)

Reverts hypothesis/h#8529