### PR TITLE
Add frontend min-length validation to name field

### DIFF
--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -54,7 +54,8 @@ function TextField({
   type,
   value,
   onChangeValue,
-  limit,
+  minLength = 0,
+  maxLength,
   label,
   testid,
   required = false,
@@ -64,7 +65,8 @@ function TextField({
   type: 'input' | 'textarea';
   value: string;
   onChangeValue: (newValue: string) => void;
-  limit: number;
+  minLength?: number;
+  maxLength: number;
   label: string;
   testid: string;
   required?: boolean;
@@ -72,12 +74,22 @@ function TextField({
   classes?: string;
 }) {
   const id = useId();
+  const [hasCommitted, setHasCommitted] = useState(false);
 
   const handleInput = (e: InputEvent) => {
     onChangeValue((e.target as HTMLInputElement).value);
   };
 
-  const error = [...value].length > limit;
+  const handleChange = (e: Event) => {
+    setHasCommitted(true);
+  };
+
+  let error = '';
+  if ([...value].length > maxLength) {
+    error = `Must be ${maxLength} characters or less.`;
+  } else if ([...value].length < minLength && hasCommitted) {
+    error = `Must be ${minLength} characters or more.`;
+  }
 
   const InputComponent = type === 'input' ? Input : Textarea;
 
@@ -87,7 +99,8 @@ function TextField({
       <InputComponent
         id={id}
         onInput={handleInput}
-        error={error ? `Must be ${limit} characters or less.` : undefined}
+        onChange={handleChange}
+        error={error}
         value={value}
         classes={classes}
         autofocus={autofocus}
@@ -97,9 +110,9 @@ function TextField({
       />
       <CharacterCounter
         value={[...value].length}
-        limit={limit}
+        limit={maxLength}
         testid={`charcounter-${testid}`}
-        error={error}
+        error={Boolean(error)}
       />
     </div>
   );
@@ -144,7 +157,8 @@ export default function CreateGroupForm() {
           type="input"
           value={name}
           onChangeValue={setName}
-          limit={25}
+          minLength={3}
+          maxLength={25}
           label="Name"
           testid="name"
           autofocus
@@ -154,7 +168,7 @@ export default function CreateGroupForm() {
           type="textarea"
           value={description}
           onChangeValue={setDescription}
-          limit={250}
+          maxLength={250}
           label="Description"
           testid="description"
           classes="h-24"


### PR DESCRIPTION
https://github.com/user-attachments/assets/fb4e37b3-7836-4157-bb1d-9880386129a1

## Testing

* When the page first loads the name field is not in its error state
* If you enter one or two chars into the name field it does not immediately go into its error state
* If focus leaves the name field while it has `<3` chars in it then the field goes into its error state
* If you try to submit the form while the name field has `<3` chars in it, whether the name field is currently focused or not, the field goes into its error state (if it wasn't in it already) and a validation error is shown
* When editing the name field as soon as you add a third character the field exits its error state (it does not wait for you to "commit" the change by changing the focus or submitting the form)
* **Known limitation:** when editing a name field that has `>=3` chars if you edit it down to `<3` chars it won't immediately enter its error state until focus leaves the field or you try to submit the form
* _Maximum_ length validation still works as it did before: as soon as you enter too many chars the field enters its error state (without waiting for you to "commit" the change) and as soon as you edit it down to `<=25` chars it exits its error state. If you try to submit the form with `>25` chars it shows a validation error