### PR TITLE
Refactor `TopLevelSecurityPolicy` to make it easier to change

### DIFF
--- a/h/security/__init__.py
+++ b/h/security/__init__.py
@@ -41,4 +41,4 @@ def includeme(config):  # pragma: no cover
             "being available to ANYONE!"
         )
 
-    config.set_security_policy(TopLevelPolicy(proxy_auth=proxy_auth))
+    config.set_security_policy(TopLevelPolicy())

--- a/h/security/policy/_api.py
+++ b/h/security/policy/_api.py
@@ -1,0 +1,37 @@
+from pyramid.request import Request, RequestLocalCache
+
+from h.security.identity import Identity
+from h.security.policy._identity_base import IdentityBasedPolicy
+
+
+class APIPolicy(IdentityBasedPolicy):
+    """The security policy for API requests. Delegates to subpolicies."""
+
+    def __init__(self, sub_policies):
+        self.sub_policies = sub_policies
+        self._identity_cache = RequestLocalCache(self._load_identity)
+
+    def forget(self, *_args, **_kwargs):
+        # forget() isn't supported for stateless API requests.
+        return []
+
+    def identity(self, request) -> Identity | None:
+        return self._identity_cache.get_or_create(request)
+
+    def remember(self, *_args, **_kwargs):
+        # remember() isn't supported for stateless API requests.
+        return []
+
+    def _load_identity(self, request: Request) -> Identity | None:
+        for policy in applicable_policies(request, self.sub_policies):
+            identity = policy.identity(request)
+            if identity:
+                return identity
+
+        return None
+
+
+def applicable_policies(request, policies):
+    """Return the security policies from `policies` that can handle `request`."""
+
+    return [policy for policy in policies if policy.handles(request)]

--- a/h/security/policy/_identity_base.py
+++ b/h/security/policy/_identity_base.py
@@ -45,9 +45,3 @@ class IdentityBasedPolicy:
             return identity.user.userid
 
         return None
-
-    def remember(self, _request, _userid, **_kwargs):
-        return []
-
-    def forget(self, _request):
-        return []

--- a/h/security/policy/_remote_user.py
+++ b/h/security/policy/_remote_user.py
@@ -10,6 +10,9 @@ class RemoteUserPolicy(IdentityBasedPolicy):
     `h.security`.
     """
 
+    def forget(self, *_args, **_kwargs):
+        return []
+
     def identity(self, request):
         user_id = request.environ.get("HTTP_X_FORWARDED_USER")
         if not user_id:
@@ -20,3 +23,6 @@ class RemoteUserPolicy(IdentityBasedPolicy):
             return None
 
         return Identity.from_models(user=user)
+
+    def remember(self, *_args, **_kwargs):
+        return []

--- a/h/security/policy/bearer_token.py
+++ b/h/security/policy/bearer_token.py
@@ -1,12 +1,10 @@
-from pyramid.interfaces import ISecurityPolicy
 from pyramid.request import RequestLocalCache
-from zope.interface import implementer
 
 from h.security.identity import Identity
 from h.security.policy._identity_base import IdentityBasedPolicy
+from h.security.policy.helpers import is_api_request
 
 
-@implementer(ISecurityPolicy)
 class BearerTokenPolicy(IdentityBasedPolicy):
     """
     A Bearer token authentication policy.
@@ -20,6 +18,11 @@ class BearerTokenPolicy(IdentityBasedPolicy):
 
     def __init__(self):
         self._identity_cache = RequestLocalCache(self._load_identity)
+
+    @staticmethod
+    def handles(request) -> bool:
+        """Return True if this policy applies to `request`."""
+        return is_api_request(request)
 
     def identity(self, request):
         """

--- a/h/security/policy/top_level.py
+++ b/h/security/policy/top_level.py
@@ -1,10 +1,7 @@
-from typing import Optional
-
-from pyramid.interfaces import ISecurityPolicy
 from pyramid.request import RequestLocalCache
-from zope.interface import implementer
 
 from h.security.identity import Identity
+from h.security.policy._api import APIPolicy
 from h.security.policy._auth_client import AuthClientPolicy
 from h.security.policy._cookie import CookiePolicy
 from h.security.policy._identity_base import IdentityBasedPolicy
@@ -13,75 +10,34 @@ from h.security.policy.bearer_token import BearerTokenPolicy
 from h.security.policy.helpers import is_api_request
 
 
-@implementer(ISecurityPolicy)
 class TopLevelPolicy(IdentityBasedPolicy):
-    """
-    The security policy for `h`.
+    """The top-level security policy. Delegates to subpolicies."""
 
-    This delegates to various different policies depending on the situation.
-    """
-
-    def __init__(self, proxy_auth=False):
-        """
-        Initialise a security policy.
-
-        :param proxy_auth: Replace the default `CookiePolicy` for the UI with
-            the `RemoteUserPolicy`.
-        """
-        self._bearer_token_policy = BearerTokenPolicy()
-        self._http_basic_auth_policy = AuthClientPolicy()
+    def __init__(self):
         self._identity_cache = RequestLocalCache(self._load_identity)
 
-        self._ui_policy = RemoteUserPolicy() if proxy_auth else CookiePolicy()
-
-    def remember(self, request, userid, **kw):
-        """Get the correct headers to remember the given user."""
-
+    def forget(self, request, **kw):
         self._identity_cache.clear(request)
+        return get_subpolicy(request).forget(request, **kw)
 
-        return self._call_sub_policies("remember", request, userid, **kw)
-
-    def forget(self, request):
-        """Get the correct headers to forget the current login."""
-
-        self._identity_cache.clear(request)
-
-        return self._call_sub_policies("forget", request)
-
-    def identity(self, request) -> Optional[Identity]:
-        """
-        Get an Identity object for valid credentials.
-
-        :param request: Pyramid request to inspect
-        """
+    def identity(self, request) -> Identity | None:
         return self._identity_cache.get_or_create(request)
 
+    def remember(self, request, userid, **kw):
+        self._identity_cache.clear(request)
+        return get_subpolicy(request).remember(request, userid, **kw)
+
     def _load_identity(self, request):
-        return self._call_sub_policies("identity", request)
+        return get_subpolicy(request).identity(request)
 
-    def _call_sub_policies(self, method, request, *args, **kwargs):
-        """
-        Delegate calls to the correct set of security policies.
 
-        :param method: Method to call (like `identity()` or `forget()`)
-        :param request: Pyramid request object
-        :param args: Args to pass to the method
-        :param kwargs: Kwargs to pass to the method
-        :return: The response from the correct sub-policy
-        """
+@RequestLocalCache()
+def get_subpolicy(request):
+    """Return the subpolicy for TopLevelSecurityPolicy to delegate to for `request`."""
+    if is_api_request(request):
+        return APIPolicy([BearerTokenPolicy(), AuthClientPolicy()])
 
-        if not is_api_request(request):
-            # This is usually the cookie policy for UI things
-            return getattr(self._ui_policy, method)(request, *args, **kwargs)
+    if request.registry.settings.get("h.proxy_auth"):
+        return RemoteUserPolicy()
 
-        # Then we try the bearer header (or `access_token` GET param)
-        result = getattr(self._bearer_token_policy, method)(request, *args, **kwargs)
-
-        if not result and self._http_basic_auth_policy.handles(request):
-            # Only then do we look for auth clients authenticating with basic
-            # HTTP auth credentials
-            return getattr(self._http_basic_auth_policy, method)(
-                request, *args, **kwargs
-            )
-
-        return result
+    return CookiePolicy()

--- a/tests/unit/h/security/policy/_api_test.py
+++ b/tests/unit/h/security/policy/_api_test.py
@@ -1,0 +1,114 @@
+from unittest.mock import create_autospec, sentinel
+
+import pytest
+from pyramid.request import Request
+
+from h.security.identity import Identity
+from h.security.policy._api import APIPolicy, applicable_policies
+
+
+class TestAPIPolicy:
+    def test_forget(self, api_policy, pyramid_request):
+        assert api_policy.forget(pyramid_request, foo="bar") == []
+
+    def test_identity_when_first_sub_policy_returns_truthy(
+        self, applicable_policies, api_policy, pyramid_request
+    ):
+        applicable_policies.return_value[0].identity.return_value = True
+        applicable_policies.return_value[1].identity.return_value = False
+
+        identity = api_policy.identity(pyramid_request)
+
+        applicable_policies.assert_called_once_with(
+            pyramid_request, sentinel.sub_policies
+        )
+        applicable_policies.return_value[0].identity.assert_called_once_with(
+            pyramid_request
+        )
+        applicable_policies.return_value[1].identity.assert_not_called()
+        assert identity == applicable_policies.return_value[0].identity.return_value
+
+    def test_identity_when_second_sub_policy_returns_truthy(
+        self, applicable_policies, api_policy, pyramid_request
+    ):
+        applicable_policies.return_value[0].identity.return_value = False
+        applicable_policies.return_value[1].identity.return_value = True
+
+        identity = api_policy.identity(pyramid_request)
+
+        applicable_policies.return_value[1].identity.assert_called_once_with(
+            pyramid_request
+        )
+        assert identity == applicable_policies.return_value[1].identity.return_value
+
+    def test_identity_when_all_sub_policies_return_falsey(
+        self, applicable_policies, api_policy, pyramid_request
+    ):
+        applicable_policies.return_value[0].identity.return_value = False
+        applicable_policies.return_value[1].identity.return_value = False
+
+        identity = api_policy.identity(pyramid_request)
+
+        assert identity is None
+
+    def test_identity_when_there_are_no_applicable_policies(
+        self, applicable_policies, api_policy, pyramid_request
+    ):
+        applicable_policies.return_value = []
+
+        identity = api_policy.identity(pyramid_request)
+
+        assert identity is None
+
+    def test_remember(self, api_policy, pyramid_request):
+        assert api_policy.remember(pyramid_request, sentinel.userid, foo="bar") == []
+
+    @pytest.fixture(autouse=True)
+    def applicable_policies(self, mocker):
+        class SubpolicySpec:
+            def identity(self, request: Request) -> Identity | None:
+                """Return the identity of the current user."""
+
+        return mocker.patch(
+            "h.security.policy._api.applicable_policies",
+            return_value=[
+                create_autospec(SubpolicySpec, instance=True, spec_set=True),
+                create_autospec(SubpolicySpec, instance=True, spec_set=True),
+            ],
+        )
+
+    @pytest.fixture
+    def api_policy(self):
+        return APIPolicy(sentinel.sub_policies)
+
+
+class TestApplicablePolicies:
+    @pytest.mark.parametrize(
+        "return_values,expected_policies",
+        [
+            ([True, True], [0, 1]),
+            ([False, True], [1]),
+            ([True, False], [0]),
+            ([False, False], []),
+        ],
+    )
+    def test_applicable_policies(
+        self, return_values, expected_policies, pyramid_request
+    ):
+        class Spec:
+            @staticmethod
+            def handles(request) -> bool:
+                """Return True if this policy can handle `request`."""
+
+        policies = [
+            create_autospec(Spec, spec_set=True),
+            create_autospec(Spec, spec_set=True),
+        ]
+        for policy, return_value in zip(policies, return_values):
+            policy.handles.return_value = return_value
+
+        returned_policies = applicable_policies(pyramid_request, policies)
+
+        for policy in policies:
+            policy.handles.assert_called_once_with(pyramid_request)
+        assert returned_policies == [policies[index] for index in expected_policies]

--- a/tests/unit/h/security/policy/_identity_base_test.py
+++ b/tests/unit/h/security/policy/_identity_base_test.py
@@ -35,12 +35,6 @@ class TestIdentityBasedPolicy:
 
         assert policy.authenticated_userid(pyramid_request) is None
 
-    def test_remember_does_nothing(self, policy, pyramid_request):
-        assert policy.remember(pyramid_request, "foo") == []
-
-    def test_forget_does_nothing(self, policy, pyramid_request):
-        assert policy.forget(pyramid_request) == []
-
     @pytest.fixture
     def identity(self, factories):
         return Identity.from_models(user=factories.User())

--- a/tests/unit/h/security/policy/_remote_user_test.py
+++ b/tests/unit/h/security/policy/_remote_user_test.py
@@ -8,6 +8,10 @@ from h.security.policy._remote_user import RemoteUserPolicy
 
 @pytest.mark.usefixtures("user_service")
 class TestRemoteUserPolicy:
+    def test_forget(self, pyramid_request):
+        # pylint:disable=use-implicit-booleaness-not-comparison
+        assert RemoteUserPolicy().forget(pyramid_request, foo="bar") == []
+
     def test_identity(self, pyramid_request, user_service):
         pyramid_request.environ["HTTP_X_FORWARDED_USER"] = sentinel.forwarded_user
 
@@ -34,3 +38,10 @@ class TestRemoteUserPolicy:
         user_service.fetch.return_value.deleted = True
 
         assert RemoteUserPolicy().identity(pyramid_request) is None
+
+    def test_remember(self, pyramid_request):
+        # pylint:disable=use-implicit-booleaness-not-comparison
+        assert (
+            RemoteUserPolicy().remember(pyramid_request, sentinel.userid, foo="bar")
+            == []
+        )

--- a/tests/unit/h/security/policy/bearer_token_test.py
+++ b/tests/unit/h/security/policy/bearer_token_test.py
@@ -8,6 +8,24 @@ from h.security.policy.bearer_token import BearerTokenPolicy
 
 @pytest.mark.usefixtures("user_service", "auth_token_service")
 class TestBearerTokenPolicy:
+    @pytest.mark.parametrize(
+        "is_api_request_return_value,expected_result",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_handles(
+        self,
+        is_api_request,
+        is_api_request_return_value,
+        expected_result,
+        pyramid_request,
+    ):
+        is_api_request.return_value = is_api_request_return_value
+
+        assert BearerTokenPolicy.handles(pyramid_request) == expected_result
+
     def test_identity(self, pyramid_request, auth_token_service, user_service):
         identity = BearerTokenPolicy().identity(pyramid_request)
 
@@ -64,3 +82,8 @@ class TestBearerTokenPolicy:
         user_service.fetch.return_value.deleted = True
 
         assert BearerTokenPolicy().identity(pyramid_request) is None
+
+
+@pytest.fixture(autouse=True)
+def is_api_request(mocker):
+    return mocker.patch("h.security.policy.bearer_token.is_api_request", autospec=True)


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h/pull/8824.

See also: <https://github.com/hypothesis/h/pull/8813> and <https://hypothes-is.slack.com/archives/C4K6M7P5E/p1721311289459899>.

## Testing

1. Non-API requests can be authenticated with cookies. To test this just go to <http://localhost:5000/login>, log in, and visit some pages.
2. API requests can be authenticated with bearer tokens. To test this go to <http://localhost:5000/account/developer>, generate a developer token, and make an API request with that token. For example: `http POST 'http://localhost:5000/api/annotations' uri=foo Authorization:'Bearer 6879-***'`
3. Requests to certain API endpoints can be authenticated using an auth client. To test this log in to <https://hypothesis.instructure.com/> and launch [a localhost test assignment](https://hypothesis.instructure.com/courses/125/assignments/873)
4. Also visit <http://localhost:5000/docs/help> and test that you can log in to the client and annotate

## Details

This refactors h's `TopLevelSecurityPolicy` to make future changes easier. In a future PR I want to make certain API requests cookie-authenticatable. The current state of `TopLevelSecurityPolicy` and especially its tests make that change difficult. In particular:

* `TopLevelSecurityPolicy` has a single, centralised `_call_sub_policies()` method that makes all the decisions about which sub-policies apply to which requests. The logic in this method is complicated and if we want to add more security policies or add more complexity to the decisions about which security policies to apply to which requests we'll have to complicate it even further.
* The `_call_sub_policies()` method is a private helper method so it can't be unit-tested directly. A crucial method like this should be directly unit-tested.
* The tests for `TopLevelSecurityPolicy` are terrible and make code changes difficult. This can't be fixed simply by rewriting the tests as the design of `TopLevelSecurityPolicy` (with the crucial logic in a private helper) is largely the reason for the poor tests.

This PR refactors things into small, simple, easy-to-understand and easy-to-test units:

1. `get_subpolicy()` is a new top-level function with its own unit tests that returns `APIPolicy` for API requests or `RemoteUserPolicy` or `CookiePolicy` for non-API requests.

2. `TopLevelPolicy` now just calls `get_subpolicy()` and delegates to the sub-policy that it returns.

3. The new `APIPolicy` is the top-level API policy that `TopLevelPolicy` will delegate all API requests to. `APIPolicy` in turn delegates to a list of API sub-policies (currently `BearerTokenPolicy` and `AuthClientPolicy`, in future also `CookiePolicy`), taking the `identity()` result from whichever policy is first to return truthy values from both `handles(request)` and `identity(request)`.

   This idea of delegating to a list of sub-policies and taking the first truthy value is problematic for requests where `remember()` or `forget()` might get called (see the discussion in [this Slack thread](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1721311289459899)) but is fine in the context of stateless API requests where only `identity()` is used (and `authenticated_userid()` and `permits()`, which are based on `identity()`).

This refactoring will enable a future PR to make certain API endpoints cookie-authenticatable by adding `CookiePolicy` to `APIPolicy`'s list of sub-policies with a `CookiePolicy.handles(request)` method that returns `True` only for requests to those API endpoints that we want to be cookie-authenticateable.