### PR TITLE
Clear error message when re-submitting

### DIFF
--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -126,6 +126,7 @@ export default function CreateGroupForm() {
 
   const createGroup = async (e: SubmitEvent) => {
     e.preventDefault();
+    setErrorMessage('');
 
     let response: CreateGroupAPIResponse;
 


### PR DESCRIPTION
Clear any error message from the create-group form when the form is
re-submitted.

It currently looks a bit odd when the form is already showing an error
message and the user re-submits the form and gets the same error message
from the server again: nothing changes and the error message just continues to
be shown.

I think it's better if the error message disappears when the form is
re-submitted and re-appears again if another error response is received:
this makes it clear that the action was re-tried and another error was
received.


https://github.com/user-attachments/assets/8b6fc34f-7cef-480b-b0bf-1bf197c3c01d

