### PR TITLE
Remove unused `AuthClientPolicy` methods

### DIFF
--- a/h/security/policy/_auth_client.py
+++ b/h/security/policy/_auth_client.py
@@ -1,14 +1,12 @@
 import hmac
 
 from pyramid.authentication import extract_http_basic_credentials
-from pyramid.security import Allowed, Denied
 from sqlalchemy.exc import StatementError
 
 from h.exceptions import InvalidUserId
 from h.models import AuthClient
 from h.models.auth_client import GrantType
 from h.security.identity import Identity
-from h.security.permits import identity_permits
 
 
 class AuthClientPolicy:
@@ -80,12 +78,6 @@ class AuthClientPolicy:
                 return None
 
         return Identity.from_models(auth_client=auth_client, user=user)
-
-    def authenticated_userid(self, request):
-        return Identity.authenticated_userid(self.identity(request))
-
-    def permits(self, request, context, permission) -> Allowed | Denied:
-        return identity_permits(self.identity(request), context, permission)
 
     @classmethod
     def _get_auth_client(cls, request):

--- a/tests/unit/h/security/policy/_auth_client_test.py
+++ b/tests/unit/h/security/policy/_auth_client_test.py
@@ -125,33 +125,6 @@ class TestAuthClientPolicy:
 
         assert AuthClientPolicy().identity(pyramid_request) is None
 
-    def test_authenticated_userid(self, pyramid_request, Identity):
-        pyramid_request.headers["X-Forwarded-User"] = sentinel.forwarded_user
-
-        authenticated_userid = AuthClientPolicy().authenticated_userid(pyramid_request)
-
-        Identity.authenticated_userid.assert_called_once_with(
-            Identity.from_models.return_value
-        )
-        assert authenticated_userid == Identity.authenticated_userid.return_value
-
-    def test_permits(self, pyramid_request, mocker, identity_permits):
-        auth_client_policy = AuthClientPolicy()
-        # pylint:disable=no-member
-        mocker.spy(auth_client_policy, "identity")
-
-        result = auth_client_policy.permits(
-            pyramid_request, sentinel.context, sentinel.permission
-        )
-
-        auth_client_policy.identity.assert_called_once_with(pyramid_request)
-        identity_permits.assert_called_once_with(
-            auth_client_policy.identity.spy_return,
-            sentinel.context,
-            sentinel.permission,
-        )
-        assert result == identity_permits.return_value
-
     @pytest.fixture
     def auth_client(self, factories):
         return factories.ConfidentialAuthClient(grant_type=GrantType.client_credentials)
@@ -180,11 +153,4 @@ class TestAuthClientPolicy:
 def Identity(mocker):
     return mocker.patch(
         "h.security.policy._auth_client.Identity", autospec=True, spec_set=True
-    )
-
-
-@pytest.fixture(autouse=True)
-def identity_permits(mocker):
-    return mocker.patch(
-        "h.security.policy._auth_client.identity_permits", autospec=True, spec_set=True
     )


### PR DESCRIPTION
Remove `AuthClientPolicy.authenticated_userid()` and `permits()`: these methods are unused.

`AuthClientPolicy` is only used by `APIPolicy` as one of its subpolicies and `APIPolicy` only calls the `handles()` and `identity()` methods of its subpolicies. `APIPolicy`'s `authenticated_userid()` and `permits()` methods work by calling `Identity.authenticated_userid()` and `identity_permits()`, they don't call the `authenticated_userid()` and `permits()` methods of subpolicies.

## Testing

`AuthClientPolicy` is what the LMS app uses, so just do some basic tests of the LMS app.