### PR TITLE
Use bulk group queries to the read replica

### DIFF
--- a/h/services/bulk_api/group.py
+++ b/h/services/bulk_api/group.py
@@ -16,8 +16,8 @@ class BulkGroup:
 class BulkGroupService:
     """A service for retrieving groups in bulk."""
 
-    def __init__(self, db: Session):
-        self._db = db
+    def __init__(self, db_replica: Session):
+        self._db_replica = db_replica
 
     def group_search(
         self, groups: List[str], annotations_created: dict
@@ -43,9 +43,9 @@ class BulkGroupService:
                 )
             ),
         )
-        results = self._db.scalars(query)
+        results = self._db_replica.scalars(query)
         return [BulkGroup(authority_provided_id=row) for row in results.all()]
 
 
 def service_factory(_context, request) -> BulkGroupService:
-    return BulkGroupService(db=request.db)
+    return BulkGroupService(db_replica=request.db_replica)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from os import environ
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 
@@ -41,3 +41,9 @@ def db_session(db_engine, db_sessionfactory):
         session.close()
         transaction.rollback()
         connection.close()
+
+
+@pytest.fixture
+def db_session_replica(db_session):
+    db_session.execute(text("SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY;"))
+    yield db_session

--- a/tests/unit/h/conftest.py
+++ b/tests/unit/h/conftest.py
@@ -139,9 +139,11 @@ def pyramid_config(pyramid_settings, pyramid_request):
 
 
 @pytest.fixture
-def pyramid_request(db_session, fake_feature, pyramid_settings):
+def pyramid_request(db_session, db_session_replica, fake_feature, pyramid_settings):
     """Return pyramid request object."""
-    request = testing.DummyRequest(db=db_session, feature=fake_feature)
+    request = testing.DummyRequest(
+        db=db_session, db_replica=db_session_replica, feature=fake_feature
+    )
     request.default_authority = "example.com"
     request.create_form = mock.Mock()
     request.matched_route = mock.Mock()

--- a/tests/unit/h/services/bulk_api/group_test.py
+++ b/tests/unit/h/services/bulk_api/group_test.py
@@ -40,7 +40,7 @@ class TestServiceFactory:
     def test_it(self, pyramid_request, BulkGroupService):
         svc = service_factory(sentinel.context, pyramid_request)
 
-        BulkGroupService.assert_called_once_with(db=pyramid_request.db)
+        BulkGroupService.assert_called_once_with(db_replica=pyramid_request.db_replica)
         assert svc == BulkGroupService.return_value
 
     @pytest.fixture


### PR DESCRIPTION
This query tends to be slow, while making the query in the replica won't
make it faster it won't affect/be affected by regular traffic to the DB.