### PR TITLE
Report num. annotations marked deleted to New Relic

### DIFF
--- a/h/tasks/cleanup.py
+++ b/h/tasks/cleanup.py
@@ -1,6 +1,9 @@
 # pylint: disable=no-member # Instance of 'Celery' has no 'request' member
 from datetime import datetime
 
+import newrelic
+from sqlalchemy import func, select
+
 from h import models
 from h.celery import celery, get_task_logger
 
@@ -10,6 +13,33 @@ log = get_task_logger(__name__)
 @celery.task
 def purge_deleted_annotations():
     celery.request.find_service(name="annotation_delete").bulk_delete()
+
+
+@celery.task
+def report_num_deleted_annotations():
+    """
+    Report the number of deleted annotations to New Relic.
+
+    Send a custom metric to New Relic that counts the number of annotations
+    that have been marked as deleted in the database but not yet "purged" (i.e.
+    actually deleted) from the database by the purge_deleted_annotations() task
+    above
+
+    This is so that we can set a New Relic alert based on this metric so that
+    we can know if the purge_deleted_annotations() task is unable to keep up
+    (since it only deletes up to a limited number of annotations per task run)
+    and we're failing to actually purge data from the database when users ask
+    us to. Otherwise annotations could be marked as deleted but never actually
+    purged and we'd never know.
+    """
+    newrelic.agent.record_custom_metric(
+        "Custom/Annotations/MarkedAsDeleted",
+        celery.request.db.scalar(
+            select(
+                func.count(models.Annotation.id)  # pylint:disable=not-callable
+            ).where(models.Annotation.deleted.is_(True))
+        ),
+    )
 
 
 @celery.task


### PR DESCRIPTION
[h's `purge_deleted_annotations()` task](https://github.com/hypothesis/h/blob/9b2b085ab2a2cc28aacffec2293c0f0de805b4e0/h/tasks/cleanup.py#L10-L12) runs [every hour](https://github.com/hypothesis/h-periodic/blob/278d10dadca06c0f4a2ce8b3861d2ec1979379c9/h_periodic/h_beat.py#L23-L27) and purges [up to 1000](https://github.com/hypothesis/h/blob/9b2b085ab2a2cc28aacffec2293c0f0de805b4e0/h/services/annotation_delete.py#L68-L72) annotations per run.

If the rate at which annotations are being deleted from h exceeds 1000 per hour on average most of the time then the task won't be able to keep up, we won't actually be deleting data from our DB when users or organizations request it, and we won't know.

This PR adds a periodic Celery task to send a [custom metric](https://docs.newrelic.com/docs/apm/agents/manage-apm-agents/agent-data/collect-custom-metrics/) to New Relic counting the number of annotations in the DB that're marked as deleted but not yet purged. We'll then be able to set an alert based on this metric so that we'll know if the `purge_deleted_annotations()` task isn't keeping up.