### PR TITLE
Log a message when issuing a missing API cookie

### DIFF
--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -1,9 +1,13 @@
+import logging
+
 from pyramid.security import Allowed, Denied
 from webob.cookies import SignedCookieProfile
 
 from h.security.identity import Identity
 from h.security.permits import identity_permits
 from h.security.policy.helpers import AuthTicketCookieHelper
+
+log = logging.getLogger(__name__)
 
 
 class CookiePolicy:
@@ -108,6 +112,7 @@ class CookiePolicy:
             request,  # pylint:disable=unused-argument
             response,
         ):
+            log.info("Fixing missing API auth cookie")
             for key, value in headers:
                 response.headerlist.append((key, value))
 


### PR DESCRIPTION
Log a message when we issue an API auth cookie because we received a
request that was authenticated with an HTML auth cookie but which was
missing an API auth cookie.

The log message will enable us to know whether the code for detecting
and fixing this situation (HTML auth cookie but no API one) is necessary
to keep around or not.
