### PR TITLE
Make `<CreateGroupForm />` character counters work

### DIFF
--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'preact/hooks';
+import { useId, useState } from 'preact/hooks';
 
 import { Button, Input, Textarea } from '@hypothesis/frontend-shared';
 
@@ -10,15 +10,20 @@ function CharacterCounter({
   value,
   limit,
   testid,
+  error = false,
 }: {
   value: number;
   limit: number;
   testid: string;
+  error?: boolean;
 }) {
   return (
     <div className="flex">
       <div className="grow" />
-      <span data-testid={testid}>
+      <span
+        data-testid={testid}
+        className={error ? 'text-red-error font-bold' : undefined}
+      >
         {value}/{limit}
       </span>
     </div>
@@ -42,10 +47,58 @@ function Label({
   );
 }
 
-export default function CreateGroupForm() {
-  const nameId = useId();
-  const descriptionId = useId();
+function TextField({
+  type,
+  limit,
+  label,
+  testid,
+  required = false,
+  autofocus = false,
+  classes = '',
+}: {
+  type: 'input' | 'textarea';
+  limit: number;
+  label: string;
+  testid: string;
+  required?: boolean;
+  autofocus?: boolean;
+  classes?: string;
+}) {
+  const id = useId();
+  const [value, setValue] = useState('');
 
+  const handleInput = (e: InputEvent) => {
+    setValue((e.target as HTMLInputElement).value);
+  };
+
+  const error = value.length > limit;
+
+  const InputComponent = type === 'input' ? Input : Textarea;
+
+  return (
+    <div className="mb-4">
+      <Label htmlFor={id} text={label} required={required} />
+      <InputComponent
+        id={id}
+        onInput={handleInput}
+        error={error ? `Must be ${limit} characters or less.` : undefined}
+        value={value}
+        classes={classes}
+        autofocus={autofocus}
+        autocomplete="off"
+        data-testid={testid}
+      />
+      <CharacterCounter
+        value={value.length}
+        limit={limit}
+        testid={`charcounter-${testid}`}
+        error={error}
+      />
+    </div>
+  );
+}
+
+export default function CreateGroupForm() {
   return (
     <div className="text-grey-6 text-sm/tight">
       <h1 className="mt-14 mb-8 text-grey-7 text-xl/none">
@@ -53,25 +106,21 @@ export default function CreateGroupForm() {
       </h1>
 
       <form>
-        <div className="mb-4">
-          <Label htmlFor={nameId} text="Name" required />
-          <Input id={nameId} autofocus autocomplete="off" required />
-          <CharacterCounter
-            value={0}
-            limit={25}
-            testid="character-counter-name"
-          />
-        </div>
-
-        <div className="mb-4">
-          <Label htmlFor={descriptionId} text="Description" />
-          <Textarea id={descriptionId} classes="h-24" />
-          <CharacterCounter
-            value={0}
-            limit={250}
-            testid="character-counter-description"
-          />
-        </div>
+        <TextField
+          type="input"
+          limit={25}
+          label="Name"
+          testid="name"
+          autofocus
+          required
+        />
+        <TextField
+          type="textarea"
+          limit={250}
+          label="Description"
+          testid="description"
+          classes="h-24"
+        />
 
         <div className="flex">
           <div className="grow" />

--- a/h/static/scripts/group-forms/components/test/CreateGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateGroupForm-test.js
@@ -3,20 +3,81 @@ import { mount } from 'enzyme';
 import CreateGroupForm from '../CreateGroupForm';
 
 describe('CreateGroupForm', () => {
-  const createWrapper = () => mount(<CreateGroupForm />);
+  /* Return true if counterEl is in its error state. */
+  const counterIsInErrorState = counterEl => {
+    return (
+      counterEl.hasClass('text-red-error') && counterEl.hasClass('font-bold')
+    );
+  };
+
+  /* Return true if component is in its error state. */
+  const componentIsInErrorState = component => {
+    return component.prop('error') !== undefined;
+  };
+
+  const getElements = wrapper => {
+    return {
+      name: {
+        counterEl: wrapper.find('[data-testid="charcounter-name"]'),
+        fieldComponent: wrapper.find('Input[data-testid="name"]'),
+        fieldEl: wrapper.find('input[data-testid="name"]'),
+      },
+      description: {
+        counterEl: wrapper.find('[data-testid="charcounter-description"]'),
+        fieldComponent: wrapper.find('Textarea[data-testid="description"]'),
+        fieldEl: wrapper.find('textarea[data-testid="description"]'),
+      },
+    };
+  };
+
+  const createWrapper = () => {
+    const wrapper = mount(<CreateGroupForm />);
+    const elements = getElements(wrapper);
+    return { wrapper, elements };
+  };
 
   [
-    { counter: 'name', limit: 25 },
-    { counter: 'description', limit: 250 },
-  ].forEach(({ counter, limit }) => {
-    describe(`${counter} character counter`, () => {
-      it(`initially renders 0/${limit}`, () => {
-        const wrapper = createWrapper();
-        const counterEl = wrapper.find(
-          `[data-testid="character-counter-${counter}"]`,
-        );
+    {
+      field: 'name',
+      limit: 25,
+    },
+    {
+      field: 'description',
+      limit: 250,
+    },
+  ].forEach(({ field, limit }) => {
+    describe(`${field} character counter`, () => {
+      it('renders a character counter', () => {
+        const { counterEl, fieldComponent } = createWrapper().elements[field];
 
         assert.equal(counterEl.text(), `0/${limit}`);
+        assert.isNotOk(counterIsInErrorState(counterEl));
+        assert.isNotOk(componentIsInErrorState(fieldComponent));
+      });
+
+      it("changes the count when the field's text changes", () => {
+        const { wrapper, elements } = createWrapper();
+        const fieldEl = elements[field].fieldEl;
+
+        fieldEl.getDOMNode().value = 'new text';
+        fieldEl.simulate('input');
+
+        const { counterEl, fieldComponent } = getElements(wrapper)[field];
+        assert.equal(counterEl.text(), `8/${limit}`);
+        assert.isNotOk(counterIsInErrorState(counterEl));
+        assert.isNotOk(componentIsInErrorState(fieldComponent));
+      });
+
+      it('goes into an error state when too many characters are entered', () => {
+        const { wrapper, elements } = createWrapper();
+        const fieldEl = elements[field].fieldEl;
+
+        fieldEl.getDOMNode().value = 'a'.repeat(limit + 1);
+        fieldEl.simulate('input');
+
+        const { counterEl, fieldComponent } = getElements(wrapper)[field];
+        assert.isOk(counterIsInErrorState(counterEl));
+        assert.isOk(componentIsInErrorState(fieldComponent));
       });
     });
   });


### PR DESCRIPTION
Make the character counters on the new create-group page (the `<CreateGroupForm />` component) actually work: the counts change as the text in the fields change, and the counters and fields go into an error state when too many characters are entered.


https://github.com/user-attachments/assets/55e12afc-dc5a-4edb-afc8-273ac6b3701d

