### PR TITLE
Use job queue to delete annotations from Elasticsearch

### DIFF
--- a/h/services/annotation_delete.py
+++ b/h/services/annotation_delete.py
@@ -1,14 +1,21 @@
 from datetime import datetime, timedelta
 
+from pyramid.request import Request
 from sqlalchemy import delete, select
 
 from h.events import AnnotationEvent
 from h.models import Annotation
 from h.services.annotation_write import AnnotationWriteService
+from h.services.job_queue import JobQueueService
 
 
 class AnnotationDeleteService:
-    def __init__(self, request, annotation_write, job_queue):
+    def __init__(
+        self,
+        request: Request,
+        annotation_write: AnnotationWriteService,
+        job_queue: JobQueueService,
+    ):
         self.request = request
         self.annotation_write = annotation_write
         self.job_queue = job_queue

--- a/h/services/annotation_sync.py
+++ b/h/services/annotation_sync.py
@@ -218,7 +218,7 @@ class Counter:
         self._counts[self.Result.SYNCED_TOTAL].add(annotation_id)
 
     def annotation_deleted(self, metric, job: Job):
-        """Record an annotation that will be deleted from Elasticsearch Elasticsearch."""
+        """Record an annotation that will be deleted from Elasticsearch."""
         annotation_id = _url_safe_annotation_id(job)
 
         self._annotation_ids_to_delete.add(annotation_id)

--- a/tests/unit/h/search/index_test.py
+++ b/tests/unit/h/search/index_test.py
@@ -132,6 +132,15 @@ class TestBatchIndexer:
 
         assert errored == expected_errored_ids
 
+    def test_delete(self, batch_indexer, factories, get_indexed_ann):
+        annotations = factories.Annotation.create_batch(2)
+        batch_indexer.index([annotation.id for annotation in annotations])
+
+        batch_indexer.delete([annotation.id for annotation in annotations])
+
+        for annotation in annotations:
+            assert get_indexed_ann(annotation.id) == {"doc": {"deleted": True}}
+
 
 @pytest.fixture
 def batch_indexer(  # pylint:disable=unused-argument


### PR DESCRIPTION
Use the job queue to ensure that annotations get deleted from Elasticsearch when the API is used to delete an annotation.

This PR fixes the annotation delete API only. There'll be a follow-up PR to build on the same solution to make bulk deletion of annotations reliable when deleting user accounts.

Depends on https://github.com/hypothesis/h/pull/8563.

Fixes https://github.com/hypothesis/h/issues/7840.

**Problem:** h's annotation delete API doesn't delete annotations from Elasticsearch with complete reliability. Sometimes an annotation is deleted from the DB but not from Elasticsearch. This means we haven't deleted the data that the user asked us to delete and it also causes some nuisance issues (e.g. https://github.com/hypothesis/client/issues/5219, https://github.com/hypothesis/h/issues/7796). This also prevents us from implementing [PRD: Self-Service User Deletion](https://docs.google.com/document/d/1SdXBraDZpgUVCARLI5OelV3DcjahHJBvQ9tticEG1GY): the self-service user deletion feature requires a reliable means of deleting a user's annotations.

**Solution:** we already use h's [job queue](https://github.com/hypothesis/h/blob/9686c96713812af3aead485129861072604756b0/h/models/job.py#L1-L67) to ensure that annotation creates and updates are always synced to Elasticsearch. See [this presentation](https://docs.google.com/presentation/d/1msC6H5wxGQUo80zUWIe1rmfAAoQtUqIlrLFdBCMD-O4/) for more details of the solution. Support for syncing annotation deletions was never added to the job queue. This PR adds annotation deletion support to the job queue so that all future deletions will reliably be synced to Elasticsearch.

Context: what happens when you delete an annotation
---------------------------------------------------

* The user clicks to delete an annotation in the client
* The [`h/views/api/annotations.py::delete()` view](https://github.com/hypothesis/h/blob/9686c96713812af3aead485129861072604756b0/h/views/api/annotations.py#L152-L166) receives the request and calls [`AnnotationDeleteService.delete()`](https://github.com/hypothesis/h/blob/9686c96713812af3aead485129861072604756b0/h/services/annotation_delete.py#L15-L28) which:
  * Marks the annotation as deleted in the DB
  * Emits an `AnnotationEvent`
* After the request's DB transaction has been committed the [`annotation_sync()` subscriber](https://github.com/hypothesis/h/blob/9686c96713812af3aead485129861072604756b0/h/subscribers.py#L41-L50) receives the `AnnotationEvent` and calls [`SearchIndexService.handle_annotation_event()`](https://github.com/hypothesis/h/blob/9686c96713812af3aead485129861072604756b0/h/services/search_index.py#L118-L147) which calls [`SearchIndexService.delete_annotation_by_id()`](https://github.com/hypothesis/h/blob/9686c96713812af3aead485129861072604756b0/h/services/search_index.py#L101-L116) which sends a foreground request to Elasticsearch to delete the annotation.
* If this request to Elasticsearch fails then the annotation has been deleted from the DB but not from Elasticsearch. The API still sends a 200 OK response to the client. The `handle_annotation_event()` method will schedule a Celery task to try calling `delete_annotation_by_id()` again, and that Celery task will be retried once if it fails the first time

This isn't reliable. The app could crash (or be killed by a deployment or autoscaling etc) after committing the DB transaction but before making the request to Elasticsearch and/or before scheduling the Celery task. Or in the case of Elasticsearch and/or RabbitMQ issues the three requests to Elasticsearch could all fail.

This is fairly easy to fix: everything can remain the same, but the DB transaction also needs to include adding a `"sync_annotation"` job to the transactional job queue in the DB. Support for deleting annotations then needs to be added to the `AnnotationSyncService.sync()` method that handles `"sync_annotation"` jobs. This will make syncing annotation deletions to Elasticsearch reliable because:

1. The `"sync_annotation"` job is added to the job queue in the same atomic DB transaction as the annotation is marked as deleted. So either both the annotation is marked as deleted in the DB and the job is added to the queue, or neither.
2. Once the `"sync_annotation"` job is on the queue the `AnnotationSyncService.sync()` method (which runs periodically and processes these jobs) will not delete the job from the queue until it has successfully deleted the annotation from Elasticsearch and verified that the annotation is deleted from Elasticsearch. If deleting the annotation fails the task will just keep trying and trying. (It actually gives up after 30 days, at which point the job is still on the queue but is "expired", and an alarm will go off notifying us of the presence of an expired job.)

Context: the job queue
----------------------

Whenever an annotation is created, updated or (as of this PR) deleted a `"sync_annotation"` job for that annotation is added to h's job queue (the `job` table in h's DB) as part of the same atomic DB transaction that created, updated or deleted the annotation.

A periodic `AnnotationSyncService.sync()` method runs every minute and consumes `"sync_annotation"` jobs from the job queue, makes sure that the annotations are synced to Elasticsearch, and deletes the jobs from the queue.

The annotation API also syncs annotations to Elasticsearch immediately in the foreground. The job queue is just a fallback. Most of the time the `AnnotationSyncService.sync()` finds that the annotation is already synced and does nothing (other than deleting the job from the queue).

As well as the annotations API, various admin pages also add `"sync_annotation"` jobs to the queue for example when all a user's annotations need to be re-indexed because the user has been renamed. In a future PR the job queue will be used to delete all a user's annotations when the user has been deleted.

It's important that there are only `"sync_annotation"` jobs rather than three separate types of job `"create_annotation"`, `"update_annotation"` and `"delete_annotation"`. The job is to read the annotation from Postgres and synchronize it to Elasticsearch (or delete it from Elasticsearch, if it's deleted from Postgres). This is important because it means that the queue can contain multiple jobs for the same annotation and those jobs can be processed out of order and this will work fine. That would not be the case if there were three separate types of job.

Context: job queue monitoring
-----------------------------

h sends various custom metrics to New Relic in order to monitor the job queue. You can view these metrics on the [job queue dashboard in New Relic](https://onenr.io/08wp3YyKxQO) and there are also various [job queue alarms](https://docs.google.com/presentation/d/1msC6H5wxGQUo80zUWIe1rmfAAoQtUqIlrLFdBCMD-O4/edit#slide=id.g9f11104581_0_101) set up in New Relic based on these metrics.

### Queue length graphs

The first graph on the New Relic dashboard is the queue length graph:

![Screenshot 2024-02-28 at 17 45 48](https://github.com/hypothesis/h/assets/22498/6bbb9fd9-4374-43cd-89da-cff96f4d2b4e)

This reports on the number of jobs on the queue and the graph can be filtered by type of job. The code that feeds this graph is in the [`JobQueueMetrics` service](https://github.com/hypothesis/h/blob/1999c2ba669dbdfb621a8bdc7cfa40c036de1e55/h/services/job_queue_metrics.py#L9-L59) and isn't touched by this PR.

### Annotations synced and jobs completed

The other graphs on the New Relic dashboard record the number of annotations being synced and the number of jobs being completed by the periodic `AnnotationSyncService.sync()` method. Again, the graphs can be filtered by type of job. Jobs tend to get completed at a steady rate (because even if the annotation is already synced to Elasticsearch, the method still completes the job) whereas annotations usually only actually get synced now and then when one is found to be out-of-sync in Elasticsearch:

![Screenshot 2024-02-28 at 17 51 15](https://github.com/hypothesis/h/assets/22498/a267f712-ad9c-43a0-a9e1-f608fb0ca5bd)
![Screenshot 2024-02-28 at 17 51 43](https://github.com/hypothesis/h/assets/22498/7889d3d6-18a4-497e-bab7-382efaa3c97b)

These graphs are fed by metrics returned by the periodic `AnnotationSyncService.sync()` method, which is the method that this PR changes. The method returns a dict of metrics recording what it did, for example:

```
{
  'Completed/storage.create_annotation/Up_to_date_in_Elastic': 1,
  'Completed/storage.create_annotation/Total': 1,
  'Completed/Total': 1
}
```

`'Completed/storage.create_annotation/Up_to_date_in_Elastic'` records the number of jobs that were created by the `storage.create_annotation` method (i.e. the create annotation API) and were completed (and deleted from the DB) because the job's annotation was found to be already up-to-date in Elasticsearch. `'Completed/storage.create_annotation/Total'` records the total number of jobs created by the create annotation API that were completed for any reason. `'Completed/Total'` records the total number of jobs that were created by any source and completed for any reason. Here the same one completed job contributes to all three metrics. There are several more metrics than this, they're all similar.

The reason why lots of different separate metrics are reported is so that we can monitor and alert on, say, jobs created by the annotation API (e.g. a spike increase in uncompleted jobs on the queue) without letting jobs created by, say, the admin pages trigger these alerts.

This dict of metrics that `SyncAnnotationService.sync()` returns is both [logged to Papertrail and sent to New Relic](https://github.com/hypothesis/h/blob/1999c2ba669dbdfb621a8bdc7cfa40c036de1e55/h/tasks/indexer.py#L37-L43) by the periodic task that calls the method.

Context: monitoring the periodic `sync_annotations` task
--------------------------------------------------------

As well as the custom metrics that're reported to the Job Queue dashboard you can also monitor the performance of the periodic `sync_annotations()` task in New Relic. This is the task that runs every minute and calls the `AnnotationSyncService.sync()` method that consumes `"sync_annotation"` tasks from the job queue. Celery tasks show up as a type of "transaction" in New Relic. Here's a link to New Relic's monitoring for the `sync_annotations()` task: https://onenr.io/0OQMakbDkQG

![Screenshot 2024-02-28 at 18 18 52](https://github.com/hypothesis/h/assets/22498/c6f11bb2-b7a2-42f1-8a03-0e449f67c52a)

Testing
=======

Deleting an annotation
----------------------

This tests the happy path, what normally happens when you delete an annotation: the delete annotation API makes a foreground call to "delete" the annotation from Elasticsearch (in fact annotations are left in Elasticsearch with the body replaced with `{"deleted": true}`) and also adds a `"sync_annotation"` job to the queue. The `"sync_annotation"` job later runs, checks that the annotation was deleted from Elasticsearch, and deletes the job from the queue.

1. Visit <http://localhost:5000/docs/help> and create an annotation

4. You should be able to see the annotation in Elasticsearch: http://localhost:9200/hypothesis/_search

5. A `"sync_annotation"` job for the annotation will have been added to the queue. Run h-periodic and you should see the `sync_annotations()` task confirming that the annotation was successfully synced from Postgres to Elasticsearch.

   Due to the job's `scheduled_at` attribute it isn't available for processing immediately, so at first you may see this output from the `sync_annotations()` task indicating that it found no jobs to do:

       h.tasks.indexer.sync_annotations[*]: {}

   Wait for the task to run again and you should see this output indicating that it checked one annotation and found it to already be up-to-date in Elasticsearch:

       h.tasks.indexer.sync_annotations[*]: {'Completed/storage.create_annotation/Up_to_date_in_Elastic': 1, 'Completed/storage.create_annotation/Total': 1, 'Completed/Total': 1}

   The `sync_annotations()` task didn't actually index anything into Elasticsearch: it just checked and found that the annotation was already up-to-date in Elasticsearch. The job will now have been deleted fro the `job` table.

6. Stop h-periodic again

7. Delete the annotation

8. You should see that the annotation has been replaced with `{"deleted": true}` in Elasticsearch: <http://localhost:9200/hypothesis/_search>. This was not done by the job queue but by the foreground call to Elasticsearch in [`SearchIndexService.delete_annotation_by_id()`](https://github.com/hypothesis/h/blob/0985761c195c61f7389a99e475a306c9c35ec931/h/services/search_index.py#L101-L116)

9. A `"sync_annotation"` job will be added to the queue. Run h-periodic again and you should see this output from the `sync_annotations()` task indicating that it confirmed that the annotation had been deleted in Elasticsearch:

       h.tasks.indexer.sync_annotations[*]: {'Completed/AnnotationDeleteService.delete_annotation/Deleted_from_db': 1, 'Completed/AnnotationDeleteService.delete_annotation/Total': 1, 'Completed/Total': 1}

   The job will also have been deleted from the queue.

Allowing the job queue to delete an annotation
----------------------------------------------

This tests what happens if the initial foreground request to Elasticsearch to delete the annotation fails and the job queue has to step in later and delete it.

1. Disable the foreground deleting of annotations from Elasticsearch:

   ```diff
   diff --git a/h/services/search_index.py b/h/services/search_index.py
   index e87752807..4774de3e8 100644
   --- a/h/services/search_index.py
   +++ b/h/services/search_index.py
   @@ -114,8 +114,6 @@ class SearchIndexService:
                operations
            """
    
   -        self._index_annotation_body(annotation_id, {"deleted": True}, refresh=refresh)
   -
        def handle_annotation_event(self, event):
            """
            Process an annotation event, taking appropriate action to the event.
   ```

   It's difficult to simulate an Elasticsearch blip or outage by taking down Elasticsearch in the dev environment: when you bring Elasticsearch back up seems to receive requests that were sent while it was down and processes them. So hacking the code as above will have to suffice.

2. Go to http://localhost:5000/docs/help and create an annotation

4. You should be able to see the annotation in Elasticsearch: http://localhost:9200/hypothesis/_search

5. Run h-periodic and wait for the `sync_annotations()` task to run and confirm that the annotation was synced to Elasticsearch.

   The job may not be scheduled for execution yet the next time the task runs, so you may need to wait for the task to run again. The task will delete the job from the queue:

       h.tasks.indexer.sync_annotations[*]: {'Completed/storage.create_annotation/Up_to_date_in_Elastic': 1, 'Completed/storage.create_annotation/Total': 1, 'Completed/Total': 1}

6. Delete the annotation. This will mark the annotation as deleted in the DB but won't delete it from Elasticsearch. From the client's point of view the delete annotation API request will receive a successful response, and to the user the annotation will appear to have been deleted. A `"sync_annotation"` job will be added to the queue.

7. Run h-periodic and wait for the `sync_annotation()` task to run.

   The job may not be scheduled for execution yet the next time the task runs, so you may need to wait for the task to run again.

   You should see the task syncing the annotation deletion to Elasticsearch:

       h.tasks.indexer.sync_annotations[*]: {'Synced/AnnotationDeleteService.delete_annotation/Deleted_from_db': 1, 'Synced/AnnotationDeleteService.delete_annotation/Total': 1}

   At this point the annotation will have been removed from Elasticsearch (http://localhost:9200/hypothesis/_search) but the job will still be in the DB.

   Wait for the task to run again and it'll confirm that the annotation was deleted from Elasticsearch and remove the job from the DB:

       h.tasks.indexer.sync_annotations[*]: {'Completed/AnnotationDeleteService.delete_annotation/Deleted_from_db': 1, 'Completed/AnnotationDeleteService.delete_annotation/Total': 1}

Deleting an annotation that's already been purged
-------------------------------------------------

The `purge_deleted_annotations()` task runs hourly whereas the `sync_annotations()` task runs every minute, so it'll be a normal occurrence for the `purge_deleted_annotations()` task to run and expunge a deleted annotation from the DB before the `sync_annotations()` task picks up that annotation's `"sync_annotation"` job.

To simulate this, delete an annotation and then run `make sql` and delete the annotation from the DB, and then run h-periodic and wait for the `sync_annotations()` task to run.