### PR TITLE
Remove python-jose dependency

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -34,9 +34,7 @@ certifi==2024.2.2
     #   -r requirements/prod.txt
     #   sentry-sdk
 cffi==1.16.0
-    # via
-    #   -r requirements/prod.txt
-    #   cryptography
+    # via -r requirements/prod.txt
 chameleon==4.4.3
     # via
     #   -r requirements/prod.txt
@@ -65,10 +63,6 @@ colander==2.0
     # via
     #   -r requirements/prod.txt
     #   deform
-cryptography==42.0.4
-    # via
-    #   -r requirements/prod.txt
-    #   python-jose
 data-tasks==0.0.3
     # via -r requirements/prod.txt
 decorator==5.1.1
@@ -77,10 +71,6 @@ decorator==5.1.1
     #   ipython
 deform==2.0.15
     # via -r requirements/prod.txt
-ecdsa==0.18.0
-    # via
-    #   -r requirements/prod.txt
-    #   python-jose
 elasticsearch==6.8.2
     # via
     #   -r requirements/prod.txt
@@ -226,11 +216,6 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyasn1==0.5.1
-    # via
-    #   -r requirements/prod.txt
-    #   python-jose
-    #   rsa
 pycparser==2.21
     # via
     #   -r requirements/prod.txt
@@ -282,8 +267,6 @@ python-dateutil==2.9.0.post0
     #   celery
     #   elasticsearch-dsl
     #   faker
-python-jose[cryptography]==3.3.0
-    # via -r requirements/prod.txt
 python-slugify==8.0.4
     # via -r requirements/prod.txt
 pytz==2024.1
@@ -305,10 +288,6 @@ rpds-py==0.16.2
     #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via
-    #   -r requirements/prod.txt
-    #   python-jose
 sentry-sdk==2.0.1
     # via
     #   -r requirements/prod.txt
@@ -318,7 +297,6 @@ six==1.16.0
     #   -r requirements/prod.txt
     #   asttokens
     #   bleach
-    #   ecdsa
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -34,9 +34,7 @@ certifi==2024.2.2
     #   -r requirements/prod.txt
     #   sentry-sdk
 cffi==1.16.0
-    # via
-    #   -r requirements/prod.txt
-    #   cryptography
+    # via -r requirements/prod.txt
 chameleon==4.4.3
     # via
     #   -r requirements/prod.txt
@@ -65,18 +63,10 @@ colander==2.0
     # via
     #   -r requirements/prod.txt
     #   deform
-cryptography==42.0.4
-    # via
-    #   -r requirements/prod.txt
-    #   python-jose
 data-tasks==0.0.3
     # via -r requirements/prod.txt
 deform==2.0.15
     # via -r requirements/prod.txt
-ecdsa==0.18.0
-    # via
-    #   -r requirements/prod.txt
-    #   python-jose
 elasticsearch==6.8.2
     # via
     #   -r requirements/prod.txt
@@ -208,11 +198,6 @@ psycopg2==2.9.9
     # via
     #   -r requirements/prod.txt
     #   data-tasks
-pyasn1==0.5.1
-    # via
-    #   -r requirements/prod.txt
-    #   python-jose
-    #   rsa
 pycparser==2.21
     # via
     #   -r requirements/prod.txt
@@ -265,8 +250,6 @@ python-dateutil==2.9.0.post0
     #   celery
     #   elasticsearch-dsl
     #   faker
-python-jose[cryptography]==3.3.0
-    # via -r requirements/prod.txt
 python-slugify==8.0.4
     # via -r requirements/prod.txt
 pytz==2024.1
@@ -288,10 +271,6 @@ rpds-py==0.16.2
     #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via
-    #   -r requirements/prod.txt
-    #   python-jose
 sentry-sdk==2.0.1
     # via
     #   -r requirements/prod.txt
@@ -300,7 +279,6 @@ six==1.16.0
     # via
     #   -r requirements/prod.txt
     #   bleach
-    #   ecdsa
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -57,7 +57,6 @@ cffi==1.16.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-    #   cryptography
 chameleon==4.4.3
     # via
     #   -r requirements/functests.txt
@@ -96,11 +95,6 @@ coverage[toml]==7.5.0
     # via
     #   -r requirements/tests.txt
     #   pytest-cov
-cryptography==42.0.4
-    # via
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
-    #   python-jose
 data-tasks==0.0.3
     # via
     #   -r requirements/functests.txt
@@ -111,11 +105,6 @@ deform==2.0.15
     #   -r requirements/tests.txt
 dill==0.3.7
     # via pylint
-ecdsa==0.18.0
-    # via
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
-    #   python-jose
 elasticsearch==6.8.2
     # via
     #   -r requirements/functests.txt
@@ -125,7 +114,7 @@ elasticsearch-dsl==6.4.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-execnet==2.0.2
+execnet==2.1.1
     # via
     #   -r requirements/tests.txt
     #   pytest-xdist
@@ -328,12 +317,6 @@ psycopg2==2.9.9
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   data-tasks
-pyasn1==0.5.1
-    # via
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
-    #   python-jose
-    #   rsa
 pycodestyle==2.11.1
     # via -r requirements/lint.in
 pycparser==2.21
@@ -415,7 +398,7 @@ pytest-cov==5.0.0
     # via -r requirements/tests.txt
 pytest-reverse==1.7.0
     # via -r requirements/functests.txt
-pytest-xdist[psutil]==3.5.0
+pytest-xdist[psutil]==3.6.1
     # via -r requirements/tests.txt
 python-dateutil==2.9.0.post0
     # via
@@ -425,10 +408,6 @@ python-dateutil==2.9.0.post0
     #   elasticsearch-dsl
     #   faker
     #   freezegun
-python-jose[cryptography]==3.3.0
-    # via
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
 python-slugify==8.0.4
     # via
     #   -r requirements/functests.txt
@@ -459,11 +438,6 @@ rpds-py==0.16.2
     #   -r requirements/tests.txt
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
-    #   python-jose
 sentry-sdk==2.0.1
     # via
     #   -r requirements/functests.txt
@@ -474,7 +448,6 @@ six==1.16.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   bleach
-    #   ecdsa
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -8,7 +8,6 @@ data_tasks
 pyramid-sanity
 
 # 3rd-party packages
-python-jose[cryptography]
 PyJWT
 SQLAlchemy
 alembic

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -25,9 +25,7 @@ certifi==2024.2.2
     #   -r requirements/prod.in
     #   sentry-sdk
 cffi==1.16.0
-    # via
-    #   -r requirements/prod.in
-    #   cryptography
+    # via -r requirements/prod.in
 chameleon==4.4.3
     # via deform
 click==8.1.7
@@ -45,14 +43,10 @@ click-repl==0.3.0
     # via celery
 colander==2.0
     # via deform
-cryptography==42.0.4
-    # via python-jose
 data-tasks==0.0.3
     # via -r requirements/prod.in
 deform==2.0.15
     # via -r requirements/prod.in
-ecdsa==0.18.0
-    # via python-jose
 elasticsearch==6.8.2
     # via
     #   -r requirements/prod.in
@@ -147,10 +141,6 @@ psycopg2==2.9.9
     # via
     #   -r requirements/prod.in
     #   data-tasks
-pyasn1==0.5.1
-    # via
-    #   python-jose
-    #   rsa
 pycparser==2.21
     # via cffi
 pycryptodomex==3.20.0
@@ -190,8 +180,6 @@ python-dateutil==2.9.0.post0
     #   -r requirements/prod.in
     #   celery
     #   elasticsearch-dsl
-python-jose[cryptography]==3.3.0
-    # via -r requirements/prod.in
 python-slugify==8.0.4
     # via -r requirements/prod.in
 pytz==2024.1
@@ -209,8 +197,6 @@ rpds-py==0.16.2
     # via
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via python-jose
 sentry-sdk==2.0.1
     # via
     #   -r requirements/prod.in
@@ -218,7 +204,6 @@ sentry-sdk==2.0.1
 six==1.16.0
     # via
     #   bleach
-    #   ecdsa
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -33,9 +33,7 @@ certifi==2024.2.2
     #   -r requirements/prod.txt
     #   sentry-sdk
 cffi==1.16.0
-    # via
-    #   -r requirements/prod.txt
-    #   cryptography
+    # via -r requirements/prod.txt
 chameleon==4.4.3
     # via
     #   -r requirements/prod.txt
@@ -68,18 +66,10 @@ coverage[toml]==7.5.0
     # via
     #   -r requirements/tests.in
     #   pytest-cov
-cryptography==42.0.4
-    # via
-    #   -r requirements/prod.txt
-    #   python-jose
 data-tasks==0.0.3
     # via -r requirements/prod.txt
 deform==2.0.15
     # via -r requirements/prod.txt
-ecdsa==0.18.0
-    # via
-    #   -r requirements/prod.txt
-    #   python-jose
 elasticsearch==6.8.2
     # via
     #   -r requirements/prod.txt
@@ -219,11 +209,6 @@ psycopg2==2.9.9
     # via
     #   -r requirements/prod.txt
     #   data-tasks
-pyasn1==0.5.1
-    # via
-    #   -r requirements/prod.txt
-    #   python-jose
-    #   rsa
 pycparser==2.21
     # via
     #   -r requirements/prod.txt
@@ -280,8 +265,6 @@ python-dateutil==2.9.0.post0
     #   elasticsearch-dsl
     #   faker
     #   freezegun
-python-jose[cryptography]==3.3.0
-    # via -r requirements/prod.txt
 python-slugify==8.0.4
     # via -r requirements/prod.txt
 pytz==2024.1
@@ -303,10 +286,6 @@ rpds-py==0.16.2
     #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via
-    #   -r requirements/prod.txt
-    #   python-jose
 sentry-sdk==2.0.1
     # via
     #   -r requirements/prod.txt
@@ -315,7 +294,6 @@ six==1.16.0
     # via
     #   -r requirements/prod.txt
     #   bleach
-    #   ecdsa
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator


### PR DESCRIPTION
This was used by a feature that was later reverted but the dep was not removed.

See: https://github.com/hypothesis/h/pull/8258

