### PR TITLE
Make the "Create group" button actually work

### DIFF
--- a/h/security/policy/_api_cookie.py
+++ b/h/security/policy/_api_cookie.py
@@ -1,0 +1,34 @@
+from pyramid.request import Request
+from pyramid.security import Allowed, Denied
+
+from h.security.identity import Identity
+from h.security.policy._cookie import CookiePolicy
+
+COOKIE_AUTHENTICATABLE_API_REQUESTS = [
+    ("api.groups", "POST"),  # Create a new group.
+    ("api.group", "PATCH"),  # Edit an existing group.
+]
+
+
+class APICookiePolicy:
+    """Authenticate API requests with cookies."""
+
+    def __init__(self, cookie_policy: CookiePolicy):
+        self.cookie_policy = cookie_policy
+
+    @staticmethod
+    def handles(request: Request) -> bool:
+        """Return True if this policy applies to `request`."""
+        return (
+            request.matched_route.name,
+            request.method,
+        ) in COOKIE_AUTHENTICATABLE_API_REQUESTS
+
+    def identity(self, request: Request) -> Identity | None:
+        return self.cookie_policy.identity(request)
+
+    def authenticated_userid(self, request: Request) -> str | None:
+        return self.cookie_policy.authenticated_userid(request)
+
+    def permits(self, request: Request, context, permission: str) -> Allowed | Denied:
+        return self.cookie_policy.permits(request, context, permission)

--- a/h/security/policy/top_level.py
+++ b/h/security/policy/top_level.py
@@ -2,6 +2,7 @@ from pyramid.request import RequestLocalCache
 
 from h.security.identity import Identity
 from h.security.policy._api import APIPolicy
+from h.security.policy._api_cookie import APICookiePolicy
 from h.security.policy._auth_client import AuthClientPolicy
 from h.security.policy._cookie import CookiePolicy
 from h.security.policy._identity_base import IdentityBasedPolicy
@@ -34,6 +35,8 @@ class TopLevelPolicy(IdentityBasedPolicy):
 def get_subpolicy(request):
     """Return the subpolicy for TopLevelSecurityPolicy to delegate to for `request`."""
     if is_api_request(request):
-        return APIPolicy([BearerTokenPolicy(), AuthClientPolicy()])
+        return APIPolicy(
+            [BearerTokenPolicy(), AuthClientPolicy(), APICookiePolicy(CookiePolicy())]
+        )
 
     return CookiePolicy()

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -1,9 +1,17 @@
+export type APIConfig = {
+  method: string;
+  url: string;
+};
+
 export type ConfigObject = {
   /** The URLs of the app's CSS stylesheets. */
   styles: string[];
+  api: {
+    createGroup: APIConfig;
+  };
 };
 
 /** Return the frontend config from the page's <script class="js-config">. */
-export default function readConfig(): ConfigObject {
+export function readConfig(): ConfigObject {
   return JSON.parse(document.querySelector('.js-config')!.textContent!);
 }

--- a/h/static/scripts/group-forms/index.tsx
+++ b/h/static/scripts/group-forms/index.tsx
@@ -1,7 +1,7 @@
 import { render } from 'preact';
 
 import CreateGroupForm from './components/CreateGroupForm';
-import readConfig from './config';
+import { readConfig } from './config';
 
 function init() {
   const shadowHost = document.querySelector('#create-group-form')!;

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -1,0 +1,101 @@
+/**
+ * A successful response from h's create-new-group API:
+ * https://h.readthedocs.io/en/latest/api-reference/v2/#tag/groups/paths/~1groups/post
+ */
+export type CreateGroupAPIResponse = {
+  links: {
+    html: string;
+  };
+};
+
+/** An error response from the h API:
+ * https://h.readthedocs.io/en/latest/api-reference/v2/#section/Hypothesis-API/Errors
+ */
+export type APIErrorResponse = {
+  reason: string;
+};
+
+export class APIError extends Error {
+  /* The fetch or JSON-parsing error that was the cause of this APIError, if any. */
+  cause: Error | null;
+  /* The response that was received, if any. */
+  response: Response | null;
+  /* The parsed JSON body of the response, if there was a valid JSON response. */
+  json: object | Array<any> | null;
+
+  constructor(
+    message: string,
+    {
+      cause = null,
+      response = null,
+      json = null,
+    }: {
+      cause?: Error | null;
+      response?: Response | null;
+      json?: object | null;
+    },
+  ) {
+    super(message);
+    this.cause = cause;
+    this.response = response;
+    this.json = json;
+  }
+}
+
+/* Make an API call and return the parsed JSON body or throw APIError. */
+export async function callAPI(
+  url: string,
+  method: string = 'GET',
+  json: object | undefined,
+): Promise<object> {
+  const options: RequestInit = {
+    method: method,
+    headers: { 'Content-Type': 'application/json; charset=UTF-8' },
+  };
+
+  if (json !== undefined) {
+    options.body = JSON.stringify(json);
+  }
+
+  let response;
+
+  try {
+    response = await fetch(url, options);
+  } catch (err) {
+    throw new APIError('Network request failed.', {
+      cause: err as Error,
+    });
+  }
+
+  let responseJSON;
+  let responseJSONError;
+
+  try {
+    responseJSON = await response.json();
+  } catch (jsonError) {
+    responseJSONError = jsonError;
+  }
+
+  if (!response.ok) {
+    responseJSON = responseJSON as APIErrorResponse;
+
+    let message;
+
+    if (responseJSON && responseJSON.reason) {
+      message = responseJSON.reason;
+    } else {
+      message = 'API request failed.';
+    }
+
+    throw new APIError(message, { response, json: responseJSON });
+  }
+
+  if (responseJSONError !== undefined) {
+    throw new APIError('Invalid API response.', {
+      cause: responseJSONError,
+      response,
+    });
+  }
+
+  return responseJSON;
+}

--- a/h/static/scripts/group-forms/utils/set-location.ts
+++ b/h/static/scripts/group-forms/utils/set-location.ts
@@ -1,0 +1,3 @@
+export function setLocation(newLocation: string): void {
+  window.location.href = newLocation;
+}

--- a/h/static/scripts/group-forms/utils/test/api-test.js
+++ b/h/static/scripts/group-forms/utils/test/api-test.js
@@ -1,0 +1,148 @@
+import { callAPI, APIError } from '../api';
+
+describe('callAPI', () => {
+  const url = 'https://api.example.com/foo';
+  let fakeFetch;
+
+  beforeEach(() => {
+    fakeFetch = sinon.stub(window, 'fetch');
+  });
+
+  afterEach(() => {
+    window.fetch.restore();
+  });
+
+  context('when the API responds successfully', () => {
+    const responseBody = { foo: 'bar' };
+
+    beforeEach(() => {
+      fakeFetch
+        .withArgs(url)
+        .resolves(new Response(JSON.stringify(responseBody), { status: 200 }));
+    });
+
+    it('makes a request for the given URL', async () => {
+      await callAPI(url);
+
+      assert.ok(
+        fakeFetch.calledOnceWith(url, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json; charset=UTF-8',
+          },
+        }),
+      );
+    });
+
+    for (const method of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']) {
+      context(`when the request method is ${method}`, () => {
+        it('makes a request using the given method', async () => {
+          await callAPI(url, method);
+
+          assert.equal(fakeFetch.lastCall.args[1].method, method);
+        });
+      });
+    }
+
+    it('makes a request with the given JSON body', async () => {
+      const json = { foo: 'bar' };
+
+      await callAPI(url, 'POST', json);
+
+      assert.equal(fakeFetch.lastCall.args[1].body, JSON.stringify(json));
+    });
+
+    it('returns the parsed JSON object', async () => {
+      const result = await callAPI(url);
+
+      assert.deepEqual(result, responseBody);
+    });
+
+    it("throws an error when the response body isn't valid json", async () => {
+      const response = new Response('not valid JSON', { status: 200 });
+      sinon.spy(response, 'json');
+      fakeFetch.withArgs(url).resolves(response);
+
+      let error;
+      try {
+        await callAPI(url);
+      } catch (err) {
+        error = err;
+      }
+
+      let cause;
+      try {
+        await response.json.returnValues[0];
+      } catch (err) {
+        cause = err;
+      }
+
+      assert.instanceOf(error, APIError);
+      assert.equal(error.message, 'Invalid API response.');
+      assert.equal(error.cause, cause);
+      assert.equal(error.response, response);
+      assert.equal(error.json, null);
+    });
+  });
+
+  it('re-throws the error from fetch() when the API fails to get a response', async () => {
+    const cause = new TypeError();
+    fakeFetch.withArgs(url).rejects(cause);
+    let error;
+
+    try {
+      await callAPI(url);
+    } catch (err) {
+      error = err;
+    }
+
+    assert.instanceOf(error, APIError);
+    assert.equal(error.message, 'Network request failed.');
+    assert.equal(error.cause, cause);
+    assert.equal(error.response, null);
+    assert.equal(error.json, null);
+  });
+
+  [
+    {
+      response: new Response(
+        JSON.stringify({ reason: 'Error message from server.' }),
+        { status: 403 },
+      ),
+      json: { reason: 'Error message from server.' },
+      message: 'Error message from server.',
+    },
+    {
+      response: new Response(JSON.stringify({ foo: 'bar' }), { status: 400 }),
+      json: { foo: 'bar' },
+      message: 'API request failed.',
+    },
+    {
+      response: new Response(JSON.stringify([]), { status: 401 }),
+      json: [],
+      message: 'API request failed.',
+    },
+    {
+      response: new Response('not valid json', { status: 500 }),
+      json: null,
+      message: 'API request failed.',
+    },
+  ].forEach(({ response, json, message }) => {
+    it('throws an error when the API responds with an error', async () => {
+      fakeFetch.withArgs(url).resolves(response);
+      let error;
+
+      try {
+        await callAPI(url);
+      } catch (err) {
+        error = err;
+      }
+
+      assert.instanceOf(error, APIError);
+      assert.equal(error.message, message);
+      assert.equal(error.cause, null);
+      assert.equal(error.response, response);
+      assert.deepEqual(error.json, json);
+    });
+  });
+});

--- a/h/templates/groups/create.html.jinja2
+++ b/h/templates/groups/create.html.jinja2
@@ -6,7 +6,13 @@
   <div id="create-group-form"></div>
   <script type="application/json" class="js-config">
     {
-      "styles": {{ asset_urls("group_forms_css")|tojson }}
+      "styles": {{ asset_urls("group_forms_css")|tojson }},
+      "api": {
+        "createGroup": {
+          "method": "POST",
+          "url": "{{ request.route_url("api.groups") }}"
+        }
+      }
     }
   </script>
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "tailwindcss": "^3.4.4"
   },
   "devDependencies": {
+    "@hypothesis/frontend-testing": "^1.2.2",
     "babel-plugin-mockable-imports": "^2.0.1",
     "chai": "^5.1.1",
     "diff": "^5.2.0",

--- a/tests/unit/h/security/policy/_api_cookie_test.py
+++ b/tests/unit/h/security/policy/_api_cookie_test.py
@@ -1,0 +1,57 @@
+from unittest.mock import create_autospec, sentinel
+
+import pytest
+
+from h.security.policy._api_cookie import APICookiePolicy
+from h.security.policy._cookie import CookiePolicy
+
+
+class TestAPICookiePolicy:
+    @pytest.mark.parametrize(
+        "route_name,request_method,expected_result",
+        [
+            ("api.groups", "POST", True),
+            ("api.group", "PATCH", True),
+            ("api.group", "DELETE", False),
+            ("anything", "POST", False),
+        ],
+    )
+    def test_handles(
+        self, pyramid_request, route_name, request_method, expected_result
+    ):
+        pyramid_request.matched_route.name = route_name
+        pyramid_request.method = request_method
+
+        assert APICookiePolicy.handles(pyramid_request) == expected_result
+
+    def test_identity(self, api_cookie_policy, cookie_policy, pyramid_request):
+        identity = api_cookie_policy.identity(pyramid_request)
+
+        cookie_policy.identity.assert_called_once_with(pyramid_request)
+        assert identity == cookie_policy.identity.return_value
+
+    def test_authenticated_userid(
+        self, api_cookie_policy, cookie_policy, pyramid_request
+    ):
+        authenticated_userid = api_cookie_policy.authenticated_userid(pyramid_request)
+
+        cookie_policy.authenticated_userid.assert_called_once_with(pyramid_request)
+        assert authenticated_userid == cookie_policy.authenticated_userid.return_value
+
+    def test_permits(self, api_cookie_policy, cookie_policy, pyramid_request):
+        permits = api_cookie_policy.permits(
+            pyramid_request, sentinel.context, sentinel.permission
+        )
+
+        cookie_policy.permits.assert_called_once_with(
+            pyramid_request, sentinel.context, sentinel.permission
+        )
+        assert permits == cookie_policy.permits.return_value
+
+    @pytest.fixture
+    def cookie_policy(self):
+        return create_autospec(CookiePolicy, instance=True, spec_set=True)
+
+    @pytest.fixture
+    def api_cookie_policy(self, cookie_policy):
+        return APICookiePolicy(cookie_policy)

--- a/tests/unit/h/security/policy/top_level_test.py
+++ b/tests/unit/h/security/policy/top_level_test.py
@@ -43,8 +43,10 @@ class TestGetSubpolicy:
         is_api_request,
         pyramid_request,
         AuthClientPolicy,
+        APICookiePolicy,
         APIPolicy,
         BearerTokenPolicy,
+        CookiePolicy,
     ):
         is_api_request.return_value = True
 
@@ -52,8 +54,14 @@ class TestGetSubpolicy:
 
         BearerTokenPolicy.assert_called_once_with()
         AuthClientPolicy.assert_called_once_with()
+        CookiePolicy.assert_called_once_with()
+        APICookiePolicy.assert_called_once_with(CookiePolicy.return_value)
         APIPolicy.assert_called_once_with(
-            [BearerTokenPolicy.return_value, AuthClientPolicy.return_value]
+            [
+                BearerTokenPolicy.return_value,
+                AuthClientPolicy.return_value,
+                APICookiePolicy.return_value,
+            ]
         )
         assert policy == APIPolicy.return_value
 
@@ -74,6 +82,11 @@ def is_api_request(mocker):
 @pytest.fixture(autouse=True)
 def AuthClientPolicy(mocker):
     return mocker.patch("h.security.policy.top_level.AuthClientPolicy", autospec=True)
+
+
+@pytest.fixture(autouse=True)
+def APICookiePolicy(mocker):
+    return mocker.patch("h.security.policy.top_level.APICookiePolicy", autospec=True)
 
 
 @pytest.fixture(autouse=True)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,6 +1683,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hypothesis/frontend-testing@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@hypothesis/frontend-testing@npm:1.2.2"
+  dependencies:
+    axe-core: ^4.8.2
+    enzyme: ^3.11.0
+    preact: ^10.18.1
+  checksum: b3892f6f1db87387aa60a420f0d2a7c89c5031a1375273cce6777aba335f5d01b223a5fee499f1fbf418044eea6c85684d8488647e8b353d9637c05ba29d15de
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -2761,6 +2772,13 @@ __metadata:
   dependencies:
     possible-typed-array-names: ^1.0.0
   checksum: 1aa3ffbfe6578276996de660848b6e95669d9a95ad149e3dd0c0cda77db6ee1dbd9d1dd723b65b6d277b882dd0c4b91a654ae9d3cf9e1254b7e93e4908d78fd3
+  languageName: node
+  linkType: hard
+
+"axe-core@npm:^4.8.2":
+  version: 4.9.1
+  resolution: "axe-core@npm:4.9.1"
+  checksum: 41d9227871781f96c2952e2a777fca73624959dd0e98864f6d82806a77602f82b4fc490852082a7e524d8cd864e50d8b4d9931819b4a150112981d8c932110c5
   languageName: node
   linkType: hard
 
@@ -5469,6 +5487,7 @@ __metadata:
     "@babel/preset-typescript": ^7.24.7
     "@hypothesis/frontend-build": ^3.0.0
     "@hypothesis/frontend-shared": ^7.11.2
+    "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^26.0.1
     "@rollup/plugin-node-resolve": ^15.2.3
@@ -7855,6 +7874,13 @@ __metadata:
     picocolors: ^1.0.1
     source-map-js: ^1.2.0
   checksum: 14b130c90f165961772bdaf99c67f907f3d16494adf0868e57ef68baa67e0d1f6762db9d41ab0f4d09bab6fb7888588dba3596afd1a235fd5c2d43fba7006ac6
+  languageName: node
+  linkType: hard
+
+"preact@npm:^10.18.1":
+  version: 10.23.1
+  resolution: "preact@npm:10.23.1"
+  checksum: fb7d28c7da1442ed80435444326fa2dcb563d4af05f631611fff8c08fb46a6f209d1a780aa7638a0bc2ac4d7a351f3304ff97bebfd6f5ee5bc4feb880d84a34f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Make the "Create group" button on the new, Preact-based version of the create-group page actually work: make it create the group (via an API call) then navigate the browser to the successfully-created group's page.

This PR ended up being on the large-ish side because it ended up having to do a few different things. Let me know if you want me to split it up into smaller PRs:

1. On the backend, allowed the group-create and group-edit APIs to be cookie-authenticated: added a new `APICookiePolicy` and changed `TopLevelPolicy` to use it (passing it into `APIPolicy`)
2. Also on the backend: added information about the the create-group API's URL and method to the `js-config` object
3. Added a frontend `callAPI()` helper for calling APIs
4. Finally, changed the `<CreateGroupForm />` component to send the API request when the form is submitted, and to either redirect the browser to the new group's page (if the request is successful) or to display an error message.
5. Added `@hypothesis/frontend-testing` to the dev dependencies so that I could use `waitForElement()` in the tests

Known issues
------------

1. Create a group with a one or two-character name results in a validation error from the backend that the frontend can only display in an ugly way. A future PR will add frontend min-length validation to avoid this. https://github.com/hypothesis/h/pull/8829
2. A future PR will add a spinner or loading-state indicator of some sort while the API request is in-flight.

Testing
-------

1. Log in as `devdata_admin`: http://localhost:5000/login
3. Go to <http://localhost:5000/admin/features> and enable the `preact_create_group_form` feature flag
4. Go to <http://localhost:5000/groups/new>:
   1. Submitting a valid group name and description should create a new group and redirect you to the new group's page.
   2. You can submit the form by clicking **Create group** or by pressing **Enter** while the keyboard focus is in the **Name** field
   3. You can create a group with an empty **Description**
   5. Trying to create a group with no name results in a browser validation error
   6. Trying to create a group with a too-long name results in a browser validation error
   7. Trying to create a group with a too-long description results in a browser validation error

If you try to create a group with a valid name and description but the API request fails then an error will be displayed. There are a number of ways to simulate this:

### 1. Error response received

Hack the code to make the backend return an API error response. You should see the error message from the backend displayed in the UI.

```diff
diff --git a/h/models/group.py b/h/models/group.py
index b3a6f9120..3fdd47c62 100644
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -10,7 +10,7 @@ from h.db import Base, mixins
 from h.util.group import split_groupid
 
 GROUP_NAME_MIN_LENGTH = 3
-GROUP_NAME_MAX_LENGTH = 25
+GROUP_NAME_MAX_LENGTH = 2
 GROUP_DESCRIPTION_MAX_LENGTH = 250
 AUTHORITY_PROVIDED_ID_PATTERN = r"^[a-zA-Z0-9._\-+!~*()']+$"
 AUTHORITY_PROVIDED_ID_MAX_LENGTH = 1024
```

### 2. Invalid JSON error response

Hack it to respond with a JSON error response but without the expected JSON format. You should see **API request failed.**

```diff
diff --git a/h/models/group.py b/h/models/group.py
index b3a6f9120..3fdd47c62 100644
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -10,7 +10,7 @@ from h.db import Base, mixins
 from h.util.group import split_groupid
 
 GROUP_NAME_MIN_LENGTH = 3
-GROUP_NAME_MAX_LENGTH = 25
+GROUP_NAME_MAX_LENGTH = 2
 GROUP_DESCRIPTION_MAX_LENGTH = 250
 AUTHORITY_PROVIDED_ID_PATTERN = r"^[a-zA-Z0-9._\-+!~*()']+$"
 AUTHORITY_PROVIDED_ID_MAX_LENGTH = 1024
diff --git a/h/views/api/errors.py b/h/views/api/errors.py
index 26d445b93..a3c1d57c9 100644
--- a/h/views/api/errors.py
+++ b/h/views/api/errors.py
@@ -53,7 +53,7 @@ def oauth_error(context, request):  # pragma: no cover
 def api_error(context, request):
     """Handle an expected/deliberately thrown API exception."""
     request.response.status_code = context.status_code
-    return {"status": "failure", "reason": context.detail}
+    return {"status": "failure", "foo": context.detail}
 
 
 @json_view(context=JSONAPIError, path_info="/api/bulk", decorator=cors_policy)
```

### 3. Non-JSON error response

Hack it to use a URL that responds with an error HTTP status but without a valid JSON body. You should see **API request failed.**

```diff
diff --git a/h/templates/groups/create.html.jinja2 b/h/templates/groups/create.html.jinja2
index f2fa60c85..e6bc2ffb3 100644
--- a/h/templates/groups/create.html.jinja2
+++ b/h/templates/groups/create.html.jinja2
@@ -10,7 +10,7 @@
       "api": {
         "createGroup": {
           "method": "POST",
-          "url": "{{ request.route_url("api.groups") }}"
+          "url": "http://localhost:5000/foo"
         }
       }
     }
```

### 4. Non-JSON successful response

Hack it to respond with a successful HTTP status but not a valid JSON body. You should see **Invalid API response.**

```diff
diff --git a/h/views/api/groups.py b/h/views/api/groups.py
index 86de1ede9..62af2b92c 100644
--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -11,6 +11,7 @@ from h.schemas.api.group import CreateGroupAPISchema, UpdateGroupAPISchema
 from h.security import Permission
 from h.views.api.config import api_config
 from h.views.api.exceptions import PayloadError
+from pyramid.view import view_config
 
 
 @api_config(
@@ -36,40 +37,14 @@ def groups(request):
     return all_groups
 
 
-@api_config(
-    versions=["v1", "v2"],
+@view_config(
     route_name="api.groups",
     request_method="POST",
     permission=Permission.Group.CREATE,
-    link_name="group.create",
-    description="Create a new group",
+    renderer="string"
 )
 def create(request):
-    """Create a group from the POST payload."""
-    appstruct = CreateGroupAPISchema(
-        default_authority=request.default_authority,
-        group_authority=request.effective_authority,
-    ).validate(_json_payload(request))
-
-    group_service = request.find_service(name="group")
-    group_create_service = request.find_service(name="group_create")
-
-    # Check for duplicate group
-    groupid = appstruct.get("groupid", None)
-    if groupid is not None:
-        duplicate_group = group_service.fetch(pubid_or_groupid=groupid)
-        if duplicate_group:
-            raise HTTPConflict(
-                _("group with groupid '{}' already exists").format(groupid)
-            )
-
-    group = group_create_service.create_private_group(
-        name=appstruct["name"],
-        userid=request.user.userid,
-        description=appstruct.get("description", None),
-        groupid=groupid,
-    )
-    return GroupJSONPresenter(group, request).asdict(expand=["organization", "scopes"])
+    return "foo"
 
 
 @api_config(
```

### 5. Invalid JSON successful successful response

Hack it to use a URL that does responds with a successful HTTP status but without the expected successful create-group API response body. You should see **Invalid API response.**

```diff
diff --git a/h/views/api/groups.py b/h/views/api/groups.py
index 86de1ede9..dfbfea1d9 100644
--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -69,7 +69,7 @@ def create(request):
         description=appstruct.get("description", None),
         groupid=groupid,
     )
-    return GroupJSONPresenter(group, request).asdict(expand=["organization", "scopes"])
+    return {"foo": "bar"}
 
 
 @api_config(
```

### 6. No API response received

Hack the code to make it use a non-responding URL for the create-group API. You should see a **Network request failed** error displayed.

```diff
diff --git a/h/static/scripts/group-forms/components/CreateGroupForm.tsx b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
index c5d948a66..3810ecefd 100644
--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -92,6 +92,7 @@ function TextField({
         classes={classes}
         autofocus={autofocus}
         autocomplete="off"
+        required={required}
         data-testid={testid}
       />
       <CharacterCounter
diff --git a/h/templates/groups/create.html.jinja2 b/h/templates/groups/create.html.jinja2
index f2fa60c85..8d6d5e520 100644
--- a/h/templates/groups/create.html.jinja2
+++ b/h/templates/groups/create.html.jinja2
@@ -10,7 +10,7 @@
       "api": {
         "createGroup": {
           "method": "POST",
-          "url": "{{ request.route_url("api.groups") }}"
+          "url": "http://localhost:9999"
         }
       }
     }
```