### PR TITLE
Revert "Bump node from 21.7-alpine to 22.0-alpine"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build static frontend assets.
-FROM node:22.0-alpine as build
+FROM node:21.7-alpine as build
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Reverts hypothesis/h#8681 because it seems to have broken the Docker build ([Slack thread](https://hypothes-is.slack.com/archives/C1M8NH76X/p1714666597219069))