### PR TITLE
Record user deletions in a new DB table

### DIFF
--- a/h/cli/commands/user.py
+++ b/h/cli/commands/user.py
@@ -101,30 +101,3 @@ def password(ctx, username, authority, password):
     request.tm.commit()
 
     click.echo(f"Password changed for {username}", err=True)
-
-
-@user.command()
-@click.argument("username")
-@click.option("--authority")
-@click.pass_context
-def delete(ctx, username, authority):
-    """
-    Delete a user with all their group memberships and annotations.
-
-    You must specify the username of a user to delete.
-    """
-    request = ctx.obj["bootstrap"]()
-
-    if not authority:
-        authority = request.default_authority
-
-    user = models.User.get_by_username(request.db, username, authority)
-    if user is None:
-        raise click.ClickException(
-            f'no user with username "{username}" and authority "{authority}"'
-        )
-
-    request.find_service(name="user_delete").delete_user(user)
-    request.tm.commit()
-
-    click.echo(f"User {username} deleted.", err=True)

--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -38,6 +38,7 @@ from h.models.setting import Setting
 from h.models.subscriptions import Subscriptions
 from h.models.token import Token
 from h.models.user import User
+from h.models.user_deletion import UserDeletion
 from h.models.user_identity import UserIdentity
 
 __all__ = (
@@ -64,5 +65,6 @@ __all__ = (
     "Subscriptions",
     "Token",
     "User",
+    "UserDeletion",
     "UserIdentity",
 )

--- a/h/models/helpers.py
+++ b/h/models/helpers.py
@@ -1,0 +1,4 @@
+def repr_(obj, attrs):
+    class_name = type(obj).__name__
+    attrs = {attrname: getattr(obj, attrname) for attrname in attrs}
+    return f"{class_name}({', '.join(f'{name}={value!r}' for name, value in attrs.items())})"

--- a/h/models/job.py
+++ b/h/models/job.py
@@ -41,6 +41,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 
 from h.db import Base
+from h.models import helpers
 
 
 class Job(Base):
@@ -67,10 +68,9 @@ class Job(Base):
     )
 
     def __repr__(self):
-        class_name = type(self).__name__
-        attrs = {
-            attrname: repr(getattr(self, attrname))
-            for attrname in [
+        return helpers.repr_(
+            self,
+            [
                 "id",
                 "name",
                 "enqueued_at",
@@ -79,6 +79,5 @@ class Job(Base):
                 "priority",
                 "tag",
                 "kwargs",
-            ]
-        }
-        return f"{class_name}({', '.join(f'{name}={value}' for name, value in attrs.items())})"
+            ],
+        )

--- a/h/models/user_deletion.py
+++ b/h/models/user_deletion.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+
+from sqlalchemy import func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from h.db import Base
+from h.models import helpers
+
+
+class UserDeletion(Base):
+    """A record of a user account that was deleted."""
+
+    __tablename__ = "user_deletion"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+
+    userid: Mapped[str]
+    """The userid of the user who was deleted."""
+
+    requested_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(),  # pylint:disable=not-callable
+    )
+    """The time at which the user deletion was requested."""
+
+    requested_by: Mapped[str]
+    """The userid of the user who requested the deletion."""
+
+    tag: Mapped[str]
+    """Just a string 'tag' field.
+
+    For example different views that delete users might put different tag
+    values here.
+    """
+
+    registered_date: Mapped[datetime]
+    """The time when the deleted user account was first registered."""
+
+    num_annotations: Mapped[int]
+    """The number of annotations that the deleted user account had."""
+
+    def __repr__(self) -> str:
+        return helpers.repr_(
+            self,
+            [
+                "id",
+                "userid",
+                "requested_at",
+                "requested_by",
+                "tag",
+                "registered_date",
+                "num_annotations",
+            ],
+        )

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -134,7 +134,7 @@ def users_delete(request):
     user = _form_request_user(request)
     svc = request.find_service(name="user_delete")
 
-    svc.delete_user(user)
+    svc.delete_user(user, requested_by=request.user, tag=request.matched_route.name)
     request.session.flash(
         f"Successfully deleted user {user.username} with authority {user.authority}"
         "success",

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -20,4 +20,5 @@ from tests.common.factories.setting import Setting
 from tests.common.factories.subscriptions import Subscriptions
 from tests.common.factories.token import DeveloperToken, OAuth2Token
 from tests.common.factories.user import User
+from tests.common.factories.user_deletion import UserDeletion
 from tests.common.factories.user_identity import UserIdentity

--- a/tests/common/factories/user_deletion.py
+++ b/tests/common/factories/user_deletion.py
@@ -1,0 +1,19 @@
+from factory import Faker, LazyAttribute
+
+from h import models
+
+from .base import ModelFactory
+
+
+class UserDeletion(ModelFactory):
+    class Meta:
+        model = models.UserDeletion
+        exclude = ("username", "requesting_username")
+
+    username = Faker("user_name")
+    userid = LazyAttribute(lambda o: f"acct:{o.username}@example.com")
+    requesting_username = Faker("user_name")
+    requested_by = LazyAttribute(lambda o: f"acct:{o.requesting_username}@example.com")
+    tag = "factory"
+    registered_date = Faker("date_time")
+    num_annotations = Faker("random_int")

--- a/tests/unit/h/cli/commands/user_test.py
+++ b/tests/unit/h/cli/commands/user_test.py
@@ -195,46 +195,6 @@ class TestPasswordCommand:
         return factories.User()
 
 
-class TestDeleteUserCommand:
-    def test_it_deletes_user(self, invoke_cli, user, user_delete_service):
-        result = invoke_cli(user_cli.delete, [user.username])
-
-        assert not result.exit_code
-        user_delete_service.delete_user.assert_called_once_with(user)
-
-    def test_it_deletes_user_with_specific_authority(
-        self, invoke_cli, user, user_delete_service
-    ):
-        user.authority = "partner.org"
-
-        result = invoke_cli(
-            user_cli.delete, ["--authority", "partner.org", user.username]
-        )
-
-        assert not result.exit_code
-        user_delete_service.delete_user.assert_called_once_with(user)
-
-    def test_it_errors_when_user_could_not_be_found(
-        self, invoke_cli, user_delete_service
-    ):
-        result = invoke_cli(user_cli.delete, ["bogus_username"])
-
-        assert result.exit_code == 1
-        user_delete_service.delete_user.assert_not_called()
-
-    def test_it_errors_when_user_with_specific_authority_could_not_be_found(
-        self, invoke_cli, user, user_delete_service
-    ):
-        result = invoke_cli(user_cli.delete, ["--authority", "foo.com", user.username])
-
-        assert result.exit_code == 1
-        user_delete_service.delete_user.assert_not_called()
-
-    @pytest.fixture
-    def user(self, factories):
-        return factories.User()
-
-
 @pytest.fixture
 def invoke_cli(cli, pyramid_request):
     pyramid_request.tm = mock.Mock()

--- a/tests/unit/h/models/helpers_test.py
+++ b/tests/unit/h/models/helpers_test.py
@@ -1,0 +1,9 @@
+from unittest.mock import Mock
+
+from h.models import helpers
+
+
+def test_repr_():
+    obj = Mock(foo="FOO", bar="BAR")
+
+    assert helpers.repr_(obj, ["foo", "bar"]) == "Mock(foo='FOO', bar='BAR')"

--- a/tests/unit/h/models/user_deletion_test.py
+++ b/tests/unit/h/models/user_deletion_test.py
@@ -2,20 +2,19 @@ import pytest
 
 
 def test___repr__(factories, helpers):
-    job = factories.Job()
-    repr_ = repr(job)
+    user_deletion = factories.UserDeletion()
+    repr_ = repr(user_deletion)
 
     helpers.repr_.assert_called_once_with(
-        job,
+        user_deletion,
         [
             "id",
-            "name",
-            "enqueued_at",
-            "scheduled_at",
-            "expires_at",
-            "priority",
+            "userid",
+            "requested_at",
+            "requested_by",
             "tag",
-            "kwargs",
+            "registered_date",
+            "num_annotations",
         ],
     )
     assert repr_ == helpers.repr_.return_value
@@ -23,7 +22,7 @@ def test___repr__(factories, helpers):
 
 @pytest.fixture(autouse=True)
 def helpers(mocker):
-    helpers = mocker.patch("h.models.job.helpers")
+    helpers = mocker.patch("h.models.user_deletion.helpers")
     # __repr__() needs to return a string or repr() raises.
     helpers.repr_.return_value = "test_string_representation"
     return helpers

--- a/tests/unit/h/views/admin/users_test.py
+++ b/tests/unit/h/views/admin/users_test.py
@@ -168,7 +168,11 @@ def test_users_delete_deletes_user(user_service, user_delete_service, pyramid_re
 
     users_delete(pyramid_request)
 
-    user_delete_service.delete_user.assert_called_once_with(user)
+    user_delete_service.delete_user.assert_called_once_with(
+        user,
+        requested_by=pyramid_request.user,
+        tag=pyramid_request.matched_route.name,
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Migration: https://github.com/hypothesis/h/pull/8722.

The code that actually queries this table is over in https://github.com/hypothesis/h/pull/8723.

Testing
=======

Log in to <http://localhost:5000/login> as `devdata_admin`, go to <http://localhost:5000/admin/users?username=devdata_user&authority=localhost> and delete `devdata_user`. You should see a record like this in the `user_deletion` table:

```
id              | 1
userid          | acct:devdata_user@localhost
requested_at    | 2024-05-22 14:32:30.891754
requested_by    | acct:devdata_admin@localhost
tag             | admin.users_delete
created_at      | 2024-05-22 14:31:07.501916
num_annotations | 0
```