### PR TITLE
Fix h's Docker build after adding Tailwind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV NODE_ENV production
 
 # Install dependencies.
 WORKDIR /tmp/frontend-build
-COPY package.json .yarnrc.yml yarn.lock ./
+COPY package.json .yarnrc.yml yarn.lock tailwind.config.js ./
 COPY .yarn ./.yarn
 RUN yarn install --immutable
 


### PR DESCRIPTION
Building the Docker image is [failing on `main`](https://github.com/hypothesis/h/actions/runs/9792858243/job/27039549452):

```
[ERR_MODULE_NOT_FOUND]: Cannot find module '/tmp/frontend-build/tailwind.config.js' imported from /tmp/frontend-build/gulpfile.js
```