### PR TITLE
Validate max length for document.link.href

### DIFF
--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -46,7 +46,7 @@ DOCUMENT_SCHEMA = {
             "items": {
                 "type": "object",
                 "properties": {
-                    "href": {"type": "string"},
+                    "href": {"type": "string", "maxLength": 3000},
                     "type": {"type": "string"},
                 },
                 "required": ["href"],
@@ -86,8 +86,8 @@ class AnnotationSchema(JSONSchema):
                 },
                 "required": ["read"],
             },
-            "references": {"type": "array", "items": {"type": "string"}},
             "tags": {"type": "array", "items": {"type": "string", "maxLength": 1000}},
+            "references": {"type": "array", "items": {"type": "string"}},
             "target": {
                 "type": "array",
                 "items": {

--- a/tests/unit/h/schemas/annotation_test.py
+++ b/tests/unit/h/schemas/annotation_test.py
@@ -123,6 +123,14 @@ class TestCreateUpdateAnnotationSchema:
                 "document.link.0.href: False is not of type 'string'",
             ),
             (
+                {
+                    "document": {
+                        "link": [{"href": f"https://example.com?{'LONG'*3000}"}]
+                    }
+                },
+                f"document.link.0.href: 'https://example.com?{'LONG'*3000}' is too long",
+            ),
+            (
                 {"document": {"link": [{"href": "http://example.com", "type": False}]}},
                 "document.link.0.type: False is not of type 'string'",
             ),


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/8498

We need to validate the max length as we are inserting some value in the DB which exceed the size for an indexable value.

The value selected here, 3000, is longer that the documented max length supported by some browsers (2083) but that allows for any encoding differences.

At the time of writing only around 15 rows in the DB out of a total of 14 milling documents are over 3000 characters long.

The main focus now is having this under control in the storage layer, we could refine this further but it doesn't seem like a common occurrence in any case.