### PR TITLE
Fix a flakey test

### DIFF
--- a/tests/unit/h/services/bulk_api/lms_stats_test.py
+++ b/tests/unit/h/services/bulk_api/lms_stats_test.py
@@ -21,22 +21,27 @@ class TestBulkLMSStatsService:
             group_by=CountsGroupBy.USER,
         )
 
-        assert stats == [
+        assert len(stats) == 2
+        assert (
             AnnotationCounts(
                 userid=user.userid,
                 display_name=user.display_name,
                 annotations=1,
                 replies=0,
                 last_activity=annotation.created,
-            ),
+            )
+            in stats
+        )
+        assert (
             AnnotationCounts(
                 userid=reply_user.userid,
                 display_name=reply_user.display_name,
                 annotations=0,
                 replies=1,
                 last_activity=annotation_reply.created,
-            ),
-        ]
+            )
+            in stats
+        )
 
     @pytest.mark.usefixtures("annotation", "user", "reply_user")
     def test_get_annotation_counts_by_assignment(


### PR DESCRIPTION
Note: you need to be careful whenever comparing ordered sequences like
tuples, lists, etc. `assert something = [ ... ]` is very likely to be a
flakey test.

If we're not going to use `h-matchers`
(`assert stats == Any.list.containing([...]).only()`) then we need some
sort of unordered list comparison assertion helper. A helper function or
fixture added to https://github.com/hypothesis/h-testkit maybe.

There is `pytest-unordered` but I'm not sure we want that dependency:
https://github.com/utapyngo/pytest-unordered

This Stack Overflow answer has a simple unordered list comparison
function:

https://stackoverflow.com/a/8866661/1175266
