### PR TITLE
Add index on group.authority_provided_id

### DIFF
--- a/h/migrations/versions/e87d20882edb_group_authority_provided_id_index.py
+++ b/h/migrations/versions/e87d20882edb_group_authority_provided_id_index.py
@@ -1,0 +1,23 @@
+"""Group authority_provided_id index."""
+
+from alembic import op
+
+revision = "e87d20882edb"
+down_revision = "c5260187b18f"
+
+
+def upgrade():
+    op.drop_index("ix__group_authority", table_name="group")
+    op.execute("COMMIT")
+    op.create_index(
+        op.f("ix__group_authority_provided_id"),
+        "group",
+        ["authority_provided_id"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix__group_authority_provided_id"), table_name="group")
+    op.create_index("ix__group_authority", "group", ["authority"], unique=False)

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -65,7 +65,7 @@ class Group(Base, mixins.Timestamps):
     # We don't expose the integer PK to the world, so we generate a short
     # random string to use as the publicly visible ID.
     pubid = sa.Column(sa.Text(), default=pubid.generate, unique=True, nullable=False)
-    authority = sa.Column(sa.UnicodeText(), nullable=False, index=True)
+    authority = sa.Column(sa.UnicodeText(), nullable=False)
     name = sa.Column(sa.UnicodeText(), nullable=False, index=True)
 
     creator_id = sa.Column(sa.Integer, sa.ForeignKey("user.id"))
@@ -90,7 +90,7 @@ class Group(Base, mixins.Timestamps):
     #: Allow authorities to define their own unique identifier for a group
     #: (versus the pubid). This identifier is owned by the authority/client
     #: versus ``pubid``, which is owned and controlled by the service.
-    authority_provided_id = sa.Column(sa.UnicodeText(), nullable=True)
+    authority_provided_id = sa.Column(sa.UnicodeText(), nullable=True, index=True)
 
     #: Which type of user is allowed to join this group, possible values are:
     #: authority, None


### PR DESCRIPTION
Correctly add index on group.authority_provided_id instead of just "authority" that was created in the previous commit by mistake.