### PR TITLE
Fix URL routes for the bulk API

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -136,12 +136,7 @@ def includeme(config):  # pylint: disable=too-many-statements
     config.add_route("api.bulk.group", "/api/bulk/group", request_method="POST")
 
     config.add_route(
-        "api.bulk.stats.users", "/api/bulk/stats/users", request_method="POST"
-    )
-    config.add_route(
-        "api.bulk.stats.assignments",
-        "/api/bulk/stats/assignments",
-        request_method="POST",
+        "api.bulk.lms.annotations", "/api/bulk/lms/annotations", request_method="POST"
     )
 
     config.add_route("api.groups", "/api/groups", factory="h.traversal.GroupRoot")

--- a/h/security/policy/_basic_http_auth.py
+++ b/h/security/policy/_basic_http_auth.py
@@ -40,8 +40,7 @@ class AuthClientPolicy(IdentityBasedPolicy):
         ("api.bulk.action", "POST"),
         ("api.bulk.annotation", "POST"),
         ("api.bulk.group", "POST"),
-        ("api.bulk.stats.assignments", "POST"),
-        ("api.bulk.stats.users", "POST"),
+        ("api.bulk.lms.annotations", "POST"),
     ]
 
     @classmethod

--- a/h/views/api/bulk/stats.py
+++ b/h/views/api/bulk/stats.py
@@ -17,10 +17,10 @@ class AssignmentStatsSchema(JSONSchema):
 
 @api_config(
     versions=["v1", "v2"],
-    route_name="api.bulk.stats.users",
+    route_name="api.bulk.lms.annotations",
     request_method="POST",
-    description="Retrieve stats grouped by user",
-    link_name="bulk.stats.assignment",
+    description="Retrieve annotations for LMS metrics",
+    link_name="bulk.lms.annotations",
     subtype="x-ndjson",
     permission=Permission.API.BULK_ACTION,
 )

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -128,13 +128,8 @@ def test_includeme():
         call("api.bulk.annotation", "/api/bulk/annotation", request_method="POST"),
         call("api.bulk.group", "/api/bulk/group", request_method="POST"),
         call(
-            "api.bulk.stats.users",
-            "/api/bulk/stats/users",
-            request_method="POST",
-        ),
-        call(
-            "api.bulk.stats.assignments",
-            "/api/bulk/stats/assignments",
+            "api.bulk.lms.annotations",
+            "/api/bulk/lms/annotations",
             request_method="POST",
         ),
         call("api.groups", "/api/groups", factory="h.traversal.GroupRoot"),


### PR DESCRIPTION
Use the annotation naming instead of "user" & "assignment".

The change in LMS is already made, I made a mistake of pushing this changes on the original H branch.