### PR TITLE
Remove export_formats feature flag, which is no longer used by client

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -15,7 +15,6 @@ FEATURES = {
     "pdf_custom_text_layer": "Use custom text layer in PDFs for improved text selection",
     "styled_highlight_clusters": "Style different clusters of highlights in the client",
     "client_user_profile": "Enable client-side user profile and preferences management",
-    "export_formats": "Allow users to select the format for their annotations export file",
     "pending_updates_notification": "Display an actionable toast-like notification when there are pending updates",
 }
 


### PR DESCRIPTION
The client is no longer using `export_formats` as of https://github.com/hypothesis/client/pull/6321, so we can remove it from h