### PR TITLE
Remove an unnecessary optimisation

### DIFF
--- a/tests/unit/h/services/auth_cookie_test.py
+++ b/tests/unit/h/services/auth_cookie_test.py
@@ -19,15 +19,6 @@ class TestAuthCookieService:
     @pytest.mark.usefixtures("with_valid_cookie")
     def test_verify_cookie(self, service, auth_ticket):
         assert service.verify_cookie() == auth_ticket.user
-        # We also set the cache as a side effect
-
-        assert service._user == auth_ticket.user  # pylint: disable=protected-access
-
-    def test_verify_cookie_short_circuits_if_user_cache_is_set(self, service):
-        # pylint: disable=protected-access
-        service._user = sentinel.user
-
-        assert service.verify_cookie() == service._user
 
     def test_verify_cookie_returns_None_if_there_is_no_cookie(self, service, cookie):
         cookie.get_value.return_value = None
@@ -89,7 +80,6 @@ class TestAuthCookieService:
 
         cookie.get_headers.assert_called_once_with([user.userid, auth_ticket.id])
         assert headers == cookie.get_headers.return_value
-        assert service._user == user  # pylint: disable=protected-access
 
     def test_create_cookie_raises_if_user_is_missing(self, service, user_service):
         user_service.fetch.return_value = None
@@ -103,7 +93,6 @@ class TestAuthCookieService:
 
         cookie.get_headers.assert_called_once_with(None, max_age=0)
         assert headers == cookie.get_headers.return_value
-        assert service._user is None  # pylint: disable=protected-access
         assert db_session.query(AuthTicket).first() is None
 
     def test_revoke_cookie_is_ok_without_a_cookie(self, service):


### PR DESCRIPTION
Remove an unnessary optimisation where
`AuthCookieService.verify_cookie()` (a method that is only ever called
by `CookiePolicy.identity()`, and returns the user identity represented
by the request's auth cookie) caches the user object as `self._user` so
that it can just return it if called again, rather than recomputing it
from the cookie.

This optimisation looks potentially dodgy to me because `self._user` is
not only set by the `verify_cookie()` method but also by
`create_cookie()`.

We probably don't need to optimise this but if we do want to optimise it
the right way would be to cache the final return value of the
`AuthCookieService.verify_cookie()` method (not an intermediate value)
or cache the return value of the higher-level `CookiePolicy.identity()`
method that calls it.
