### PR TITLE
Extract `AuthTicketCookieHelper` class

### DIFF
--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -1,13 +1,9 @@
-import base64
-from functools import lru_cache
-from os import urandom
-
-import webob
 from pyramid.security import Allowed, Denied
+from webob.cookies import SignedCookieProfile
 
 from h.security.identity import Identity
 from h.security.permits import identity_permits
-from h.services.auth_ticket import AuthTicketService
+from h.security.policy.helpers import AuthTicketCookieHelper
 
 
 class CookiePolicy:
@@ -18,32 +14,22 @@ class CookiePolicy:
     straps the login for the client (when the popup shows).
     """
 
-    def __init__(self, cookie: webob.cookies.SignedCookieProfile):
+    def __init__(self, cookie: SignedCookieProfile, helper: AuthTicketCookieHelper):
         self.cookie = cookie
+        self.helper = helper
 
     def identity(self, request):
-        self._add_vary_by_cookie(request)
-
-        userid, ticket_id = self._get_cookie_value()
-
-        user = request.find_service(AuthTicketService).verify_ticket(userid, ticket_id)
-
-        if (not user) or user.deleted:
-            return None
-
-        return Identity.from_models(user=user)
+        self.helper.add_vary_by_cookie(request)
+        return self.helper.identity(self.cookie, request)
 
     def authenticated_userid(self, request):
         return Identity.authenticated_userid(self.identity(request))
 
     def remember(self, request, userid, **kw):  # pylint:disable=unused-argument
-        """Get a list of headers which will remember the user in a cookie."""
-
-        self._add_vary_by_cookie(request)
+        self.helper.add_vary_by_cookie(request)
 
         previous_userid = self.authenticated_userid(request)
 
-        # Clear the previous session
         if previous_userid != userid:
             request.session.invalidate()
         else:
@@ -55,37 +41,11 @@ class CookiePolicy:
             request.session.update(data)
             request.session.new_csrf_token()
 
-        ticket_id = base64.urlsafe_b64encode(urandom(32)).rstrip(b"=").decode("ascii")
-        request.find_service(AuthTicketService).add_ticket(userid, ticket_id)
-        return self.cookie.get_headers([userid, ticket_id])
+        return self.helper.remember(self.cookie, request, userid)
 
     def forget(self, request):
-        """Get a list of headers which will delete appropriate cookies."""
-
-        self._add_vary_by_cookie(request)
-
-        # Clear the session by invalidating it
-        request.session.invalidate()
-
-        _, ticket_id = self._get_cookie_value()
-
-        if ticket_id:
-            request.find_service(AuthTicketService).remove_ticket(ticket_id)
-
-        return self.cookie.get_headers(None, max_age=0)
+        self.helper.add_vary_by_cookie(request)
+        return self.helper.forget(self.cookie, request)
 
     def permits(self, request, context, permission) -> Allowed | Denied:
         return identity_permits(self.identity(request), context, permission)
-
-    @staticmethod
-    @lru_cache  # Ensure we only add this once per request
-    def _add_vary_by_cookie(request):
-        def vary_add(request, response):  # pylint:disable=unused-argument
-            vary = set(response.vary if response.vary is not None else [])
-            vary.add("Cookie")
-            response.vary = list(vary)
-
-        request.add_response_callback(vary_add)
-
-    def _get_cookie_value(self):
-        return self.cookie.get_value() or (None, None)

--- a/h/security/policy/helpers.py
+++ b/h/security/policy/helpers.py
@@ -1,3 +1,56 @@
+from base64 import urlsafe_b64encode
+from functools import lru_cache
+from os import urandom
+
+from pyramid.request import Request
+from webob.cookies import SignedCookieProfile
+
+from h.security.identity import Identity
+from h.services.auth_ticket import AuthTicketService
+
+
 def is_api_request(request) -> bool:
     """Return True if `request` is an API request."""
     return bool(request.matched_route and request.matched_route.name.startswith("api."))
+
+
+class AuthTicketCookieHelper:
+    def identity(
+        self, cookie: SignedCookieProfile, request: Request
+    ) -> Identity | None:
+        userid, ticket_id = self.get_cookie_value(cookie)
+
+        user = request.find_service(AuthTicketService).verify_ticket(userid, ticket_id)
+
+        if (not user) or user.deleted:
+            return None
+
+        return Identity.from_models(user=user)
+
+    def remember(self, cookie: SignedCookieProfile, request: Request, userid: str):
+        ticket_id = urlsafe_b64encode(urandom(32)).rstrip(b"=").decode("ascii")
+        request.find_service(AuthTicketService).add_ticket(userid, ticket_id)
+        return cookie.get_headers([userid, ticket_id])
+
+    def forget(self, cookie: SignedCookieProfile, request: Request):
+        request.session.invalidate()
+        _, ticket_id = self.get_cookie_value(cookie)
+
+        if ticket_id:
+            request.find_service(AuthTicketService).remove_ticket(ticket_id)
+
+        return cookie.get_headers(None, max_age=0)
+
+    @staticmethod
+    @lru_cache  # Ensure we only add this once per request
+    def add_vary_by_cookie(request: Request):
+        def vary_add(request, response):  # pylint:disable=unused-argument
+            vary = set(response.vary if response.vary is not None else [])
+            vary.add("Cookie")
+            response.vary = list(vary)
+
+        request.add_response_callback(vary_add)
+
+    @staticmethod
+    def get_cookie_value(cookie: SignedCookieProfile):
+        return cookie.get_value() or (None, None)

--- a/h/security/policy/top_level.py
+++ b/h/security/policy/top_level.py
@@ -8,7 +8,7 @@ from h.security.policy._api_cookie import APICookiePolicy
 from h.security.policy._auth_client import AuthClientPolicy
 from h.security.policy._cookie import CookiePolicy
 from h.security.policy.bearer_token import BearerTokenPolicy
-from h.security.policy.helpers import is_api_request
+from h.security.policy.helpers import AuthTicketCookieHelper, is_api_request
 
 
 class TopLevelPolicy:
@@ -56,8 +56,8 @@ def get_subpolicy(request):
             [
                 BearerTokenPolicy(),
                 AuthClientPolicy(),
-                APICookiePolicy(CookiePolicy(cookie)),
+                APICookiePolicy(cookie, AuthTicketCookieHelper()),
             ]
         )
 
-    return CookiePolicy(cookie)
+    return CookiePolicy(cookie, AuthTicketCookieHelper())

--- a/tests/unit/h/security/policy/_cookie_test.py
+++ b/tests/unit/h/security/policy/_cookie_test.py
@@ -1,185 +1,82 @@
 from unittest.mock import create_autospec, sentinel
 
 import pytest
-import webob
-from h_matchers import Any
 
-from h.security.policy import _cookie
-from h.security.policy._cookie import CookiePolicy, base64
+from h.security.policy._cookie import CookiePolicy
+from h.security.policy.helpers import AuthTicketCookieHelper
 
 
-@pytest.mark.usefixtures("auth_ticket_service")
 class TestCookiePolicy:
-    def test_identity(
-        self, pyramid_request, auth_ticket_service, cookie_policy, user, Identity
-    ):
+    def test_identity(self, cookie_policy, helper, pyramid_request):
         identity = cookie_policy.identity(pyramid_request)
 
-        auth_ticket_service.verify_ticket.assert_called_once_with(
-            user.userid, sentinel.ticket_id
-        )
-        Identity.from_models.assert_called_once_with(
-            user=auth_ticket_service.verify_ticket.return_value
-        )
-        assert identity == Identity.from_models.return_value
-
-    def test_identity_when_user_marked_as_deleted(
-        self, pyramid_request, auth_ticket_service, cookie_policy
-    ):
-        auth_ticket_service.verify_ticket.return_value.deleted = True
-
-        assert cookie_policy.identity(pyramid_request) is None
-
-    def test_identity_with_no_auth_ticket(
-        self, pyramid_request, auth_ticket_service, cookie_policy
-    ):
-        auth_ticket_service.verify_ticket.return_value = None
-
-        assert cookie_policy.identity(pyramid_request) is None
+        helper.add_vary_by_cookie.assert_called_once_with(pyramid_request)
+        helper.identity.assert_called_once_with(sentinel.cookie, pyramid_request)
+        assert identity == helper.identity.return_value
 
     def test_authenticated_userid(
-        self, pyramid_request, cookie_policy, Identity, mocker
+        self, cookie_policy, helper, pyramid_request, Identity
     ):
-        mocker.spy(cookie_policy, "identity")
-
         authenticated_userid = cookie_policy.authenticated_userid(pyramid_request)
 
-        cookie_policy.identity.assert_called_once_with(pyramid_request)
+        helper.add_vary_by_cookie.assert_called_once_with(pyramid_request)
+        helper.identity.assert_called_once_with(sentinel.cookie, pyramid_request)
         Identity.authenticated_userid.assert_called_once_with(
-            cookie_policy.identity.spy_return
+            helper.identity.return_value
         )
         assert authenticated_userid == Identity.authenticated_userid.return_value
 
-    def test_remember(
-        self,
-        pyramid_request,
-        auth_ticket_service,
-        user,
-        cookie,
-        cookie_policy,
-        urlsafe_b64encode,
-        urandom,
-    ):
+    def test_remember(self, cookie_policy, helper, pyramid_request):
         pyramid_request.session["data"] = "old"
-        auth_ticket_service.verify_ticket.return_value = user
 
-        result = cookie_policy.remember(pyramid_request, sentinel.userid)
+        headers = cookie_policy.remember(pyramid_request, sentinel.userid, foo="bar")
 
-        # The `pyramid.testing.DummySession` is a dict so this is the closest
-        # we can get to saying it's been invalidated
         assert not pyramid_request.session
-        urandom.assert_called_once_with(32)
-        urlsafe_b64encode.assert_called_once_with(urandom.spy_return)
-        ticket_id = urlsafe_b64encode.spy_return.rstrip(b"=").decode("ascii")
-        auth_ticket_service.add_ticket.assert_called_once_with(
-            sentinel.userid, ticket_id
+        helper.remember.assert_called_once_with(
+            sentinel.cookie, pyramid_request, sentinel.userid
         )
-        cookie.get_headers.assert_called_once_with([sentinel.userid, ticket_id])
-        assert result == cookie.get_headers.return_value
+        assert headers == helper.remember.return_value
 
     def test_remember_with_existing_user(
-        self, pyramid_request, user, cookie_policy, Identity
+        self, cookie_policy, pyramid_request, factories, Identity
     ):
+        user = factories.User()
         pyramid_request.session["data"] = "old"
         # This is a secret parameter used by `pyramid.testing.DummySession`
         pyramid_request.session["_csrft_"] = "old_csrf_token"
         Identity.authenticated_userid.return_value = user.userid
 
-        cookie_policy.remember(pyramid_request, user.userid)
+        cookie_policy.remember(pyramid_request, user.userid, foo="bar")
 
         assert pyramid_request.session["data"] == "old"
         assert pyramid_request.session["_csrft_"] != "old_csrf_token"
 
-    def test_forget(self, pyramid_request, auth_ticket_service, cookie_policy, cookie):
-        pyramid_request.session["data"] = "old"
+    def test_forget(self, cookie_policy, helper, pyramid_request):
+        headers = cookie_policy.forget(pyramid_request)
 
-        result = cookie_policy.forget(pyramid_request)
+        helper.add_vary_by_cookie.assert_called_once_with(pyramid_request)
+        helper.forget.assert_called_once_with(sentinel.cookie, pyramid_request)
+        assert headers == helper.forget.return_value
 
-        # The `pyramid.testing.DummySession` is a dict so this is the closest
-        # we can get to saying it's been invalidated
-        assert not pyramid_request.session
-        auth_ticket_service.remove_ticket.assert_called_once_with(sentinel.ticket_id)
-        cookie.get_headers.assert_called_once_with(None, max_age=0)
-        assert result == cookie.get_headers.return_value
-
-    def test_forget_when_no_ticket_id_in_cookie(
-        self, auth_ticket_service, cookie, cookie_policy, pyramid_request
-    ):
-        cookie.get_value.return_value = None
-
-        result = cookie_policy.forget(pyramid_request)
-
-        assert not pyramid_request.session
-        auth_ticket_service.remove_ticket.assert_not_called()
-        cookie.get_headers.assert_called_once_with(None, max_age=0)
-        assert result == cookie.get_headers.return_value
-
-    def test_permits(self, cookie_policy, pyramid_request, mocker, identity_permits):
-        mocker.spy(cookie_policy, "identity")
-
-        result = cookie_policy.permits(
+    def test_permits(self, cookie_policy, helper, pyramid_request, identity_permits):
+        permits = cookie_policy.permits(
             pyramid_request, sentinel.context, sentinel.permission
         )
 
-        cookie_policy.identity.assert_called_once_with(pyramid_request)
+        helper.add_vary_by_cookie.assert_called_once_with(pyramid_request)
+        helper.identity.assert_called_once_with(sentinel.cookie, pyramid_request)
         identity_permits.assert_called_once_with(
-            cookie_policy.identity.spy_return, sentinel.context, sentinel.permission
+            helper.identity.return_value, sentinel.context, sentinel.permission
         )
-        assert result == identity_permits.return_value
-
-    @pytest.mark.parametrize(
-        "method,args",
-        (("identity", ()), ("remember", (sentinel.userid,)), ("forget", ())),
-    )
-    @pytest.mark.parametrize(
-        "vary,expected_vary",
-        (
-            (None, ["Cookie"]),
-            (["Cookie"], ["Cookie"]),
-            (["Other"], ["Cookie", "Other"]),
-        ),
-    )
-    def test_methods_add_vary_callback(
-        self, pyramid_request, method, args, vary, expected_vary, cookie_policy
-    ):
-        pyramid_request.response.vary = vary
-        getattr(cookie_policy, method)(pyramid_request, *args)
-
-        assert len(pyramid_request.response_callbacks) == 1
-        callback = pyramid_request.response_callbacks[0]
-
-        callback(pyramid_request, pyramid_request.response)
-
-        assert (
-            pyramid_request.response.vary
-            == Any.iterable.containing(expected_vary).only()
-        )
+        assert permits == identity_permits.return_value
 
     @pytest.fixture
-    def cookie(self, user):
-        cookie = create_autospec(
-            webob.cookies.SignedCookieProfile, instance=True, spec_set=True
-        )
-        cookie.get_value.return_value = (user.userid, sentinel.ticket_id)
-        return cookie
+    def helper(self):
+        return create_autospec(AuthTicketCookieHelper, instance=True, spec_set=True)
 
     @pytest.fixture
-    def cookie_policy(self, cookie):
-        return CookiePolicy(cookie)
-
-    @pytest.fixture
-    def user(self, factories):
-        return factories.User()
-
-
-@pytest.fixture(autouse=True)
-def urlsafe_b64encode(mocker):
-    return mocker.spy(base64, "urlsafe_b64encode")
-
-
-@pytest.fixture(autouse=True)
-def urandom(mocker):
-    return mocker.spy(_cookie, "urandom")
+    def cookie_policy(self, helper):
+        return CookiePolicy(sentinel.cookie, helper)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/h/security/policy/helpers_test.py
+++ b/tests/unit/h/security/policy/helpers_test.py
@@ -1,22 +1,138 @@
+from unittest.mock import create_autospec, sentinel
+
 import pytest
+from webob.cookies import SignedCookieProfile
 
-from h.security.policy.helpers import is_api_request
-
-
-@pytest.mark.parametrize(
-    "route_name,expected_result",
-    [
-        ("anything", False),
-        ("api.anything", True),
-    ],
-)
-def test_is_api_request(pyramid_request, route_name, expected_result):
-    pyramid_request.matched_route.name = route_name
-
-    assert is_api_request(pyramid_request) == expected_result
+from h.security.policy import helpers
+from h.security.policy.helpers import AuthTicketCookieHelper, is_api_request
 
 
-def test_is_api_request_when_matched_route_is_None(pyramid_request):
-    pyramid_request.matched_route = None
+class TestIsAPIRequest:
+    @pytest.mark.parametrize(
+        "route_name,expected_result",
+        [
+            ("anything", False),
+            ("api.anything", True),
+        ],
+    )
+    def test_it(self, pyramid_request, route_name, expected_result):
+        pyramid_request.matched_route.name = route_name
 
-    assert is_api_request(pyramid_request) is False
+        assert is_api_request(pyramid_request) == expected_result
+
+    def test_it_when_matched_route_is_None(self, pyramid_request):
+        pyramid_request.matched_route = None
+
+        assert is_api_request(pyramid_request) is False
+
+
+class TestAuthTicketCookieHelper:
+    def test_identity(
+        self, auth_ticket_service, cookie, helper, pyramid_request, Identity
+    ):
+        identity = helper.identity(cookie, pyramid_request)
+
+        auth_ticket_service.verify_ticket.assert_called_once_with(
+            sentinel.userid, sentinel.ticket_id
+        )
+        Identity.from_models.assert_called_once_with(
+            user=auth_ticket_service.verify_ticket.return_value
+        )
+        assert identity == Identity.from_models.return_value
+
+    def test_identity_when_no_user(
+        self, auth_ticket_service, cookie, helper, pyramid_request
+    ):
+        auth_ticket_service.verify_ticket.return_value = None
+
+        assert helper.identity(cookie, pyramid_request) is None
+
+    def test_identity_when_user_deleted(
+        self, auth_ticket_service, cookie, helper, pyramid_request
+    ):
+        auth_ticket_service.verify_ticket.return_value.deleted = True
+
+        assert helper.identity(cookie, pyramid_request) is None
+
+    def test_remember(
+        self, auth_ticket_service, cookie, helper, pyramid_request, mocker
+    ):
+        urandom = mocker.spy(helpers, "urandom")
+        urlsafe_b64encode = mocker.spy(helpers, "urlsafe_b64encode")
+
+        headers = helper.remember(cookie, pyramid_request, "test_userid")
+
+        urandom.assert_called_once_with(32)
+        urlsafe_b64encode.assert_called_once_with(urandom.spy_return)
+        ticket_id = urlsafe_b64encode.spy_return.rstrip(b"=").decode("ascii")
+        auth_ticket_service.add_ticket.assert_called_once_with("test_userid", ticket_id)
+        cookie.get_headers.assert_called_once_with(["test_userid", ticket_id])
+        assert headers == cookie.get_headers.return_value
+
+    def test_forget(self, auth_ticket_service, cookie, helper, pyramid_request):
+        headers = helper.forget(cookie, pyramid_request)
+
+        auth_ticket_service.remove_ticket.assert_called_once_with(sentinel.ticket_id)
+        cookie.get_headers.assert_called_once_with(None, max_age=0)
+        assert headers == cookie.get_headers.return_value
+
+    def test_forget_when_no_ticket_id(
+        self, auth_ticket_service, cookie, helper, pyramid_request
+    ):
+        cookie.get_value.return_value = None
+
+        headers = helper.forget(cookie, pyramid_request)
+
+        auth_ticket_service.remove_ticket.assert_not_called()
+        cookie.get_headers.assert_called_once_with(None, max_age=0)
+        assert headers == cookie.get_headers.return_value
+
+    @pytest.mark.parametrize(
+        "vary,expected_vary",
+        (
+            (None, ["Cookie"]),
+            (["Cookie"], ["Cookie"]),
+            (["Other"], ["Cookie", "Other"]),
+        ),
+    )
+    def test_add_vary_by_cookie(self, pyramid_request, vary, expected_vary):
+        pyramid_request.response.vary = vary
+
+        AuthTicketCookieHelper.add_vary_by_cookie(pyramid_request)
+
+        assert len(pyramid_request.response_callbacks) == 1
+        callback = pyramid_request.response_callbacks[0]
+        callback(pyramid_request, pyramid_request.response)
+        assert sorted(pyramid_request.response.vary) == sorted(expected_vary)
+
+    @pytest.mark.parametrize(
+        "value,expected_result",
+        [
+            (None, (None, None)),
+            (
+                (sentinel.userid, sentinel.ticket_id),
+                (sentinel.userid, sentinel.ticket_id),
+            ),
+        ],
+    )
+    def test_get_cookie_value(self, cookie, value, expected_result):
+        cookie.get_value.return_value = value
+
+        assert AuthTicketCookieHelper.get_cookie_value(cookie) == expected_result
+
+    @pytest.fixture
+    def cookie(self):
+        cookie = create_autospec(SignedCookieProfile, instance=True, spec_set=True)
+        cookie.get_value.return_value = (sentinel.userid, sentinel.ticket_id)
+        return cookie
+
+    @pytest.fixture
+    def helper(self):
+        return AuthTicketCookieHelper()
+
+
+@pytest.fixture(autouse=True)
+def Identity(mocker):
+    return mocker.patch(
+        "h.security.policy.helpers.Identity", autospec=True, spec_set=True
+    )


### PR DESCRIPTION
In a future PR (https://github.com/hypothesis/h/pull/8861) I want to evolve `CookiePolicy` and `APICookiePolicy` in separate directions. The code currently makes this difficult because `APICookiePolicy` is implemented by delegating method calls to `CookiePolicy`.

Also, it's weird for one security policy to use another security policy.

This PR extracts the shared code into a `AuthTicketCookieHelper` class that both `CookiePolicy` and `APICookiePolicy` call, so `CookiePolicy` and `APICookiePolicy` are now separate from each other and can be easily evolved in separate directions.

The design is based on [Pyramid's `AuthTktCookieHelper`](https://docs.pylonsproject.org/projects/pyramid/en/latest/api/authentication.html#pyramid.authentication.AuthTktCookieHelper) which is the normal and easy way to implement cookie-based authentication in Pyramid. For historical reasons h doesn't use `AuthTktCookieHelper`: a decision was made many years ago to use [pyramid-authsanity](https://pyramid-authsanity.readthedocs.io/) in h (I don't know why, but `pyramid-authsanity` does provide features like database-based auth tickets that may have attracted people). The `pyramid-authsanity` dependency was later removed and `pyramid-authsanity`'s code was copy-pasted into h instead, and then it was changed, resulting in h's current implementation of cookie auth: custom and vaguely `pyramid-authsanity`-like but different. I don't want to bite off the task of fixing h to just use Pyramid's built-in `AuthTktCookieHelper`. But this PR at least improves the design of h's cookie auth, making it more similar to how `AuthTktCookieHelper`-based auth would be, and enables the change I want to make in https://github.com/hypothesis/h/pull/8861.

## Testing

Cookies and auth tickets are used to authenticate h's HTML pages and the new create-group page's API requests, so try logging in, visiting different HTML pages, and logging out. Also try [logging in](http://localhost:5000/login) as `devdata_admin`, going to <http://localhost:5000/admin/features> and enable the `preact_create_group_form` feature flag, then going to <http://localhost:5000/groups/new> and creating a new group.