### PR TITLE
Use Pyramid's `Allowed()` and `Denied()`, not booleans

### DIFF
--- a/h/security/permits.py
+++ b/h/security/permits.py
@@ -1,10 +1,14 @@
 from typing import Optional
 
+from pyramid.security import Allowed, Denied
+
 from h.security.identity import Identity
 from h.security.permission_map import PERMISSION_MAP
 
 
-def identity_permits(identity: Optional[Identity], context, permission) -> bool:
+def identity_permits(
+    identity: Optional[Identity], context, permission
+) -> Allowed | Denied:
     """
     Check whether a given identity has permission to operate on a context.
 
@@ -17,13 +21,14 @@ def identity_permits(identity: Optional[Identity], context, permission) -> bool:
     """
     if clauses := PERMISSION_MAP.get(permission):
         # Grant the permissions if for *any* single clause...
-        return any(
+        if any(
             # .. *all* elements in it are true
             all(_predicate_true(predicate, identity, context) for predicate in clause)
             for clause in clauses
-        )
+        ):
+            return Allowed("Allowed")
 
-    return False
+    return Denied("Denied")
 
 
 def _predicate_true(predicate, identity, context):

--- a/h/security/policy/_identity_base.py
+++ b/h/security/policy/_identity_base.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from pyramid.security import Allowed, Denied
+
 from h.security.identity import Identity
 from h.security.permits import identity_permits
 
@@ -24,7 +26,7 @@ class IdentityBasedPolicy:
         """
         return None
 
-    def permits(self, request, context, permission) -> bool:
+    def permits(self, request, context, permission) -> Allowed | Denied:
         """
         Get whether a given request has the requested permission on the context.
 

--- a/tests/unit/h/security/permits_test.py
+++ b/tests/unit/h/security/permits_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, sentinel
 
 import pytest
+from pyramid.security import Allowed, Denied
 
 from h.security import Identity, Permission
 from h.security.permits import PERMISSION_MAP, identity_permits
@@ -27,21 +28,21 @@ class TestIdentityPermits:
         "clauses,grants",
         (
             # At least one clause must be true, so if there are none, it's false
-            ([], False),
+            ([], Denied("Denied")),
             # A clause requires each element in it to be true
-            ([[always_true]], True),
-            ([[always_false]], False),
-            ([[always_true, always_true]], True),
-            ([[always_true, always_true, always_false]], False),
+            ([[always_true]], Allowed("Allowed")),
+            ([[always_false]], Denied("Denied")),
+            ([[always_true, always_true]], Allowed("Allowed")),
+            ([[always_true, always_true, always_false]], Denied("Denied")),
             # An empty clause is always true
-            ([[]], True),
+            ([[]], Allowed("Allowed")),
             # We lazy evaluate, so if anything in a clause is false we don't
             # evaluate predicates beyond it
-            ([[always_false, explode]], False),
+            ([[always_false, explode]], Denied("Denied")),
             # Only one clause has to be true
-            ([[always_false], [always_true]], True),
-            ([[always_true], [always_false]], True),
-            ([[always_true], [explode]], True),
+            ([[always_false], [always_true]], Allowed("Allowed")),
+            ([[always_true], [always_false]], Allowed("Allowed")),
+            ([[always_true], [explode]], Allowed("Allowed")),
         ),
     )
     def test_it(self, PERMISSION_MAP, clauses, grants):
@@ -54,9 +55,9 @@ class TestIdentityPermits:
         assert result == grants
 
     def test_it_denies_with_missing_permission(self):
-        assert not identity_permits(
+        assert identity_permits(
             sentinel.identity, sentinel.context, sentinel.non_existent_permission
-        )
+        ) == Denied("Denied")
 
     @pytest.fixture(autouse=True)
     def PERMISSION_MAP(self):


### PR DESCRIPTION
Return `pyramid.security.Allowed()` and `Denied()` instances, not bools,
from security policy `permits()` methods.

Pyramid's `ISecurityPolicy` requires that `permits()` returns
`Allowed()` or `Denied()` not a bool, see:

https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/security.html
https://docs.pylonsproject.org/projects/pyramid/en/latest/api/interfaces.html#pyramid.interfaces.ISecurityPolicy.permits

I think we're getting away with this because `Allowed()` and `Denied()`
are truthy and falsey (and even compare equal to `True`, `False`, and
other truthy and falsey values) so it at least mostly works, but
Pyramid's docs are clear that permits should return `Allowed()` or
`Denied()` not `bool` and returning `bool` could break Pyramid things
because `Allowed()` and `Denied()` have attributes that booleans don't
have (an `msg` string, `__str__()` and `__repr__()` methods, and a
`boolval` attr, and they also inherit from Python's builtin `int`).

h used to return `Allowed` and `Denied`. The `identity_permits()` helper
function was added in https://github.com/hypothesis/h/pull/6977. At
that time `identity_permits()` was a wrapper for Pyramid's
`ACLAuthorizationPolicy.permits()` which returns `Allowed` or `Denied`,
but even then `identity_permits()` function was incorrectly documented
as returning `bool`.

Later, in https://github.com/hypothesis/h/pull/7041,
`identity_permits()` was changed to actually return `bool`.