### PR TITLE
Add `User.deleted` column to model code

### DIFF
--- a/h/data_tasks/report/create_from_scratch/03_annotations/02_initial_fill.sql
+++ b/h/data_tasks/report/create_from_scratch/03_annotations/02_initial_fill.sql
@@ -25,7 +25,7 @@ SELECT
     -- As we do our partial updates based on updated date, it's good if this
     -- is actually high res timestamp, so we get less overlap
     annotation.updated,
-    deleted,
+    annotation.deleted,
     shared,
     JSONB_ARRAY_LENGTH(target_selectors) <> 0 AS anchored,
     LENGTH(text) AS size,

--- a/h/data_tasks/report/refresh/01_annotations_refresh.sql
+++ b/h/data_tasks/report/refresh/01_annotations_refresh.sql
@@ -28,7 +28,7 @@ SELECT
     authorities.id as authority_id,
     annotation.created::date,
     annotation.updated::date,
-    deleted,
+    annotation.deleted,
     shared,
     JSONB_ARRAY_LENGTH(target_selectors) <> 0 AS anchored,
     LENGTH(text) AS size,

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -280,6 +280,14 @@ class User(Base):
     #: upgrading their passwords and setting this column to None.
     salt = sa.Column(sa.UnicodeText(), nullable=True)
 
+    #: Has this user been marked for deletion?
+    deleted = sa.Column(
+        sa.Boolean,
+        default=False,
+        nullable=False,
+        server_default=sa.sql.expression.false(),
+    )
+
     tokens = sa.orm.relationship("Token", back_populates="user")
 
     @sa.orm.validates("email")

--- a/tests/common/factories/user.py
+++ b/tests/common/factories/user.py
@@ -50,3 +50,4 @@ class User(ModelFactory):
     email = factory.LazyAttribute(unique_email)
     display_name = factory.Faker("name")
     registered_date = factory.Faker("date_time_this_decade")
+    deleted = False


### PR DESCRIPTION
This is going to be used by the new incremental user delete service (https://github.com/hypothesis/h/pull/8700): deleting a user will immediately mark them as `User.deleted = True` and then will incrementally delete all their data (and eventually the user row itself) in the backround. Users with `deleted = True` won't be allowed to log in so that users can't be creating more data while we're incrementally deleting their account.

Migration: https://github.com/hypothesis/h/pull/8711