### PR TITLE
Use Shadow DOM for the `CreateGroupForm` app

### DIFF
--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -1,3 +1,5 @@
+import { Button, Input, Textarea } from '@hypothesis/frontend-shared';
+
 export default function CreateGroupForm() {
   return (
     <>
@@ -5,32 +7,23 @@ export default function CreateGroupForm() {
 
       <form>
         <div>
-          <label for="name">
-            Name <span>*</span>
-          </label>
-          <input type="text" id="name" autofocus autocomplete="off" required />
-          <span>0/25</span>
+          <label for="name">Name*</label>
+          <Input id="name" autofocus autocomplete="off" required />
+          0/25
         </div>
 
         <div>
           <label for="description">Description</label>
-          <textarea id="description"></textarea>
-          <span>0/250</span>
+          <Textarea id="description" />
+          0/250
         </div>
 
         <div>
-          <div>
-            <button>Create group</button>
-          </div>
+          <Button variant="primary">Create group</Button>
         </div>
       </form>
 
-      <footer>
-        <span>
-          <span>*</span>
-          <span>Required</span>
-        </span>
-      </footer>
+      <footer>*Required</footer>
     </>
   );
 }

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -1,53 +1,34 @@
 export default function CreateGroupForm() {
   return (
     <>
-      <h1 class="form-header">Create a new private group</h1>
+      <h1>Create a new private group</h1>
 
-      <form class="form group-form__form">
-        <div class="form-input">
-          <label for="name" class="form-input__label group-form__name-label">
-            Name <span class="form-input__required">*</span>
+      <form>
+        <div>
+          <label for="name">
+            Name <span>*</span>
           </label>
-          <input
-            type="text"
-            id="name"
-            class="form-input__input group-form__name-input has-label"
-            autofocus
-            autocomplete="off"
-            required
-          />
-          <span class="form-input__character-counter is-ready">0/25</span>
+          <input type="text" id="name" autofocus autocomplete="off" required />
+          <span>0/25</span>
         </div>
 
-        <div class="form-input">
-          <label
-            class="form-input__label group-form__description-label"
-            for="description"
-          >
-            Description
-          </label>
-          <textarea
-            id="description"
-            class="form-input__input group-form__description-input has-label"
-          ></textarea>
-          <span class="form-input__character-counter is-ready">0/250</span>
+        <div>
+          <label for="description">Description</label>
+          <textarea id="description"></textarea>
+          <span>0/250</span>
         </div>
 
-        <div class="form-actions">
-          <div class="u-stretch"></div>
-
-          <div class="form-actions__buttons">
-            <button class="form-actions__btn btn primary-action-btn group-form__submit-btn">
-              Create group
-            </button>
+        <div>
+          <div>
+            <button>Create group</button>
           </div>
         </div>
       </form>
 
-      <footer class="form-footer">
-        <span class="form-footer__required">
-          <span class="form-footer__symbol">*</span>
-          <span class="form-footer__text">Required</span>
+      <footer>
+        <span>
+          <span>*</span>
+          <span>Required</span>
         </span>
       </footer>
     </>

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -1,0 +1,9 @@
+export type ConfigObject = {
+  /** The URLs of the app's CSS stylesheets. */
+  styles: string[];
+};
+
+/** Return the frontend config from the page's <script class="js-config">. */
+export default function readConfig(): ConfigObject {
+  return JSON.parse(document.querySelector('.js-config')!.textContent!);
+}

--- a/h/static/scripts/group-forms/index.tsx
+++ b/h/static/scripts/group-forms/index.tsx
@@ -3,7 +3,9 @@ import { render } from 'preact';
 import CreateGroupForm from './components/CreateGroupForm';
 
 function init() {
-  render(<CreateGroupForm />, document.querySelector('#create-group-form')!);
+  const shadowHost = document.querySelector('#create-group-form')!;
+  const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+  render(<CreateGroupForm />, shadowRoot);
 }
 
 init();

--- a/h/static/scripts/group-forms/index.tsx
+++ b/h/static/scripts/group-forms/index.tsx
@@ -1,11 +1,22 @@
 import { render } from 'preact';
 
 import CreateGroupForm from './components/CreateGroupForm';
+import readConfig from './config';
 
 function init() {
   const shadowHost = document.querySelector('#create-group-form')!;
   const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
-  render(<CreateGroupForm />, shadowRoot);
+  const config = readConfig();
+  const stylesheetLinks = config.styles.map(stylesheetURL => (
+    <link rel="stylesheet" href={stylesheetURL} />
+  ));
+  render(
+    <>
+      {stylesheetLinks}
+      <CreateGroupForm />
+    </>,
+    shadowRoot,
+  );
 }
 
 init();

--- a/h/templates/groups/create.html.jinja2
+++ b/h/templates/groups/create.html.jinja2
@@ -2,16 +2,13 @@
 
 {% set page_title = 'Create a new private group' %}
 
-{% block styles %}
-  {{ super() }}
-
-  {% for url in asset_urls('group_forms_css') %}
-    <link rel="stylesheet" href="{{ url }}">
-  {% endfor %}
-{% endblock %}
-
 {% block page_content %}
   <div id="create-group-form"></div>
+  <script type="application/json" class="js-config">
+    {
+      "styles": {{ asset_urls("group_forms_css")|tojson }}
+    }
+  </script>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
1. Move the Preact app for the new (feature-flagged) create-group-form page into a shadow DOM so the CSS of the surrounding site doesn't affect the Preact app and vice-versa.
2. Remove the legacy CSS classes from the Preact app's HTML since they no longer do anything. Also simplify the HTML a bit, no longer mimicking the HTML structure of the legacy page. We may end up adding back some of this structure or something similar as we style the page in future PRs.
3. Use [frontend-shared](https://github.com/hypothesis/frontend-shared)'s `<Input>`, `<Textarea>` and `<Button>` components in the new form
4. Move the Tailwind/frontend-shared CSS into the shadow DOM, so that it applies to the Preact app and not to the surrounding site. This requires the Jinja templates to render the CSS URLs into a `js-config` object, and the Preact app to read the CSS URLs from this `js-config` object and render them into `<style>`'s within the shadow DOM.

This results in a form that's largely unstyled, apart from the styling that frontend-shared applies to the `<input>`, `<textarea>` and `<button>`. The form does also acquire a `max-width`, centered positioning, `padding`, etc because it's contained within the surrounding pages layout divs. The next PR's job will be to add Tailwind-style CSS to make the form once again look more like the legacy form, replacing the legacy styling that has been lost by the move into a shadow DOM.

![image](https://github.com/hypothesis/h/assets/22498/c6bc7281-6751-4498-816d-d8385befd4ed)