### PR TITLE
Fix user deletion

### DIFF
--- a/h/models/job.py
+++ b/h/models/job.py
@@ -28,6 +28,8 @@ This home-grown job queue differs from our Celery task queue in a few ways:
    that really need Postgres transactionality should use this custom job queue.
 """
 
+from enum import Enum
+
 from sqlalchemy import (
     Column,
     DateTime,
@@ -46,6 +48,11 @@ from h.models import helpers
 
 class Job(Base):
     """A job in the job queue."""
+
+    class JobName(str, Enum):
+        SYNC_ANNOTATION = "sync_annotation"
+        ANNOTATION_SLIM = "annotation_slim"
+        PURGE_USER = "purge_user"
 
     __tablename__ = "job"
 

--- a/h/services/job_queue.py
+++ b/h/services/job_queue.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from enum import Enum
 
 from sqlalchemy import and_, func, literal_column, select
 from zope.sqlalchemy import mark_changed
@@ -15,10 +14,6 @@ class Priority:
 
 
 class JobQueueService:
-    class JobName(str, Enum):
-        SYNC_ANNOTATION = "sync_annotation"
-        ANNOTATION_SLIM = "annotation_slim"
-
     def __init__(self, db):
         self._db = db
 

--- a/h/services/user_delete.py
+++ b/h/services/user_delete.py
@@ -1,70 +1,361 @@
-import sqlalchemy as sa
+import logging
+from datetime import datetime
 
-from h.models import Annotation, Group, Token, User, UserDeletion
-from h.services.annotation_delete import AnnotationDeleteService
+from sqlalchemy import and_, delete, func, select, update
+
+from h.models import (
+    Annotation,
+    AnnotationSlim,
+    AuthTicket,
+    FeatureCohortUser,
+    Flag,
+    Group,
+    GroupMembership,
+    Job,
+    Token,
+    User,
+    UserDeletion,
+)
+
+log = logging.getLogger(__name__)
 
 
 class UserDeleteService:
-    def __init__(
-        self,
-        db_session: sa.orm.Session,
-        annotation_delete_service: AnnotationDeleteService,
-    ):
-        self._db = db_session
-        self._annotation_delete_service = annotation_delete_service
+
+    def __init__(self, db, job_queue, user_svc):
+        self.db = db
+        self.job_queue = job_queue
+        self.user_svc = user_svc
 
     def delete_user(self, user: User, requested_by: User, tag: str):
-        """
-        Delete a user with all their group memberships and annotations.
+        """Mark `user` as deleted and start purging their data in the background."""
 
-        If a user owns groups with collaborators, meaning there are annotations
-        in the group that have been made by other users, the user is unassigned
-        as creator but the group persists.
-        """
-        self._db.execute(sa.delete(Token).where(Token.user == user))
+        # Mark the user as deleted so they can't login anymore.
+        user.deleted = True
 
-        # Delete all annotations
-        self._annotation_delete_service.delete_annotations(
-            annotations=self._db.query(Annotation).filter_by(userid=user.userid).all()
+        # We can't just purge all the user's data right now because for users
+        # with a lot of data this takes too long for an HTTP request and the
+        # request times out.
+        #
+        # So add a job to purge the user's data in the background.
+        self.db.add(
+            Job(
+                name=Job.JobName.PURGE_USER,
+                priority=0,
+                tag="UserDeleteService.delete_user",
+                kwargs={"userid": user.userid},
+            )
         )
 
-        # Delete or remove our link to groups we've created
-        for group, annotations_by_other_users in self._db.execute(
-            # pylint:disable=not-callable
-            sa.select(Group, sa.func.count(Annotation.id))
-            .where(Group.creator == user)
-            .outerjoin(
-                Annotation,
-                sa.and_(
-                    Annotation.groupid == Group.pubid, Annotation.userid != user.userid
-                ),
-            )
-            .group_by(Group.id)
-        ):
-            if annotations_by_other_users:
-                group.creator = None
-            else:
-                self._db.delete(group)
-
-        self._db.add(
+        # Record the deletion for record-keeping purposes.
+        self.db.add(
             UserDeletion(
                 userid=user.userid,
                 requested_by=requested_by.userid,
                 tag=tag,
                 registered_date=user.registered_date,
-                num_annotations=self._db.scalar(
-                    sa.select(
-                        sa.func.count(Annotation.id)  # pylint:disable=not-callable
+                num_annotations=self.db.scalar(
+                    select(
+                        func.count(Annotation.id)  # pylint:disable=not-callable
                     ).where(Annotation.userid == user.userid)
                 ),
             )
         )
 
-        self._db.delete(user)
+    def purge_deleted_users(self, limit=1000):
+        """Incrementally purge data of users who've been marked as deleted."""
+        jobs = self.job_queue.get(Job.JobName.PURGE_USER, limit)
+
+        if not jobs:
+            return
+
+        completed_jobs = []
+        purger = UserPurger(self.db, self.job_queue, LimitedWorker(self.db, limit))
+
+        for job in jobs:
+            userid = job.kwargs.get("userid")
+
+            if not userid:
+                log.info("Invalid '%s' job: %s", job.JobName.PURGE_USER, job)
+                completed_jobs.append(job)
+                continue
+
+            user = self.user_svc.fetch(userid)
+
+            if user is None:
+                log.info("Couldn't fetch user: %s", userid)
+                completed_jobs.append(job)
+                continue
+
+            log.info("Purging user: %s", user.userid)
+
+            try:
+                purger.delete_authtickets(user)
+                purger.delete_tokens(user)
+                purger.delete_flags(user)
+                purger.delete_featurecohort_memberships(user)
+                purger.delete_annotations(user)
+                purger.delete_groups(user)
+                purger.delete_group_memberships(user)
+                purger.delete_group_creators(user)
+                purger.delete_user(user)
+            except LimitReached:
+                break
+            else:
+                completed_jobs.append(job)
+
+        self.job_queue.delete(completed_jobs)
+
+
+class UserPurger:
+    """Helper methods for purging data belonging to a given user."""
+
+    def __init__(self, db, job_queue, worker):
+        self.db = db
+        self.job_queue = job_queue
+        self.worker = worker
+
+    def delete_authtickets(self, user):
+        """Delete all AuthTicket's belonging to `user`."""
+        self.worker.delete(
+            AuthTicket, select(AuthTicket.id).where(AuthTicket.user == user)
+        )
+
+    def delete_tokens(self, user):
+        """Delete all tokens belonging to `user`."""
+        self.worker.delete(Token, select(Token.id).where(Token.user == user))
+
+    def delete_flags(self, user):
+        """Delete all flags created by `user`."""
+        self.worker.delete(Flag, select(Flag.id).where(Flag.user_id == user.id))
+
+    def delete_featurecohort_memberships(self, user):
+        """Remove `user` from all feature cohorts."""
+        self.worker.delete(
+            FeatureCohortUser,
+            select(FeatureCohortUser.id).where(FeatureCohortUser.user_id == user.id),
+        )
+
+    def delete_annotations(self, user):
+        """Delete all of `user`'s annotations from both Postgres and Elasticsearch."""
+        now = datetime.utcnow()
+
+        deleted_annotation_ids = self.worker.update(
+            Annotation,
+            select(Annotation.id)
+            .where(Annotation.userid == user.userid)
+            .where(Annotation.deleted.is_(False)),
+            {
+                # We don't actually delete the user's annotations from the DB,
+                # we only mark them as deleted.
+                # The marked-as-deleted annotations will later be purged by the
+                # periodic purge_deleted_annotations() task.
+                #
+                # This is because there are parts of h that don't work if
+                # annotations are deleted immediately, including the WebSocket
+                # and the call to JobQueueService.add_by_id() below.
+                #
+                # This is the same as what happens when annotations are deleted
+                # individually by the API.
+                "deleted": True,
+                # Bump the annotation's updated time when marking it as deleted.
+                # This is to prevent the purge_deleted_annotations() task from
+                # purging the annotation too soon: that task only purges
+                # deleted annotations whose updated time is more than ten mins
+                # ago.
+                "updated": now,
+            },
+        )
+
+        # Whenever we update annotations we also need to update the corresponding annotation_slims.
+        num_deleted_annotation_slims = self.db.execute(
+            update(AnnotationSlim)
+            .where(AnnotationSlim.pubid.in_(deleted_annotation_ids))
+            .values({"deleted": True, "updated": now})
+        ).rowcount
+        if num_deleted_annotation_slims:
+            log.info(
+                "Updated %d rows from annotation_slim", num_deleted_annotation_slims
+            )
+        else:  # pragma: nocover
+            pass
+
+        # Add jobs to the queue so the annotations will eventually be deleted from Elasticsearch.
+        for annotation_id in deleted_annotation_ids:
+            self.job_queue.add_by_id(
+                name="sync_annotation",
+                annotation_id=annotation_id,
+                tag="UserDeleteService.delete_annotations",
+                schedule_in=60,
+            )
+        log.info(
+            "Enqueued jobs to delete %i annotations from Elasticsearch",
+            len(deleted_annotation_ids),
+        )
+
+    def delete_groups(self, user):
+        """
+        Delete groups created by `user` that have no annotations.
+
+        Delete groups that were created by `user` and that don't contain any
+        non-deleted annotations.
+
+        If delete_annotations() (above) is called first then all of `user`'s
+        own annotations will already have been deleted, so ultimately any
+        groups created by `user` that don't contain any annotations by *other*
+        users will get deleted.
+
+        Known issue: if this method does not delete a group because it contains
+        annotations by other users, and those annotations other users are later
+        deleted, then the group will no longer contain any annotations but will
+        never be deleted.
+
+        Known issue: this will also delete all of the groups memberships due to
+        a foreign key constraint with ondelete="cascade". If a group had a
+        really large number of members this could take too long and cause a
+        timeout.
+        """
+        # pylint:disable=not-callable,use-implicit-booleaness-not-comparison-to-zero
+        self.worker.delete(
+            Group,
+            select(Group.id)
+            .where(Group.creator_id == user.id)
+            .outerjoin(
+                Annotation,
+                and_(
+                    Annotation.groupid == Group.pubid,
+                    Annotation.deleted.is_(False),
+                ),
+            )
+            .group_by(Group.id)
+            .having(func.count(Annotation.id) == 0),
+        )
+
+    def delete_group_memberships(self, user):
+        """
+        Delete `user`'s group memberships.
+
+        Known issue: this can leave groups that were created by `user` in an
+        odd state - `user` will no longer be a member of the group but will
+        still be its creator. But this state can occur in other ways as well,
+        for example the web interface currently allows a group's creator to
+        leave the group.
+
+        If `delete_group_creators()` (below) is called after this method then
+        the situation will be only temporary: `user` will soon be removed as
+        the group's creator as well.
+        """
+        self.worker.delete(
+            GroupMembership,
+            select(GroupMembership.id)
+            .where(GroupMembership.user_id == user.id)
+            .join(Group, GroupMembership.group_id == Group.id),
+        )
+
+    def delete_group_creators(self, user):
+        """
+        Delete `user` as the creator of any groups they created.
+
+        Known issue: this will leave groups in an odd state - with no creator
+        (group.creator = None).
+        """
+        self.worker.update(
+            Group, select(Group.id).where(Group.creator == user), {"creator_id": None}
+        )
+
+    def delete_user(self, user):
+        """Delete `user`."""
+        self.worker.delete(User, select(User.id).where(User.id == user.id))
+
+
+class LimitReached(Exception):
+    """A LimitedWorker has reached its limit and won't do any more work."""
+
+
+class LimitedWorker:
+    """
+    Executes given SQL statements until it has affected `limit` rows.
+
+    Once a LimitedWorker instance has updated or deleted `limit` rows (across
+    all SQL statements that it has executed) it refuses to do any more work: if
+    you ask it to execute any more statments it'll raise `LimitReached`.
+
+    For example:
+
+        >>> worker = LimitedWorker(db, limit=10)
+
+        >>> # Update 6 rows. Reduces `worker.limit` from 10 to 4.
+        >>> worker.update(ModelClass, select_stmnt_matching_6_rows, values)
+
+        >>> # Update 2 more rows. Reduces `worker.limit` from 4 to 2.
+        >>> worker.update(ModelClass, select_stmnt_matching_2_rows, values)
+
+        >>> # Even though the given delete statement matches 4 rows this will
+        >>> # only delete 2 rows because `worker.limit` is only 2.
+        >>> # This will reduce `worker.limit` from 2 to 0.
+        >>> worker.delete(ModelClass, select_stmnt_matching_4_rows, values)
+
+        >>> # Now that `worker.limit` is 0 any further calls will raise LimitReached.
+        >>> worker.update(...)
+        LimitReached()
+
+        >>> worker.delete(...)
+        LimitReached()
+
+    """
+
+    def __init__(self, db, limit: int):
+        self.db = db
+        self.limit = limit
+
+    def update(self, model_class, select_stmnt, values: dict) -> list:
+        """
+        Update up to self.limit rows matching select_stmnt with `values`.
+
+        :return: the IDs of the rows that were updated
+        """
+        updated_ids = self._execute(
+            update(model_class)
+            .where(model_class.id.in_(select(select_stmnt.limit(self.limit).cte())))
+            .values(values)
+            .returning(model_class.id)
+        )
+        if updated_ids:
+            log.info(
+                "Updated %d rows from %s", len(updated_ids), model_class.__tablename__
+            )
+        return updated_ids
+
+    def delete(self, model_class, select_stmnt) -> list:
+        """
+        Delete up to self.limit rows matching select_stmnt.
+
+        :return: the IDs of the rows that were deleted
+        """
+        deleted_ids = self._execute(
+            delete(model_class)
+            .where(model_class.id.in_(select(select_stmnt.limit(self.limit).cte())))
+            .returning(model_class.id)
+        )
+        if deleted_ids:
+            log.info(
+                "Deleted %d rows from %s", len(deleted_ids), model_class.__tablename__
+            )
+        return deleted_ids
+
+    def _execute(self, stmnt):
+        if self.limit < 1:
+            raise LimitReached()
+
+        affected_ids = self.db.scalars(stmnt).all()
+        self.limit -= len(affected_ids)
+
+        return affected_ids
 
 
 def service_factory(_context, request):
     return UserDeleteService(
-        db_session=request.db,
-        annotation_delete_service=request.find_service(name="annotation_delete"),
+        request.db,
+        job_queue=request.find_service(name="queue_service"),
+        user_svc=request.find_service(name="user"),
     )

--- a/h/tasks/cleanup.py
+++ b/h/tasks/cleanup.py
@@ -38,3 +38,9 @@ def purge_expired_tokens():
 def purge_removed_features():
     """Remove old feature flags from the database."""
     models.Feature.remove_old_flags(celery.request.db)
+
+
+@celery.task
+def purge_deleted_users():
+    """Remove data belonging to deleted users."""
+    celery.request.find_service(name="user_delete").purge_deleted_users()

--- a/h/templates/admin/users.html.jinja2
+++ b/h/templates/admin/users.html.jinja2
@@ -85,13 +85,6 @@
         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <input type="hidden" name="userid" value="{{user.userid}}">
 
-        {% if user_meta['annotations_count'] > 100 %}
-          <div class="alert alert-warning" role="alert">
-            User has a lot of annotations, it might be safer to delete this user
-            directly in a shell.
-          </div>
-        {% endif %}
-
         <button class="btn btn-danger" type="submit">Delete user</button>
       </form>
 

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -11,10 +11,11 @@ from tests.common.factories.authz_code import AuthzCode
 from tests.common.factories.base import set_session
 from tests.common.factories.document import Document, DocumentMeta, DocumentURI
 from tests.common.factories.feature import Feature
+from tests.common.factories.feature_cohort import FeatureCohort
 from tests.common.factories.flag import Flag
 from tests.common.factories.group import Group, OpenGroup, RestrictedGroup
 from tests.common.factories.group_scope import GroupScope
-from tests.common.factories.job import Job, SyncAnnotationJob
+from tests.common.factories.job import ExpungeUserJob, Job, SyncAnnotationJob
 from tests.common.factories.organization import Organization
 from tests.common.factories.setting import Setting
 from tests.common.factories.subscriptions import Subscriptions

--- a/tests/common/factories/feature_cohort.py
+++ b/tests/common/factories/feature_cohort.py
@@ -1,0 +1,22 @@
+from factory import Sequence, post_generation
+
+from h import models
+
+from .base import ModelFactory
+
+
+class FeatureCohort(ModelFactory):
+    class Meta:
+        model = models.FeatureCohort
+
+    name = Sequence(lambda n: f"featurecohort_{n}")
+
+    @post_generation
+    def members(self, _create, extracted, **_kwargs):
+        if extracted:
+            self.members.extend(extracted)
+
+    @post_generation
+    def features(self, _create, extracted, **_kwargs):
+        if extracted:
+            self.features.extend(extracted)

--- a/tests/common/factories/job.py
+++ b/tests/common/factories/job.py
@@ -7,6 +7,7 @@ from h.db.types import URLSafeUUID
 
 from .annotation import Annotation
 from .base import ModelFactory
+from .user import User
 
 
 class Job(ModelFactory):
@@ -48,3 +49,13 @@ class SyncAnnotationJob(Job):
             "force": o.force,
         }
     )
+
+
+class ExpungeUserJob(Job):
+    class Meta:
+        exclude = "user"
+
+    user = SubFactory(User)
+
+    name = "expunge_user"
+    kwargs = LazyAttribute(lambda o: {"userid": o.user.userid})

--- a/tests/unit/h/models/annotation_test.py
+++ b/tests/unit/h/models/annotation_test.py
@@ -250,6 +250,12 @@ def test_uuid(factories):
     assert annotation.uuid == UUID(URLSafeUUID.url_safe_to_hex(annotation.id))
 
 
+def test_repr(factories):
+    annotation = factories.Annotation()
+
+    assert repr(annotation) == f"<Annotation {annotation.id}>"
+
+
 @pytest.fixture
 def markdown_render(patch):
     return patch("h.models.annotation.markdown_render")

--- a/tests/unit/h/services/user_delete_test.py
+++ b/tests/unit/h/services/user_delete_test.py
@@ -1,56 +1,53 @@
-from unittest.mock import sentinel
+import logging
+from datetime import datetime
+from unittest.mock import call, sentinel
 
 import pytest
-import sqlalchemy
 from h_matchers import Any
+from sqlalchemy import Select, func, select
 
-from h.models import GroupMembership, Token, UserDeletion
-from h.services.user_delete import UserDeleteService, service_factory
+from h.models import (
+    Annotation,
+    AuthTicket,
+    FeatureCohortUser,
+    Flag,
+    Group,
+    GroupMembership,
+    Job,
+    Token,
+    User,
+    UserDeletion,
+)
+from h.services.user_delete import (
+    LimitedWorker,
+    LimitReached,
+    UserDeleteService,
+    UserPurger,
+    service_factory,
+)
 
 
-class TestDeleteUserService:
-    @pytest.mark.usefixtures("user_developer_token", "user_oauth2_token")
-    def test_it(
-        self,
-        svc,
-        db_session,
-        annotation_delete_service,
-        user,
-        requested_by,
-        created_group,
-        joined_group,
-        user_annotations,
-        other_developer_token,
-        other_oauth2_token,
-    ):
+class TestUserDeleteService:
+    def test_delete_user(self, db_session, factories, svc):
+        user, other_user, requested_by = factories.User.create_batch(3)
+        user_annotations = factories.Annotation.create_batch(2, userid=user.userid)
+
         svc.delete_user(user, requested_by, "test_tag")
 
-        # Check the user was deleted
-        assert user in db_session.deleted
-        # Check we delete this user's annotations
-        annotation_delete_service.delete_annotations.assert_called_once_with(
-            Any.iterable.containing(user_annotations).only()
-        )
-        # Check we delete groups we created, but not ones we joined
-        assert sqlalchemy.inspect(created_group).was_deleted
-        assert not sqlalchemy.inspect(joined_group).was_deleted
-        # Check we remove their group memberships
+        assert user.deleted is True
+        assert other_user.deleted is False
+        assert db_session.scalars(select(Job)).all() == [
+            Any.instance_of(Job).with_attrs(
+                {
+                    "name": "purge_user",
+                    "priority": 0,
+                    "tag": "UserDeleteService.delete_user",
+                    "kwargs": {"userid": user.userid},
+                }
+            )
+        ]
         assert (
-            not db_session.query(GroupMembership)
-            .where(GroupMembership.user_id == user.id)
-            .all()
-        )
-        assert (
-            not db_session.query(GroupMembership)
-            .where(GroupMembership.group_id == created_group.id)
-            .all()
-        )
-        assert (
-            db_session.scalars(sqlalchemy.select(Token)).all()
-            == Any.list.containing([other_developer_token, other_oauth2_token]).only()
-        )
-        assert (
-            db_session.scalars(sqlalchemy.select(UserDeletion)).all()
+            db_session.scalars(select(UserDeletion)).all()
             == Any.list.containing(
                 [
                     Any.instance_of(UserDeletion).with_attrs(
@@ -66,84 +63,538 @@ class TestDeleteUserService:
             ).only()
         )
 
-    def test_it_doesnt_delete_groups_others_have_annotated_in(
-        self, svc, factories, user, requested_by, member, created_group
+    def test_purge_deleted_users(
+        self,
+        db_session,
+        factories,
+        queue_service,
+        svc,
+        user_service,
+        LimitedWorker,
+        limited_worker,
+        UserPurger,
+        purger,
+        caplog,
     ):
-        factories.Annotation(userid=member.userid, groupid=created_group.pubid)
+        users = factories.User.create_batch(3)
+        user_service.fetch.side_effect = users
+        jobs = [factories.Job(kwargs={"userid": user.userid}) for user in users]
+        queue_service.get.return_value = jobs
+        # Make UserPurger raise LimitReached part-way through purging
+        # the third user, when delete_annotations() is called the third time.
+        purger.delete_annotations.side_effect = [None, None, LimitReached]
 
-        svc.delete_user(user, requested_by, "test_tag")
+        svc.purge_deleted_users()
 
-        # Check we don't delete groups which other people have annotated in
-        assert not sqlalchemy.inspect(created_group).was_deleted
-        # But that we are removed as the creator
-        assert not created_group.creator
+        queue_service.get.assert_called_once_with("purge_user", 1000)
+        LimitedWorker.assert_called_once_with(db_session, 1000)
+        UserPurger.assert_called_once_with(db_session, queue_service, limited_worker)
+        assert user_service.fetch.call_args_list == [
+            call(user.userid) for user in users
+        ]
+        assert caplog.record_tuples == [
+            (
+                "h.services.user_delete",
+                logging.INFO,
+                f"Purging user: {user.userid}",
+            )
+            for user in users
+        ]
+        assert purger.delete_authtickets.call_args_list == [
+            call(user) for user in users
+        ]
+        assert purger.delete_tokens.call_args_list == [call(user) for user in users]
+        assert purger.delete_flags.call_args_list == [call(user) for user in users]
+        assert purger.delete_featurecohort_memberships.call_args_list == [
+            call(user) for user in users
+        ]
+        assert purger.delete_annotations.call_args_list == [
+            call(user) for user in users
+        ]
+        assert purger.delete_groups.call_args_list == [call(user) for user in users[:2]]
+        assert purger.delete_group_memberships.call_args_list == [
+            call(user) for user in users[:2]
+        ]
+        assert purger.delete_group_creators.call_args_list == [
+            call(user) for user in users[:2]
+        ]
+        assert purger.delete_user.call_args_list == [call(user) for user in users[:2]]
+        queue_service.delete.assert_called_once_with(jobs[:2])
+
+    def test_purge_deleted_users_with_no_jobs(
+        self, svc, queue_service, caplog, LimitedWorker, UserPurger, user_service
+    ):
+        queue_service.get.return_value = []
+
+        svc.purge_deleted_users()
+
+        assert caplog.record_tuples == []
+        LimitedWorker.assert_not_called()
+        UserPurger.assert_not_called()
+        user_service.fetch.assert_not_called()
+        queue_service.delete.assert_not_called()
+
+    def test_purge_deleted_users_with_an_invalid_job(
+        self, svc, queue_service, caplog, factories
+    ):
+        invalid_job = factories.Job(kwargs={})  # No Job.kwargs["userid"].
+        queue_service.get.return_value = [invalid_job]
+
+        svc.purge_deleted_users()
+
+        assert caplog.record_tuples == [
+            (
+                "h.services.user_delete",
+                logging.INFO,
+                f"Invalid 'JobName.PURGE_USER' job: {invalid_job!r}",
+            )
+        ]
+        queue_service.delete.assert_called_once_with([invalid_job])
+
+    def test_purge_deleted_users_when_a_jobs_user_doesnt_exist(
+        self, svc, queue_service, user_service, caplog, factories
+    ):
+        job = factories.Job(kwargs={"userid": "doesnt_exist"})
+        queue_service.get.return_value = [job]
+        user_service.fetch.return_value = None
+
+        svc.purge_deleted_users()
+
+        assert caplog.record_tuples == [
+            (
+                "h.services.user_delete",
+                logging.INFO,
+                "Couldn't fetch user: doesnt_exist",
+            )
+        ]
+        queue_service.delete.assert_called_once_with([job])
+
+    @pytest.fixture(autouse=True)
+    def UserPurger(self, mocker):
+        return mocker.patch("h.services.user_delete.UserPurger")
 
     @pytest.fixture
-    def user(self, factories):
-        """Return the user who will be deleted."""
-        return factories.User()
+    def purger(self, UserPurger):
+        return UserPurger.return_value
+
+    @pytest.fixture(autouse=True)
+    def LimitedWorker(self, mocker):
+        return mocker.patch("h.services.user_delete.LimitedWorker")
 
     @pytest.fixture
-    def requested_by(self, factories):
-        """Return the user who will be requesting the user deletion."""
-        return factories.User()
+    def limited_worker(self, LimitedWorker):
+        return LimitedWorker.return_value
 
-    @pytest.fixture
-    def member(self, factories):
-        return factories.User()
 
-    @pytest.fixture
-    def created_group(self, factories, user, member):
-        return factories.Group(
-            authority=user.authority, creator=user, members=[user, member]
+class TestUserPurger:
+    def test_delete_authtickets(self, worker, purger, factories, user, db_session):
+        factories.AuthTicket.create_batch(2, user=user)
+        # An AuthTicket belonging to another user. This shouldn't get deleted.
+        other_ticket = factories.AuthTicket()
+
+        purger.delete_authtickets(user)
+
+        worker.delete.assert_called_once_with(AuthTicket, Any.instance_of(Select))
+        assert db_session.scalars(select(AuthTicket)).all() == [other_ticket]
+
+    def test_delete_tokens(self, worker, purger, factories, user, db_session):
+        factories.DeveloperToken(user=user)
+        factories.OAuth2Token(user=user)
+        # Tokens belonging to other users. These shouldn't get deleted.
+        other_tokens = [factories.DeveloperToken(), factories.OAuth2Token()]
+
+        purger.delete_tokens(user)
+
+        worker.delete.assert_called_once_with(Token, Any.instance_of(Select))
+        assert (
+            db_session.scalars(select(Token)).all()
+            == Any.list.containing(other_tokens).only()
         )
 
-    @pytest.fixture
-    def joined_group(self, factories, user, member):
-        return factories.Group(
-            authority=user.authority, creator=member, members=[user, member]
-        )
+    def test_delete_flags(self, worker, purger, factories, user, db_session):
+        factories.Flag.create_batch(2, user=user)
+        # A flag created by another user. This shouldn't get deleted.
+        other_flag = factories.Flag()
 
-    @pytest.fixture
-    def user_annotations(self, factories, user, created_group, joined_group):
-        return [
-            factories.Annotation(userid=user.userid, groupid=group.pubid)
-            for group in (created_group, joined_group)
+        purger.delete_flags(user)
+
+        worker.delete.assert_called_once_with(Flag, Any.instance_of(Select))
+        assert db_session.scalars(select(Flag)).all() == [other_flag]
+
+    def test_delete_featurecohort_memberships(
+        self, worker, purger, user, factories, db_session
+    ):
+        cohorts = factories.FeatureCohort.create_batch(2, members=[user])
+        # A FeatureCohortUser belonging to a different user.
+        # This shouldn't get deleted.
+        other_user = factories.User()
+        cohorts[0].members.append(other_user)
+
+        purger.delete_featurecohort_memberships(user)
+
+        worker.delete.assert_called_once_with(
+            FeatureCohortUser, Any.instance_of(Select)
+        )
+        assert db_session.scalars(select(FeatureCohortUser)).all() == [
+            Any.instance_of(FeatureCohortUser).with_attrs(
+                {"cohort_id": cohorts[0].id, "user_id": other_user.id}
+            )
         ]
 
-    @pytest.fixture
-    def user_developer_token(self, user, factories):
-        return factories.DeveloperToken(user=user)
+    def test_delete_annotations(
+        self, caplog, worker, purger, user, factories, queue_service
+    ):
+        annotations = factories.Annotation.create_batch(2, userid=user.userid)
+        annotation_slims = [
+            factories.AnnotationSlim(annotation=annotation)
+            for annotation in annotations
+        ]
+        # An annotation belonging to a different user.
+        # This shouldn't get deleted.
+        other_users_annotation = factories.Annotation()
 
-    @pytest.fixture
-    def user_oauth2_token(self, user, factories):
-        return factories.OAuth2Token(user=user)
+        purger.delete_annotations(user)
 
-    @pytest.fixture
-    def other_developer_token(self, factories):
-        return factories.DeveloperToken()
-
-    @pytest.fixture
-    def other_oauth2_token(self, factories):
-        return factories.OAuth2Token()
-
-    @pytest.fixture
-    def svc(self, db_session, annotation_delete_service):
-        return UserDeleteService(
-            db_session=db_session, annotation_delete_service=annotation_delete_service
+        worker.update.assert_called_once_with(
+            Annotation,
+            Any.instance_of(Select),
+            {"deleted": True, "updated": Any.instance_of(datetime)},
         )
+        for annotation in annotations:
+            assert annotation.deleted is True
+        for annotation_slim in annotation_slims:
+            assert annotation_slim.deleted is True
+        assert other_users_annotation.deleted is False
+        assert (
+            queue_service.add_by_id.call_args_list
+            == Any.list.containing(
+                [
+                    call(
+                        name="sync_annotation",
+                        annotation_id=annotation.id,
+                        tag="UserDeleteService.delete_annotations",
+                        schedule_in=60,
+                    )
+                    for annotation in annotations
+                ]
+            ).only()
+        )
+        assert (
+            caplog.record_tuples
+            == Any.list.containing(
+                [
+                    (
+                        "h.services.user_delete",
+                        logging.INFO,
+                        "Updated 2 rows from annotation",
+                    ),
+                    (
+                        "h.services.user_delete",
+                        logging.INFO,
+                        "Updated 2 rows from annotation_slim",
+                    ),
+                    (
+                        "h.services.user_delete",
+                        logging.INFO,
+                        f"Enqueued jobs to delete {len(annotations)} annotations from Elasticsearch",
+                    ),
+                ]
+            ).only()
+        )
+
+    def test_delete_groups(self, user, db_session, worker, factories, purger):
+        factories.Group(creator=user)
+
+        purger.delete_groups(user)
+
+        worker.delete.assert_called_once_with(Group, Any.instance_of(Select))
+        assert (
+            db_session.scalars(select(Group).where(Group.creator == user)).all() == []
+        )
+
+    def test_delete_groups_still_deletes_groups_if_they_have_deleted_annotations(
+        self, user, db_session, factories, purger
+    ):
+        group = factories.Group(creator=user)
+        # An annotation in the group, but the annotation has already been
+        # marked as deleted (meaning it'll soon be purged from the DB) so this
+        # shouldn't prevent the group from being deleted.
+        factories.Annotation(group=group, deleted=True)
+
+        purger.delete_groups(user)
+
+        assert (
+            db_session.scalars(select(Group).where(Group.creator == user)).all() == []
+        )
+
+    def test_delete_groups_doesnt_delete_groups_created_by_other_users(
+        self, user, db_session, factories, purger
+    ):
+        group = factories.Group()
+
+        purger.delete_groups(user)
+
+        assert group in db_session.scalars(select(Group)).all()
+
+    def test_delete_groups_doesnt_delete_groups_with_annotations(
+        self, user, db_session, factories, purger
+    ):
+        group = factories.Group(creator=user)
+        # The group contains an annotation by another user.
+        # This should prevent the group from being deleted.
+        factories.Annotation(group=group)
+
+        purger.delete_groups(user)
+
+        assert group in db_session.scalars(select(Group)).all()
+
+    def test_delete_group_memberships(
+        self, user, factories, purger, worker, db_session
+    ):
+        other_user = factories.User()
+        groups = [
+            # A group that `user` created.
+            factories.Group(creator=user, members=[other_user]),
+            # A group that `user` is a member of but didn't create.
+            factories.Group(members=[user, other_user]),
+            # A group that `user` is neither a creator or member of.
+            factories.Group(members=[other_user]),
+        ]
+
+        purger.delete_group_memberships(user)
+
+        worker.delete.assert_called_once_with(GroupMembership, Any.instance_of(Select))
+        # It deletes the given user's group memberships.
+        assert (
+            db_session.scalars(
+                select(GroupMembership).where(GroupMembership.user_id == user.id)
+            ).all()
+            == []
+        )
+        # It doesn't delete group memberships of other users.
+        assert (
+            db_session.scalars(
+                select(GroupMembership).where(GroupMembership.user_id == other_user.id)
+            ).all()
+            == Any.list.containing(
+                [
+                    Any.instance_of(GroupMembership).with_attrs(
+                        {"group_id": group.id, "user_id": other_user.id}
+                    )
+                    for group in groups
+                ]
+            ).only()
+        )
+
+    def test_delete_group_creators(self, user, factories, purger, worker):
+        groups = factories.Group.create_batch(2, creator=user)
+        other_group = factories.Group()
+
+        purger.delete_group_creators(user)
+
+        worker.update.assert_called_once_with(
+            Group, Any.instance_of(Select), {"creator_id": None}
+        )
+        for group in groups:
+            assert group.creator_id is None
+        assert other_group.creator_id
+
+    def test_delete_group_creators_doesnt_delete_other_group_creators(
+        self, user, factories, purger
+    ):
+        other_group_creator = factories.User()
+        group = factories.Group(creator=other_group_creator)
+
+        purger.delete_group_creators(user)
+
+        assert group.creator_id == other_group_creator.id
+
+    def test_delete_user(self, db_session, purger, factories, user):
+        other_user = factories.User()
+
+        purger.delete_user(user)
+
+        assert db_session.scalars(select(User)).all() == [other_user]
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "delete_authtickets",
+            "delete_tokens",
+            "delete_flags",
+            "delete_featurecohort_memberships",
+            "delete_annotations",
+            "delete_groups",
+            "delete_group_memberships",
+            "delete_group_creators",
+            "delete_user",
+        ],
+    )
+    def test_it_when_limit_exceeded(
+        self, db_session, queue_service, mocker, factories, method
+    ):
+        worker = mocker.create_autospec(LimitedWorker, spec_set=True, instance=True)
+        worker.delete.side_effect = LimitReached
+        worker.update.side_effect = LimitReached
+        purger = UserPurger(db_session, queue_service, worker)
+
+        with pytest.raises(LimitReached):
+            getattr(purger, method)(factories.User())
+
+    @pytest.fixture
+    def worker(self, db_session, mocker):
+        worker = LimitedWorker(db_session, limit=1000)
+        mocker.spy(worker, "delete")
+        mocker.spy(worker, "update")
+        return worker
+
+    @pytest.fixture
+    def purger(self, db_session, queue_service, worker):
+        return UserPurger(db_session, queue_service, worker)
+
+    @pytest.fixture
+    def user(self, factories, db_session):
+        user = factories.User()
+        # Flush the DB to generate user.id.
+        db_session.flush()
+        return user
+
+
+class TestLimitedWorker:
+    def test_update_when_limit_exceeded(self, db_session, factories):
+        annotation = factories.Annotation()
+        original_text = annotation.text
+        worker = LimitedWorker(db_session, limit=0)
+
+        with pytest.raises(LimitReached):
+            worker.update(Annotation, select(Annotation.id), {"text": "UPDATED"})
+
+        # pylint:disable=use-implicit-booleaness-not-comparison-to-zero
+        assert worker.limit == 0
+        assert annotation.text == original_text
+
+    def test_update_with_limit_remaining(self, caplog, db_session, factories):
+        annotations = factories.Annotation.create_batch(2)
+        original_limit = len(annotations) + 1
+        worker = LimitedWorker(db_session, original_limit)
+
+        updated_annotation_ids = worker.update(
+            Annotation, select(Annotation.id), {"text": "UPDATED"}
+        )
+
+        assert sorted(updated_annotation_ids) == sorted(
+            [annotation.id for annotation in annotations]
+        )
+        assert worker.limit == original_limit - len(updated_annotation_ids)
+        for annotation in annotations:
+            assert annotation.text == "UPDATED"
+        assert caplog.record_tuples == [
+            ("h.services.user_delete", logging.INFO, "Updated 2 rows from annotation")
+        ]
+
+    def test_update_when_limit_reached(self, caplog, db_session, factories):
+        annotations = factories.Annotation.create_batch(2)
+        original_limit = len(annotations) - 1
+        worker = LimitedWorker(db_session, original_limit)
+
+        updated_annotation_ids = worker.update(
+            Annotation, select(Annotation.id), {"text": "UPDATED"}
+        )
+
+        assert len(updated_annotation_ids) == original_limit
+        assert len(set(updated_annotation_ids)) == len(updated_annotation_ids)
+        for updated_annotation_id in updated_annotation_ids:
+            assert updated_annotation_id in [
+                annotation.id for annotation in annotations
+            ]
+        # pylint:disable=use-implicit-booleaness-not-comparison-to-zero
+        assert worker.limit == 0
+        for annotation in annotations:
+            if annotation.id in updated_annotation_ids:
+                assert annotation.text == "UPDATED"
+            else:
+                assert annotation.text != "UPDATED"
+        assert caplog.record_tuples == [
+            ("h.services.user_delete", logging.INFO, "Updated 1 rows from annotation")
+        ]
+
+    def test_delete_when_limit_exceeded(self, db_session, factories):
+        annotation = factories.Annotation()
+        worker = LimitedWorker(db_session, limit=0)
+
+        with pytest.raises(LimitReached):
+            worker.delete(Annotation, select(Annotation.id))
+
+        # pylint:disable=use-implicit-booleaness-not-comparison-to-zero
+        assert worker.limit == 0
+        assert db_session.scalars(select(Annotation)).all() == [annotation]
+
+    def test_delete_with_limit_remaining(self, caplog, db_session, factories):
+        annotations = factories.Annotation.create_batch(2)
+        original_limit = len(annotations) + 1
+        worker = LimitedWorker(db_session, original_limit)
+
+        deleted_annotation_ids = worker.delete(Annotation, select(Annotation.id))
+
+        assert sorted(deleted_annotation_ids) == sorted(
+            [annotation.id for annotation in annotations]
+        )
+        assert worker.limit == original_limit - len(deleted_annotation_ids)
+        assert db_session.scalars(select(Annotation)).all() == []
+        assert caplog.record_tuples == [
+            ("h.services.user_delete", logging.INFO, "Deleted 2 rows from annotation")
+        ]
+
+    def test_delete_when_limit_reached(self, caplog, db_session, factories):
+        annotations = factories.Annotation.create_batch(2)
+        original_limit = len(annotations) - 1
+        worker = LimitedWorker(db_session, original_limit)
+
+        deleted_annotation_ids = worker.delete(Annotation, select(Annotation.id))
+
+        assert len(deleted_annotation_ids) == original_limit
+        assert len(set(deleted_annotation_ids)) == len(deleted_annotation_ids)
+        for deleted_annotation_id in deleted_annotation_ids:
+            assert deleted_annotation_id in [
+                annotation.id for annotation in annotations
+            ]
+        # pylint:disable=use-implicit-booleaness-not-comparison-to-zero
+        assert worker.limit == 0
+        assert (
+            db_session.scalar(select(func.count(Annotation.id)))
+            == len(annotations) - original_limit
+        )
+        assert caplog.record_tuples == [
+            ("h.services.user_delete", logging.INFO, "Deleted 1 rows from annotation")
+        ]
 
 
 class TestServiceFactory:
-    def test_it(self, pyramid_request, annotation_delete_service, UserDeleteService):
+    def test_it(self, pyramid_request, UserDeleteService, queue_service, user_service):
         svc = service_factory(sentinel.context, pyramid_request)
 
         UserDeleteService.assert_called_once_with(
-            db_session=pyramid_request.db,
-            annotation_delete_service=annotation_delete_service,
+            pyramid_request.db,
+            job_queue=queue_service,
+            user_svc=user_service,
         )
         assert svc == UserDeleteService.return_value
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def UserDeleteService(self, patch):
         return patch("h.services.user_delete.UserDeleteService")
+
+
+@pytest.fixture
+def svc(db_session, queue_service, user_service):
+    return UserDeleteService(
+        db_session,
+        job_queue=queue_service,
+        user_svc=user_service,
+    )
+
+
+@pytest.fixture
+def caplog(caplog):
+    caplog.set_level(logging.INFO)
+    return caplog

--- a/tests/unit/h/tasks/cleanup_test.py
+++ b/tests/unit/h/tasks/cleanup_test.py
@@ -5,6 +5,7 @@ import pytest
 from h.models import AuthTicket, AuthzCode, Token
 from h.tasks.cleanup import (
     purge_deleted_annotations,
+    purge_deleted_users,
     purge_expired_auth_tickets,
     purge_expired_authz_codes,
     purge_expired_tokens,
@@ -125,6 +126,14 @@ class TestPurgeRemovedFeatures:
         purge_removed_features()
 
         Feature.remove_old_flags.assert_called_once_with(db_session)
+
+
+@pytest.mark.usefixtures("celery")
+class TestPurgeDeletedUsers:
+    def test_it(self, user_delete_service):
+        purge_deleted_users()
+
+        user_delete_service.purge_deleted_users.assert_called_once_with()
 
 
 @pytest.fixture


### PR DESCRIPTION
Replace `UserDeleteService` with a completely new service that marks users as deleted and then purges their data incrementally in the background. This should fix issues with the user delete admin page timing out when trying to delete users with large amounts of data because `UserDeleteService` tries to delete all the user's data at once during the web request and this takes too long.

The way the new service works is:

1. The delete user admin page calls `UserDeleteService.delete_user()` which:

   1. Sets `user.deleted = True`
   3. Adds a `"purge_user"` job to the job table in the DB
   4. Adds a record of the deletion to the `user_deletion` table

   All three are done in the same DB transaction, so it's not possible to mark a user as deleted but fail to add the `"purge_user"` job. The `"purge_user"` job won't be deleted from the DB until all of the user's data has been purged.

2. A periodic `purge_deleted_users()` task (https://github.com/hypothesis/h-periodic/pull/441) runs every hour and calls `UserDeleteService.purge_deleted_users()` which:

   1. Takes `"purge_user"` jobs from the table
   2. Deletes up to a fixed maximum amount of the user's data (authtickets, tokens, flags, feature cohort memberships, annotations, groups, group memberships, group creators, and finally the user row itself). If it has deleted all of the user's data then `purge_deleted_users()` deletes the `"purge_user"` job. Otherwise it leaves the job on the queue and it will pick up the same job again next time and continue working on it.
      1. `purge_deleted_users()` doesn't actually delete annotations from the DB, it just marks them as deleted by setting `Annotation.deleted=True`. The existing [`purge_deleted_annotations()` task](https://github.com/hypothesis/h/blob/cbd17336582afdc830a9b6838eb4a3251a134b46/h/tasks/cleanup.py#L10-L12) will come along later and actually delete them from the DB. This is the same way that annotations are deleted when deleting them one-by-one via the API, so it's good to be consistent. It's done this way because the WebSocket code can have issues if annotations are deleted immediately. Also, `JobQueueService.add_by_id()` can only add a `"sync_annotation"` job for an annotation if that annotation still exists in the DB.
      1. Whenever `purge_deleted_users()` marks an annotation as deleted it also adds a `"sync_annotation"` job to the job queue. This is done in the same DB transaction, so it's not possible to mark an annotation as deleted without adding a `"sync_annotation"` job to the queue.
      1. The already-existing periodic task `sync_annotations()` will then consume these `"sync_annotation"` jobs and delete the annotations from Elasticseach, and won't delete the `"sync_annotation"` job from the queue until it has verified that the annotation has been deleted from Elasticsearch.

Testing
=======

1. Checkout <https://github.com/hypothesis/h-periodic/pull/441> and run h-periodic's `make dev`

2. You might want to hack h-periodic to run the `purge-deleted-annotations` and `purge-deleted-users` tasks more frequently:

   ```diff
   diff --git a/h_periodic/h_beat.py b/h_periodic/h_beat.py
   index 3ddf9dc..46d07a0 100644
   --- a/h_periodic/h_beat.py
   +++ b/h_periodic/h_beat.py
   @@ -23,7 +23,7 @@ celery.conf.update(
            "purge-deleted-annotations": {
                "options": {"expires": 1800},
                "task": "h.tasks.cleanup.purge_deleted_annotations",
   -            "schedule": timedelta(hours=1),
   +            "schedule": timedelta(minutes=1),
            },
            "purge-expired-authtickets": {
                "options": {"expires": 1800},
   @@ -48,7 +48,7 @@ celery.conf.update(
            "purge-deleted-users": {
                "options": {"expires": 1800},
                "task": "h.tasks.cleanup.purge_deleted_users",
   -            "schedule": timedelta(hours=1),
   +            "schedule": timedelta(minutes=1),
            },
            "sync-annotations": {
                "options": {"expires": 30},
   ```

3. You might want to hack h to delete fewer rows per run of the `purge_deleted_users()` task, to force it to take more than one task run to purge the test user:

   ```diff
   diff --git a/h/services/user_delete.py b/h/services/user_delete.py
   index 3f38b339f..3f965af39 100644
   --- a/h/services/user_delete.py
   +++ b/h/services/user_delete.py
   @@ -61,7 +61,7 @@ class UserDeleteService:
                )
            )
    
   -    def purge_deleted_users(self, limit=1000):
   +    def purge_deleted_users(self, limit=2):
            """Incrementally purge data of users who've been marked as deleted."""
            jobs = self.job_queue.get(self.job_name, limit)
   ``` 

1. Log in to <http://localhost:5000/login> as `devdata_admin` in one browser and as `devdata_user` in another browser (logging in will create two authtickets in the DB, one of which will be deleted when we delete `devdata_user` below)
2. Create a developer token for `devdata_user`: go to http://localhost:5000/account/developer and click <kbd>Generate your API token</kbd>
3. Go to <http://localhost:5000/docs/help> as `devdata_user` and log in to the client. This will create an OAuth token in the DB
4. Create a couple of annotations on <http://localhost:5000/docs/help> as `devdata_user`
6. Go to <http://localhost:5000/docs/help> as `devdata_admin`, log in, and flag one of `devdata_user`'s annotations by clicking the flag icon on the annotation
7. Create an annotation of <http://localhost:5000/docs/help> as `devdata_admin`
8. Go to <http://localhost:5000/docs/help> as `devdata_user` and flag `devdata_admin`'s annotation
9. As `devdata_admin` go to <http://localhost:5000/admin/features/cohorts>, create a feature cohort, and add `devdata_user` to the feature cohort
10. As `devdata_user` go to <http://localhost:5000/groups/new> and create **three** groups
11. As `devdata_user` go to <http://localhost:5000/docs/help> and create some annotations in the first group
12. Have `devdata_admin` join the second group (you need to copy the group's invite link as `devdata_user` and open it as `devdata_admin`)
13. Have `devdata_admin` join the third group and create an annotation in it
14. As `devdata_admin` go to <http://localhost:5000/groups/new>, create a group, copy the invite link, and have `devdata_user` join the group
15. At this point you should be able to see lots of data belonging to `devdata_user` and their annotations in the DB: annotations in the `annotation`table; an auth ticket (used for logging in to h's web pages) in `authticket`; a feature cohort membership in `featurecohort_user`; flags in `flag`; groups in `group`; group memberships in `user_group`; an OAuth 2 token (used by the client) and a developer token in `token`; There are some other related tables where users may have data, e.g. `annotation_slim`, `annotation_metadata`, `annotation_moderation`, `user_identity`, but these have foreign keys to `annotation` or `user` with `ON DELETE CASCADE` so any data in these tables will be deleted when the annotations or user are deleted.
16. You should also be able to see `devdata_user`'s annotations in Elasticsearch at <http://localhost:9200/_search>.

17. Go to <http://localhost:5000/admin/users?username=devdata_user&authority=localhost> as `devdata_admin` and delete `devdata_user`

You should see output like this in the terminal:

```
Task h.tasks.cleanup.purge_deleted_users[...] received
...
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from authticket
h.tasks.cleanup.purge_deleted_users[...] Deleted 1 rows from token
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from flag
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from featurecohort_user
h.tasks.cleanup.purge_deleted_users[...] Deleted 1 rows from annotation
h.tasks.cleanup.purge_deleted_users[...] Enqueued job to delete annotation from Elasticsearch: ...
h.tasks.cleanup.purge_deleted_users[...] Task h.tasks.cleanup.purge_deleted_users[...] succeeded in 0....s: None
...
Task h.tasks.cleanup.purge_deleted_users[...] received
...
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from authticket
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from token
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from flag
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from featurecohort_user
h.tasks.cleanup.purge_deleted_users[...] Deleted 2 rows from annotation
h.tasks.cleanup.purge_deleted_users[...] Enqueued job to delete annotation from Elasticsearch: ...
h.tasks.cleanup.purge_deleted_users[...] Enqueued job to delete annotation from Elasticsearch: ...
h.tasks.cleanup.purge_deleted_users[...] Task h.tasks.cleanup.purge_deleted_users[...] succeeded in 0....s: None
...
Task h.tasks.cleanup.purge_deleted_users[...] received
...
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from authticket
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from token
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from flag
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from featurecohort_user
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from annotation
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from group
h.tasks.cleanup.purge_deleted_users[...] Deleted 0 rows from user_group
h.tasks.cleanup.purge_deleted_users[...] Updated 0 rows from group
h.tasks.cleanup.purge_deleted_users[...] Deleted 1 rows from user
h.tasks.cleanup.purge_deleted_users[...] Task h.tasks.cleanup.purge_deleted_users[...] succeeded in 0....s: None
...
Task h.tasks.cleanup.purge_deleted_users[...] received
...
h.tasks.cleanup.purge_deleted_users[...] There are no 'purge_user' jobs
Task h.tasks.cleanup.purge_deleted_users[...] succeeded in 0....s: None
```

You should also see messages from the `sync_annotations` task about syncing the deleted annotations. It can take a minute or two after deleting the annotations from the DB before these appear:

```
{'Synced/UserDeleteService.delete_annotations/Deleted_from_db': 1, 'Synced/UserDeleteService.delete_annotations/Total': 1, 'Synced/Total': 1}
...
{'Completed/UserDeleteService.delete_annotations/Deleted_from_db': 1, 'Completed/UserDeleteService.delete_annotations/Total': 1, 'Completed/Total': 1}
```

If you inspect the DB and Elasticsearch you should see that all the user's data and annotations are gone.