### PR TITLE
Require a CSRF token to use the API auth cookie

### DIFF
--- a/h/static/scripts/group-forms/components/CreateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateGroupForm.tsx
@@ -146,14 +146,14 @@ export default function CreateGroupForm() {
     setSaving(true);
 
     try {
-      response = (await callAPI(
-        config.api.createGroup.url,
-        config.api.createGroup.method,
-        {
+      response = (await callAPI(config.api.createGroup.url, {
+        method: config.api.createGroup.method,
+        headers: config.api.createGroup.headers,
+        json: {
           name,
           description,
         },
-      )) as CreateGroupAPIResponse;
+      })) as CreateGroupAPIResponse;
     } catch (apiError) {
       setErrorMessage(apiError.message);
       setSaving(false);

--- a/h/static/scripts/group-forms/components/test/CreateGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateGroupForm-test.js
@@ -8,6 +8,7 @@ const config = {
     createGroup: {
       method: 'POST',
       url: 'https://example.com/api/groups',
+      headers: { foo: 'bar' },
     },
   },
 };
@@ -209,14 +210,14 @@ describe('CreateGroupForm', () => {
     await wrapper.find('form[data-testid="form"]').simulate('submit');
 
     assert.isTrue(
-      fakeCallAPI.calledOnceWithExactly(
-        config.api.createGroup.url,
-        config.api.createGroup.method,
-        {
+      fakeCallAPI.calledOnceWithExactly(config.api.createGroup.url, {
+        method: config.api.createGroup.method,
+        headers: config.api.createGroup.headers,
+        json: {
           name,
           description,
         },
-      ),
+      }),
     );
     assert.isTrue(fakeSetLocation.calledOnceWithExactly(groupURL));
   });

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -1,6 +1,7 @@
 export type APIConfig = {
   method: string;
   url: string;
+  headers: object;
 };
 
 export type ConfigObject = {

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -45,15 +45,25 @@ export class APIError extends Error {
 /* Make an API call and return the parsed JSON body or throw APIError. */
 export async function callAPI(
   url: string,
-  method: string = 'GET',
-  json: object | undefined,
+  {
+    method = 'GET',
+    json = null,
+    headers = {},
+  }: {
+    method?: string;
+    json?: object | null;
+    headers?: any;
+  } = {},
 ): Promise<object> {
   const options: RequestInit = {
-    method: method,
-    headers: { 'Content-Type': 'application/json; charset=UTF-8' },
+    method,
+    headers: {
+      ...headers,
+      'Content-Type': 'application/json; charset=UTF-8',
+    },
   };
 
-  if (json !== undefined) {
+  if (json) {
     options.body = JSON.stringify(json);
   }
 

--- a/h/static/scripts/group-forms/utils/test/api-test.js
+++ b/h/static/scripts/group-forms/utils/test/api-test.js
@@ -37,7 +37,7 @@ describe('callAPI', () => {
     for (const method of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']) {
       context(`when the request method is ${method}`, () => {
         it('makes a request using the given method', async () => {
-          await callAPI(url, method);
+          await callAPI(url, { method });
 
           assert.equal(fakeFetch.lastCall.args[1].method, method);
         });
@@ -47,9 +47,18 @@ describe('callAPI', () => {
     it('makes a request with the given JSON body', async () => {
       const json = { foo: 'bar' };
 
-      await callAPI(url, 'POST', json);
+      await callAPI(url, { method: 'POST', json });
 
       assert.equal(fakeFetch.lastCall.args[1].body, JSON.stringify(json));
+    });
+
+    it('makes a request with the given headers', async () => {
+      const headers = { foo: 'bar' };
+
+      await callAPI(url, { method: 'POST', headers });
+
+      headers['Content-Type'] = 'application/json; charset=UTF-8';
+      assert.deepEqual(fakeFetch.lastCall.args[1].headers, headers);
     });
 
     it('returns the parsed JSON object', async () => {

--- a/h/templates/groups/create.html.jinja2
+++ b/h/templates/groups/create.html.jinja2
@@ -20,7 +20,10 @@
       "api": {
         "createGroup": {
           "method": "POST",
-          "url": "{{ request.route_url("api.groups") }}"
+          "url": "{{ request.route_url("api.groups") }}",
+          "headers": {
+            "X-CSRF-Token": "{{ get_csrf_token() }}"
+          }
         }
       }
     }

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -6,6 +6,7 @@ import colander
 import deform
 from markupsafe import Markup
 from pyramid import httpexceptions, security
+from pyramid.config import not_
 from pyramid.exceptions import BadCSRFToken
 from pyramid.view import view_config, view_defaults
 from sqlalchemy import func, select
@@ -50,6 +51,7 @@ def _login_redirect_url(request):
     context=BadCSRFToken,
     accept="text/html",
     renderer="h:templates/accounts/session_invalid.html.jinja2",
+    path_info=not_("/api"),
 )
 def bad_csrf_token_html(_context, request):
     request.response.status_code = 403

--- a/h/views/api/errors.py
+++ b/h/views/api/errors.py
@@ -7,6 +7,7 @@ API views.
 
 from h_api.exceptions import JSONAPIError
 from pyramid import httpexceptions
+from pyramid.exceptions import BadCSRFOrigin, BadCSRFToken
 from pyramid.view import forbidden_view_config, notfound_view_config, view_config
 
 from h.i18n import TranslationString as _
@@ -73,3 +74,21 @@ def json_error(context, request):  # pragma: no cover
         " if the problem persists."
     )
     return {"status": "failure", "reason": message}
+
+
+@json_view(context=BadCSRFOrigin, path_info="/api/", decorator=cors_policy)
+def bad_csrf_origin(request):
+    request.response.status_code = 400
+    return {
+        "status": "failure",
+        "reason": "CSRF validation failed: invalid Origin or Referrer.",
+    }
+
+
+@json_view(context=BadCSRFToken, path_info="/api/", decorator=cors_policy)
+def bad_csrf_token(request):
+    request.response.status_code = 400
+    return {
+        "status": "failure",
+        "reason": "CSRF validation failed: invalid or missing CSRF token.",
+    }

--- a/tests/unit/h/conftest.py
+++ b/tests/unit/h/conftest.py
@@ -168,6 +168,8 @@ def pyramid_request(db_session, db_session_replica, fake_feature, pyramid_settin
 def pyramid_csrf_request(pyramid_request):
     """Return a dummy Pyramid request object with a valid CSRF token."""
     pyramid_request.headers["X-CSRF-Token"] = pyramid_request.session.get_csrf_token()
+    pyramid_request.referrer = "https://example.com"
+    pyramid_request.host_port = "80"
     return pyramid_request
 
 

--- a/tests/unit/h/security/policy/_api_cookie_test.py
+++ b/tests/unit/h/security/policy/_api_cookie_test.py
@@ -1,6 +1,8 @@
 from unittest.mock import create_autospec, sentinel
 
 import pytest
+from pyramid.csrf import SessionCSRFStoragePolicy
+from pyramid.exceptions import BadCSRFOrigin, BadCSRFToken
 
 from h.security.policy._api_cookie import APICookiePolicy
 from h.security.policy.helpers import AuthTicketCookieHelper
@@ -17,41 +19,64 @@ class TestAPICookiePolicy:
         ],
     )
     def test_handles(
-        self, pyramid_request, route_name, request_method, expected_result
+        self, pyramid_csrf_request, route_name, request_method, expected_result
     ):
-        pyramid_request.matched_route.name = route_name
-        pyramid_request.method = request_method
+        pyramid_csrf_request.matched_route.name = route_name
+        pyramid_csrf_request.method = request_method
 
-        assert APICookiePolicy.handles(pyramid_request) == expected_result
+        assert APICookiePolicy.handles(pyramid_csrf_request) == expected_result
 
-    def test_identity(self, api_cookie_policy, helper, pyramid_request):
-        identity = api_cookie_policy.identity(pyramid_request)
+    def test_identity(self, api_cookie_policy, helper, pyramid_csrf_request):
+        identity = api_cookie_policy.identity(pyramid_csrf_request)
 
-        helper.add_vary_by_cookie.assert_called_once_with(pyramid_request)
-        helper.identity.assert_called_once_with(sentinel.cookie, pyramid_request)
+        helper.add_vary_by_cookie.assert_called_once_with(pyramid_csrf_request)
+        helper.identity.assert_called_once_with(sentinel.cookie, pyramid_csrf_request)
         assert identity == helper.identity.return_value
 
-    def test_authenticated_userid(
-        self, api_cookie_policy, helper, pyramid_request, Identity
+    def test_identity_with_no_auth_cookie(
+        self, api_cookie_policy, helper, pyramid_request
     ):
-        authenticated_userid = api_cookie_policy.authenticated_userid(pyramid_request)
+        helper.identity.return_value = None
 
-        helper.add_vary_by_cookie.assert_called_once_with(pyramid_request)
-        helper.identity.assert_called_once_with(sentinel.cookie, pyramid_request)
+        assert api_cookie_policy.identity(pyramid_request) is None
+
+    def test_identity_with_wrong_origin(self, api_cookie_policy, pyramid_csrf_request):
+        pyramid_csrf_request.referrer = "https://evil.com"
+
+        with pytest.raises(BadCSRFOrigin):
+            api_cookie_policy.identity(pyramid_csrf_request)
+
+    def test_identity_with_wrong_csrf_token(
+        self, api_cookie_policy, pyramid_csrf_request
+    ):
+        del pyramid_csrf_request.headers["X-CSRF-Token"]
+
+        with pytest.raises(BadCSRFToken):
+            api_cookie_policy.identity(pyramid_csrf_request)
+
+    def test_authenticated_userid(
+        self, api_cookie_policy, helper, pyramid_csrf_request, Identity
+    ):
+        authenticated_userid = api_cookie_policy.authenticated_userid(
+            pyramid_csrf_request
+        )
+
+        helper.add_vary_by_cookie.assert_called_once_with(pyramid_csrf_request)
+        helper.identity.assert_called_once_with(sentinel.cookie, pyramid_csrf_request)
         Identity.authenticated_userid.assert_called_once_with(
             helper.identity.return_value
         )
         assert authenticated_userid == Identity.authenticated_userid.return_value
 
     def test_permits(
-        self, api_cookie_policy, helper, pyramid_request, identity_permits
+        self, api_cookie_policy, helper, pyramid_csrf_request, identity_permits
     ):
         permits = api_cookie_policy.permits(
-            pyramid_request, sentinel.context, sentinel.permission
+            pyramid_csrf_request, sentinel.context, sentinel.permission
         )
 
-        helper.add_vary_by_cookie.assert_called_once_with(pyramid_request)
-        helper.identity.assert_called_once_with(sentinel.cookie, pyramid_request)
+        helper.add_vary_by_cookie.assert_called_once_with(pyramid_csrf_request)
+        helper.identity.assert_called_once_with(sentinel.cookie, pyramid_csrf_request)
         identity_permits.assert_called_once_with(
             helper.identity.return_value, sentinel.context, sentinel.permission
         )
@@ -78,3 +103,9 @@ def identity_permits(mocker):
     return mocker.patch(
         "h.security.policy._api_cookie.identity_permits", autospec=True, spec_set=True
     )
+
+
+@pytest.fixture(autouse=True)
+def pyramid_config(pyramid_config):
+    pyramid_config.set_csrf_storage_policy(SessionCSRFStoragePolicy())
+    return pyramid_config

--- a/tests/unit/h/views/api/errors_test.py
+++ b/tests/unit/h/views/api/errors_test.py
@@ -32,3 +32,23 @@ def test_json_error_view(patch, pyramid_request):
     handle_exception.assert_called_once_with(pyramid_request, exception)
     assert result["status"] == "failure"
     assert result["reason"]
+
+
+def test_bad_csrf_origin(pyramid_request):
+    result = views.bad_csrf_origin(pyramid_request)
+
+    assert pyramid_request.response.status_code == 400
+    assert result == {
+        "status": "failure",
+        "reason": "CSRF validation failed: invalid Origin or Referrer.",
+    }
+
+
+def test_bad_csrf_token(pyramid_request):
+    result = views.bad_csrf_token(pyramid_request)
+
+    assert pyramid_request.response.status_code == 400
+    assert result == {
+        "status": "failure",
+        "reason": "CSRF validation failed: invalid or missing CSRF token.",
+    }


### PR DESCRIPTION
Require any JSON API request authenticated with an API auth cookie to also have a valid CSRF token in an `X-CSRF-Token` header and to have the first-party domain in the `Referer` header.

This helps prevent CSRF attacks against any API endpoints that are authenticatable with API auth cookies.

Testing
=======

Visit <http://localhost:5000/groups/new> and test that you can successfully create a group.

The easiest way to test what happens if the request doesn't contain a valid CSRF token is to hack it to send an invalid one then try to create a group:

```diff
diff --git a/h/templates/groups/create.html.jinja2 b/h/templates/groups/create.html.jinja2
index 1d95d03a7..1c69ebb1d 100644
--- a/h/templates/groups/create.html.jinja2
+++ b/h/templates/groups/create.html.jinja2
@@ -12,7 +12,7 @@
           "method": "POST",
           "url": "{{ request.route_url("api.groups") }}",
           "headers": {
-            "X-CSRF-Token": "{{ get_csrf_token() }}"
+            "X-CSRF-Token": "invalid"
           }
         }
       }
```