### PR TITLE
Style the new create-group-form

### DIFF
--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -9,7 +9,7 @@ export default function CreateGroupForm() {
 
       <form>
         <div className="mb-[15px]">
-          <label for="name" className="text-[#7a7a7a] text-[13px] leading-[15px]">
+          <label htmlFor="name" className="text-[#7a7a7a] text-[13px] leading-[15px]">
             Name<span className="text-[#d00032]">*</span>
           </label>
           <Input id="name" autofocus autocomplete="off" required />
@@ -21,7 +21,7 @@ export default function CreateGroupForm() {
 
         <div className="mb-[15px]">
           <label
-            for="description"
+            htmlFor="description"
             className="text-[#7a7a7a] text-[13px] leading-[15px]"
           >
             Description

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -21,12 +21,7 @@ export default function CreateGroupForm() {
             Name<span className="text-[#d00032]">*</span>
           </label>
           <Input id={nameId} autofocus autocomplete="off" required />
-          <div className="flex">
-            <div className="grow" />
-            <span className="text-[#7a7a7a] text-[13px] leading-[15px]">
-              0/25
-            </span>
-          </div>
+          <CharacterCounter value={0} limit={25} />
         </div>
 
         <div className="mb-[15px]">
@@ -37,12 +32,7 @@ export default function CreateGroupForm() {
             Description
           </label>
           <Textarea id={descriptionId} />
-          <div className="flex">
-            <div className="grow" />
-            <span className="text-[#7a7a7a] text-[13px] leading-[15px]">
-              0/250
-            </span>
-          </div>
+          <CharacterCounter value={0} limit={250} />
         </div>
 
         <div className="flex">
@@ -62,5 +52,16 @@ export default function CreateGroupForm() {
         </div>
       </footer>
     </>
+  );
+}
+
+function CharacterCounter({ value, limit }: { value: number; limit: number }) {
+  return (
+    <div className="flex">
+      <div className="grow" />
+      <span className="text-[#7a7a7a] text-[13px] leading-[15px]">
+        {value}/{limit}
+      </span>
+    </div>
   );
 }

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -3,27 +3,52 @@ import { Button, Input, Textarea } from '@hypothesis/frontend-shared';
 export default function CreateGroupForm() {
   return (
     <>
-      <h1>Create a new private group</h1>
+      <h1 class="mt-[55px] mb-[30px] text-[#3f3f3f] text-[19px] leading-[15px]">
+        Create a new private group
+      </h1>
 
       <form>
-        <div>
-          <label for="name">Name*</label>
+        <div class="mb-[15px]">
+          <label for="name" class="text-[#7a7a7a] text-[13px] leading-[15px]">
+            Name<span class="text-[#d00032]">*</span>
+          </label>
           <Input id="name" autofocus autocomplete="off" required />
-          0/25
+          <div class="flex">
+            <div class="grow"></div>
+            <span class="text-[#7a7a7a] text-[13px] leading-[15px]">0/25</span>
+          </div>
         </div>
 
-        <div>
-          <label for="description">Description</label>
+        <div class="mb-[15px]">
+          <label
+            for="description"
+            class="text-[#7a7a7a] text-[13px] leading-[15px]"
+          >
+            Description
+          </label>
           <Textarea id="description" />
-          0/250
+          <div class="flex">
+            <div class="grow"></div>
+            <span class="text-[#7a7a7a] text-[13px] leading-[15px]">0/250</span>
+          </div>
         </div>
 
-        <div>
-          <Button variant="primary">Create group</Button>
+        <div class="flex">
+          <div class="grow"></div>
+          <div>
+            <Button variant="primary">Create group</Button>
+          </div>
         </div>
       </form>
 
-      <footer>*Required</footer>
+      <footer class="text-[#7a7a7a] text-[13px] leading-[15px] mt-[50px] pt-[15px] border-t border-t-[#dbdbdb]">
+        <div class="flex">
+          <div class="grow"></div>
+          <div>
+            <span class="text-[#d00032]">*</span> Required
+          </div>
+        </div>
+      </footer>
     </>
   );
 }

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -7,7 +7,7 @@ export default function CreateGroupForm() {
   const descriptionId = useId();
 
   return (
-    <>
+    <div className="text-grey-6 text-sm/tight">
       <h1 className="mt-[55px] mb-[30px] text-grey-7 text-xl/none">
         Create a new private group
       </h1>
@@ -35,13 +35,13 @@ export default function CreateGroupForm() {
         </div>
       </form>
 
-      <footer className="text-grey-6 text-sm/tight mt-[50px] pt-[15px] border-t border-t-text-grey-6">
+      <footer className="mt-[50px] pt-[15px] border-t border-t-text-grey-6">
         <div className="flex">
           <div className="grow" />
           <span className="text-brand">*</span> Required
         </div>
       </footer>
-    </>
+    </div>
   );
 }
 
@@ -49,9 +49,7 @@ function CharacterCounter({ value, limit }: { value: number; limit: number }) {
   return (
     <div className="flex">
       <div className="grow" />
-      <span className="text-grey-6 text-sm/tight">
-        {value}/{limit}
-      </span>
+      {value}/{limit}
     </div>
   );
 }
@@ -66,10 +64,7 @@ function Label({
   required: boolean;
 }) {
   return (
-    <label
-      htmlFor={htmlFor}
-      className="text-grey-6 text-sm/tight"
-    >
+    <label htmlFor={htmlFor}>
       {text}
       <Required required={required} />
     </label>

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -1,6 +1,11 @@
+import { useId } from 'preact/hooks';
+
 import { Button, Input, Textarea } from '@hypothesis/frontend-shared';
 
 export default function CreateGroupForm() {
+  const nameId = useId();
+  const descriptionId = useId();
+
   return (
     <>
       <h1 className="mt-[55px] mb-[30px] text-[#3f3f3f] text-[19px] leading-[15px]">
@@ -10,12 +15,12 @@ export default function CreateGroupForm() {
       <form>
         <div className="mb-[15px]">
           <label
-            htmlFor="name"
+            htmlFor={nameId}
             className="text-[#7a7a7a] text-[13px] leading-[15px]"
           >
             Name<span className="text-[#d00032]">*</span>
           </label>
-          <Input id="name" autofocus autocomplete="off" required />
+          <Input id={nameId} autofocus autocomplete="off" required />
           <div className="flex">
             <div className="grow" />
             <span className="text-[#7a7a7a] text-[13px] leading-[15px]">
@@ -26,12 +31,12 @@ export default function CreateGroupForm() {
 
         <div className="mb-[15px]">
           <label
-            htmlFor="description"
+            htmlFor={descriptionId}
             className="text-[#7a7a7a] text-[13px] leading-[15px]"
           >
             Description
           </label>
-          <Textarea id="description" />
+          <Textarea id={descriptionId} />
           <div className="flex">
             <div className="grow" />
             <span className="text-[#7a7a7a] text-[13px] leading-[15px]">

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -38,7 +38,8 @@ export default function CreateGroupForm() {
       <footer className="mt-14 pt-4 border-t border-t-text-grey-6">
         <div className="flex">
           <div className="grow" />
-          <span className="text-brand">*</span> Required
+          <Star />
+          &nbsp;Required
         </div>
       </footer>
     </div>
@@ -66,15 +67,11 @@ function Label({
   return (
     <label htmlFor={htmlFor}>
       {text}
-      <Required required={required} />
+      {required ? <Star /> : null}
     </label>
   );
 }
 
-function Required({ required }: { required: boolean }) {
-  if (required) {
-    return <span className="text-brand">*</span>;
-  }
-
-  return null;
+function Star() {
+  return <span className="text-brand">*</span>;
 }

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -31,18 +31,14 @@ export default function CreateGroupForm() {
 
         <div className="flex">
           <div className="grow" />
-          <div>
-            <Button variant="primary">Create group</Button>
-          </div>
+          <Button variant="primary">Create group</Button>
         </div>
       </form>
 
       <footer className="text-[#7a7a7a] text-[13px] leading-[15px] mt-[50px] pt-[15px] border-t border-t-[#dbdbdb]">
         <div className="flex">
           <div className="grow" />
-          <div>
-            <span className="text-[#d00032]">*</span> Required
-          </div>
+          <span className="text-[#d00032]">*</span> Required
         </div>
       </footer>
     </>

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -17,7 +17,7 @@ export default function CreateGroupForm() {
           </label>
           <Input id="name" autofocus autocomplete="off" required />
           <div className="flex">
-            <div className="grow"></div>
+            <div className="grow" />
             <span className="text-[#7a7a7a] text-[13px] leading-[15px]">
               0/25
             </span>
@@ -33,7 +33,7 @@ export default function CreateGroupForm() {
           </label>
           <Textarea id="description" />
           <div className="flex">
-            <div className="grow"></div>
+            <div className="grow" />
             <span className="text-[#7a7a7a] text-[13px] leading-[15px]">
               0/250
             </span>
@@ -41,7 +41,7 @@ export default function CreateGroupForm() {
         </div>
 
         <div className="flex">
-          <div className="grow"></div>
+          <div className="grow" />
           <div>
             <Button variant="primary">Create group</Button>
           </div>
@@ -50,7 +50,7 @@ export default function CreateGroupForm() {
 
       <footer className="text-[#7a7a7a] text-[13px] leading-[15px] mt-[50px] pt-[15px] border-t border-t-[#dbdbdb]">
         <div className="flex">
-          <div className="grow"></div>
+          <div className="grow" />
           <div>
             <span className="text-[#d00032]">*</span> Required
           </div>

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -9,13 +9,18 @@ export default function CreateGroupForm() {
 
       <form>
         <div className="mb-[15px]">
-          <label htmlFor="name" className="text-[#7a7a7a] text-[13px] leading-[15px]">
+          <label
+            htmlFor="name"
+            className="text-[#7a7a7a] text-[13px] leading-[15px]"
+          >
             Name<span className="text-[#d00032]">*</span>
           </label>
           <Input id="name" autofocus autocomplete="off" required />
           <div className="flex">
             <div className="grow"></div>
-            <span className="text-[#7a7a7a] text-[13px] leading-[15px]">0/25</span>
+            <span className="text-[#7a7a7a] text-[13px] leading-[15px]">
+              0/25
+            </span>
           </div>
         </div>
 
@@ -29,7 +34,9 @@ export default function CreateGroupForm() {
           <Textarea id="description" />
           <div className="flex">
             <div className="grow"></div>
-            <span className="text-[#7a7a7a] text-[13px] leading-[15px]">0/250</span>
+            <span className="text-[#7a7a7a] text-[13px] leading-[15px]">
+              0/250
+            </span>
           </div>
         </div>
 

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -8,18 +8,18 @@ export default function CreateGroupForm() {
 
   return (
     <div className="text-grey-6 text-sm/tight">
-      <h1 className="mt-[55px] mb-[30px] text-grey-7 text-xl/none">
+      <h1 className="mt-14 mb-8 text-grey-7 text-xl/none">
         Create a new private group
       </h1>
 
       <form>
-        <div className="mb-[15px]">
+        <div className="mb-4">
           <Label htmlFor={nameId} text={'Name'} required={true} />
           <Input id={nameId} autofocus autocomplete="off" required />
           <CharacterCounter value={0} limit={25} />
         </div>
 
-        <div className="mb-[15px]">
+        <div className="mb-4">
           <Label
             htmlFor={descriptionId}
             text={'Description'}
@@ -35,7 +35,7 @@ export default function CreateGroupForm() {
         </div>
       </form>
 
-      <footer className="mt-[50px] pt-[15px] border-t border-t-text-grey-6">
+      <footer className="mt-14 pt-4 border-t border-t-text-grey-6">
         <div className="flex">
           <div className="grow" />
           <span className="text-brand">*</span> Required

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -25,7 +25,7 @@ export default function CreateGroupForm() {
             text={'Description'}
             required={false}
           />
-          <Textarea id={descriptionId} />
+          <Textarea id={descriptionId} classes="h-24" />
           <CharacterCounter value={0} limit={250} />
         </div>
 

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -14,23 +14,17 @@ export default function CreateGroupForm() {
 
       <form>
         <div className="mb-[15px]">
-          <label
-            htmlFor={nameId}
-            className="text-[#7a7a7a] text-[13px] leading-[15px]"
-          >
-            Name<span className="text-[#d00032]">*</span>
-          </label>
+          <Label htmlFor={nameId} text={'Name'} required={true} />
           <Input id={nameId} autofocus autocomplete="off" required />
           <CharacterCounter value={0} limit={25} />
         </div>
 
         <div className="mb-[15px]">
-          <label
+          <Label
             htmlFor={descriptionId}
-            className="text-[#7a7a7a] text-[13px] leading-[15px]"
-          >
-            Description
-          </label>
+            text={'Description'}
+            required={false}
+          />
           <Textarea id={descriptionId} />
           <CharacterCounter value={0} limit={250} />
         </div>
@@ -64,4 +58,32 @@ function CharacterCounter({ value, limit }: { value: number; limit: number }) {
       </span>
     </div>
   );
+}
+
+function Label({
+  htmlFor,
+  text,
+  required,
+}: {
+  htmlFor: string;
+  text: string;
+  required: boolean;
+}) {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className="text-[#7a7a7a] text-[13px] leading-[15px]"
+    >
+      {text}
+      <Required required={required} />
+    </label>
+  );
+}
+
+function Required({ required }: { required: boolean }) {
+  if (required) {
+    return <span className="text-[#d00032]">*</span>;
+  }
+
+  return null;
 }

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -2,6 +2,36 @@ import { useId } from 'preact/hooks';
 
 import { Button, Input, Textarea } from '@hypothesis/frontend-shared';
 
+function Star() {
+  return <span className="text-brand">*</span>;
+}
+
+function CharacterCounter({ value, limit }: { value: number; limit: number }) {
+  return (
+    <div className="flex">
+      <div className="grow" />
+      {value}/{limit}
+    </div>
+  );
+}
+
+function Label({
+  htmlFor,
+  text,
+  required,
+}: {
+  htmlFor: string;
+  text: string;
+  required?: boolean;
+}) {
+  return (
+    <label htmlFor={htmlFor}>
+      {text}
+      {required ? <Star /> : null}
+    </label>
+  );
+}
+
 export default function CreateGroupForm() {
   const nameId = useId();
   const descriptionId = useId();
@@ -40,34 +70,4 @@ export default function CreateGroupForm() {
       </footer>
     </div>
   );
-}
-
-function CharacterCounter({ value, limit }: { value: number; limit: number }) {
-  return (
-    <div className="flex">
-      <div className="grow" />
-      {value}/{limit}
-    </div>
-  );
-}
-
-function Label({
-  htmlFor,
-  text,
-  required,
-}: {
-  htmlFor: string;
-  text: string;
-  required?: boolean;
-}) {
-  return (
-    <label htmlFor={htmlFor}>
-      {text}
-      {required ? <Star /> : null}
-    </label>
-  );
-}
-
-function Star() {
-  return <span className="text-brand">*</span>;
 }

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -8,7 +8,7 @@ export default function CreateGroupForm() {
 
   return (
     <>
-      <h1 className="mt-[55px] mb-[30px] text-grey-7 text-[19px] leading-[15px]">
+      <h1 className="mt-[55px] mb-[30px] text-grey-7 text-xl/none">
         Create a new private group
       </h1>
 
@@ -35,7 +35,7 @@ export default function CreateGroupForm() {
         </div>
       </form>
 
-      <footer className="text-grey-6 text-[13px] leading-[15px] mt-[50px] pt-[15px] border-t border-t-text-grey-6">
+      <footer className="text-grey-6 text-sm/tight mt-[50px] pt-[15px] border-t border-t-text-grey-6">
         <div className="flex">
           <div className="grow" />
           <span className="text-brand">*</span> Required
@@ -49,7 +49,7 @@ function CharacterCounter({ value, limit }: { value: number; limit: number }) {
   return (
     <div className="flex">
       <div className="grow" />
-      <span className="text-grey-6 text-[13px] leading-[15px]">
+      <span className="text-grey-6 text-sm/tight">
         {value}/{limit}
       </span>
     </div>
@@ -68,7 +68,7 @@ function Label({
   return (
     <label
       htmlFor={htmlFor}
-      className="text-grey-6 text-[13px] leading-[15px]"
+      className="text-grey-6 text-sm/tight"
     >
       {text}
       <Required required={required} />

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -44,13 +44,13 @@ export default function CreateGroupForm() {
 
       <form>
         <div className="mb-4">
-          <Label htmlFor={nameId} text={'Name'} required />
+          <Label htmlFor={nameId} text="Name" required />
           <Input id={nameId} autofocus autocomplete="off" required />
           <CharacterCounter value={0} limit={25} />
         </div>
 
         <div className="mb-4">
-          <Label htmlFor={descriptionId} text={'Description'} />
+          <Label htmlFor={descriptionId} text="Description" />
           <Textarea id={descriptionId} classes="h-24" />
           <CharacterCounter value={0} limit={250} />
         </div>

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -8,7 +8,7 @@ export default function CreateGroupForm() {
 
   return (
     <>
-      <h1 className="mt-[55px] mb-[30px] text-[#3f3f3f] text-[19px] leading-[15px]">
+      <h1 className="mt-[55px] mb-[30px] text-grey-7 text-[19px] leading-[15px]">
         Create a new private group
       </h1>
 
@@ -35,10 +35,10 @@ export default function CreateGroupForm() {
         </div>
       </form>
 
-      <footer className="text-[#7a7a7a] text-[13px] leading-[15px] mt-[50px] pt-[15px] border-t border-t-[#dbdbdb]">
+      <footer className="text-grey-6 text-[13px] leading-[15px] mt-[50px] pt-[15px] border-t border-t-text-grey-6">
         <div className="flex">
           <div className="grow" />
-          <span className="text-[#d00032]">*</span> Required
+          <span className="text-brand">*</span> Required
         </div>
       </footer>
     </>
@@ -49,7 +49,7 @@ function CharacterCounter({ value, limit }: { value: number; limit: number }) {
   return (
     <div className="flex">
       <div className="grow" />
-      <span className="text-[#7a7a7a] text-[13px] leading-[15px]">
+      <span className="text-grey-6 text-[13px] leading-[15px]">
         {value}/{limit}
       </span>
     </div>
@@ -68,7 +68,7 @@ function Label({
   return (
     <label
       htmlFor={htmlFor}
-      className="text-[#7a7a7a] text-[13px] leading-[15px]"
+      className="text-grey-6 text-[13px] leading-[15px]"
     >
       {text}
       <Required required={required} />
@@ -78,7 +78,7 @@ function Label({
 
 function Required({ required }: { required: boolean }) {
   if (required) {
-    return <span className="text-[#d00032]">*</span>;
+    return <span className="text-brand">*</span>;
   }
 
   return null;

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -3,49 +3,49 @@ import { Button, Input, Textarea } from '@hypothesis/frontend-shared';
 export default function CreateGroupForm() {
   return (
     <>
-      <h1 class="mt-[55px] mb-[30px] text-[#3f3f3f] text-[19px] leading-[15px]">
+      <h1 className="mt-[55px] mb-[30px] text-[#3f3f3f] text-[19px] leading-[15px]">
         Create a new private group
       </h1>
 
       <form>
-        <div class="mb-[15px]">
-          <label for="name" class="text-[#7a7a7a] text-[13px] leading-[15px]">
-            Name<span class="text-[#d00032]">*</span>
+        <div className="mb-[15px]">
+          <label for="name" className="text-[#7a7a7a] text-[13px] leading-[15px]">
+            Name<span className="text-[#d00032]">*</span>
           </label>
           <Input id="name" autofocus autocomplete="off" required />
-          <div class="flex">
-            <div class="grow"></div>
-            <span class="text-[#7a7a7a] text-[13px] leading-[15px]">0/25</span>
+          <div className="flex">
+            <div className="grow"></div>
+            <span className="text-[#7a7a7a] text-[13px] leading-[15px]">0/25</span>
           </div>
         </div>
 
-        <div class="mb-[15px]">
+        <div className="mb-[15px]">
           <label
             for="description"
-            class="text-[#7a7a7a] text-[13px] leading-[15px]"
+            className="text-[#7a7a7a] text-[13px] leading-[15px]"
           >
             Description
           </label>
           <Textarea id="description" />
-          <div class="flex">
-            <div class="grow"></div>
-            <span class="text-[#7a7a7a] text-[13px] leading-[15px]">0/250</span>
+          <div className="flex">
+            <div className="grow"></div>
+            <span className="text-[#7a7a7a] text-[13px] leading-[15px]">0/250</span>
           </div>
         </div>
 
-        <div class="flex">
-          <div class="grow"></div>
+        <div className="flex">
+          <div className="grow"></div>
           <div>
             <Button variant="primary">Create group</Button>
           </div>
         </div>
       </form>
 
-      <footer class="text-[#7a7a7a] text-[13px] leading-[15px] mt-[50px] pt-[15px] border-t border-t-[#dbdbdb]">
-        <div class="flex">
-          <div class="grow"></div>
+      <footer className="text-[#7a7a7a] text-[13px] leading-[15px] mt-[50px] pt-[15px] border-t border-t-[#dbdbdb]">
+        <div className="flex">
+          <div className="grow"></div>
           <div>
-            <span class="text-[#d00032]">*</span> Required
+            <span className="text-[#d00032]">*</span> Required
           </div>
         </div>
       </footer>

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -14,17 +14,13 @@ export default function CreateGroupForm() {
 
       <form>
         <div className="mb-4">
-          <Label htmlFor={nameId} text={'Name'} required={true} />
+          <Label htmlFor={nameId} text={'Name'} required />
           <Input id={nameId} autofocus autocomplete="off" required />
           <CharacterCounter value={0} limit={25} />
         </div>
 
         <div className="mb-4">
-          <Label
-            htmlFor={descriptionId}
-            text={'Description'}
-            required={false}
-          />
+          <Label htmlFor={descriptionId} text={'Description'} />
           <Textarea id={descriptionId} classes="h-24" />
           <CharacterCounter value={0} limit={250} />
         </div>
@@ -62,7 +58,7 @@ function Label({
 }: {
   htmlFor: string;
   text: string;
-  required: boolean;
+  required?: boolean;
 }) {
   return (
     <label htmlFor={htmlFor}>


### PR DESCRIPTION
Style the new create-group-form to look similar to the legacy one, but using Tailwind for CSS.

This involves a lot of hard-coded values that we'll probably want to replace.

![Screenshot from 2024-07-05 17-34-00](https://github.com/hypothesis/h/assets/22498/885013d5-d916-4518-9b24-68b1b547c70a)
