### PR TITLE
Remove obsolete field `version` in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   postgres:
     image: postgres:15.6-alpine


### PR DESCRIPTION
This removes the warning while running make services

See: https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete