### PR TITLE
Remove unused `BearerTokenPolicy` methods

### DIFF
--- a/h/security/__init__.py
+++ b/h/security/__init__.py
@@ -10,11 +10,7 @@ from h.security.encryption import (  # noqa:F401
 from h.security.identity import Identity  # noqa:F401
 from h.security.permissions import Permission  # noqa:F401
 from h.security.permits import identity_permits
-from h.security.policy.top_level import BearerTokenPolicy, TopLevelPolicy
-
-# We export this for the websocket to use as it's main policy
-__all__ = ("BearerTokenPolicy",)
-
+from h.security.policy import StreamerPolicy, TopLevelPolicy
 
 log = logging.getLogger(__name__)
 

--- a/h/security/policy/__init__.py
+++ b/h/security/policy/__init__.py
@@ -1,2 +1,2 @@
-from h.security.policy.bearer_token import BearerTokenPolicy
+from h.security.policy.streamer import StreamerPolicy
 from h.security.policy.top_level import TopLevelPolicy

--- a/h/security/policy/_bearer_token.py
+++ b/h/security/policy/_bearer_token.py
@@ -1,8 +1,6 @@
 from pyramid.request import RequestLocalCache
-from pyramid.security import Allowed, Denied
 
 from h.security.identity import Identity
-from h.security.permits import identity_permits
 from h.security.policy.helpers import is_api_request
 
 
@@ -37,12 +35,6 @@ class BearerTokenPolicy:
         """
 
         return self._identity_cache.get_or_create(request)
-
-    def authenticated_userid(self, request):
-        return Identity.authenticated_userid(self.identity(request))
-
-    def permits(self, request, context, permission) -> Allowed | Denied:
-        return identity_permits(self.identity(request), context, permission)
 
     def _load_identity(self, request):
         token_svc = request.find_service(name="auth_token")

--- a/h/security/policy/streamer.py
+++ b/h/security/policy/streamer.py
@@ -1,0 +1,25 @@
+from h.security.identity import Identity
+from h.security.permits import identity_permits
+from h.security.policy._bearer_token import BearerTokenPolicy
+
+
+class StreamerPolicy:
+    """The Pyramid security policy for the separate "streamer" app."""
+
+    def __init__(self):
+        self._bearer_token_policy = BearerTokenPolicy()
+
+    def forget(self, *_args, **_kwargs):
+        return []
+
+    def identity(self, *args, **kwargs):
+        return self._bearer_token_policy.identity(*args, **kwargs)
+
+    def authenticated_userid(self, request):
+        return Identity.authenticated_userid(self.identity(request))
+
+    def remember(self, *_args, **_kwargs):
+        return []
+
+    def permits(self, request, context, permission):
+        return identity_permits(self.identity(request), context, permission)

--- a/h/security/policy/top_level.py
+++ b/h/security/policy/top_level.py
@@ -6,8 +6,8 @@ from h.security.identity import Identity
 from h.security.policy._api import APIPolicy
 from h.security.policy._api_cookie import APICookiePolicy
 from h.security.policy._auth_client import AuthClientPolicy
+from h.security.policy._bearer_token import BearerTokenPolicy
 from h.security.policy._cookie import CookiePolicy
-from h.security.policy.bearer_token import BearerTokenPolicy
 from h.security.policy.helpers import AuthTicketCookieHelper, is_api_request
 
 

--- a/h/streamer/app.py
+++ b/h/streamer/app.py
@@ -1,7 +1,7 @@
 import pyramid
 
 from h.config import configure
-from h.security import BearerTokenPolicy
+from h.security import StreamerPolicy
 from h.sentry_filters import SENTRY_FILTERS
 
 
@@ -12,7 +12,7 @@ def create_app(_global_config, **settings):
 
     config.include("h.security")
     # Override the default authentication policy.
-    config.set_security_policy(BearerTokenPolicy())
+    config.set_security_policy(StreamerPolicy())
 
     config.include("h.db")
     config.include("h.session")

--- a/tests/unit/h/security/policy/_bearer_token_test.py
+++ b/tests/unit/h/security/policy/_bearer_token_test.py
@@ -2,7 +2,7 @@ from unittest.mock import sentinel
 
 import pytest
 
-from h.security.policy.bearer_token import BearerTokenPolicy
+from h.security.policy._bearer_token import BearerTokenPolicy
 
 
 @pytest.mark.usefixtures("user_service", "auth_token_service")
@@ -87,46 +87,14 @@ class TestBearerTokenPolicy:
 
         assert BearerTokenPolicy().identity(pyramid_request) is None
 
-    def test_authenticated_userid(self, pyramid_request, Identity):
-        authenticated_userid = BearerTokenPolicy().authenticated_userid(pyramid_request)
-
-        Identity.authenticated_userid.assert_called_once_with(
-            Identity.from_models.return_value
-        )
-        assert authenticated_userid == Identity.authenticated_userid.return_value
-
-    def test_permits(self, pyramid_request, mocker, identity_permits):
-        bearer_token_policy = BearerTokenPolicy()
-        # pylint:disable=no-member
-        mocker.spy(bearer_token_policy, "identity")
-
-        result = bearer_token_policy.permits(
-            pyramid_request, sentinel.context, sentinel.permission
-        )
-
-        bearer_token_policy.identity.assert_called_once_with(pyramid_request)
-        identity_permits.assert_called_once_with(
-            bearer_token_policy.identity.spy_return,
-            sentinel.context,
-            sentinel.permission,
-        )
-        assert result == identity_permits.return_value
-
 
 @pytest.fixture(autouse=True)
 def is_api_request(mocker):
-    return mocker.patch("h.security.policy.bearer_token.is_api_request", autospec=True)
+    return mocker.patch("h.security.policy._bearer_token.is_api_request", autospec=True)
 
 
 @pytest.fixture(autouse=True)
 def Identity(mocker):
     return mocker.patch(
-        "h.security.policy.bearer_token.Identity", autospec=True, spec_set=True
-    )
-
-
-@pytest.fixture(autouse=True)
-def identity_permits(mocker):
-    return mocker.patch(
-        "h.security.policy.bearer_token.identity_permits", autospec=True, spec_set=True
+        "h.security.policy._bearer_token.Identity", autospec=True, spec_set=True
     )

--- a/tests/unit/h/security/policy/streamer_test.py
+++ b/tests/unit/h/security/policy/streamer_test.py
@@ -1,0 +1,77 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from h.security.policy.streamer import StreamerPolicy
+
+
+class TestStreamerPolicy:
+    def test_forget(self, streamer_policy, pyramid_request):
+        assert streamer_policy.forget(pyramid_request, foo="bar") == []
+
+    def test_identity(self, bearer_token_policy, streamer_policy, pyramid_request):
+        identity = streamer_policy.identity(pyramid_request)
+
+        bearer_token_policy.identity.assert_called_once_with(pyramid_request)
+        assert identity == bearer_token_policy.identity.return_value
+
+    def test_authenticated_userid(
+        self, bearer_token_policy, streamer_policy, pyramid_request, Identity
+    ):
+        authenticated_userid = streamer_policy.authenticated_userid(pyramid_request)
+
+        bearer_token_policy.identity.assert_called_once_with(pyramid_request)
+        Identity.authenticated_userid.assert_called_once_with(
+            bearer_token_policy.identity.return_value
+        )
+        assert authenticated_userid == Identity.authenticated_userid.return_value
+
+    def test_remember(self, streamer_policy, pyramid_request):
+        assert (
+            streamer_policy.remember(pyramid_request, sentinel.userid, foo="bar") == []
+        )
+
+    def test_permits(
+        self, bearer_token_policy, streamer_policy, identity_permits, pyramid_request
+    ):
+        permits = streamer_policy.permits(
+            pyramid_request, sentinel.context, sentinel.permission
+        )
+
+        bearer_token_policy.identity.assert_called_once_with(pyramid_request)
+        identity_permits.assert_called_once_with(
+            bearer_token_policy.identity.return_value,
+            sentinel.context,
+            sentinel.permission,
+        )
+        assert permits == identity_permits.return_value
+
+    @pytest.fixture
+    def streamer_policy(self):
+        return StreamerPolicy()
+
+
+@pytest.fixture
+def bearer_token_policy(BearerTokenPolicy):
+    return BearerTokenPolicy.return_value
+
+
+@pytest.fixture(autouse=True)
+def BearerTokenPolicy(mocker):
+    return mocker.patch(
+        "h.security.policy.streamer.BearerTokenPolicy", autospec=True, spec_set=True
+    )
+
+
+@pytest.fixture(autouse=True)
+def Identity(mocker):
+    return mocker.patch(
+        "h.security.policy.streamer.Identity", autospec=True, spec_set=True
+    )
+
+
+@pytest.fixture(autouse=True)
+def identity_permits(mocker):
+    return mocker.patch(
+        "h.security.policy.streamer.identity_permits", autospec=True, spec_set=True
+    )


### PR DESCRIPTION
`BearerTokenPolicy` is currently used in two contexts:

1. For API requests `BearerTokenPolicy` is used as one of `APIPolicy`'s subpolicies.
   
2. `BearerTokenPolicy` is also used as the Pyramid security policy for the separate streamer (WebSocket) app.
   There are two problems with this:

1. In the context of API requests `BearerTokenPolicy`'s `authenticated_userid()` and `permits()` methods aren't used: `APIPolicy.authenticated_userid()` and `APIPolicy.permits()` don't delegate to the `authenticated_userid()` and `permits()` methods of subpolicies. This is confusing: I could imagine someone making a change to `BearerTokenPolicy.authenticated_userid()` or `BearerTokenPolicy.permits()` and assuming the change would be effective for API requests but in fact these methods aren't called.

2. In the context of WebSocket requests `BearerTokenPolicy` is used as the Pyramid security policy but doesn't implement all of the required `ISecurityPolicy` interface: it's missing the `remember()` and `forget()` methods.

This commit removes `BearerTokenPolicy.authenticated_userid()` and `BearerTokenPolicy.permits()` so `BearerTokenPolicy` now only provides the methods that `APIPolicy` calls: `handles()` and `identity()`.

This commit then adds a new `StreamerPolicy` class that's used as the Pyramid security policy for the separate streamer app. `StreamerPolicy` delegates to `BearerTokenPolicy` for the `identity()` method and provides its own implementations for the rest of `ISecurityPolicy`'s methods.
