### PR TITLE
Update browser support baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "url": "https://github.com/hypothesis/h/issues"
   },
   "homepage": "https://github.com/hypothesis/h",
-  "browserslist": "chrome 57, edge 17, firefox 53, safari 10.1",
+  "browserslist": "chrome 92, firefox 90, safari 14.1",
   "prettier": {
     "arrowParens": "avoid",
     "singleQuote": true


### PR DESCRIPTION
Update the baseline to match https://github.com/hypothesis/client/pull/6438.