### PR TITLE
Add request.db_replica property connecting to a DB replica

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -57,6 +57,9 @@ def configure(environ=None, settings=None):  # pylint: disable=too-many-statemen
     settings_manager.set("mail.host", "MAIL_HOST")
     settings_manager.set("mail.port", "MAIL_PORT", type_=int)
     settings_manager.set("sqlalchemy.url", "DATABASE_URL", required=True)
+    settings_manager.set(
+        "sqlalchemy.replica.url", "REPLICA_DATABASE_URL", required=False
+    )
 
     # Configuration for Pyramid
     settings_manager.set("secret_key", "SECRET_KEY", type_=_to_utf8, required=True)

--- a/h/views/status.py
+++ b/h/views/status.py
@@ -17,6 +17,13 @@ def status(request):
         log.exception(err)
         raise HTTPInternalServerError("Database connection failed") from err
 
+    if "replica" in request.params:
+        try:
+            request.db_replica.execute(text("SELECT 1"))
+        except Exception as err:
+            log.exception(err)
+            raise HTTPInternalServerError("Replica database connection failed") from err
+
     if "sentry" in request.params:
         capture_message("Test message from h's status view")
 

--- a/tests/unit/h/views/status_test.py
+++ b/tests/unit/h/views/status_test.py
@@ -28,10 +28,25 @@ class TestStatus:
 
         capture_message.assert_called_once_with("Test message from h's status view")
 
+    def test_it_access_the_replica(self, pyramid_request, db_replica):
+        pyramid_request.params["replica"] = ""
+        db_replica.execute.side_effect = Exception("explode!")
+
+        with pytest.raises(HTTPInternalServerError) as exc:
+            status(pyramid_request)
+
+        assert "Replica database connection failed" in str(exc.value)
+
     @pytest.fixture
     def db(self, pyramid_request):
         db = mock.Mock()
         pyramid_request.db = db
+        return db
+
+    @pytest.fixture
+    def db_replica(self, pyramid_request):
+        db = mock.Mock()
+        pyramid_request.db_replica = db
         return db
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -101,6 +101,7 @@ setenv =
     dev: WEB_CONCURRENCY = {env:WEB_CONCURRENCY:2}
     tests: COVERAGE_FILE = {env:COVERAGE_FILE:.coverage.{envname}}
     dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost/postgres}
+    dev: REPLICA_DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost/postgres}
     tests: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost/h_tests}
     functests: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost/h_functests}
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES


### PR DESCRIPTION
This commit only adds the setup necessary and a /_status check for the new property.

Follow up commits will start using the new property in endpoints that potentially make long queries.


# Deployment plan

- Deploy this PR to staging, sanity check normal behaviour.
- Check that /_status?replica=1 does fail.
- Set up REPLICA_DATABASE_URL

If we do have a replica in staging, point it to that, otherwise point it to the regular DB string.

- Check that /_status?replica=1 succeeds now.
- Deploy to prod. 
- Check that /_status?replica=1 does fail.
- Set up REPLICA_DATABASE_URL
- Check that /_status?replica=1 succeeds now.


