### PR TITLE
Replace `AuthCookieService` with `AuthTicketService`

### DIFF
--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -1,4 +1,6 @@
+import base64
 from functools import lru_cache
+from os import urandom
 
 import webob
 
@@ -52,7 +54,9 @@ class CookiePolicy(IdentityBasedPolicy):
             request.session.update(data)
             request.session.new_csrf_token()
 
-        return request.find_service(AuthCookieService).create_cookie(userid)
+        ticket_id = base64.urlsafe_b64encode(urandom(32)).rstrip(b"=").decode("ascii")
+        request.find_service(AuthCookieService).add_ticket(userid, ticket_id)
+        return self.cookie.get_headers([userid, ticket_id])
 
     def forget(self, request):
         """Get a list of headers which will delete appropriate cookies."""

--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -25,9 +25,6 @@ class CookiePolicy(IdentityBasedPolicy):
 
         userid, ticket_id = self._get_cookie_value()
 
-        if not ticket_id:
-            return None
-
         user = request.find_service(AuthTicketService).verify_ticket(userid, ticket_id)
 
         if (not user) or user.deleted:

--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -6,7 +6,7 @@ import webob
 
 from h.security.identity import Identity
 from h.security.policy._identity_base import IdentityBasedPolicy
-from h.services.auth_cookie import AuthCookieService
+from h.services.auth_ticket import AuthTicketService
 
 
 class CookiePolicy(IdentityBasedPolicy):
@@ -28,7 +28,7 @@ class CookiePolicy(IdentityBasedPolicy):
         if not ticket_id:
             return None
 
-        user = request.find_service(AuthCookieService).verify_ticket(userid, ticket_id)
+        user = request.find_service(AuthTicketService).verify_ticket(userid, ticket_id)
 
         if (not user) or user.deleted:
             return None
@@ -55,7 +55,7 @@ class CookiePolicy(IdentityBasedPolicy):
             request.session.new_csrf_token()
 
         ticket_id = base64.urlsafe_b64encode(urandom(32)).rstrip(b"=").decode("ascii")
-        request.find_service(AuthCookieService).add_ticket(userid, ticket_id)
+        request.find_service(AuthTicketService).add_ticket(userid, ticket_id)
         return self.cookie.get_headers([userid, ticket_id])
 
     def forget(self, request):
@@ -69,7 +69,7 @@ class CookiePolicy(IdentityBasedPolicy):
         _, ticket_id = self._get_cookie_value()
 
         if ticket_id:
-            request.find_service(AuthCookieService).remove_ticket(ticket_id)
+            request.find_service(AuthTicketService).remove_ticket(ticket_id)
 
         return self.cookie.get_headers(None, max_age=0)
 

--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -66,7 +66,12 @@ class CookiePolicy(IdentityBasedPolicy):
         # Clear the session by invalidating it
         request.session.invalidate()
 
-        return request.find_service(AuthCookieService).revoke_cookie()
+        _, ticket_id = self._get_cookie_value()
+
+        if ticket_id:
+            request.find_service(AuthCookieService).remove_ticket(ticket_id)
+
+        return self.cookie.get_headers(None, max_age=0)
 
     @staticmethod
     @lru_cache  # Ensure we only add this once per request

--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -1,5 +1,7 @@
 from functools import lru_cache
 
+import webob
+
 from h.security.identity import Identity
 from h.security.policy._identity_base import IdentityBasedPolicy
 from h.services.auth_cookie import AuthCookieService
@@ -12,6 +14,9 @@ class CookiePolicy(IdentityBasedPolicy):
     This policy kicks in when accessing the UI presented by `h` and also boot
     straps the login for the client (when the popup shows).
     """
+
+    def __init__(self, cookie: webob.cookies.SignedCookieProfile):
+        self.cookie = cookie
 
     def identity(self, request):
         self._add_vary_by_cookie(request)

--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -84,8 +84,4 @@ class CookiePolicy(IdentityBasedPolicy):
         request.add_response_callback(vary_add)
 
     def _get_cookie_value(self):
-        value = self.cookie.get_value()
-        if not value:
-            return None, None
-
-        return value
+        return self.cookie.get_value() or (None, None)

--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -21,7 +21,13 @@ class CookiePolicy(IdentityBasedPolicy):
     def identity(self, request):
         self._add_vary_by_cookie(request)
 
-        user = request.find_service(AuthCookieService).verify_cookie()
+        userid, ticket_id = self._get_cookie_value()
+
+        if not ticket_id:
+            return None
+
+        user = request.find_service(AuthCookieService).verify_ticket(userid, ticket_id)
+
         if (not user) or user.deleted:
             return None
 
@@ -67,3 +73,10 @@ class CookiePolicy(IdentityBasedPolicy):
             response.vary = list(vary)
 
         request.add_response_callback(vary_add)
+
+    def _get_cookie_value(self):
+        value = self.cookie.get_value()
+        if not value:
+            return None, None
+
+        return value

--- a/h/security/policy/top_level.py
+++ b/h/security/policy/top_level.py
@@ -35,24 +35,6 @@ class TopLevelPolicy(IdentityBasedPolicy):
 @RequestLocalCache()
 def get_subpolicy(request):
     """Return the subpolicy for TopLevelSecurityPolicy to delegate to for `request`."""
-    if is_api_request(request):
-        cookie = webob.cookies.SignedCookieProfile(
-            secret=request.registry.settings["h_auth_cookie_secret"],
-            salt="authsanity",
-            cookie_name="auth",
-            max_age=30 * 24 * 3600,  # 30 days
-            httponly=True,
-            secure=request.scheme == "https",
-        )
-        cookie = cookie.bind(request)
-        return APIPolicy(
-            [
-                BearerTokenPolicy(),
-                AuthClientPolicy(),
-                APICookiePolicy(CookiePolicy(cookie)),
-            ]
-        )
-
     cookie = webob.cookies.SignedCookieProfile(
         secret=request.registry.settings["h_auth_cookie_secret"],
         salt="authsanity",
@@ -62,4 +44,14 @@ def get_subpolicy(request):
         secure=request.scheme == "https",
     )
     cookie = cookie.bind(request)
+
+    if is_api_request(request):
+        return APIPolicy(
+            [
+                BearerTokenPolicy(),
+                AuthClientPolicy(),
+                APICookiePolicy(CookiePolicy(cookie)),
+            ]
+        )
+
     return CookiePolicy(cookie)

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -4,7 +4,7 @@ from h.services.annotation_metadata import AnnotationMetadataService
 from h.services.annotation_read import AnnotationReadService
 from h.services.annotation_sync import AnnotationSyncService
 from h.services.annotation_write import AnnotationWriteService
-from h.services.auth_cookie import AuthCookieService
+from h.services.auth_ticket import AuthTicketService
 from h.services.bulk_api import (
     BulkAnnotationService,
     BulkGroupService,
@@ -45,7 +45,7 @@ def includeme(config):  # pragma: no cover
 
     # Other services
     config.register_service_factory(
-        "h.services.auth_cookie.factory", iface=AuthCookieService
+        "h.services.auth_ticket.factory", iface=AuthTicketService
     )
     config.register_service_factory(
         "h.services.auth_token.auth_token_service_factory", name="auth_token"

--- a/h/services/auth_cookie.py
+++ b/h/services/auth_cookie.py
@@ -74,21 +74,13 @@ class AuthCookieService:
         )
         self._session.add(ticket)
 
-    def revoke_cookie(self):
-        """
-        Create headers to revoke the cookie used to log in a user.
+    def remove_ticket(self, ticket_id: str) -> None:
+        """Remove any ticket with the given ID from the DB."""
 
-        :return: An iterable of headers to return to the browser
-        """
+        self._session.query(AuthTicket).filter_by(id=ticket_id).delete()
 
-        _, ticket_id = self._get_cookie_value()
-        if ticket_id:
-            self._session.query(AuthTicket).filter_by(id=ticket_id).delete()
-
-        # Empty the cached user to force revalidation
+        # Empty the cached user to force revalidation.
         self._user = None
-
-        return self._cookie.get_headers(None, max_age=0)
 
     def _get_cookie_value(self):
         value = self._cookie.get_value()

--- a/h/services/auth_cookie.py
+++ b/h/services/auth_cookie.py
@@ -1,5 +1,3 @@
-import base64
-import os
 from datetime import datetime, timedelta
 
 import sqlalchemy as sa
@@ -60,13 +58,8 @@ class AuthCookieService:
 
         return self._user
 
-    def create_cookie(self, userid):
-        """
-        Create headers for a persistent cookie to log in the user.
-
-        :param userid: Id of the user to log in
-        :return: An iterable of headers to return to the browser
-        """
+    def add_ticket(self, userid: str, ticket_id: str) -> None:
+        """Add a new auth ticket for the given userid and token_id to the DB."""
 
         # Update the user cache to allow quick checking if we are called again
         self._user = self._user_service.fetch(userid)
@@ -74,14 +67,12 @@ class AuthCookieService:
             raise ValueError(f"Cannot find user with userid {userid}")
 
         ticket = AuthTicket(
-            id=base64.urlsafe_b64encode(os.urandom(32)).rstrip(b"=").decode("ascii"),
+            id=ticket_id,
             user=self._user,
             user_userid=self._user.userid,
             expires=datetime.utcnow() + self.TICKET_TTL,
         )
         self._session.add(ticket)
-
-        return self._cookie.get_headers([self._user.userid, ticket.id])
 
     def revoke_cookie(self):
         """

--- a/h/services/auth_cookie.py
+++ b/h/services/auth_cookie.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import sqlalchemy as sa
 from webob.cookies import SignedCookieProfile
 
-from h.models import AuthTicket
+from h.models import AuthTicket, User
 
 
 class AuthCookieService:
@@ -22,20 +22,18 @@ class AuthCookieService:
         self._cookie = cookie
         self._user = None
 
-    def verify_cookie(self):
+    def verify_ticket(self, userid: str, ticket_id: str) -> User | None:
         """
-        Get the authenticated user by cookie (if any).
+        Return the User object matching the given userid and ticket_id, or None.
 
-        :return: The logged in `User` or None
+        Verify that there is an unexpired AuthTicket in the DB matching the
+        given `userid` and `ticket_id` and if so return the User corresponding
+        User object.
         """
 
         if self._user:
             # We've already vetted the user!
             return self._user
-
-        userid, ticket_id = self._get_cookie_value()
-        if not ticket_id:
-            return None
 
         ticket = (
             self._session.query(AuthTicket)

--- a/h/services/auth_ticket.py
+++ b/h/services/auth_ticket.py
@@ -18,13 +18,12 @@ class AuthTicketService:
         self._user_service = user_service
         self._user = None
 
-    def verify_ticket(self, userid: str, ticket_id: str) -> User | None:
+    def verify_ticket(self, userid: str | None, ticket_id: str | None) -> User | None:
         """
         Return the User object matching the given userid and ticket_id, or None.
 
         Verify that there is an unexpired AuthTicket in the DB matching the
-        given `userid` and `ticket_id` and if so return the User corresponding
-        User object.
+        given `userid` and `ticket_id` and if so return the corresponding User.
         """
 
         if self._user:

--- a/h/services/auth_ticket.py
+++ b/h/services/auth_ticket.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 from h.models import AuthTicket, User
 
 
-class AuthCookieService:
+class AuthTicketService:
     TICKET_TTL = timedelta(days=7)
 
     # We only want to update the `expires` column when the tickets `expires` is
@@ -82,6 +82,6 @@ class AuthCookieService:
 
 
 def factory(_context, request):
-    """Return a AuthCookieService instance for the passed context and request."""
+    """Return a AuthTicketService instance for the passed context and request."""
 
-    return AuthCookieService(request.db, user_service=request.find_service(name="user"))
+    return AuthTicketService(request.db, user_service=request.find_service(name="user"))

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -139,7 +139,7 @@ def annotation_metadata_service(mock_service):
 @pytest.fixture
 def auth_cookie_service(mock_service):
     auth_cookie_service = mock_service(AuthCookieService)
-    auth_cookie_service.verify_cookie.return_value.deleted = False
+    auth_cookie_service.verify_ticket.return_value.deleted = False
     return auth_cookie_service
 
 

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -10,7 +10,7 @@ from h.services.annotation_moderation import AnnotationModerationService
 from h.services.annotation_read import AnnotationReadService
 from h.services.annotation_sync import AnnotationSyncService
 from h.services.annotation_write import AnnotationWriteService
-from h.services.auth_cookie import AuthCookieService
+from h.services.auth_ticket import AuthTicketService
 from h.services.auth_token import AuthTokenService
 from h.services.bulk_api import (
     BulkAnnotationService,
@@ -51,7 +51,7 @@ __all__ = (
     "annotation_read_service",
     "annotation_sync_service",
     "annotation_write_service",
-    "auth_cookie_service",
+    "auth_ticket_service",
     "auth_token_service",
     "bulk_annotation_service",
     "bulk_group_service",
@@ -137,10 +137,10 @@ def annotation_metadata_service(mock_service):
 
 
 @pytest.fixture
-def auth_cookie_service(mock_service):
-    auth_cookie_service = mock_service(AuthCookieService)
-    auth_cookie_service.verify_ticket.return_value.deleted = False
-    return auth_cookie_service
+def auth_ticket_service(mock_service):
+    auth_ticket_service = mock_service(AuthTicketService)
+    auth_ticket_service.verify_ticket.return_value.deleted = False
+    return auth_ticket_service
 
 
 @pytest.fixture

--- a/tests/unit/h/conftest.py
+++ b/tests/unit/h/conftest.py
@@ -160,6 +160,7 @@ def pyramid_request(db_session, db_session_replica, fake_feature, pyramid_settin
     request.GET = request.params
     request.POST = request.params
     request.user = None
+    request.scheme = "https"
     return request
 
 

--- a/tests/unit/h/security/policy/_cookie_test.py
+++ b/tests/unit/h/security/policy/_cookie_test.py
@@ -21,13 +21,6 @@ class TestCookiePolicy:
             user=auth_ticket_service.verify_ticket.return_value
         )
 
-    def test_identity_when_no_ticket_in_cookie(
-        self, cookie, cookie_policy, pyramid_request
-    ):
-        cookie.get_value.return_value = None
-
-        assert cookie_policy.identity(pyramid_request) is None
-
     def test_identity_when_user_marked_as_deleted(
         self, pyramid_request, auth_ticket_service, cookie_policy
     ):

--- a/tests/unit/h/security/policy/_cookie_test.py
+++ b/tests/unit/h/security/policy/_cookie_test.py
@@ -75,7 +75,7 @@ class TestCookiePolicy:
         assert pyramid_request.session["data"] == "old"
         assert pyramid_request.session["_csrft_"] != "old_csrf_token"
 
-    def test_forget(self, pyramid_request, auth_cookie_service, cookie_policy):
+    def test_forget(self, pyramid_request, auth_cookie_service, cookie_policy, cookie):
         pyramid_request.session["data"] = "old"
 
         result = cookie_policy.forget(pyramid_request)
@@ -83,8 +83,9 @@ class TestCookiePolicy:
         # The `pyramid.testing.DummySession` is a dict so this is the closest
         # we can get to saying it's been invalidated
         assert not pyramid_request.session
-        auth_cookie_service.revoke_cookie.assert_called_once_with()
-        assert result == auth_cookie_service.revoke_cookie.return_value
+        auth_cookie_service.remove_ticket.assert_called_once_with(sentinel.ticket_id)
+        cookie.get_headers.assert_called_once_with(None, max_age=0)
+        assert result == cookie.get_headers.return_value
 
     @pytest.mark.parametrize(
         "method,args",

--- a/tests/unit/h/security/policy/_cookie_test.py
+++ b/tests/unit/h/security/policy/_cookie_test.py
@@ -21,6 +21,13 @@ class TestCookiePolicy:
             user=auth_ticket_service.verify_ticket.return_value
         )
 
+    def test_identity_when_no_ticket_in_cookie(
+        self, cookie, cookie_policy, pyramid_request
+    ):
+        cookie.get_value.return_value = None
+
+        assert cookie_policy.identity(pyramid_request) is None
+
     def test_identity_when_user_marked_as_deleted(
         self, pyramid_request, auth_ticket_service, cookie_policy
     ):
@@ -84,6 +91,18 @@ class TestCookiePolicy:
         # we can get to saying it's been invalidated
         assert not pyramid_request.session
         auth_ticket_service.remove_ticket.assert_called_once_with(sentinel.ticket_id)
+        cookie.get_headers.assert_called_once_with(None, max_age=0)
+        assert result == cookie.get_headers.return_value
+
+    def test_forget_when_no_ticket_id_in_cookie(
+        self, auth_ticket_service, cookie, cookie_policy, pyramid_request
+    ):
+        cookie.get_value.return_value = None
+
+        result = cookie_policy.forget(pyramid_request)
+
+        assert not pyramid_request.session
+        auth_ticket_service.remove_ticket.assert_not_called()
         cookie.get_headers.assert_called_once_with(None, max_age=0)
         assert result == cookie.get_headers.return_value
 

--- a/tests/unit/h/services/auth_cookie_test.py
+++ b/tests/unit/h/services/auth_cookie_test.py
@@ -92,17 +92,11 @@ class TestAuthCookieService:
         ):
             service.add_ticket(sentinel.userid, sentinel.ticket_id)
 
-    @pytest.mark.usefixtures("with_valid_cookie")
-    def test_revoke_cookie(self, service, cookie, db_session):
-        headers = service.revoke_cookie()
+    def test_remove_ticket(self, auth_ticket, service, db_session):
+        service.remove_ticket(auth_ticket.id)
 
-        cookie.get_headers.assert_called_once_with(None, max_age=0)
-        assert headers == cookie.get_headers.return_value
         assert service._user is None  # pylint: disable=protected-access
         assert db_session.query(AuthTicket).first() is None
-
-    def test_revoke_cookie_is_ok_without_a_cookie(self, service):
-        service.revoke_cookie()
 
     @pytest.fixture
     def user(self, factories):

--- a/tests/unit/h/services/auth_ticket_test.py
+++ b/tests/unit/h/services/auth_ticket_test.py
@@ -31,8 +31,18 @@ class TestAuthTicketService:
             service.verify_ticket(sentinel.userid, sentinel.ticket_id) == service._user
         )
 
-    def test_verify_ticket_returns_None_if_there_is_no_ticket(self, service, user):
+    @pytest.mark.usefixtures("auth_ticket")
+    def test_verify_ticket_returns_None_if_theres_no_matching_ticket(
+        self, service, user
+    ):
         assert service.verify_ticket(user.userid, ticket_id="does_not_exist") is None
+
+    def test_verify_ticket_when_theres_no_userid(self, service, auth_ticket):
+        assert service.verify_ticket(None, ticket_id=auth_ticket.id) is None
+
+    @pytest.mark.usefixtures("auth_ticket")
+    def test_verify_ticket_when_theres_no_ticket_id(self, service, user):
+        assert service.verify_ticket(user.userid, ticket_id=None) is None
 
     def test_verify_ticket_returns_None_if_the_ticket_has_expired(
         self, service, auth_ticket

--- a/tests/unit/h/services/auth_ticket_test.py
+++ b/tests/unit/h/services/auth_ticket_test.py
@@ -4,7 +4,7 @@ from unittest.mock import sentinel
 import pytest
 
 from h.models import AuthTicket
-from h.services.auth_cookie import AuthCookieService, factory
+from h.services.auth_ticket import AuthTicketService, factory
 
 
 def assert_nearly_equal(first_date, second_date):
@@ -13,7 +13,7 @@ def assert_nearly_equal(first_date, second_date):
     assert diff < timedelta(seconds=1)
 
 
-class TestAuthCookieService:
+class TestAuthTicketService:
     def test_verify_ticket(self, service, auth_ticket):
         assert (
             service.verify_ticket(auth_ticket.user.userid, auth_ticket.id)
@@ -45,9 +45,9 @@ class TestAuthCookieService:
         "offset,expect_update",
         (
             (timedelta(seconds=0), False),
-            (AuthCookieService.TICKET_REFRESH_INTERVAL + timedelta(seconds=-1), False),
-            (AuthCookieService.TICKET_REFRESH_INTERVAL, True),
-            (AuthCookieService.TICKET_REFRESH_INTERVAL + timedelta(seconds=1), True),
+            (AuthTicketService.TICKET_REFRESH_INTERVAL + timedelta(seconds=-1), False),
+            (AuthTicketService.TICKET_REFRESH_INTERVAL, True),
+            (AuthTicketService.TICKET_REFRESH_INTERVAL + timedelta(seconds=1), True),
         ),
     )
     def test_verify_ticket_updates_the_expiry_time(
@@ -60,7 +60,7 @@ class TestAuthCookieService:
 
         if expect_update:
             assert_nearly_equal(
-                auth_ticket.expires, datetime.utcnow() + AuthCookieService.TICKET_TTL
+                auth_ticket.expires, datetime.utcnow() + AuthTicketService.TICKET_TTL
             )
         else:
             assert auth_ticket.expires == expires
@@ -76,7 +76,7 @@ class TestAuthCookieService:
         assert auth_ticket.user_userid == user.userid
         assert auth_ticket.id == "test_ticket_id"
         assert_nearly_equal(
-            auth_ticket.expires, datetime.utcnow() + AuthCookieService.TICKET_TTL
+            auth_ticket.expires, datetime.utcnow() + AuthTicketService.TICKET_TTL
         )
         assert service._user == user  # pylint: disable=protected-access
 
@@ -104,21 +104,21 @@ class TestAuthCookieService:
 
     @pytest.fixture
     def service(self, db_session, user_service):
-        return AuthCookieService(session=db_session, user_service=user_service)
+        return AuthTicketService(session=db_session, user_service=user_service)
 
 
 class TestFactory:
-    def test_it(self, pyramid_request, AuthCookieService, user_service):
+    def test_it(self, pyramid_request, AuthTicketService, user_service):
         cookie_service = factory(sentinel.context, pyramid_request)
 
-        AuthCookieService.assert_called_once_with(
+        AuthTicketService.assert_called_once_with(
             pyramid_request.db, user_service=user_service
         )
-        assert cookie_service == AuthCookieService.return_value
+        assert cookie_service == AuthTicketService.return_value
 
     @pytest.fixture
-    def AuthCookieService(self, patch):
-        return patch("h.services.auth_cookie.AuthCookieService")
+    def AuthTicketService(self, patch):
+        return patch("h.services.auth_ticket.AuthTicketService")
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
In a future PR (https://github.com/hypothesis/h/pull/8861) I need to change h to use two separate auth cookies for HTML and API requests. The current design of the code makes this difficult to do: a lot of the code for handling the auth cookies and their corresponding auth tickets in the DB is in an [`AuthCookieService`](https://github.com/hypothesis/h/blob/3687f3347955a5fea49e63bb902a9f67e592e733/h/services/auth_cookie.py#L11-L109) class and the single instance of `AuthCookieService` is [hard-coded to always use the same, single cookie](https://github.com/hypothesis/h/blob/3687f3347955a5fea49e63bb902a9f67e592e733/h/services/auth_cookie.py#L115-L129). So the fact that there's only one auth cookie is sort of inherent in the code design.

Replace `AuthCookieService` (which mixes two separate concerns of cookies and auth tickets together into one service, and makes it impossible for the h to have two different cookies) with an `AuthTicketService` that is just about auth tickets and doesn't know anything about cookies. Move the cookie stuff into `CookiePolicy`, which is the only user of `AuthCookieService` / `AuthTicketService`.

This creates a nice separation of concerns in which `CookiePolicy` is about cookies and just delegates to `AuthTicketService` for auth ticket stuff, and `AuthTicketService` is just about auth tickets and dooesn't know anything about cookies.

This means that `AuthTicketService` can potentially have multiple different users in future, for example `CookiePolicy` and `APICookiePolicy` (using two different cookies) or a security policy based on something other than cookies (e.g. headers).

## History

h used to use [pyramid-authsanity](https://github.com/usingnamespace/pyramid_authsanity) which requires you to implement an [`IAuthService`](https://github.com/usingnamespace/pyramid_authsanity/blob/b4f41eb70a783f40c39d8547b663338cc0aab420/src/pyramid_authsanity/interfaces.py#L22-L47) interface for reading and writing auth tickets in the DB that just deals with auth tickets and doesn't know anything about cookies. `pyramid-authsanity` can then use your `IAuthService` implementation to authenticate requests using different authentication sources: cookies, headers, etc. To that end, h actually [had an `AuthTicketService`](https://github.com/hypothesis/h/blob/df88e10c4e83275b066ea1d8e521843248ff2b4f/h/services/auth_ticket.py#L22-L109) that just dealt with auth tickets in the DB and didn't know anything about cookies. This was all changed in https://github.com/hypothesis/h/pull/6963 which changed `AuthTicketService` into an `AuthCookieService` that baked-in the fact the cookies, and only a single cookie, could be used for authentication. This PR changes it back to `AuthTicketService` and a more `pyramid-authsanity`-like design.

## Testing

Cookies and auth tickets are used to authenticate h's HTML pages and the new create-group page's API requests, so try logging in, visiting different HTML pages, and logging out. Also try [logging in](http://localhost:5000/login) as `devdata_admin`, going to <http://localhost:5000/admin/features> and enable the `preact_create_group_form` feature flag, then going to <http://localhost:5000/groups/new> and creating a new group.