### PR TITLE
Create a FF for the LMS analytics dashboard

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -17,6 +17,7 @@ FEATURES = {
     "client_user_profile": "Enable client-side user profile and preferences management",
     "export_formats": "Allow users to select the format for their annotations export file",
     "pending_updates_notification": "Display an actionable toast-like notification when there are pending updates",
+    "lms_analytics_dashboard": "Display an entry point in the user dropdown for the LMS analytics dashboard",
 }
 
 


### PR DESCRIPTION
Part of https://github.com/orgs/hypothesis/projects/135/views/1?pane=issue&itemId=53521476

Adding a new feature flag to control if the entry point for the LMS analytics dashboard should be displayed in the sidebar user menu.

This FF will then be checked together with other conditions, as this entry point should not be displayed for non-instructor users or when the sidebar is rendered outside of the LMS context.