### PR TITLE
Refactor h's `SecurityPolicy` to make it easier to change

### DIFF
--- a/h/security/__init__.py
+++ b/h/security/__init__.py
@@ -41,4 +41,4 @@ def includeme(config):  # pragma: no cover
             "being available to ANYONE!"
         )
 
-    config.set_security_policy(SecurityPolicy(proxy_auth=proxy_auth))
+    config.set_security_policy(SecurityPolicy())

--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -2,6 +2,7 @@ from functools import lru_cache
 
 from h.security.identity import Identity
 from h.security.policy._identity_base import IdentityBasedPolicy
+from h.security.policy.helpers import is_api_request
 from h.services.auth_cookie import AuthCookieService
 
 
@@ -12,6 +13,15 @@ class CookiePolicy(IdentityBasedPolicy):
     This policy kicks in when accessing the UI presented by `h` and also boot
     straps the login for the client (when the popup shows).
     """
+
+    @staticmethod
+    def handles(request) -> bool:
+        """Return True if this policy applies to `request`."""
+
+        if is_api_request(request):
+            return False
+
+        return not request.registry.settings.get("h.proxy_auth")
 
     def identity(self, request):
         self._add_vary_by_cookie(request)

--- a/h/security/policy/_remote_user.py
+++ b/h/security/policy/_remote_user.py
@@ -1,5 +1,6 @@
 from h.security.identity import Identity
 from h.security.policy._identity_base import IdentityBasedPolicy
+from h.security.policy.helpers import is_api_request
 
 
 class RemoteUserPolicy(IdentityBasedPolicy):
@@ -9,6 +10,15 @@ class RemoteUserPolicy(IdentityBasedPolicy):
     This is enabled by setting `h.proxy_auth` in the config as described in
     `h.security`.
     """
+
+    @staticmethod
+    def handles(request) -> bool:
+        """Return True if this policy applies to `request`."""
+
+        if is_api_request(request):
+            return False
+
+        return bool(request.registry.settings.get("h.proxy_auth"))
 
     def identity(self, request):
         user_id = request.environ.get("HTTP_X_FORWARDED_USER")

--- a/h/security/policy/bearer_token.py
+++ b/h/security/policy/bearer_token.py
@@ -4,6 +4,7 @@ from zope.interface import implementer
 
 from h.security.identity import Identity
 from h.security.policy._identity_base import IdentityBasedPolicy
+from h.security.policy.helpers import is_api_request
 
 
 @implementer(ISecurityPolicy)
@@ -20,6 +21,11 @@ class BearerTokenPolicy(IdentityBasedPolicy):
 
     def __init__(self):
         self._identity_cache = RequestLocalCache(self._load_identity)
+
+    @staticmethod
+    def handles(request) -> bool:
+        """Return True if this policy applies to `request`."""
+        return is_api_request(request)
 
     def identity(self, request):
         """

--- a/tests/unit/h/security/policy/_cookie_test.py
+++ b/tests/unit/h/security/policy/_cookie_test.py
@@ -9,6 +9,26 @@ from h.security.policy._cookie import CookiePolicy
 
 @pytest.mark.usefixtures("auth_cookie_service")
 class TestCookiePolicy:
+    @pytest.mark.parametrize(
+        "route_name,proxy_auth,expected_result",
+        [
+            ("api.anything", True, False),
+            ("api.anything", False, False),
+            ("anything", True, False),
+            ("anything", False, True),
+        ],
+    )
+    def test_handles(self, pyramid_request, route_name, proxy_auth, expected_result):
+        pyramid_request.matched_route.name = route_name
+        pyramid_request.registry.settings["h.proxy_auth"] = proxy_auth
+
+        assert CookiePolicy.handles(pyramid_request) == expected_result
+
+    def test_handles_when_no_proxy_auth_setting(self, pyramid_request):
+        assert "h.proxy_auth" not in pyramid_request.registry.settings
+
+        assert CookiePolicy.handles(pyramid_request) is True
+
     def test_identity(self, pyramid_request, auth_cookie_service):
         identity = CookiePolicy().identity(pyramid_request)
 

--- a/tests/unit/h/security/policy/_remote_user_test.py
+++ b/tests/unit/h/security/policy/_remote_user_test.py
@@ -8,6 +8,33 @@ from h.security.policy._remote_user import RemoteUserPolicy
 
 @pytest.mark.usefixtures("user_service")
 class TestRemoteUserPolicy:
+    @pytest.mark.parametrize(
+        "is_api_request_return_value,proxy_auth,expected_result",
+        [
+            (False, False, False),
+            (False, True, True),
+            (True, False, False),
+            (True, True, False),
+        ],
+    )
+    def test_handles(
+        self,
+        is_api_request,
+        is_api_request_return_value,
+        proxy_auth,
+        expected_result,
+        pyramid_request,
+    ):
+        is_api_request.return_value = is_api_request_return_value
+        pyramid_request.registry.settings["h.proxy_auth"] = proxy_auth
+
+        assert RemoteUserPolicy.handles(pyramid_request) == expected_result
+
+    def test_handles_when_no_proxy_auth_setting(self, pyramid_request, is_api_request):
+        is_api_request.return_value = False
+
+        assert RemoteUserPolicy.handles(pyramid_request) is False
+
     def test_identity(self, pyramid_request, user_service):
         pyramid_request.environ["HTTP_X_FORWARDED_USER"] = sentinel.forwarded_user
 
@@ -34,3 +61,7 @@ class TestRemoteUserPolicy:
         user_service.fetch.return_value.deleted = True
 
         assert RemoteUserPolicy().identity(pyramid_request) is None
+
+    @pytest.fixture(autouse=True)
+    def is_api_request(self, mocker):
+        return mocker.patch("h.security.policy._remote_user.is_api_request")

--- a/tests/unit/h/security/policy/bearer_token_test.py
+++ b/tests/unit/h/security/policy/bearer_token_test.py
@@ -8,6 +8,24 @@ from h.security.policy.bearer_token import BearerTokenPolicy
 
 @pytest.mark.usefixtures("user_service", "auth_token_service")
 class TestBearerTokenPolicy:
+    @pytest.mark.parametrize(
+        "is_api_request_return_value,expected_result",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_handles(
+        self,
+        is_api_request,
+        is_api_request_return_value,
+        expected_result,
+        pyramid_request,
+    ):
+        is_api_request.return_value = is_api_request_return_value
+
+        assert BearerTokenPolicy.handles(pyramid_request) == expected_result
+
     def test_identity(self, pyramid_request, auth_token_service, user_service):
         identity = BearerTokenPolicy().identity(pyramid_request)
 
@@ -64,3 +82,7 @@ class TestBearerTokenPolicy:
         user_service.fetch.return_value.deleted = True
 
         assert BearerTokenPolicy().identity(pyramid_request) is None
+
+    @pytest.fixture(autouse=True)
+    def is_api_request(self, mocker):
+        return mocker.patch("h.security.policy.bearer_token.is_api_request")

--- a/tests/unit/h/security/policy/combined_test.py
+++ b/tests/unit/h/security/policy/combined_test.py
@@ -1,150 +1,184 @@
-from unittest.mock import patch, sentinel
+from unittest.mock import create_autospec, sentinel
 
 import pytest
 
 from h.security.policy import SecurityPolicy
-
-# pylint: disable=protected-access
+from h.security.policy.combined import applicable_policies, call_policies
 
 
 class TestSecurityPolicy:
-    def test_construction(self, BearerTokenPolicy, AuthClientPolicy, CookiePolicy):
-        policy = SecurityPolicy(proxy_auth=False)
+    def test_remember(self, call_policies, policy, pyramid_request):
+        headers = policy.remember(pyramid_request, sentinel.userid, foo=sentinel.foo)
 
-        BearerTokenPolicy.assert_called_once_with()
-        assert policy._bearer_token_policy == BearerTokenPolicy.return_value
-        AuthClientPolicy.assert_called_once_with()
-        assert policy._http_basic_auth_policy == AuthClientPolicy.return_value
-        CookiePolicy.assert_called_once_with()
-        assert policy._ui_policy == CookiePolicy.return_value
-
-    def test_construction_for_proxy_auth(self, RemoteUserPolicy):
-        policy = SecurityPolicy(proxy_auth=True)
-
-        RemoteUserPolicy.assert_called_once_with()
-        assert policy._ui_policy == RemoteUserPolicy.return_value
-
-    @pytest.mark.parametrize(
-        "method,args,kwargs",
-        (
-            ("remember", [sentinel.userid], {"kwargs": True}),
-            ("forget", [], {}),
-            ("identity", [], {}),
-        ),
-    )
-    def test_most_methods_delegate(self, pyramid_request, method, args, kwargs):
-        policy = SecurityPolicy()
-
-        with patch.object(policy, "_call_sub_policies") as _call_sub_policies:
-            auth_method = getattr(policy, method)
-
-            result = auth_method(pyramid_request, *args, **kwargs)
-
-            _call_sub_policies.assert_called_once_with(
-                method, pyramid_request, *args, **kwargs
-            )
-            assert result == _call_sub_policies.return_value
-
-    def test_identity_caches(self, pyramid_request, CookiePolicy):
-        policy = SecurityPolicy()
-
-        policy.identity(pyramid_request)
-        policy.identity(pyramid_request)
-
-        CookiePolicy.return_value.identity.assert_called_once()
-
-    @pytest.mark.parametrize("method,args", (("remember", ["userid"]), ("forget", [])))
-    def test_remember_and_forget_reset_cache(
-        self, pyramid_request, CookiePolicy, method, args
-    ):
-        policy = SecurityPolicy()
-
-        policy.identity(pyramid_request)
-        getattr(policy, method)(pyramid_request, *args)
-        policy.identity(pyramid_request)
-
-        assert CookiePolicy.return_value.identity.call_count == 2
-
-    @pytest.mark.parametrize(
-        "route_name,is_ui",
-        (
-            ("anything", True),
-            ("api.anything", False),
-        ),
-    )
-    def test_calls_are_routed_based_on_api_or_not(
-        self, pyramid_request, route_name, is_ui
-    ):
-        pyramid_request.matched_route.name = route_name
-        policy = SecurityPolicy()
-
-        # Use `remember()` as an example, we've proven above which methods use
-        # this
-        result = policy.remember(pyramid_request, sentinel.userid, kwarg=True)
-
-        if is_ui:
-            called_policy, uncalled_policy = (
-                policy._ui_policy,
-                policy._bearer_token_policy,
-            )
-        else:
-            called_policy, uncalled_policy = (
-                policy._bearer_token_policy,
-                policy._ui_policy,
-            )
-
-        called_policy.remember.assert_called_once_with(  # pylint:disable=no-member
-            pyramid_request, sentinel.userid, kwarg=True
+        call_policies.assert_called_once_with(
+            "remember", [], pyramid_request, sentinel.userid, foo=sentinel.foo
         )
-        assert result == called_policy.remember.return_value  # pylint:disable=no-member
+        assert headers == call_policies.return_value
 
-        uncalled_policy.remember.assert_not_called()  # pylint:disable=no-member
+    def test_forget(self, call_policies, policy, pyramid_request):
+        headers = policy.forget(pyramid_request, foo=sentinel.foo)
 
-    @pytest.mark.parametrize("bearer_returns", (True, False))
-    @pytest.mark.parametrize("basic_auth_handles", (True, False))
-    def test_api_calls_are_passed_on(
-        self, pyramid_request, bearer_returns, basic_auth_handles
+        call_policies.assert_called_once_with(
+            "forget", [], pyramid_request, foo=sentinel.foo
+        )
+        assert headers == call_policies.return_value
+
+    def test_identity(self, call_policies, policy, pyramid_request):
+        identity = policy.identity(pyramid_request)
+
+        call_policies.assert_called_once_with("identity", None, pyramid_request)
+        assert identity == call_policies.return_value
+
+    @pytest.fixture
+    def policy(self):
+        return SecurityPolicy()
+
+    @pytest.fixture(autouse=True)
+    def call_policies(self, mocker):
+        return mocker.patch("h.security.policy.combined.call_policies")
+
+
+class TestCallPolicies:
+    def test_call_policies_when_first_policy_returns_truthy(
+        self,
+        applicable_policies,
+        policies,
+        policy_classes,
+        pyramid_request,
     ):
-        # Pick a URL instead of retesting which URLs trigger the API behavior
-        pyramid_request.matched_route.name = "api.anything"
-        policy = SecurityPolicy()
-        policy._bearer_token_policy.remember.return_value = bearer_returns
-        policy._http_basic_auth_policy.handles.return_value = basic_auth_handles
+        # The first policy returns truthy.
+        policies[0].method.return_value = True
 
-        result = policy.remember(pyramid_request, sentinel.userid, kwarg=True)
+        result = call_policies(
+            "method", sentinel.fallback, pyramid_request, "arg", kwarg="kwarg"
+        )
 
-        if not bearer_returns:
-            policy._http_basic_auth_policy.handles.assert_called_once_with(
-                pyramid_request
-            )
+        applicable_policies.assert_called_once_with(pyramid_request, policy_classes)
+        # It just returns the truthy result from the first policy,
+        # and doesn't even call the second policy.
+        policies[0].method.assert_called_once_with(
+            pyramid_request, "arg", kwarg="kwarg"
+        )
+        policies[1].method.assert_not_called()
+        # It doesn't even instantiate the second policy.
+        applicable_policies.return_value[1].assert_not_called()
+        assert result == policies[0].method.return_value
 
-        if basic_auth_handles and not bearer_returns:
-            policy._http_basic_auth_policy.remember.assert_called_once_with(  # pylint:disable=no-member
-                pyramid_request, sentinel.userid, kwarg=True
-            )
-            assert (
-                result
-                == policy._http_basic_auth_policy.remember.return_value  # pylint:disable=no-member
-            )
-        else:
-            policy._http_basic_auth_policy.remember.assert_not_called()  # pylint:disable=no-member
-            assert (
-                result
-                == policy._bearer_token_policy.remember.return_value  # pylint:disable=no-member
-            )
+    def test_call_policies_when_second_policy_returns_truthy(
+        self, applicable_policies, policies, policy_classes, pyramid_request
+    ):
+        # The first policy returns falsey but the second policy returns truthy.
+        policies[0].method.return_value = False
+        policies[1].method.return_value = True
+
+        result = call_policies(
+            "method", sentinel.fallback, pyramid_request, "arg", kwarg="kwarg"
+        )
+
+        applicable_policies.assert_called_once_with(pyramid_request, policy_classes)
+        # It calls both policies and returns the truthy result from the second policy.
+        policies[0].method.assert_called_once_with(
+            pyramid_request, "arg", kwarg="kwarg"
+        )
+        policies[1].method.assert_called_once_with(
+            pyramid_request, "arg", kwarg="kwarg"
+        )
+        assert result == policies[1].method.return_value
+
+    def test_call_policies_when_all_policies_return_falsey(
+        self, applicable_policies, policies, policy_classes, pyramid_request
+    ):
+        # Both policies return falsey.
+        policies[0].method.return_value = False
+        policies[1].method.return_value = False
+
+        result = call_policies(
+            "method", sentinel.fallback, pyramid_request, "arg", kwarg="kwarg"
+        )
+
+        applicable_policies.assert_called_once_with(pyramid_request, policy_classes)
+        # It calls all policies and returns the falsey result from the last policy.
+        policies[0].method.assert_called_once_with(
+            pyramid_request, "arg", kwarg="kwarg"
+        )
+        policies[1].method.assert_called_once_with(
+            pyramid_request, "arg", kwarg="kwarg"
+        )
+        assert result == sentinel.fallback
+
+    def test_call_policies_when_there_are_no_applicable_policies(
+        self, applicable_policies, pyramid_request
+    ):
+        applicable_policies.return_value = []
+
+        result = call_policies("method", sentinel.fallback, pyramid_request)
+
+        assert result == sentinel.fallback
+
+    @pytest.fixture
+    def policy_classes(
+        self, RemoteUserPolicy, CookiePolicy, BearerTokenPolicy, AuthClientPolicy
+    ):
+        return [RemoteUserPolicy, CookiePolicy, BearerTokenPolicy, AuthClientPolicy]
 
     @pytest.fixture(autouse=True)
-    def BearerTokenPolicy(self, patch):
-        return patch("h.security.policy.combined.BearerTokenPolicy")
+    def applicable_policies(self, mocker, CookiePolicy, BearerTokenPolicy):
+        return mocker.patch(
+            "h.security.policy.combined.applicable_policies",
+            return_value=[CookiePolicy, BearerTokenPolicy],
+        )
+
+    @pytest.fixture
+    def policies(self, applicable_policies):
+        return [
+            policy_class.return_value
+            for policy_class in applicable_policies.return_value
+        ]
 
     @pytest.fixture(autouse=True)
-    def AuthClientPolicy(self, patch):
-        return patch("h.security.policy.combined.AuthClientPolicy")
+    def AuthClientPolicy(self, mocker):
+        return mocker.patch("h.security.policy.combined.AuthClientPolicy")
 
     @pytest.fixture(autouse=True)
-    def RemoteUserPolicy(self, patch):
-        return patch("h.security.policy.combined.RemoteUserPolicy")
+    def BearerTokenPolicy(self, mocker):
+        return mocker.patch("h.security.policy.combined.BearerTokenPolicy")
 
     @pytest.fixture(autouse=True)
-    def CookiePolicy(self, patch):
-        return patch("h.security.policy.combined.CookiePolicy")
+    def CookiePolicy(self, mocker):
+        return mocker.patch("h.security.policy.combined.CookiePolicy")
+
+    @pytest.fixture(autouse=True)
+    def RemoteUserPolicy(self, mocker):
+        return mocker.patch("h.security.policy.combined.RemoteUserPolicy")
+
+
+class TestApplicablePolicies:
+    @pytest.mark.parametrize(
+        "return_values,expected_policies",
+        [
+            ([True, True], [0, 1]),
+            ([False, True], [1]),
+            ([True, False], [0]),
+            ([False, False], []),
+        ],
+    )
+    def test_applicable_policies(
+        self, return_values, expected_policies, pyramid_request
+    ):
+        class Spec:
+            @staticmethod
+            def handles(request) -> bool:
+                """Return True if this policy can handle `request`."""
+
+        policies = [
+            create_autospec(Spec, spec_set=True),
+            create_autospec(Spec, spec_set=True),
+        ]
+        for policy, return_value in zip(policies, return_values):
+            policy.handles.return_value = return_value
+
+        returned_policies = applicable_policies(pyramid_request, policies)
+
+        for policy in policies:
+            policy.handles.assert_called_once_with(pyramid_request)
+        assert returned_policies == [policies[index] for index in expected_policies]


### PR DESCRIPTION
I need to make a change to h's security policies so that the create-group API (and in future the edit-group API and other APIs) can be authenticated using cookies. The current state of the security policy code and its tests makes it difficult to make this change.

This PR refactors the security policy code to replace a complicated private helper method and some awful tests with several simple, well-defined, easy-to-explain, separate units that each have their own nice and simple unit tests.

This refactoring will enable a future PR to make the following simple change to allow certain API requests to be cookie-authenticated:

```diff
diff --git a/h/security/policy/_cookie.py b/h/security/policy/_cookie.py
index abfb922e7..e049060ce 100644
--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -6,6 +6,12 @@ from h.security.policy.helpers import is_api_request
 from h.services.auth_cookie import AuthCookieService
 
 
+COOKIE_AUTHENTICATABLE_API_REQUESTS = [
+    ("api.groups", "POST"),  # Create a new group.
+    ("api.group", "PATCH"),  # Edit an existing group.
+]
+
+
 class CookiePolicy(IdentityBasedPolicy):
     """
     An authentication policy based on cookies.
@@ -19,7 +25,10 @@ class CookiePolicy(IdentityBasedPolicy):
         """Return True if this policy applies to `request`."""
 
         if is_api_request(request):
-            return False
+            return (
+                request.matched_route.name,
+                request.method,
+            ) in COOKIE_AUTHENTICATABLE_API_REQUESTS
 
         return not request.registry.settings.get("h.proxy_auth")
 
diff --git a/tests/unit/h/security/policy/_cookie_test.py b/tests/unit/h/security/policy/_cookie_test.py
index d19d45dc9..83785b9c8 100644
--- a/tests/unit/h/security/policy/_cookie_test.py
+++ b/tests/unit/h/security/policy/_cookie_test.py
@@ -10,16 +10,20 @@ from h.security.policy._cookie import CookiePolicy
 @pytest.mark.usefixtures("auth_cookie_service")
 class TestCookiePolicy:
     @pytest.mark.parametrize(
-        "route_name,proxy_auth,expected_result",
+        "route_name,request_method,proxy_auth,expected_result",
         [
-            ("api.anything", True, False),
-            ("api.anything", False, False),
-            ("anything", True, False),
-            ("anything", False, True),
+            ("api.groups", "POST", True, True),
+            ("api.group", "PATCH", True, True),
+            ("api.group", "DELETE", True, False),
+            ("api.anything", "GET", True, False),
+            ("api.anything", "GET", False, False),
+            ("anything", "GET", True, False),
+            ("anything", "GET", False, True),
         ],
     )
-    def test_handles(self, pyramid_request, route_name, proxy_auth, expected_result):
+    def test_handles(self, pyramid_request, route_name, request_method, proxy_auth, expected_result):
         pyramid_request.matched_route.name = route_name
+        pyramid_request.method = request_method
         pyramid_request.registry.settings["h.proxy_auth"] = proxy_auth
 
         assert CookiePolicy.handles(pyramid_request) == expected_result
```

## Problems with the existing code

1. It has a single, centralised `_call_sub_policies()` method that makes all the decisions about which security policies apply to which requests. The logic in this method is complicated and as a result its tests are complicated. This doesn't scale: if we want to add more security policies or add more complexity to the decisions about which security policies to apply to which requests we'll have to keep making this already-complicated centralised delegation method even more complicated.

   The method doesn't actually centralise all the decisions in one method either: it calls out to other methods like `is_api_request()` or `AuthClientPolicy.handles()` to make some of the decisions. Even worse, the method depends on `self._ui_policy` which is elsewhere set to either `RemoteUserPolicy()` or `CookiePolicy()` depending on the value of a setting. So `_call_sub_policies()` has all the downsides of a single centralised method without the benefit of actually centralising all the logic in one place.

3. The `_call_sub_policies()` method is a private helper method so it can't be unit-tested directly. A crucial method like this should be directly unit-tested.

   The private method results in bad test code as the tests try to test the complicated logic of `_call_sub_policies()` indirectly via the three higher-level public methods that call it but they get confused about which of these three public methods they're testing (in some cases the same test is repeated for all three public methods; in other cases an aspect of `_call_sub_policies()` is tested for only one of the public methods. Comments in the code attempt (but fail) to explain what's going on, for example: `# Use remember() as an example, we've proven above which methods use this` (with no clarity about what "this" refers to, nor should one test depend on what has been "proven above" by other tests that should be decoupled).

   Some of the tests also patch the private method.

4. While the tests contort themselves to avoid testing the private method directly, ironically they have a `# pylint: disable=protected-access` at the top of the file because they contain all sorts of private attribute accesses: lots of assertions like `assert policy._bearer_token_policy == <something>`, `policy._ui_policy.assert_called_once_with()`, `assert result == policy._cookie_policy.remember.return_value`. There's also lots of places where the tests *write* to private attributes: `policy._http_basic_auth_policy.handles.return_value = basic_auth_handle` etc.

5. The tests are generally very poor. They don't fully cover the behavior of the code and they're difficult to change. They're very inconsistent with our usual testing style. There are tests like `test_most_methods_delegate()`, `test_calls_are_routed_based_on_api_or_not()` and `test_api_calls_are_passed_on()` that test multiple methods (sometimes by having the test actually call multiple methods; sometimes by picking one method at random as a stand-in for testing the others(!)), rather than each method having its own separate tests. Lots of `if` / `else` logic in the tests. Weird fixtures with names like `bearer_returns` and `basic_auth_handles`. Etc.

## How it works now

### `handles(request)` methods

Each security policy class has a staticmethod `handles(request) -> bool` that returns whether this security policy can handle this request: `CookiePolicy.handles(request)`, `RemoteUserPolicy.handles(request)`, `BearerTokenPolicy.handles(request)`, and `AuthClientPolicy.handles(request)`. Example:

```python
class CookiePolicy:
    @staticmethod
    def handles(request) -> bool:
        """Return True if this policy applies to `request`."""

        if is_api_request(request):
            return False

        return bool(request.registry.settings.get("h.proxy_auth"))
```

This gets rid of the complicated and unscaleable centralized delegation logic that was in `_call_sub_policies()`: each `handles()` method is really simple and has really simple tests, and this design will scale as more security policies are added or as the decisons about which policies to apply to which requests become more complex.

### `applicable_policies(request, policies)` function

I've extracted a function that takes a request and a list of policies and returns those policies that are "applicable to" the request: those policies for which `policy.handles(request)` returns truthy. This is a one-liner:

```python
def applicable_policies(request, policies):
    return [policy for policy in policies if policy.handles(request)]
```

This is a top-level function (not a private helper) with its own unit tests.

### `call_policies()` function

I've also extracted a `call_policies(method: str, request, *args, **kwargs)` function that calls `applicable_policies()` to get the policies that can handle `request` and then calls the given `method()` of each policy (passing `request`, `*args`, and `**kwargs` as arguments) and returns the first truthy result:

```python
def call_policies(method: str, fallback, request, *args, **kwargs):
    policies = [RemoteUserPolicy, CookiePolicy, BearerTokenPolicy, AuthClientPolicy]

    for policy in applicable_policies(request, policies):
        result = getattr(policy(), method)(request, *args, **kwargs)
        if result:
            return result

    return fallback
```

Again this is a top-level function with its own unit tests.

### `SecurityPolicy`

The top-level `SecurityPolicy` class's three methods now just delegate to this `call_policies()` function:

```python
class SecurityPolicy:
    def remember(self, request, userid, **kw):
        ...
        return call_policies("remember", [], request, userid, **kw)

    def forget(self, request, **kw):
        ...
        return call_policies("forget", [], request, **kw)

    def identity(self, request):
        ...
        return call_policies("identity", None, request)
```

### The new methods can be concisely described

The precise behavior of each of the new methods can be concisely described. This was not the case with the previous `_call_sub_policies()` helper:

* `CookiePolicy.handles(request)`: returns `True` if the request is *not* an API request and `PROXY_AUTH` is falsey
* `RemoteUserPolicy.handles(request)`: returns `True` if the request is *not* an API request and `PROXY_AUTH` is truthy
* `BearerTokenPolicy.handles(request)`: returns `True` if the request is an API request
* `applicable_policies(request, policies)`: returns those policies from `policies` that can handle `request` (`policy.handles(request)` returns truthy)
* `call_policies(method: str, request, *args, **kwargs)`: call `method()` on each policy that is applicable to `request` in turn, returning the first truthy result

### The test weirdness is gone

The tests use normal pytest fixtures and parametrization and all the weird stuff is gone:

* No more reading, writing or patching private attributes
* No more tests with weird names like `test_most_methods_delegate()` that test multiple methods or that are meant to test multiple methods but actually don't
* No more logic in tests
* No more weird fixtures like `bearer_returns` and `basic_auth_handles`

## Testing

1. Non-API requests can be authenticated with cookies. To test this just go to <http://localhost:5000/login>, log in, and visit some pages.
2. API requests can be authenticated with bearer tokens. To test this go to <http://localhost:5000/account/developer>, generate a developer token, and make an API request with that token. For example: `http POST 'http://localhost:5000/api/annotations' uri=foo Authorization:'Bearer 6879-***'`
3. Requests to certain API endpoints can be authenticated using an auth client. To test this log in to <https://hypothesis.instructure.com/> and launch [a localhost test assignment](https://hypothesis.instructure.com/courses/125/assignments/873)