### PR TITLE
Prevent deleted users from authenticating

### DIFF
--- a/h/security/policy/_basic_http_auth.py
+++ b/h/security/policy/_basic_http_auth.py
@@ -76,7 +76,7 @@ class AuthClientPolicy(IdentityBasedPolicy):
                 return None
 
             # If you forward a user it must exist and match your authority
-            if not user or user.authority != auth_client.authority:
+            if (not user) or user.deleted or (user.authority != auth_client.authority):
                 return None
 
         return Identity.from_models(auth_client=auth_client, user=user)

--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -17,7 +17,7 @@ class CookiePolicy(IdentityBasedPolicy):
         self._add_vary_by_cookie(request)
 
         user = request.find_service(AuthCookieService).verify_cookie()
-        if not user:
+        if (not user) or user.deleted:
             return None
 
         return Identity.from_models(user=user)

--- a/h/security/policy/_remote_user.py
+++ b/h/security/policy/_remote_user.py
@@ -16,7 +16,7 @@ class RemoteUserPolicy(IdentityBasedPolicy):
             return None
 
         user = request.find_service(name="user").fetch(user_id)
-        if user is None:
+        if user is None or user.deleted:
             return None
 
         return Identity.from_models(user=user)

--- a/h/security/policy/bearer_token.py
+++ b/h/security/policy/bearer_token.py
@@ -57,7 +57,7 @@ class BearerTokenPolicy(IdentityBasedPolicy):
             return None
 
         user = request.find_service(name="user").fetch(token.userid)
-        if user is None:
+        if user is None or user.deleted:
             return None
 
         return Identity.from_models(user=user)

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -138,7 +138,9 @@ def annotation_metadata_service(mock_service):
 
 @pytest.fixture
 def auth_cookie_service(mock_service):
-    return mock_service(AuthCookieService)
+    auth_cookie_service = mock_service(AuthCookieService)
+    auth_cookie_service.verify_cookie.return_value.deleted = False
+    return auth_cookie_service
 
 
 @pytest.fixture
@@ -279,7 +281,9 @@ def user_password_service(mock_service):
 
 @pytest.fixture
 def user_service(mock_service):
-    return mock_service(UserService, name="user")
+    user_service = mock_service(UserService, name="user")
+    user_service.fetch.return_value.deleted = False
+    return user_service
 
 
 @pytest.fixture

--- a/tests/unit/h/security/policy/_basic_http_auth_test.py
+++ b/tests/unit/h/security/policy/_basic_http_auth_test.py
@@ -101,6 +101,13 @@ class TestAuthClientPolicy:
 
         assert AuthClientPolicy().identity(pyramid_request) is None
 
+    def test_identify_returns_None_if_forwarded_user_is_marked_as_deleted(
+        self, user_service, pyramid_request
+    ):
+        user_service.fetch.return_value.deleted = True
+
+        assert AuthClientPolicy().identity(pyramid_request) is None
+
     def test_identify_returns_None_if_forwarded_userid_is_invalid(
         self, user_service, pyramid_request
     ):

--- a/tests/unit/h/security/policy/_cookie_test.py
+++ b/tests/unit/h/security/policy/_cookie_test.py
@@ -17,6 +17,13 @@ class TestCookiePolicy:
             user=auth_cookie_service.verify_cookie.return_value
         )
 
+    def test_identity_when_user_marked_as_deleted(
+        self, pyramid_request, auth_cookie_service
+    ):
+        auth_cookie_service.verify_cookie.return_value.deleted = True
+
+        assert CookiePolicy().identity(pyramid_request) is None
+
     def test_identity_with_no_cookie(self, pyramid_request, auth_cookie_service):
         auth_cookie_service.verify_cookie.return_value = None
 

--- a/tests/unit/h/security/policy/_remote_user_test.py
+++ b/tests/unit/h/security/policy/_remote_user_test.py
@@ -26,3 +26,11 @@ class TestRemoteUserPolicy:
         user_service.fetch.return_value = None
 
         assert RemoteUserPolicy().identity(pyramid_request) is None
+
+    def test_identity_returns_None_for_user_marked_as_deleted(
+        self, pyramid_request, user_service
+    ):
+        pyramid_request.environ["HTTP_X_FORWARDED_USER"] = sentinel.forwarded_user
+        user_service.fetch.return_value.deleted = True
+
+        assert RemoteUserPolicy().identity(pyramid_request) is None

--- a/tests/unit/h/security/policy/bearer_token_test.py
+++ b/tests/unit/h/security/policy/bearer_token_test.py
@@ -57,3 +57,10 @@ class TestBearerTokenPolicy:
         user_service.fetch.return_value = None
 
         assert BearerTokenPolicy().identity(pyramid_request) is None
+
+    def test_identity_returns_None_for_user_marked_as_deleted(
+        self, pyramid_request, user_service
+    ):
+        user_service.fetch.return_value.deleted = True
+
+        assert BearerTokenPolicy().identity(pyramid_request) is None


### PR DESCRIPTION
Prevent users who've been marked as deleted (but still exist in the DB,
for now) from authenticating with auth clients, cookies,
`HTTP_X_FORWARDED_USER` headers, or bearer tokens.
