### PR TITLE
Switch to `{app}.{area}.{event}` format for analytics events

### DIFF
--- a/h/schemas/analytics.py
+++ b/h/schemas/analytics.py
@@ -10,7 +10,7 @@ class EventSchema(JSONSchema):
         "properties": {
             "event": {
                 "type": "string",
-                "enum": ["APPLY_PENDING_UPDATES"],
+                "enum": ["client.realtime.apply_updates"],
             },
         },
     }

--- a/tests/unit/h/schemas/analytics_test.py
+++ b/tests/unit/h/schemas/analytics_test.py
@@ -12,7 +12,7 @@ class TestCreateEventSchema:
             ({"foo": "bar"}, "'event' is a required property"),
             (
                 {"event": "invalid"},
-                "event: 'invalid' is not one of \\['APPLY_PENDING_UPDATES'\\]",
+                "event: 'invalid' is not one of \\['client.realtime.apply_updates'\\]",
             ),
         ],
     )
@@ -23,6 +23,6 @@ class TestCreateEventSchema:
 
     def test_valid_data_is_returned(self):
         schema = CreateEventSchema()
-        result = schema.validate({"event": "APPLY_PENDING_UPDATES"})
+        result = schema.validate({"event": "client.realtime.apply_updates"})
 
-        assert result == {"event": "APPLY_PENDING_UPDATES"}
+        assert result == {"event": "client.realtime.apply_updates"}

--- a/tests/unit/h/views/api/analytics_test.py
+++ b/tests/unit/h/views/api/analytics_test.py
@@ -7,7 +7,7 @@ from h.views.api.analytics import create_event
 @pytest.mark.usefixtures("analytics_service")
 class TestCreateEvent:
     def test_analytics_service_is_invoked(self, pyramid_request, analytics_service):
-        pyramid_request.json_body = {"event": "APPLY_PENDING_UPDATES"}
+        pyramid_request.json_body = {"event": "client.realtime.apply_updates"}
         res = create_event(pyramid_request)
 
         assert analytics_service.create.called


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/6255

As suggested in https://github.com/hypothesis/client/pull/6275#discussion_r1547973097, this PR switches to a different format for analytics events, which will help when searching for related events or events belonging to the same context.

For now, the only existing event is `APPLY_PENDING_UPDATES`, which has been replaced by `client.realtime.apply_updates`.

This should not be a breaking change, as this capability is not yet being used by the client.

### Testing

Follow the testing steps described in https://github.com/hypothesis/h/pull/8623, but with `client.realtime.apply_updates` instead of `APPLY_PENDING_UPDATES`.