### PR TITLE
Fix outdated `.coveragerc` file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,7 @@ branch = True
 parallel = True
 source =
     h
-    tests/h
+    tests/unit
 omit =
     h/debug.py
     h/migrations/*

--- a/tests/unit/h/util/db_test.py
+++ b/tests/unit/h/util/db_test.py
@@ -81,7 +81,7 @@ class TestOnTransactionEnd:
 
         @on_transaction_end(db_session)
         def transaction_ended():
-            spy()
+            spy()  # pragma: nocover
 
         db_session.dispatch.after_transaction_end(db_session, mock_transaction)
 


### PR DESCRIPTION
h hasn't actually been tracking coverage of its unit tests file since
the `tests/h/` directory was moved to `tests/unit/h/`.
