### PR TITLE
Pass `SENTRY_ENVIRONMENT` through to frontend

### DIFF
--- a/h/static/scripts/base/sentry.ts
+++ b/h/static/scripts/base/sentry.ts
@@ -9,6 +9,7 @@ import * as Sentry from '@sentry/browser';
 
 export type SentryConfig = {
   dsn: string;
+  environment: string;
   release: string;
   userid?: string;
 };
@@ -16,6 +17,7 @@ export type SentryConfig = {
 export function init(config: SentryConfig) {
   Sentry.init({
     dsn: config.dsn,
+    environment: config.environment,
     release: config.release,
   });
 

--- a/h/static/scripts/tests/base/sentry-test.js
+++ b/h/static/scripts/tests/base/sentry-test.js
@@ -23,6 +23,7 @@ describe('sentry', () => {
     it('configures the Sentry client', () => {
       sentry.init({
         dsn: 'dsn',
+        environment: 'prod',
         release: 'release',
         userid: 'acct:foobar@hypothes.is',
       });
@@ -30,6 +31,7 @@ describe('sentry', () => {
         fakeSentry.init,
         sinon.match({
           dsn: 'dsn',
+          environment: 'prod',
           release: 'release',
         }),
       );

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -27,6 +27,7 @@ def add_renderer_globals(event):
     if "h.sentry_dsn_frontend" in request.registry.settings:
         event["frontend_settings"]["sentry"] = {
             "dsn": request.registry.settings["h.sentry_dsn_frontend"],
+            "environment": request.registry.settings["h.sentry_environment"],
             "release": __version__,
             "userid": request.authenticated_userid,
         }

--- a/tests/unit/h/subscribers_test.py
+++ b/tests/unit/h/subscribers_test.py
@@ -4,7 +4,7 @@ import pytest
 from kombu.exceptions import OperationalError
 from transaction import TransactionManager
 
-from h import subscribers
+from h import __version__, subscribers
 from h.events import AnnotationEvent
 from h.exceptions import RealtimeMessageQueueError
 
@@ -30,26 +30,26 @@ class TestAddRendererGlobals:
 
     def test_adds_frontend_settings(self, event):
         subscribers.add_renderer_globals(event)
-
         assert event["frontend_settings"] == {}
 
-    def test_adds_frontend_settings_sentry(self, event, pyramid_request):
-        settings = pyramid_request.registry.settings
-        settings["h.sentry_dsn_frontend"] = "https://sentry.io/flibble"
-
+    @pytest.mark.usefixtures("sentry_config")
+    def test_adds_frontend_settings_sentry(self, event):
         subscribers.add_renderer_globals(event)
-        result = event["frontend_settings"]["sentry"]
 
-        assert result["dsn"] == "https://sentry.io/flibble"
-        assert result["release"]
-        assert result["userid"] is None
+        assert event["frontend_settings"]["sentry"] == {
+            "dsn": "https://sentry.io/flibble",
+            "environment": "prod",
+            "release": __version__,
+            "userid": None,
+        }
 
-    def test_adds_frontend_settings_sentry_user(
-        self, event, pyramid_config, pyramid_request
+    @pytest.mark.usefixtures("sentry_config")
+    def test_adds_frontend_settings_sentry_userid(
+        self,
+        event,
+        pyramid_config,
     ):
         pyramid_config.testing_securitypolicy("acct:safet.baljić@example.com")
-        settings = pyramid_request.registry.settings
-        settings["h.sentry_dsn_frontend"] = "https://sentry.io/flibble"
 
         subscribers.add_renderer_globals(event)
         result = event["frontend_settings"]["sentry"]["userid"]
@@ -63,6 +63,12 @@ class TestAddRendererGlobals:
     @pytest.fixture
     def routes(self, pyramid_config):
         pyramid_config.add_route("index", "/idx")
+
+    @pytest.fixture
+    def sentry_config(self, pyramid_request):
+        settings = pyramid_request.registry.settings
+        settings["h.sentry_dsn_frontend"] = "https://sentry.io/flibble"
+        settings["h.sentry_environment"] = "prod"
 
 
 class TestPublishAnnotationEvent:


### PR DESCRIPTION
Propagate the Sentry environment name through to the frontend code that initializes the Sentry JS SDK.