### PR TITLE
Don't return replies to hidden annotations in the bulk API

### DIFF
--- a/tests/common/factories/annotation_slim.py
+++ b/tests/common/factories/annotation_slim.py
@@ -13,7 +13,9 @@ class AnnotationSlim(ModelFactory):
     class Meta:
         model = models.AnnotationSlim
 
-    annotation = factory.SubFactory(Annotation)
+    annotation = factory.SubFactory(
+        Annotation, shared=factory.SelfAttribute("..shared")
+    )
     user = factory.SubFactory(User)
     group = factory.SubFactory(Group)
     document = factory.SubFactory(Document)


### PR DESCRIPTION
Potential fix for: https://github.com/hypothesis/support/issues/66

Join on the main annotation table to find the reference to the parent, if any and check that it's visible.