### PR TITLE
Add `pytest-mock` test requirement

### DIFF
--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -392,9 +392,12 @@ pytest==8.2.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pytest-cov
+    #   pytest-mock
     #   pytest-reverse
     #   pytest-xdist
 pytest-cov==5.0.0
+    # via -r requirements/tests.txt
+pytest-mock==3.14.0
     # via -r requirements/tests.txt
 pytest-reverse==1.7.0
     # via -r requirements/functests.txt

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -4,6 +4,7 @@ coverage
 pytest
 pytest-cov
 pytest-xdist[psutil]
+pytest-mock
 freezegun
 factory-boy
 hypothesis

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -253,8 +253,11 @@ pytest==8.2.0
     # via
     #   -r requirements/tests.in
     #   pytest-cov
+    #   pytest-mock
     #   pytest-xdist
 pytest-cov==5.0.0
+    # via -r requirements/tests.in
+pytest-mock==3.14.0
     # via -r requirements/tests.in
 pytest-xdist[psutil]==3.6.1
     # via -r requirements/tests.in


### PR DESCRIPTION
We already use `pytest-mock` in some of our other projects.

It can be used alongside h's built-in `patch()` fixture and direct
`unittest.mock` usage, though perhaps `pytest-mock` should be preferred
for new code.

`pytest-mock` provides a bunch of useful stuff that h doesn't have
otherwise: fancy integration with pytest fixtures, stubs and spies,
better pytest output when assertions involving mocks fail, etc.
