### PR TITLE
Cascade-delete group members when deleting groups

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -41,7 +41,11 @@ class GroupMembership(Base):
     id = sa.Column("id", sa.Integer, autoincrement=True, primary_key=True)
     user_id = sa.Column("user_id", sa.Integer, sa.ForeignKey("user.id"), nullable=False)
     group_id = sa.Column(
-        "group_id", sa.Integer, sa.ForeignKey("group.id"), nullable=False, index=True
+        "group_id",
+        sa.Integer,
+        sa.ForeignKey("group.id", ondelete="cascade"),
+        nullable=False,
+        index=True,
     )
 
 


### PR DESCRIPTION
This just means you don't have to manually delete a group's memberships
before deleting a group, you can just delete the group and all its
memberships will be automatically deleted with it.
