### PR TITLE
Create index on AnnotationSlim.document_id

### DIFF
--- a/h/migrations/versions/ecf91905c143_annotation_slim_document_id_index.py
+++ b/h/migrations/versions/ecf91905c143_annotation_slim_document_id_index.py
@@ -1,0 +1,21 @@
+"""Create index on annotation_slim.document_id."""
+
+from alembic import op
+
+revision = "ecf91905c143"
+down_revision = "1671cf35fb34"
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.create_index(
+        op.f("ix__annotation_slim_document_id"),
+        "annotation_slim",
+        ["document_id"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix__annotation_slim_document_id"), table_name="annotation_slim")

--- a/h/models/annotation_slim.py
+++ b/h/models/annotation_slim.py
@@ -72,7 +72,10 @@ class AnnotationSlim(Base):
     )
 
     document_id = sa.Column(
-        sa.Integer, sa.ForeignKey("document.id", ondelete="CASCADE"), nullable=False
+        sa.Integer,
+        sa.ForeignKey("document.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     document = sa.orm.relationship("Document")
 


### PR DESCRIPTION
Missing this is causing slow updates, see:

https://one.newrelic.com/nr1-core/apm-features/databases/MTM4NTI4M3xBUE18QVBQTElDQVRJT058MjI2ODg2MzE?account=1385283&duration=604800000&state=1c9028a5-93ba-20c8-72cd-88240d5955a5

While doing `File "/var/lib/hypothesis/h/models/document/_document.py", line 163, in merge_documents`


## Testing

`tox -e dev --run-command 'alembic upgrade head'`

```                                              
dev run-test-pre: PYTHONHASHSEED='4080454129'
dev run-test: commands[0] | alembic upgrade head
2024-06-20 15:22:52 3870316 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2024-06-20 15:22:52 3870316 alembic.runtime.migration [INFO] Will assume transactional DDL.
2024-06-20 15:22:52 3870316 alembic.runtime.migration [INFO] Running upgrade 1671cf35fb34 -> ecf91905c143, Create index on annotation_slim.document_id.
```
