### PR TITLE
Remove pending_updates_notification feature flag

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -15,7 +15,6 @@ FEATURES = {
     "pdf_custom_text_layer": "Use custom text layer in PDFs for improved text selection",
     "styled_highlight_clusters": "Style different clusters of highlights in the client",
     "client_user_profile": "Enable client-side user profile and preferences management",
-    "pending_updates_notification": "Display an actionable toast-like notification when there are pending updates",
 }
 
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/client/pull/6392

Remove the `pending_updates_notification` feature flag, as the client no longer uses it.