### PR TITLE
Show loading state when create-group API request in-flight

### DIFF
--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -1,6 +1,6 @@
 import { useId, useMemo, useState } from 'preact/hooks';
 
-import { Button, Input, Textarea } from '@hypothesis/frontend-shared';
+import { Button, Input, Spinner, Textarea } from '@hypothesis/frontend-shared';
 import { readConfig } from '../config';
 import { callAPI, CreateGroupAPIResponse } from '../utils/api';
 import { setLocation } from '../utils/set-location';
@@ -122,12 +122,15 @@ export default function CreateGroupForm() {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [saving, setSaving] = useState(false);
   const config = useMemo(() => readConfig(), []);
 
   const createGroup = async (e: SubmitEvent) => {
     e.preventDefault();
 
     let response: CreateGroupAPIResponse;
+
+    setSaving(true);
 
     try {
       response = (await callAPI(
@@ -140,6 +143,7 @@ export default function CreateGroupForm() {
       )) as CreateGroupAPIResponse;
     } catch (apiError) {
       setErrorMessage(apiError.message);
+      setSaving(false);
       return;
     }
 
@@ -174,7 +178,7 @@ export default function CreateGroupForm() {
           classes="h-24"
         />
 
-        <div className="flex items-center">
+        <div className="flex items-center gap-x-4">
           {errorMessage && (
             <div
               className="text-red-error font-bold"
@@ -184,7 +188,13 @@ export default function CreateGroupForm() {
             </div>
           )}
           <div className="grow" />
-          <Button type="submit" variant="primary">
+          {saving && <Spinner data-testid="spinner" />}
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={saving}
+            data-testid="button"
+          >
             Create group
           </Button>
         </div>

--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useState } from 'preact/hooks';
+import { useEffect, useId, useMemo, useState } from 'preact/hooks';
 
 import { Button, Input, Spinner, Textarea } from '@hypothesis/frontend-shared';
 import { readConfig } from '../config';
@@ -124,6 +124,18 @@ export default function CreateGroupForm() {
   const [errorMessage, setErrorMessage] = useState('');
   const [saving, setSaving] = useState(false);
   const config = useMemo(() => readConfig(), []);
+
+  useEffect(() => {
+    const listener = (e: PageTransitionEvent) => {
+      if (e.persisted) {
+        // Disable the "saving" state if the user uses the browser's Back button to navigate
+        // back to the group form.
+        setSaving(false);
+      }
+    };
+    window.addEventListener('pageshow', listener);
+    return () => window.removeEventListener('pageshow', listener);
+  }, []);
 
   const createGroup = async (e: SubmitEvent) => {
     e.preventDefault();

--- a/h/static/scripts/group-forms/components/test/CreateGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateGroupForm-test.js
@@ -62,11 +62,22 @@ describe('CreateGroupForm', () => {
     };
   };
 
+  let wrappers;
+
   const createWrapper = () => {
     const wrapper = mount(<CreateGroupForm />);
+    wrappers.push(wrapper);
     const elements = getElements(wrapper);
     return { wrapper, elements };
   };
+
+  beforeEach(() => {
+    wrappers = [];
+  });
+
+  afterEach(() => {
+    wrappers.forEach(wrapper => wrapper.unmount());
+  });
 
   [
     {


### PR DESCRIPTION
When in its loading state the component:

1. Disables the create-group button
2. Shows a spinner

In the case of a successful API request the component goes into its loading state when the form is submitted _and remains in its loading state_ after the successful API response is received. This is because after receiving the successful response the component redirects the browser (the browser starts showing a spinner on its tab) and we don't want the component to exit its loading state while the browser is navigating to the next page: we don't want the create-group button to be clicked again during navigation, nor do we want the spinner to disappear.

https://github.com/user-attachments/assets/d4b18e0c-3ccb-4fe6-b5c7-7ccce979e9a2

In the case of an _unsuccessful_ API request the component exits its loading state on receiving the response. To test this:

```diff
diff --git a/h/views/api/groups.py b/h/views/api/groups.py
index 86de1ede9..baa514d41 100644
--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -46,6 +46,7 @@ def groups(request):
 )
 def create(request):
     """Create a group from the POST payload."""
+    raise RuntimeError()
     appstruct = CreateGroupAPISchema(
         default_authority=request.default_authority,
         group_authority=request.effective_authority,
```

https://github.com/user-attachments/assets/d1394498-2678-4f81-aba9-a652f90b1584

Known Issues
============

If you create a group and then use the browser's back button to return to the `/groups/new` page the component will be stuck in its loading state.