### PR TITLE
Split up `AnnotationSyncService`

### DIFF
--- a/h/services/annotation_sync.py
+++ b/h/services/annotation_sync.py
@@ -3,33 +3,17 @@ from collections import defaultdict
 from dateutil.parser import isoparse
 
 from h.db.types import URLSafeUUID
-from h.models import Annotation
+from h.models import Annotation, Job
 from h.search.index import BatchIndexer
-
-
-class Result:
-    """String values for logging and metrics."""
-
-    # These are in the style of New Relic custom metric names.
-    SYNCED_MISSING = "Synced/{tag}/Missing_from_Elastic"
-    SYNCED_DIFFERENT = "Synced/{tag}/Different_in_Elastic"
-    SYNCED_FORCED = "Synced/{tag}/Forced"
-    SYNCED_TAG_TOTAL = "Synced/{tag}/Total"
-    SYNCED_TOTAL = "Synced/Total"
-    COMPLETED_UP_TO_DATE = "Completed/{tag}/Up_to_date_in_Elastic"
-    COMPLETED_DELETED = "Completed/{tag}/Deleted_from_db"
-    COMPLETED_FORCED = "Completed/{tag}/Forced"
-    COMPLETED_TAG_TOTAL = "Completed/{tag}/Total"
-    COMPLETED_TOTAL = "Completed/Total"
 
 
 class AnnotationSyncService:
     """A service for synchronizing annotations from Postgres to Elasticsearch."""
 
-    def __init__(self, batch_indexer, db, es, queue_service):
+    def __init__(self, batch_indexer, db_helper, es_helper, queue_service):
         self._batch_indexer = batch_indexer
-        self._db = db
-        self._es = es
+        self._db_helper = db_helper
+        self._es_helper = es_helper
         self._queue_service = queue_service
 
     def sync(self, limit):
@@ -54,69 +38,47 @@ class AnnotationSyncService:
         if not jobs:
             return {}
 
-        counts = defaultdict(set)
-
-        annotation_ids = {
-            URLSafeUUID.hex_to_url_safe(job.kwargs["annotation_id"])
-            for job in jobs
-            if not job.kwargs.get("force", False)
-        }
-        if annotation_ids:
-            annotations_from_db = self._get_annotations_from_db(annotation_ids)
-            annotations_from_es = self._get_annotations_from_es(annotation_ids)
-        else:
-            annotations_from_db = {}
-            annotations_from_es = {}
-
-        # Completed jobs that can be removed from the queue.
-        job_complete = []
-
-        # IDs of annotations to (re-)add to Elasticsearch because they're
-        # either missing from Elasticsearch or are different in Elasticsearch
-        # than in the DB.
-        annotation_ids_to_sync = set()
+        counter = Counter()
+        annotations_from_db = self._db_helper.get(jobs)
+        annotations_from_es = self._es_helper.get(jobs)
 
         for job in jobs:
-            annotation_id = URLSafeUUID.hex_to_url_safe(job.kwargs["annotation_id"])
+            annotation_id = _url_safe_annotation_id(job)
             annotation_from_db = annotations_from_db.get(annotation_id)
             annotation_from_es = annotations_from_es.get(annotation_id)
 
             if job.kwargs.get("force", False):
-                annotation_ids_to_sync.add(annotation_id)
-                job_complete.append(job)
-                counts[Result.SYNCED_FORCED.format(tag=job.tag)].add(annotation_id)
-                counts[Result.SYNCED_TAG_TOTAL.format(tag=job.tag)].add(annotation_id)
-                counts[Result.SYNCED_TOTAL].add(annotation_id)
-                counts[Result.COMPLETED_FORCED.format(tag=job.tag)].add(job.id)
-                counts[Result.COMPLETED_TAG_TOTAL.format(tag=job.tag)].add(job.id)
-                counts[Result.COMPLETED_TOTAL].add(job.id)
+                # If the job has force=True then always (re-)index the
+                # annotation into Elasticsearch no matter what, even if the
+                # annotation is already present and up-to-date in Elasticsearch.
+                counter.annotation_synced(counter.Result.SYNCED_FORCED, job)
+                counter.job_completed(counter.Result.COMPLETED_FORCED, job)
             elif not annotation_from_db:
-                job_complete.append(job)
-                counts[Result.COMPLETED_DELETED.format(tag=job.tag)].add(job.id)
-                counts[Result.COMPLETED_TAG_TOTAL.format(tag=job.tag)].add(job.id)
-                counts[Result.COMPLETED_TOTAL].add(job.id)
+                # The annotation isn't in the DB or is marked as
+                # Annotation.deleted=True in the DB so we can't index it into
+                # Elasticsearch.
+                # (This method doesn't support deleting annotations from Elasticsearch yet.)
+                counter.job_completed(counter.Result.COMPLETED_DELETED, job)
             elif not annotation_from_es:
-                annotation_ids_to_sync.add(annotation_id)
-                counts[Result.SYNCED_MISSING.format(tag=job.tag)].add(annotation_id)
-                counts[Result.SYNCED_TAG_TOTAL.format(tag=job.tag)].add(annotation_id)
-                counts[Result.SYNCED_TOTAL].add(annotation_id)
+                # The annotation is present in the DB but missing from
+                # Elasticsearch. Index the annotation into Elasticsearch.
+                counter.annotation_synced(counter.Result.SYNCED_MISSING, job)
             elif not self._equal(annotation_from_es, annotation_from_db):
-                annotation_ids_to_sync.add(annotation_id)
-                counts[Result.SYNCED_DIFFERENT.format(tag=job.tag)].add(annotation_id)
-                counts[Result.SYNCED_TAG_TOTAL.format(tag=job.tag)].add(annotation_id)
-                counts[Result.SYNCED_TOTAL].add(annotation_id)
+                # The annotation is present in Elasticsearch but different from
+                # the copy in the DB. Re-index the annotation into Elasticsearch.
+                counter.annotation_synced(counter.Result.SYNCED_DIFFERENT, job)
             else:
-                job_complete.append(job)
-                counts[Result.COMPLETED_UP_TO_DATE.format(tag=job.tag)].add(job.id)
-                counts[Result.COMPLETED_TAG_TOTAL.format(tag=job.tag)].add(job.id)
-                counts[Result.COMPLETED_TOTAL].add(job.id)
+                # The annotation is present and up-to-date in Elasticsearch so
+                # it doesn't need to be re-indexed. Delete the job from the
+                # queue, it has been completed.
+                counter.job_completed(counter.Result.COMPLETED_UP_TO_DATE, job)
 
-        self._queue_service.delete(job_complete)
+        self._queue_service.delete(counter.jobs_to_delete)
 
-        if annotation_ids_to_sync:
-            self._batch_indexer.index(list(annotation_ids_to_sync))
+        if counter.annotation_ids_to_sync:
+            self._batch_indexer.index(counter.annotation_ids_to_sync)
 
-        return {key: len(value) for key, value in counts.items()}
+        return counter.counts
 
     @staticmethod
     def _equal(annotation_from_es, annotation_from_db):
@@ -126,7 +88,37 @@ class AnnotationSyncService:
             and annotation_from_es["user"] == annotation_from_db.userid
         )
 
-    def _get_annotations_from_db(self, annotation_ids):
+
+class DBHelper:
+    """Helper for woking with annotations in the DB."""
+
+    def __init__(self, db):
+        self._db = db
+
+    def get(self, jobs: list[Job]) -> dict:
+        """
+        Return a dict of annotations from the DB for the given `jobs`.
+
+        Return a dict mapping annotation IDs to their (annotation_id,
+        annotation_updated_datetime, annotation_userid) tuples from the DB.
+
+        If `jobs` contains multiple jobs for the same annotation these will be
+        deduplicated and only one copy of the annotation will be returned.
+
+        Any jobs with `Job.force=True` will be filtered out: their annotations
+        won't be returned.
+
+        Any annotations with `Annotation.deleted=True` in the DB will be
+        filtered out and won't be returned.
+
+        Any jobs whose annotations aren't in the DB will be filtered out:
+        nothing will be returned for these jobs.
+        """
+        annotation_ids = _url_safe_annotation_ids(jobs)
+
+        if not annotation_ids:
+            return {}
+
         return {
             annotation.id: annotation
             for annotation in self._db.query(
@@ -136,7 +128,34 @@ class AnnotationSyncService:
             .filter(Annotation.id.in_(annotation_ids))
         }
 
-    def _get_annotations_from_es(self, annotation_ids):
+
+class ESHelper:
+    """Helper for working with annotations in Elasticsearch."""
+
+    def __init__(self, es):
+        self._es = es
+
+    def get(self, jobs: list[Job]) -> dict:
+        """
+        Return a dict of annotations from Elasticsearch for the given `jobs`.
+
+        Return a dict mapping annotation IDs to their {"updated": <datetime>,
+        "user": <userid>} dicts from Elasticsearch.
+
+        If `jobs` contains multiple jobs for the same annotation this will be
+        deduplicated and only one copy of the annotation will be returned.
+
+        Any jobs with `Job.force=True` will be filtered out: their annotations
+        won't be returned.
+
+        Any jobs whose annotations aren't in the search index will be filtered
+        out: nothing will be returned for these jobs.
+        """
+        annotation_ids = _url_safe_annotation_ids(jobs)
+
+        if not annotation_ids:
+            return {}
+
         hits = self._es.conn.search(
             body={
                 "_source": ["updated", "user"],
@@ -154,10 +173,79 @@ class AnnotationSyncService:
         return {hit["_id"]: hit["_source"] for hit in hits}
 
 
+class Counter:
+    """A helper for counting metrics about work that AnnotationSyncService has done."""
+
+    class Result:
+        """String values for logging and metrics."""
+
+        # These are in the style of New Relic custom metric names.
+        SYNCED_MISSING = "Synced/{tag}/Missing_from_Elastic"
+        SYNCED_DIFFERENT = "Synced/{tag}/Different_in_Elastic"
+        SYNCED_FORCED = "Synced/{tag}/Forced"
+        SYNCED_TAG_TOTAL = "Synced/{tag}/Total"
+        SYNCED_TOTAL = "Synced/Total"
+        COMPLETED_UP_TO_DATE = "Completed/{tag}/Up_to_date_in_Elastic"
+        COMPLETED_DELETED = "Completed/{tag}/Deleted_from_db"
+        COMPLETED_FORCED = "Completed/{tag}/Forced"
+        COMPLETED_TAG_TOTAL = "Completed/{tag}/Total"
+        COMPLETED_TOTAL = "Completed/Total"
+
+    def __init__(self):
+        self._counts = defaultdict(set)
+        self._annotation_ids_to_sync = set()
+        self._jobs_to_delete = set()
+
+    def annotation_synced(self, metric, job: Job):
+        """Record an annotation that will be (re-)synced to Elasticsearch."""
+        annotation_id = _url_safe_annotation_id(job)
+
+        self._annotation_ids_to_sync.add(annotation_id)
+        self._counts[metric.format(tag=job.tag)].add(annotation_id)
+        self._counts[self.Result.SYNCED_TAG_TOTAL.format(tag=job.tag)].add(
+            annotation_id
+        )
+        self._counts[self.Result.SYNCED_TOTAL].add(annotation_id)
+
+    def job_completed(self, metric, job: Job):
+        """Record a job that will be completed."""
+        self._jobs_to_delete.add(job)
+        self._counts[metric.format(tag=job.tag)].add(job.id)
+        self._counts[self.Result.COMPLETED_TAG_TOTAL.format(tag=job.tag)].add(job.id)
+        self._counts[self.Result.COMPLETED_TOTAL].add(job.id)
+
+    @property
+    def annotation_ids_to_sync(self) -> list:
+        """Return a list of the annotation IDs to be synced to Elasticsearch."""
+        return list(self._annotation_ids_to_sync)
+
+    @property
+    def jobs_to_delete(self) -> list[Job]:
+        """Return a list of the jobs to be deleted from the DB."""
+        return list(self._jobs_to_delete)
+
+    @property
+    def counts(self) -> dict:
+        """Return a dict of metrics of the work that has been done."""
+        return {key: len(value) for key, value in self._counts.items()}
+
+
+def _url_safe_annotation_ids(jobs):
+    return {
+        _url_safe_annotation_id(job)
+        for job in jobs
+        if not job.kwargs.get("force", False)
+    }
+
+
+def _url_safe_annotation_id(job):
+    return URLSafeUUID.hex_to_url_safe(job.kwargs["annotation_id"])
+
+
 def factory(_context, request):
     return AnnotationSyncService(
         batch_indexer=BatchIndexer(request.db, request.es, request),
-        db=request.db,
-        es=request.es,
+        db_helper=DBHelper(db=request.db),
+        es_helper=ESHelper(es=request.es),
         queue_service=request.find_service(name="queue_service"),
     )

--- a/tests/unit/h/services/annotation_sync_test.py
+++ b/tests/unit/h/services/annotation_sync_test.py
@@ -2,10 +2,17 @@ import datetime
 from unittest.mock import create_autospec, sentinel
 
 import pytest
+from h_matchers import Any
 
 from h.db.types import URLSafeUUID
 from h.search.index import BatchIndexer
-from h.services.annotation_sync import AnnotationSyncService, Result, factory
+from h.services.annotation_sync import (
+    AnnotationSyncService,
+    Counter,
+    DBHelper,
+    ESHelper,
+    factory,
+)
 from h.services.search_index import SearchIndexService
 
 pytestmark = [
@@ -33,15 +40,15 @@ class TestAnnotationSyncService:
         counts = svc.sync(1)
 
         assert counts == {
-            Result.SYNCED_FORCED.format(tag="test_tag"): 1,
-            Result.SYNCED_TAG_TOTAL.format(tag="test_tag"): 1,
-            Result.SYNCED_TOTAL: 1,
-            Result.COMPLETED_FORCED.format(tag="test_tag"): 1,
-            Result.COMPLETED_TAG_TOTAL.format(tag="test_tag"): 1,
-            Result.COMPLETED_TOTAL: 1,
+            Counter.Result.SYNCED_FORCED.format(tag="test_tag"): 1,
+            Counter.Result.SYNCED_TAG_TOTAL.format(tag="test_tag"): 1,
+            Counter.Result.SYNCED_TOTAL: 1,
+            Counter.Result.COMPLETED_FORCED.format(tag="test_tag"): 1,
+            Counter.Result.COMPLETED_TAG_TOTAL.format(tag="test_tag"): 1,
+            Counter.Result.COMPLETED_TOTAL: 1,
         }
         queue_service.delete.assert_called_once_with([job])
-        batch_indexer.index.assert_called_once_with([self.url_safe_id(job)])
+        batch_indexer.index.assert_called_once_with([url_safe_annotation_id(job)])
 
     def test_if_the_annotation_isnt_in_the_DB_it_deletes_the_job_from_the_queue(
         self, db_session, factories, svc, queue_service
@@ -59,9 +66,9 @@ class TestAnnotationSyncService:
         counts = svc.sync(1)
 
         assert counts == {
-            Result.COMPLETED_DELETED.format(tag="test_tag"): 1,
-            Result.COMPLETED_TAG_TOTAL.format(tag="test_tag"): 1,
-            Result.COMPLETED_TOTAL: 1,
+            Counter.Result.COMPLETED_DELETED.format(tag="test_tag"): 1,
+            Counter.Result.COMPLETED_TAG_TOTAL.format(tag="test_tag"): 1,
+            Counter.Result.COMPLETED_TOTAL: 1,
         }
         queue_service.delete.assert_called_once_with([job])
 
@@ -76,9 +83,9 @@ class TestAnnotationSyncService:
         counts = svc.sync(1)
 
         assert counts == {
-            Result.COMPLETED_DELETED.format(tag="test_tag"): 1,
-            Result.COMPLETED_TAG_TOTAL.format(tag="test_tag"): 1,
-            Result.COMPLETED_TOTAL: 1,
+            Counter.Result.COMPLETED_DELETED.format(tag="test_tag"): 1,
+            Counter.Result.COMPLETED_TAG_TOTAL.format(tag="test_tag"): 1,
+            Counter.Result.COMPLETED_TOTAL: 1,
         }
         queue_service.delete.assert_called_once_with([job])
 
@@ -91,11 +98,11 @@ class TestAnnotationSyncService:
         counts = svc.sync(1)
 
         assert counts == {
-            Result.SYNCED_MISSING.format(tag="test_tag"): 1,
-            Result.SYNCED_TAG_TOTAL.format(tag="test_tag"): 1,
-            Result.SYNCED_TOTAL: 1,
+            Counter.Result.SYNCED_MISSING.format(tag="test_tag"): 1,
+            Counter.Result.SYNCED_TAG_TOTAL.format(tag="test_tag"): 1,
+            Counter.Result.SYNCED_TOTAL: 1,
         }
-        batch_indexer.index.assert_called_once_with([self.url_safe_id(job)])
+        batch_indexer.index.assert_called_once_with([url_safe_annotation_id(job)])
 
     def test_if_the_annotation_is_already_in_Elastic_it_removes_the_job_from_the_queue(
         self, batch_indexer, factories, index, svc, queue_service
@@ -108,9 +115,9 @@ class TestAnnotationSyncService:
         counts = svc.sync(1)
 
         assert counts == {
-            Result.COMPLETED_UP_TO_DATE.format(tag="test_tag"): 1,
-            Result.COMPLETED_TAG_TOTAL.format(tag="test_tag"): 1,
-            Result.COMPLETED_TOTAL: 1,
+            Counter.Result.COMPLETED_UP_TO_DATE.format(tag="test_tag"): 1,
+            Counter.Result.COMPLETED_TAG_TOTAL.format(tag="test_tag"): 1,
+            Counter.Result.COMPLETED_TOTAL: 1,
         }
         queue_service.delete.assert_called_once_with([job])
         batch_indexer.index.assert_not_called()
@@ -129,9 +136,9 @@ class TestAnnotationSyncService:
         counts = svc.sync(1)
 
         assert counts == {
-            Result.SYNCED_DIFFERENT.format(tag="test_tag"): 1,
-            Result.SYNCED_TAG_TOTAL.format(tag="test_tag"): 1,
-            Result.SYNCED_TOTAL: 1,
+            Counter.Result.SYNCED_DIFFERENT.format(tag="test_tag"): 1,
+            Counter.Result.SYNCED_TAG_TOTAL.format(tag="test_tag"): 1,
+            Counter.Result.SYNCED_TOTAL: 1,
         }
         batch_indexer.index.assert_called_once_with([annotation.id])
 
@@ -148,9 +155,9 @@ class TestAnnotationSyncService:
         counts = svc.sync(1)
 
         assert counts == {
-            Result.SYNCED_DIFFERENT.format(tag="test_tag"): 1,
-            Result.SYNCED_TAG_TOTAL.format(tag="test_tag"): 1,
-            Result.SYNCED_TOTAL: 1,
+            Counter.Result.SYNCED_DIFFERENT.format(tag="test_tag"): 1,
+            Counter.Result.SYNCED_TAG_TOTAL.format(tag="test_tag"): 1,
+            Counter.Result.SYNCED_TOTAL: 1,
         }
         batch_indexer.index.assert_called_once_with([annotation.id])
 
@@ -164,9 +171,9 @@ class TestAnnotationSyncService:
         counts = svc.sync(len(jobs))
 
         assert counts == {
-            Result.SYNCED_MISSING.format(tag="test_tag"): 1,
-            Result.SYNCED_TAG_TOTAL.format(tag="test_tag"): 1,
-            Result.SYNCED_TOTAL: 1,
+            Counter.Result.SYNCED_MISSING.format(tag="test_tag"): 1,
+            Counter.Result.SYNCED_TAG_TOTAL.format(tag="test_tag"): 1,
+            Counter.Result.SYNCED_TOTAL: 1,
         }
         # It only syncs the annotation to Elasticsearch once, even though it
         # processed two separate jobs (for the same annotation).
@@ -183,11 +190,11 @@ class TestAnnotationSyncService:
         counts = svc.sync(len(jobs))
 
         assert counts == {
-            Result.COMPLETED_UP_TO_DATE.format(tag="test_tag"): 2,
-            Result.COMPLETED_TAG_TOTAL.format(tag="test_tag"): 2,
-            Result.COMPLETED_TOTAL: 2,
+            Counter.Result.COMPLETED_UP_TO_DATE.format(tag="test_tag"): 2,
+            Counter.Result.COMPLETED_TAG_TOTAL.format(tag="test_tag"): 2,
+            Counter.Result.COMPLETED_TOTAL: 2,
         }
-        queue_service.delete.assert_called_once_with(jobs)
+        queue_service.delete.assert_called_once_with(Any.list.containing(jobs).only())
         batch_indexer.index.assert_not_called()
 
     def test_metrics(self, factories, index, now, svc, queue_service):
@@ -230,48 +237,6 @@ class TestAnnotationSyncService:
             "Completed/test_tag/Deleted_from_db": 1,
         }
 
-    def url_safe_id(self, job):
-        """Return the URL-safe version of the given job's annotation ID."""
-        return URLSafeUUID.hex_to_url_safe(job.kwargs["annotation_id"])
-
-    @pytest.fixture
-    def index(
-        self,
-        pyramid_request,
-        es_client,
-        moderation_service,  # pylint:disable=unused-argument
-        nipsa_service,  # pylint:disable=unused-argument
-    ):
-        """Return a method that indexes an annotation into Elasticsearch."""
-
-        # Construct a real (not mock) SearchIndexService so we can call its
-        # methods to index annotations.
-        #
-        # This isn't ideal because it means these AnnotationSyncService
-        # unit tests are coupled to SearchIndexService and any other services
-        # or code that SearchIndexService calls.
-        #
-        # On the other hand, this avoids these tests having to duplicate
-        # SearchIndexService's code for indexing annotations and ensures that
-        # the documents in the search index are the same as they would be in
-        # production.
-        #
-        # (FIXME: The real solution to this issue is to refactor the services
-        # to be more coherent and avoid this testing dilemma.)
-        search_index_service = SearchIndexService(
-            request=pyramid_request,
-            es=es_client,
-            settings={},
-            annotation_read_service=sentinel.annotation_read_service,
-        )
-
-        def index(annotation):
-            """Index `annotation` into Elasticsearch."""
-            search_index_service.add_annotation(annotation)
-            es_client.conn.indices.refresh(index=es_client.index)
-
-        return index
-
     @pytest.fixture
     def now(self):
         """Return the current UTC time."""
@@ -299,26 +264,279 @@ class TestAnnotationSyncService:
     def svc(self, batch_indexer, db_session, es_client, queue_service):
         return AnnotationSyncService(
             batch_indexer=batch_indexer,
-            db=db_session,
-            es=es_client,
+            db_helper=DBHelper(db=db_session),
+            es_helper=ESHelper(es=es_client),
             queue_service=queue_service,
         )
 
 
+class TestDBHelper:
+    def test_get_with_no_jobs(self, db_helper):
+        assert db_helper.get([]) == {}
+
+    def test_get_when_all_jobs_have_force_True(self, db_helper, db_session, factories):
+        jobs = factories.SyncAnnotationJob.create_batch(2, force=True)
+        # Flush the DB to generate job.id values.
+        db_session.flush()
+
+        assert db_helper.get(jobs) == {}
+
+    def test_get_filters_out_duplicate_annotations(
+        self, db_helper, db_session, factories
+    ):
+        annotation = factories.Annotation()
+        # Two jobs for the same annotation.
+        jobs = factories.SyncAnnotationJob.create_batch(2, annotation=annotation)
+        # Flush the DB to generate job.id values.
+        db_session.flush()
+
+        result = db_helper.get(jobs)
+
+        assert list(result.keys()) == [annotation.id]
+
+    def test_get(self, db_helper, db_session, factories):
+        annotations = factories.Annotation.create_batch(2)
+        jobs = [
+            factories.SyncAnnotationJob(annotation=annotation)
+            for annotation in annotations
+        ]
+        # A duplicate job for one of the same annotations. This should be ignored.
+        jobs.append(factories.SyncAnnotationJob(annotation=annotations[0]))
+        # A job whose annotation is marked as deleted. This should be ignored.
+        jobs.append(
+            factories.SyncAnnotationJob(annotation=factories.Annotation(deleted=True))
+        )
+        # A job that has force=True. This should be ignored.
+        jobs.append(factories.SyncAnnotationJob(force=True))
+        # An annotation that has no job. This should be ignored.
+        factories.Annotation()
+        # Flush the DB to generate job.id values.
+        db_session.flush()
+
+        result = db_helper.get(jobs)
+
+        assert result == {
+            annotations[0].id: (
+                annotations[0].id,
+                annotations[0].updated,
+                annotations[0].userid,
+            ),
+            annotations[1].id: (
+                annotations[1].id,
+                annotations[1].updated,
+                annotations[1].userid,
+            ),
+        }
+
+    # TODO: Annotations that don't exist in the DB.
+
+    @pytest.fixture
+    def db_helper(self, db_session):
+        return DBHelper(db_session)
+
+
+class TestESHelper:
+    def test_get_with_no_jobs(self, es_helper):
+        assert es_helper.get([]) == {}
+
+    def test_get_when_all_jobs_have_force_True(self, db_session, es_helper, factories):
+        jobs = factories.SyncAnnotationJob.create_batch(2, force=True)
+        # Flush the DB to generate job.id values.
+        db_session.flush()
+
+        assert es_helper.get(jobs) == {}
+
+    def test_get_filters_out_duplicate_annotations(
+        self, db_session, es_helper, factories, index
+    ):
+        annotation = factories.Annotation()
+        index(annotation)
+        # Two jobs for the same annotation.
+        jobs = factories.SyncAnnotationJob.create_batch(2, annotation=annotation)
+        # Flush the DB to generate job.id values.
+        db_session.flush()
+
+        result = es_helper.get(jobs)
+
+        assert list(result.keys()) == [annotation.id]
+
+    def test_get_doesnt_return_annotations_that_arent_in_the_search_index(
+        self, db_session, es_helper, factories
+    ):
+        jobs = factories.SyncAnnotationJob.create_batch(1)
+        # Flush the DB to generate job.id values.
+        db_session.flush()
+
+        assert es_helper.get(jobs) == {}
+
+    def test_get(self, db_session, es_helper, factories, index):
+        annotations = factories.Annotation.create_batch(2)
+        for annotation in annotations:
+            index(annotation)
+        jobs = [
+            factories.SyncAnnotationJob(annotation=annotation)
+            for annotation in annotations
+        ]
+        # An annotation with no job. This should be ignored.
+        index(factories.Annotation())
+        # Flush the DB to generate job.id values.
+        db_session.flush()
+
+        result = es_helper.get(jobs)
+
+        assert result == {
+            annotations[0].id: {
+                "updated": annotations[0].updated,
+                "user": annotations[0].userid,
+            },
+            annotations[1].id: {
+                "updated": annotations[1].updated,
+                "user": annotations[1].userid,
+            },
+        }
+
+    @pytest.fixture
+    def es_helper(self, es_client):
+        return ESHelper(es_client)
+
+
+class TestCounter:
+    def test_annotation_synced(self, counter, db_session, factories):
+        foo_jobs = factories.SyncAnnotationJob.create_batch(4, tag="foo")
+        bar_jobs = factories.SyncAnnotationJob.create_batch(2, tag="bar")
+        # Flush the DB to generate job.id values.
+        db_session.flush()
+
+        counter.annotation_synced(counter.Result.SYNCED_MISSING, foo_jobs[0])
+        counter.annotation_synced(counter.Result.SYNCED_MISSING, bar_jobs[0])
+        counter.annotation_synced(counter.Result.SYNCED_FORCED, foo_jobs[1])
+        counter.annotation_synced(counter.Result.SYNCED_DIFFERENT, foo_jobs[2])
+        counter.annotation_synced(counter.Result.SYNCED_MISSING, foo_jobs[3])
+        counter.annotation_synced(counter.Result.SYNCED_DIFFERENT, bar_jobs[1])
+
+        assert counter.counts == {
+            counter.Result.SYNCED_MISSING.format(tag="foo"): 2,
+            counter.Result.SYNCED_MISSING.format(tag="bar"): 1,
+            counter.Result.SYNCED_FORCED.format(tag="foo"): 1,
+            counter.Result.SYNCED_DIFFERENT.format(tag="foo"): 1,
+            counter.Result.SYNCED_DIFFERENT.format(tag="bar"): 1,
+            counter.Result.SYNCED_TAG_TOTAL.format(tag="foo"): 4,
+            counter.Result.SYNCED_TAG_TOTAL.format(tag="bar"): 2,
+            counter.Result.SYNCED_TOTAL: 6,
+        }
+        assert (
+            counter.annotation_ids_to_sync
+            == Any.list.containing(
+                [url_safe_annotation_id(job) for job in foo_jobs + bar_jobs]
+            ).only()
+        )
+
+    def test_annotation_synced_ignores_duplicates(self, counter, db_session, factories):
+        # Two jobs for the same annotation.
+        jobs = factories.SyncAnnotationJob.create_batch(
+            2, annotation=factories.Annotation(), tag="foo"
+        )
+        # Flush the DB to generate job.id values.
+        db_session.flush()
+
+        counter.annotation_synced(counter.Result.SYNCED_MISSING, jobs[0])
+        counter.annotation_synced(counter.Result.SYNCED_MISSING, jobs[1])
+
+        assert counter.counts == {
+            counter.Result.SYNCED_MISSING.format(tag="foo"): 1,
+            counter.Result.SYNCED_TAG_TOTAL.format(tag="foo"): 1,
+            counter.Result.SYNCED_TOTAL: 1,
+        }
+        assert counter.annotation_ids_to_sync == [url_safe_annotation_id(jobs[0])]
+
+    def test_job_completed(self, counter, db_session, factories):
+        foo_jobs = factories.SyncAnnotationJob.create_batch(4, tag="foo")
+        bar_jobs = factories.SyncAnnotationJob.create_batch(2, tag="bar")
+        # Flush the DB to generate job.id values.
+        db_session.flush()
+
+        counter.job_completed(counter.Result.COMPLETED_UP_TO_DATE, foo_jobs[0])
+        counter.job_completed(counter.Result.COMPLETED_UP_TO_DATE, bar_jobs[0])
+        counter.job_completed(counter.Result.COMPLETED_FORCED, foo_jobs[1])
+        counter.job_completed(counter.Result.COMPLETED_DELETED, foo_jobs[2])
+        counter.job_completed(counter.Result.COMPLETED_UP_TO_DATE, foo_jobs[3])
+        counter.job_completed(counter.Result.COMPLETED_DELETED, bar_jobs[1])
+
+        assert counter.counts == {
+            counter.Result.COMPLETED_UP_TO_DATE.format(tag="foo"): 2,
+            counter.Result.COMPLETED_UP_TO_DATE.format(tag="bar"): 1,
+            counter.Result.COMPLETED_FORCED.format(tag="foo"): 1,
+            counter.Result.COMPLETED_DELETED.format(tag="foo"): 1,
+            counter.Result.COMPLETED_DELETED.format(tag="bar"): 1,
+            counter.Result.COMPLETED_TAG_TOTAL.format(tag="foo"): 4,
+            counter.Result.COMPLETED_TAG_TOTAL.format(tag="bar"): 2,
+            counter.Result.COMPLETED_TOTAL: 6,
+        }
+        assert counter.jobs_to_delete == Any.list.containing(foo_jobs + bar_jobs).only()
+
+    def test_job_completed_ignores_duplicates(self, counter, db_session, factories):
+        # Two jobs for the same annotation.
+        job = factories.SyncAnnotationJob()
+        # Flush the DB to generate job.id values.
+        db_session.flush()
+
+        counter.job_completed(counter.Result.COMPLETED_UP_TO_DATE, job)
+        counter.job_completed(counter.Result.COMPLETED_UP_TO_DATE, job)
+
+        assert counter.counts == {
+            counter.Result.COMPLETED_UP_TO_DATE.format(tag=job.tag): 1,
+            counter.Result.COMPLETED_TAG_TOTAL.format(tag=job.tag): 1,
+            counter.Result.COMPLETED_TOTAL: 1,
+        }
+        assert counter.jobs_to_delete == [job]
+
+    def test_annotation_synced_and_job_completed_together(
+        self, counter, db_session, factories
+    ):
+        jobs = factories.SyncAnnotationJob.create_batch(2, tag="foo")
+        # Flush the DB to generate job.id values.
+        db_session.flush()
+
+        counter.annotation_synced(counter.Result.SYNCED_MISSING, jobs[0])
+        counter.job_completed(counter.Result.COMPLETED_UP_TO_DATE, jobs[1])
+
+        assert counter.counts == {
+            counter.Result.SYNCED_MISSING.format(tag="foo"): 1,
+            counter.Result.SYNCED_TAG_TOTAL.format(tag="foo"): 1,
+            counter.Result.SYNCED_TOTAL: 1,
+            counter.Result.COMPLETED_UP_TO_DATE.format(tag="foo"): 1,
+            counter.Result.COMPLETED_TAG_TOTAL.format(tag="foo"): 1,
+            counter.Result.COMPLETED_TOTAL: 1,
+        }
+
+    @pytest.fixture
+    def counter(self):
+        return Counter()
+
+
 class TestFactory:
     def test_it(
-        self, AnnotationSyncService, BatchIndexer, pyramid_request, queue_service
+        self,
+        AnnotationSyncService,
+        BatchIndexer,
+        DBHelper,
+        ESHelper,
+        db_session,
+        pyramid_request,
+        queue_service,
     ):
         svc = factory(sentinel.context, pyramid_request)
 
         BatchIndexer.assert_called_once_with(
             pyramid_request.db, pyramid_request.es, pyramid_request
         )
+        DBHelper.assert_called_once_with(db=db_session)
+        ESHelper.assert_called_once_with(es=pyramid_request.es)
         AnnotationSyncService.assert_called_once_with(
-            BatchIndexer.return_value,
-            pyramid_request.db,
-            pyramid_request.es,
-            queue_service,
+            batch_indexer=BatchIndexer.return_value,
+            db_helper=DBHelper.return_value,
+            es_helper=ESHelper.return_value,
+            queue_service=queue_service,
         )
         assert svc == AnnotationSyncService.return_value
 
@@ -330,7 +548,58 @@ class TestFactory:
     def BatchIndexer(self, patch):
         return patch("h.services.annotation_sync.BatchIndexer")
 
+    @pytest.fixture(autouse=True)
+    def DBHelper(self, patch):
+        return patch("h.services.annotation_sync.DBHelper")
+
+    @pytest.fixture(autouse=True)
+    def ESHelper(self, patch):
+        return patch("h.services.annotation_sync.ESHelper")
+
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.es = sentinel.es
         return pyramid_request
+
+
+@pytest.fixture
+def index(
+    pyramid_request,
+    es_client,
+    moderation_service,  # pylint:disable=unused-argument
+    nipsa_service,  # pylint:disable=unused-argument
+):
+    """Return a method that indexes an annotation into Elasticsearch."""
+
+    # Construct a real (not mock) SearchIndexService so we can call its
+    # methods to index annotations.
+    #
+    # This isn't ideal because it means these AnnotationSyncService
+    # unit tests are coupled to SearchIndexService and any other services
+    # or code that SearchIndexService calls.
+    #
+    # On the other hand, this avoids these tests having to duplicate
+    # SearchIndexService's code for indexing annotations and ensures that
+    # the documents in the search index are the same as they would be in
+    # production.
+    #
+    # (FIXME: The real solution to this issue is to refactor the services
+    # to be more coherent and avoid this testing dilemma.)
+    search_index_service = SearchIndexService(
+        request=pyramid_request,
+        es=es_client,
+        settings={},
+        annotation_read_service=sentinel.annotation_read_service,
+    )
+
+    def index(annotation):
+        """Index `annotation` into Elasticsearch."""
+        search_index_service.add_annotation(annotation)
+        es_client.conn.indices.refresh(index=es_client.index)
+
+    return index
+
+
+def url_safe_annotation_id(job):
+    """Return the URL-safe version of the given job's annotation ID."""
+    return URLSafeUUID.hex_to_url_safe(job.kwargs["annotation_id"])


### PR DESCRIPTION
Split up `AnnotationSyncService` by breaking various parts of the code out into separate helper classes.

This is necessary for a future PR to be able to add delete support to `AnnotationSyncService` without triggering a bunch of pylint warnings like `too-many-statements`, `too-complex`, `too-many-locals`, and `too-many-branches`.

I think it's also good to break up this complex part of the code into separate helper classes and methods that have their own docstrings and unit tests. This allows us to pin down the code much more closely with unit tests, rather than relying only on testing the whole thing in integration.

It would now be possible to rewrite `AnnotationSyncService`'s tests to mock out the new helpers and test only the remaining code in `AnnotationSyncService`. This would probably be an improvement (the tests would be simpler and easier to follow and would probably provide better coverage of the logic) but for now, just to save time, I've left `AnnotationSyncService`'s tests untouched so they test it in integration with the code that has been split out into helpers.
