### PR TITLE
Add route to log pushed analytics events

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -183,6 +183,8 @@ def includeme(config):  # pylint: disable=too-many-statements
     config.add_route("oauth_authorize", "/oauth/authorize")
     config.add_route("oauth_revoke", "/oauth/revoke")
 
+    config.add_route("api.analytics.events", "/api/analytics/events")
+
     # Client
     config.add_route("sidebar_app", "/app.html")
     config.add_route("notebook_app", "/notebook")

--- a/h/schemas/analytics.py
+++ b/h/schemas/analytics.py
@@ -1,0 +1,30 @@
+from typing import TypedDict
+
+from h.schemas.base import JSONSchema
+
+
+class EventSchema(JSONSchema):
+    schema = {
+        "type": "object",
+        "required": ["event"],
+        "properties": {
+            "event": {
+                "type": "string",
+                "enum": ["APPLY_PENDING_UPDATES"],
+            },
+        },
+    }
+
+
+class Event(TypedDict):
+    event: str
+
+
+class CreateEventSchema:
+    """Validate the POSTed data of a create event request."""
+
+    def __init__(self):
+        self._structure = EventSchema()
+
+    def validate(self, data: dict) -> Event:
+        return self._structure.validate(data)

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -150,3 +150,6 @@ def includeme(config):  # pragma: no cover
     config.register_service_factory(
         "h.services.url_migration.service_factory", name="url_migration"
     )
+    config.register_service_factory(
+        "h.services.analytics.analytics_service_factory", name="analytics"
+    )

--- a/h/services/analytics.py
+++ b/h/services/analytics.py
@@ -1,0 +1,13 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class AnalyticsService:
+    def create(self, event_metadata: dict):
+        # TODO Enhance this
+        log.info(event_metadata)
+
+
+def analytics_service_factory(_context, _request):
+    return AnalyticsService()

--- a/h/services/analytics.py
+++ b/h/services/analytics.py
@@ -2,13 +2,14 @@ import logging
 
 from h.schemas.analytics import Event
 
-log = logging.getLogger(__name__)
-
 
 class AnalyticsService:
+    def __init__(self):
+        self._log = logging.getLogger(__name__)
+
     def create(self, event: Event):
         # TODO Enhance this
-        log.info(event)
+        self._log.info(event)
 
 
 def analytics_service_factory(_context, _request):

--- a/h/services/analytics.py
+++ b/h/services/analytics.py
@@ -1,12 +1,14 @@
 import logging
 
+from h.schemas.analytics import Event
+
 log = logging.getLogger(__name__)
 
 
 class AnalyticsService:
-    def create(self, event_metadata: dict):
+    def create(self, event: Event):
         # TODO Enhance this
-        log.info(event_metadata)
+        log.info(event)
 
 
 def analytics_service_factory(_context, _request):

--- a/h/views/api/analytics.py
+++ b/h/views/api/analytics.py
@@ -1,6 +1,7 @@
 from pyramid.httpexceptions import HTTPNoContent
 from pyramid.request import Request
 
+from h.schemas.analytics import CreateEventSchema
 from h.services.analytics import AnalyticsService
 from h.views.api.config import api_config
 
@@ -14,8 +15,9 @@ from h.views.api.config import api_config
 )
 def create_event(request: Request):
     """Create a new analytics event."""
+    schema = CreateEventSchema()
     analytics_service: AnalyticsService = request.find_service(name="analytics")
 
-    analytics_service.create(request.json_body)
+    analytics_service.create(schema.validate(request.json_body))
 
     return HTTPNoContent()

--- a/h/views/api/analytics.py
+++ b/h/views/api/analytics.py
@@ -1,0 +1,21 @@
+from pyramid.httpexceptions import HTTPNoContent
+from pyramid.request import Request
+
+from h.services.analytics import AnalyticsService
+from h.views.api.config import api_config
+
+
+@api_config(
+    versions=["v1", "v2"],
+    route_name="api.analytics.events",
+    request_method="POST",
+    link_name="analytics.events.create",
+    description="Create a new analytics event",
+)
+def create_event(request: Request):
+    """Create a new analytics event."""
+    analytics_service: AnalyticsService = request.find_service(name="analytics")
+
+    analytics_service.create(request.json_body)
+
+    return HTTPNoContent()

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -2,6 +2,7 @@ from unittest.mock import create_autospec
 
 import pytest
 
+from h.services.analytics import AnalyticsService
 from h.services.annotation_delete import AnnotationDeleteService
 from h.services.annotation_json import AnnotationJSONService
 from h.services.annotation_metadata import AnnotationMetadataService
@@ -39,6 +40,7 @@ from h.services.user_update import UserUpdateService
 
 __all__ = (
     "mock_service",
+    "analytics_service",
     "annotation_delete_service",
     "annotation_json_service",
     "annotation_metadata_service",
@@ -92,6 +94,11 @@ def mock_service(pyramid_config):
         return service
 
     return mock_service
+
+
+@pytest.fixture
+def analytics_service(mock_service):
+    return mock_service(AnalyticsService, name="analytics")
 
 
 @pytest.fixture

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -174,6 +174,7 @@ def test_includeme():
         call("token", "/api/token"),
         call("oauth_authorize", "/oauth/authorize"),
         call("oauth_revoke", "/oauth/revoke"),
+        call("api.analytics.events", "/api/analytics/events"),
         call("sidebar_app", "/app.html"),
         call("notebook_app", "/notebook"),
         call("profile_app", "/user-profile"),

--- a/tests/unit/h/schemas/analytics_test.py
+++ b/tests/unit/h/schemas/analytics_test.py
@@ -1,0 +1,28 @@
+import pytest
+
+from h.schemas import ValidationError
+from h.schemas.analytics import CreateEventSchema
+
+
+class TestCreateEventSchema:
+    @pytest.mark.parametrize(
+        "payload,expected_error",
+        [
+            ({}, "'event' is a required property"),
+            ({"foo": "bar"}, "'event' is a required property"),
+            (
+                {"event": "invalid"},
+                "event: 'invalid' is not one of \\['APPLY_PENDING_UPDATES'\\]",
+            ),
+        ],
+    )
+    def test_error_for_invalid_data(self, payload: dict, expected_error: str):
+        schema = CreateEventSchema()
+        with pytest.raises(ValidationError, match=expected_error):
+            schema.validate(payload)
+
+    def test_valid_data_is_returned(self):
+        schema = CreateEventSchema()
+        result = schema.validate({"event": "APPLY_PENDING_UPDATES"})
+
+        assert result == {"event": "APPLY_PENDING_UPDATES"}

--- a/tests/unit/h/services/analytics_test.py
+++ b/tests/unit/h/services/analytics_test.py
@@ -1,0 +1,16 @@
+import logging
+from unittest import mock
+
+from h.services.analytics import analytics_service_factory
+
+
+class TestAnalyticsService:
+    @mock.patch.object(logging, "getLogger")
+    def test_it_logs_events(self, mock_get_logger):
+        mock_logger = mock.Mock()
+        mock_get_logger.return_value = mock_logger
+
+        svc = analytics_service_factory({}, None)
+        svc.create({"foo": "bar"})
+
+        mock_logger.info.assert_called_once_with({"foo": "bar"})

--- a/tests/unit/h/views/api/analytics_test.py
+++ b/tests/unit/h/views/api/analytics_test.py
@@ -1,0 +1,23 @@
+import pytest
+
+from h.schemas import ValidationError
+from h.views.api.analytics import create_event
+
+
+@pytest.mark.usefixtures("analytics_service")
+class TestCreateEvent:
+    def test_analytics_service_is_invoked(self, pyramid_request, analytics_service):
+        pyramid_request.json_body = {"event": "APPLY_PENDING_UPDATES"}
+        res = create_event(pyramid_request)
+
+        assert analytics_service.create.called
+        assert res.status_code == 204
+
+    def test_error_if_invalid_event_payload_is_provided(
+        self, pyramid_request, analytics_service
+    ):
+        pyramid_request.json_body = {}
+        with pytest.raises(ValidationError):
+            create_event(pyramid_request)
+
+        assert not analytics_service.create.called


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/6255

Implement a new endpoint that can be used to track arbitrary events, with the intention to use it as a sort of analytics backend.

Events will be persisted in the form of standard application logs for now, but we can send them somewhere else eventually.

In order to avoid our logs to be flooded with nonsense data, we validate the payload, allowing only known events. At the moment, the only valid payload is this:

```json
{
  "event": "APPLY_PENDING_UPDATES"
}
```

### Testing steps

Run the next script:

```bash
curl --request POST \
  --url http://localhost:5000/api/analytics/events \
  --data '{
  "event": "APPLY_PENDING_UPDATES"
}'
```

You should see a line like this in `h` logs: `[h.services.analytics:INFO] {'event': 'APPLY_PENDING_UPDATES'}`

![image](https://github.com/hypothesis/h/assets/2719332/e20e3f25-6895-460a-8a1f-6e4a0c3a7806)

If you run the same with an invalid payload, you should get an error back

```bash
curl --request POST \
  --url http://localhost:5000/api/analytics/events \
  --data '{
  "event": "invalid"
}'
```

`{"status": "failure", "reason": "event: 'invalid' is not one of ['APPLY_PENDING_UPDATES']"}`

