### PR TITLE
Refactor group API schema tests

### DIFF
--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -90,7 +90,7 @@ class GroupAPISchema(JSONSchema):
                 # pylint:disable=consider-using-f-string
                 "{err_msg} '{authority}'".format(
                     err_msg=_(
-                        "groupid may only be set on groups oustide of the default authority"
+                        "groupid may only be set on groups outside of the default authority"
                     ),
                     authority=self.default_authority,
                 )


### PR DESCRIPTION
Instead of lots of separate tests have two parametrized tests `test_valid()` and `test_invalid()`. This reduces the chances of test mistakes (e.g. forgetting to assert the specific error message) by reducing test code duplication. This should also make the tests easier to change in a future PR (see https://github.com/hypothesis/h/pull/8891/commits/9c10fe500b1270c845083224933688e978c9cbf2).

The new tests cover all the same cases as the previous ones, plus a couple more.

Also corrected a typo in an error message.
