### PR TITLE
Upgrade postgres to 15.6 in preparation for the production upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest-32-cores
     services:
       postgres:
-        image: postgres:11.5-alpine
+        image: postgres:15.6-alpine
         ports:
         - 5432:5432
         env:
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11.5-alpine
+        image: postgres:15.6-alpine
         ports:
         - 5432:5432
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,14 @@
 version: '3'
 services:
   postgres:
-    image: postgres:11.5-alpine
+    image: postgres:15.6-alpine
     ports:
       - '127.0.0.1:5432:5432'
     healthcheck:
         test: ["CMD", "pg_isready", "-U", "postgres"]
         interval: 1s
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
     networks:
       - dbs
   elasticsearch:

--- a/tests/unit/h/models/user_identity_test.py
+++ b/tests/unit/h/models/user_identity_test.py
@@ -44,8 +44,7 @@ class TestUserIdentity:
         db_session.add(models.UserIdentity(provider_unique_id="1", user=user))
 
         with pytest.raises(
-            sqlalchemy.exc.IntegrityError,
-            match='null value in column "provider" violates not-null constraint',
+            sqlalchemy.exc.IntegrityError, match='null value in column "provider"'
         ):
             db_session.flush()
 
@@ -54,7 +53,7 @@ class TestUserIdentity:
 
         with pytest.raises(
             sqlalchemy.exc.IntegrityError,
-            match='null value in column "provider_unique_id" violates not-null constraint',
+            match='null value in column "provider_unique_id"',
         ):
             db_session.flush()
 
@@ -62,8 +61,7 @@ class TestUserIdentity:
         db_session.add(models.UserIdentity(provider="provider", provider_unique_id="1"))
 
         with pytest.raises(
-            sqlalchemy.exc.IntegrityError,
-            match='null value in column "user_id" violates not-null constraint',
+            sqlalchemy.exc.IntegrityError, match='null value in column "user_id"'
         ):
             db_session.flush()
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/playbook/issues/1147

## Testing and local env setup

- If you don't have the service running you can just

`make services dev`

and the right postgres version will start.


If you do have a container running it won't start after the upgrade:

- Optionally, backup the contents


```docker exec -it h-postgres-1 pg_dumpall -U postgres > upgrade_backup.sql```


- Find the the volume ID:

```
docker inspect -f '{{ .Mounts }}' h-postgres-1
[{volume e22d1a81e263ceb8a63b29a14bc7ec2dbe9f023e7c05742cba6694a4999a6076 /var/lib/docker/volumes/e22d1a81e263ceb8a63b29a14bc7ec2dbe9f023e7c05742cba6694a4999a6076/_data /var/lib/postgresql/data local  true }]
```

- Stop the container

`docker compose down postgres`


- And remove the volume:

`docker volume rm e22d1a81e263ceb8a63b29a14bc7ec2dbe9f023e7c05742cba6694a4999a6076`


- Start the services again

`docker compose up`

- Optionally restore the DB

```cat upgrade_backup.sql | docker exec -i h-postgres-1 psql -U postgres```


- Start  server do double check everything is ok

`make services dev`
