### PR TITLE
Add form for users to delete their own accounts

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -245,6 +245,21 @@ class PasswordChangeSchema(CSRFSchema):
             raise exc
 
 
+class DeleteAccountSchema(CSRFSchema):
+    password = password_node(title=_("Confirm password"))
+
+    def validator(self, node, value):
+        super().validator(node, value)
+
+        request = node.bindings["request"]
+        svc = request.find_service(name="user_password")
+
+        if not svc.check_password(request.user, value.get("password")):
+            exc = colander.Invalid(node)
+            exc["password"] = _("Wrong password.")
+            raise exc
+
+
 class NotificationsSchema(CSRFSchema):
     types = (("reply", _("Email me when someone replies to one of my annotations.")),)
 

--- a/h/form.py
+++ b/h/form.py
@@ -87,7 +87,7 @@ def configure_environment(config):  # pragma: no cover
     config.registry[ENVIRONMENT_KEY] = create_environment(base)
 
 
-def handle_form_submission(request, form, on_success, on_failure):
+def handle_form_submission(request, form, on_success, on_failure, flash_success=True):
     """
     Handle the submission of the given form in a standard way.
 
@@ -114,6 +114,11 @@ def handle_form_submission(request, form, on_success, on_failure):
         not an XHR request.
     :type on_failure: callable
 
+    :param flash_success:
+        Whether to show a "success" flash message if handling the form succeeds.
+        Applies to non-XHR form submissions only.
+    :type flash_success: bool
+
     """
     try:
         appstruct = form.validate(request.POST.items())
@@ -126,7 +131,7 @@ def handle_form_submission(request, form, on_success, on_failure):
         if result is None:
             result = httpexceptions.HTTPFound(location=request.url)
 
-        if not request.is_xhr:  # pragma: no cover
+        if (not request.is_xhr) and flash_success:
             request.session.flash(_("Success. We've saved your changes."), "success")
 
     return to_xhr_response(request, result, form)

--- a/h/routes.py
+++ b/h/routes.py
@@ -16,6 +16,8 @@ def includeme(config):  # pylint: disable=too-many-statements
     config.add_route("account_profile", "/account/profile")
     config.add_route("account_notifications", "/account/settings/notifications")
     config.add_route("account_developer", "/account/developer")
+    config.add_route("account_delete", "/account/delete")
+    config.add_route("account_deleted", "/account/deleted")
     config.add_route("claim_account_legacy", "/claim_account/{token}")
     config.add_route("dismiss_sidebar_tutorial", "/app/dismiss_sidebar_tutorial")
 

--- a/h/static/styles/components/_btn.scss
+++ b/h/static/styles/components/_btn.scss
@@ -10,6 +10,12 @@
 
   min-height: 30px;
 
+  /* Vertically center text within buttons.
+     This works even if the element is not a button,
+     e.g. <a class="btn"> */
+  display: flex;
+  align-items: center;
+
   background-color: color.$grey-6;
   border: none;
   border-radius: 2px;

--- a/h/static/styles/components/_form.scss
+++ b/h/static/styles/components/_form.scss
@@ -126,14 +126,6 @@
   padding-right: 15px;
 }
 
-// A form footer with no top border, useful for additional sections at the
-// bottom of a footer.
-.form-footer--no-border {
-  @include form-footer;
-
-  margin-top: 15px;
-}
-
 .form-help-text {
   color: color.$grey-5;
 }
@@ -146,4 +138,12 @@
 .form-footer__symbol {
   color: color.$brand;
   margin-right: 3px;
+}
+
+.form-footer__left {
+  float: left;
+}
+
+.form-footer__right {
+  float: right;
 }

--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -7,13 +7,9 @@
   <div class="form-vertical">
     {{ email_form }}
     {{ password_form }}
-
-    <footer class="form-footer">
-      {% trans %}
-        If you would like to delete your account, please email us at
-        <a class="link--footer" href="mailto:support@hypothes.is">support@hypothes.is</a> from your
-        registered email address, and we'll take it from there.
-      {% endtrans %}
-    </footer>
   </div>
 {% endblock page_content %}
+
+{% block form_footer_right %}
+<a class="link--footer" href="{{ request.route_path('account_delete') }}">{% trans %}Delete your account{% endtrans %}</a>
+{% endblock %}

--- a/h/templates/accounts/delete.html.jinja2
+++ b/h/templates/accounts/delete.html.jinja2
@@ -1,0 +1,48 @@
+{% extends "h:templates/layouts/account.html.jinja2" %}
+
+{% set page_route = 'account_delete' %}
+{% set page_title = 'Delete your account' %}
+
+{% block tabs %}{% endblock tabs %}
+
+{% block page_content %}
+  <h1 class="form-header">{% trans %}Delete your account{% endtrans %}</h1>
+
+  <div class="form-description">
+    <p>{% trans %}Are you sure you want to delete your account?{% endtrans %}</p>
+
+    <p>
+      {% set username = request.user.username %}
+
+      {% if count == 0 %}
+        {% trans %}This will delete user <strong>{{ username }}</strong>.{% endtrans %}
+      {% else %}
+        {% set oldest_str = oldest.strftime("%B %-d %Y") %}
+        {% set newest_str = newest.strftime("%B %-d %Y") %}
+
+        {% if oldest_str == newest_str %}
+          {% trans count=count %}
+            This will delete user <strong>{{ username }}</strong>,
+            including 1 annotation
+            from <strong>{{ oldest_str }}</strong>.
+          {% pluralize count %}
+            This will delete user <strong>{{ username }}</strong>,
+            including <strong>{{ count }}</strong> annotations
+            from <strong>{{ oldest_str }}</strong>.
+          {% endtrans %}
+        {% else %}
+          {% trans %}
+            This will delete user <strong>{{ username }}</strong>,
+            including <strong>{{ count }}</strong> annotations
+            spanning <strong>{{ oldest_str }}</strong>
+            to <strong>{{ newest_str }}</strong>.
+          {% endtrans %}
+        {% endif %}
+      {% endif %}
+   </p>
+
+    <p>{% trans %}This cannot be undone!{% endtrans %}</p>
+  </div>
+
+  {{ form }}
+{% endblock page_content %}

--- a/h/templates/accounts/deleted.html.jinja2
+++ b/h/templates/accounts/deleted.html.jinja2
@@ -1,0 +1,6 @@
+{% extends "h:templates/accounts/base.html.jinja2" %}
+
+{% block page_title %}{% trans %}Account deleted{% endtrans %}{% endblock %}
+
+{% set form_message %}{% trans %}Your account has been deleted.{% endtrans %}{% endset %}
+{% set signup_message = "Don't have a Hypothesis account?" %}

--- a/h/templates/accounts/developer.html.jinja2
+++ b/h/templates/accounts/developer.html.jinja2
@@ -31,9 +31,12 @@
           </button>
         {% endif %}
       </form>
-      <footer class="form-footer">
-        You can learn more about the Hypothesis API at
-        <a class="link--footer" href="https://h.readthedocs.io/en/latest/api.html">h.readthedocs.io/en/latest/api.html</a>
-      </footer>
   </div>
 {% endblock page_content %}
+
+{% block form_footer_left %}
+  <p>
+    You can learn more about the Hypothesis API at
+    <a class="link--footer" href="https://h.readthedocs.io/en/latest/api.html">h.readthedocs.io/en/latest/api.html</a>
+  </p>
+{% endblock %}

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -35,6 +35,10 @@
     <button type="button"
             class="btn btn--cancel js-form-cancel">Cancel</button>
     {% endif %}
+    {% if field.back_link %}
+    <a class="btn btn--cancel"
+       href="{{ field.back_link.href }}">{{ field.back_link.text }}</a>
+    {% endif %}
     <div class="u-stretch"></div>
     <div class="form-actions__buttons">
       {%- for button in field.buttons -%}

--- a/h/templates/layouts/account.html.jinja2
+++ b/h/templates/layouts/account.html.jinja2
@@ -17,6 +17,7 @@
 {% block content %}
   <div class="content paper">
     <div class="form-container">
+      {% block tabs %}
       <nav class="tabs">
         <ul>
           {% for route, title in nav_pages %}
@@ -29,12 +30,35 @@
           {% endfor %}
         </ul>
       </nav>
+      {% endblock tabs %}
       {% include "h:templates/includes/flash-messages.html.jinja2" %}
       {{ self.page_content() }}
 
-      <footer class="form-footer--no-border">
-        {% include "h:templates/includes/back_link.html.jinja2" %}
-      </footer>
+      {% with %}
+        {% set footer_left %}
+          {% block form_footer_left %}{% endblock form_footer_left %}
+          {% include "h:templates/includes/back_link.html.jinja2" %}
+        {% endset %}
+
+        {% set footer_right %}
+          {% block form_footer_right %}{% endblock form_footer_right %}
+        {% endset %}
+
+        {% if footer_left|trim or footer_right|trim %}
+          <footer class="form-footer">
+            {% if footer_left|trim %}
+            <div class="form-footer__left">
+              {{ footer_left }}
+            </div>
+            {% endif %}
+            {% if footer_right|trim %}
+            <div class="form-footer__right">
+              {{ footer_right }}
+            </div>
+            {% endif %}
+          </footer>
+        {% endif %}
+      {% endwith %}
     </div>
   </div>
 {% endblock content %}

--- a/tests/unit/h/form_test.py
+++ b/tests/unit/h/form_test.py
@@ -230,6 +230,33 @@ class TestHandleFormSubmission:
 
         assert pyramid_request.session.peek_flash("success")
 
+    def test_it_doesnt_show_a_flash_message_for_XHR_requests(
+        self, form_validating_to, pyramid_request
+    ):
+        pyramid_request.is_xhr = True
+
+        form.handle_form_submission(
+            pyramid_request,
+            form_validating_to("anything"),
+            mock_callable(),
+            mock.sentinel.on_failure,
+        )
+
+        assert not pyramid_request.session.peek_flash("success")
+
+    def test_it_doesnt_show_a_flash_message_if_asked_not_to(
+        self, form_validating_to, pyramid_request
+    ):
+        form.handle_form_submission(
+            pyramid_request,
+            form_validating_to("anything"),
+            mock_callable(),
+            mock.sentinel.on_failure,
+            flash_success=False,
+        )
+
+        assert not pyramid_request.session.peek_flash("success")
+
     def test_if_validation_succeeds_it_calls_to_xhr_response(
         self, form_validating_to, matchers, pyramid_request, to_xhr_response
     ):

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -27,6 +27,8 @@ def test_includeme():
         call("account_profile", "/account/profile"),
         call("account_notifications", "/account/settings/notifications"),
         call("account_developer", "/account/developer"),
+        call("account_delete", "/account/delete"),
+        call("account_deleted", "/account/deleted"),
         call("claim_account_legacy", "/claim_account/{token}"),
         call("dismiss_sidebar_tutorial", "/app/dismiss_sidebar_tutorial"),
         call("activity.search", "/search"),


### PR DESCRIPTION
Add a new `/account/delete` form that allows a user to delete their own account by calling the new user deletion backend (`UserDeleteService.delete_user()`, https://github.com/hypothesis/h/pull/8700).

This completes the delivery of the "self-service user deletion" feature ([PRD](https://docs.google.com/document/d/1SdXBraDZpgUVCARLI5OelV3DcjahHJBvQ9tticEG1GY), [DD](https://docs.google.com/document/d/1czDOdzls7OqONxZgiHs39SyWSXnzqfERlDnF26MV-Fc)).

UI Design Changes
=================

I made some small changes to the design of h's account settings forms in order to accommodate the desired design for the user deletion UI.

Current design of account settings forms
----------------------------------------

Here's what the <https://hypothes.is/account/settings> form looks like currently:

![image](https://github.com/hypothesis/h/assets/22498/438fffca-e12a-4c40-a464-e15a2506667f)

If you navigate to the form from your user profile page it gets a **Back to your profile** page in the bottom-left of the footer:

![image](https://github.com/hypothesis/h/assets/22498/74855ee8-6b50-49bd-91f5-8ea2071ab3df)

This link instead reads **Back to group overview page** if navigated from a group page.

In fact all four account settings pages (**Account details**, **Edit profile**, **Notifications** and **Developer**) have two versions depending on how you navigate to them--with or without the **Back...** link in the footer:

![image](https://github.com/hypothesis/h/assets/22498/ebd86885-fcd4-4e20-8438-396faa01fa91)

![image](https://github.com/hypothesis/h/assets/22498/fb4522bc-9f34-47ff-9fcd-822e91b32377)

![image](https://github.com/hypothesis/h/assets/22498/21520d70-c9b9-4dc1-b1da-22b3e9667552)

![image](https://github.com/hypothesis/h/assets/22498/4fb85698-1adc-4203-b23b-8b5f784febce)

![Screenshot from 2024-06-05 15-37-18-obfuscated](https://github.com/hypothesis/h/assets/22498/4ff11c93-54f6-4f87-be46-74d85daafd78)

![Screenshot from 2024-06-05 15-36-49-obfuscated](https://github.com/hypothesis/h/assets/22498/ff4e84a1-cc6b-4d6e-bbbf-1f3796613c8b)

The current design is inconsistent
----------------------------------

Note that the **Back** link is sometimes shown below a grey horizontal line (marking the start of the form footer), but sometimes this line is not present:

![image](https://github.com/hypothesis/h/assets/22498/e35fee4a-bf7a-43ad-91a8-db053aaaf86f)

![image](https://github.com/hypothesis/h/assets/22498/aa1e47c0-f6fb-415f-8ae1-1cc63feebd24)

![image](https://github.com/hypothesis/h/assets/22498/369cbd44-8269-4d29-bd12-6178ec56b33b)

![image](https://github.com/hypothesis/h/assets/22498/63644313-e7d3-4db7-9af1-3b1ee1e89fdd)

New design
----------

The design for the user deletion feature (https://github.com/hypothesis/h/issues/8504) calls for a **Delete your account** button in the bottom-right, beneath the horizontal grey line:

![image](https://github.com/hypothesis/h/assets/22498/6ffc4e6d-3ab3-4220-b40f-00762cf898bc)

The design failed to account for the **Back** link that is sometimes present, but it's fairly obvious how this should be accommodated:

![image](https://github.com/hypothesis/h/assets/22498/7cc4f018-ec77-48bf-b443-a1a8217296c5)

I've decided to change the base template shared by all the account settings form so that the **Back...** link will always be shown beneath a horizontal grey line. This is more consistent and it more clearly separates the **Back...** link from the form elements:

![image](https://github.com/hypothesis/h/assets/22498/24f1d7d8-7793-46fc-ba29-153a0501787a)

![image](https://github.com/hypothesis/h/assets/22498/cb6d41a8-7c65-4d94-b376-b8c65d921700)

![image](https://github.com/hypothesis/h/assets/22498/8d872a12-8ff4-49a0-9fd8-5e65a2d546b2)

![Screenshot from 2024-06-05 15-51-11-obfuscated](https://github.com/hypothesis/h/assets/22498/05ee59e0-db80-4cc8-980d-5bf2255b9294)

When there's no back link, and no other footer content to show, then the grey horizontal line marking the start of the footer will not be shown at all (this is the same as on `main` currently):

![image](https://github.com/hypothesis/h/assets/22498/63b5267b-4f6d-4d06-bf9b-5f06ed86924c)

![image](https://github.com/hypothesis/h/assets/22498/900269da-19a3-431d-9200-1ec803d03fa8)

Testing
=======

1. Log in as `devdata_user`: <http://localhost:5000/login>

2. Click on the gear icon in the top right and select <samp>Account details</samp>

3. Click on <samp>Delete your account</samp> in the bottom-right

4. You'll see this form:

   ![image](https://github.com/hypothesis/h/assets/22498/543b84f3-e0fe-426a-aa4e-b12965761b15)

5. Go to <http://localhost:5000/docs/help> and create **one** annotation then reload <http://localhost:5000/account/delete> and you should see this version of the form:

   ![image](https://github.com/hypothesis/h/assets/22498/6ef959c3-525b-4cc9-b043-9d9dbca56c73)

6. Create some more annotations then reload <http://localhost:5000/account/delete> and you should see this version of the form:

   ![image](https://github.com/hypothesis/h/assets/22498/e63aec56-1722-4f9a-b161-b025fdc1ed75)

7. Finally, there's a version of the form when the oldest and newest annotations were created on different days. To get this, hack the created date of one of your annotations:

   ```sql
   $ make sql
   postgres=# update annotation set created = '1970-01-01' where id = 'a5d...d83';
   ```

   Now load <http://localhost:5000/account/delete> again and you'll see this version of the form:

   ![image](https://github.com/hypothesis/h/assets/22498/1840b09f-2e7d-4b84-8bde-0118ca649034)

8. Delete some of your annotations then reload <http://localhost:5000/account/delete> and test that your deleted annotations aren't counted, even if they haven't been purged from the DB yet.

9. If you try to submit the form without entering a password you'll get this error:

   ![image](https://github.com/hypothesis/h/assets/22498/e716c79d-6326-455d-a3ae-d1d0d7564b98)

10. If you try to submit the form with the wrong password you'll get this error:

   ![image](https://github.com/hypothesis/h/assets/22498/517b5577-9431-461b-839e-ce631753429e)

11. If you click the **Back to safety** link it'll take you back to <http://localhost:5000/account/settings>

12. Finally, if you enter the correct password and click **Delete your account** you'll be redirected to this page:

   ![image](https://github.com/hypothesis/h/assets/22498/7c408874-eed8-4f3c-89c3-5bc23c6d75d2)

   You'll be logged out, including in any other tabs or clients etc that you had open.

   A `"purge_user"` job will have been added to the `job` table, and a row will have been added to the `user_deletions` table.