### PR TITLE
Fix `factories.Group` creator membership

### DIFF
--- a/tests/unit/h/services/group_list_test.py
+++ b/tests/unit/h/services/group_list_test.py
@@ -63,9 +63,12 @@ class TestAssociatedGroups:
         # the creator of the group. That means that this private group is still associated
         # with this user in some form—but we want to make sure it does not appear
         # in these results.
-        private_group = factories.Group(
-            creator=user, authority=user.authority, members=[]
-        )
+        private_group = factories.Group(creator=user, authority=user.authority)
+        # Remove `private_group.creator` from `private_group.members`.
+        # The creator is still attached to `private_group` as `private_group.creator`.
+        private_group.members = [
+            user for user in private_group.members if user is not private_group.creator
+        ]
 
         groups = svc.associated_groups(user)
 

--- a/tests/unit/h/views/activity_test.py
+++ b/tests/unit/h/views/activity_test.py
@@ -1208,8 +1208,7 @@ def group(factories):
 
 @pytest.fixture
 def no_creator_group(factories):
-    group = factories.Group()
-    group.creator = None
+    group = factories.Group(creator=None)
     group.members.extend([factories.User(), factories.User()])
     return group
 
@@ -1236,8 +1235,7 @@ def restricted_group(factories):
 
 @pytest.fixture
 def no_creator_open_group(factories):
-    open_group = factories.OpenGroup()
-    open_group.creator = None
+    open_group = factories.OpenGroup(creator=None)
     return open_group
 
 


### PR DESCRIPTION
When creating a group, the user `my_group.creator` should also be added
as the first user in `my_group.members`. With `factories.Group` this
currently works correctly as long as no `members` argument is passed to
the factory:

    >>> group = factories.Group()
    >>> group.creator
    <User: cookekathleen__0>
    >>> group.members
    [<User: cookekathleen__0>]
    >>> user = factories.User()
    >>> group = factories.Group(creator=user)
    >>> group.creator
    <User: pmitchell__1>
    >>> group.members
    [<User: pmitchell__1>]

But when a `members` argument is passed to the factory a group can be
created with `group.creator` missing from `group.members`, which is
abnormal:

    >>> group = factories.Group(members=[user])
    >>> group.creator
    <User: arthurturner__2>
    >>> group.members
    [<User: pmitchell__1>]

Fix `factories.Group` to ensure that `group.creator` is always added as
the first user in `group.members` even if a `members` list that does not
include the creator is passed to the factory.

Tests of the new version:

    >>> group = factories.Group()
    >>> group.creator
    <User: abeasley__0>
    >>> group.members
    [<User: abeasley__0>]
    >>> user = factories.User()
    >>> group = factories.Group(members=[user])
    >>> group.creator
    <User: kristinegutierrez__2>
    >>> group.members
    [<User: kristinegutierrez__2>, <User: kristina79__1>]
    >>> group = factories.Group(creator=user, members=[user])
    >>> group.creator
    <User: kristina79__1>
    >>> group.members
    [<User: kristina79__1>]
