### PR TITLE
Create index on Group.authority_provided_id

### DIFF
--- a/h/migrations/versions/c5260187b18f_group_authority_id_index.py
+++ b/h/migrations/versions/c5260187b18f_group_authority_id_index.py
@@ -1,0 +1,21 @@
+"""Create index on Group.authority_provided_id."""
+
+from alembic import op
+
+revision = "c5260187b18f"
+down_revision = "63e2559e0339"
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.create_index(
+        op.f("ix__group_authority"),
+        "group",
+        ["authority"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix__group_authority"), table_name="group")

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -65,7 +65,7 @@ class Group(Base, mixins.Timestamps):
     # We don't expose the integer PK to the world, so we generate a short
     # random string to use as the publicly visible ID.
     pubid = sa.Column(sa.Text(), default=pubid.generate, unique=True, nullable=False)
-    authority = sa.Column(sa.UnicodeText(), nullable=False)
+    authority = sa.Column(sa.UnicodeText(), nullable=False, index=True)
     name = sa.Column(sa.UnicodeText(), nullable=False, index=True)
 
     creator_id = sa.Column(sa.Integer, sa.ForeignKey("user.id"))


### PR DESCRIPTION
We do have an existing index on (authority, authority_provided_id) but that can't be used on IN (...)  type of queries which are common.

Create this index for that type of query and keep the existing one for uniqueness and individual group look ups.