### PR TITLE
Group API `type` param 4/n: add `type` param to group create, update and upsert APIs

### DIFF
--- a/docs/_extra/api-reference/schemas/group-new.yaml
+++ b/docs/_extra/api-reference/schemas/group-new.yaml
@@ -10,6 +10,10 @@ Group:
       type: string
       description: group description
       maxLength: 250
+    type:
+      type: string
+      enum: [private, restricted, open]
+      default: private
     groupid:
       type: string
       pattern: "group:[a-zA-Z0-9._\\-+!~*()']{1,1024}@.*$"

--- a/docs/_extra/api-reference/schemas/group-update.yaml
+++ b/docs/_extra/api-reference/schemas/group-update.yaml
@@ -10,6 +10,10 @@ Group:
       type: string
       description: group description
       maxLength: 250
+    type:
+      type: string
+      enum: [private, restricted, open]
+      default: private
     groupid:
       type: string
       pattern: "group:[a-zA-Z0-9._\\-+!~*()']{1,1024}@.*$"

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -17,6 +17,7 @@ GROUP_SCHEMA_PROPERTIES = {
     },
     "description": {"type": "string", "maxLength": GROUP_DESCRIPTION_MAX_LENGTH},
     "groupid": {"type": "string", "pattern": GROUPID_PATTERN},
+    "type": {"enum": ["private", "restricted", "open"]},
 }
 
 

--- a/tests/unit/h/schemas/api/group_test.py
+++ b/tests/unit/h/schemas/api/group_test.py
@@ -40,6 +40,21 @@ class TestGroupAPISchema:
                 {"groupid": "group:1234abcd!~*()@thirdparty.com"},
                 {"groupid": "group:1234abcd!~*()@thirdparty.com"},
             ),
+            (  # Valid type.
+                DEFAULT_AUTHORITY,
+                {"type": "private"},
+                {"type": "private"},
+            ),
+            (  # Valid type.
+                DEFAULT_AUTHORITY,
+                {"type": "restricted"},
+                {"type": "restricted"},
+            ),
+            (  # Valid type.
+                DEFAULT_AUTHORITY,
+                {"type": "open"},
+                {"type": "open"},
+            ),
             (  # All valid fields at once.
                 "thirdparty.com",
                 {
@@ -146,6 +161,18 @@ class TestGroupAPISchema:
                 "thirdparty.com",
                 {"groupid": 42},
                 "groupid: 42 is not of type 'string'",
+            ),
+            (
+                # type not a string.
+                DEFAULT_AUTHORITY,
+                {"type": 42},
+                r"type: 42 is not one of \['private', 'restricted', 'open'\]",
+            ),
+            (
+                # Invalid type.
+                DEFAULT_AUTHORITY,
+                {"type": "invalid"},
+                r"type: 'invalid' is not one of \['private', 'restricted', 'open'\]",
             ),
         ],
     )

--- a/tests/unit/h/views/api/groups_test.py
+++ b/tests/unit/h/views/api/groups_test.py
@@ -92,7 +92,11 @@ class TestCreate:
         "appstruct,group_create_service_method_call",
         [
             (
-                {"name": sentinel.name, "description": sentinel.description},
+                {
+                    "name": sentinel.name,
+                    "description": sentinel.description,
+                    "type": "private",
+                },
                 call.create_private_group(
                     name=sentinel.name,
                     userid=sentinel.userid,
@@ -128,6 +132,100 @@ class TestCreate:
         assert_it_returns_group_as_json(
             response,
             group=group_create_service.create_private_group.return_value,
+        )
+
+    @pytest.mark.parametrize(
+        "appstruct,group_create_service_method_call",
+        [
+            (
+                {
+                    "name": sentinel.name,
+                    "description": sentinel.description,
+                    "type": "restricted",
+                },
+                call.create_restricted_group(
+                    name=sentinel.name,
+                    userid=sentinel.userid,
+                    scopes=[],
+                    description=sentinel.description,
+                    groupid=None,
+                ),
+            ),
+            (
+                {"name": sentinel.name, "type": "restricted"},
+                call.create_restricted_group(
+                    name=sentinel.name,
+                    userid=sentinel.userid,
+                    scopes=[],
+                    description=None,
+                    groupid=None,
+                ),
+            ),
+        ],
+    )
+    def test_create_restricted_group(
+        self,
+        pyramid_request,
+        CreateGroupAPISchema,
+        group_create_service,
+        assert_it_returns_group_as_json,
+        appstruct,
+        group_create_service_method_call,
+    ):
+        CreateGroupAPISchema.return_value.validate.return_value = appstruct
+
+        response = views.create(pyramid_request)
+
+        assert group_create_service.method_calls == [group_create_service_method_call]
+        assert_it_returns_group_as_json(
+            response, group=group_create_service.create_restricted_group.return_value
+        )
+
+    @pytest.mark.parametrize(
+        "appstruct,group_create_service_method_call",
+        [
+            (
+                {
+                    "name": sentinel.name,
+                    "description": sentinel.description,
+                    "type": "open",
+                },
+                call.create_open_group(
+                    name=sentinel.name,
+                    userid=sentinel.userid,
+                    scopes=[],
+                    description=sentinel.description,
+                    groupid=None,
+                ),
+            ),
+            (
+                {"name": sentinel.name, "type": "open"},
+                call.create_open_group(
+                    name=sentinel.name,
+                    userid=sentinel.userid,
+                    scopes=[],
+                    description=None,
+                    groupid=None,
+                ),
+            ),
+        ],
+    )
+    def test_create_open_group(
+        self,
+        pyramid_request,
+        CreateGroupAPISchema,
+        group_create_service,
+        assert_it_returns_group_as_json,
+        appstruct,
+        group_create_service_method_call,
+    ):
+        CreateGroupAPISchema.return_value.validate.return_value = appstruct
+
+        response = views.create(pyramid_request)
+
+        assert group_create_service.method_calls == [group_create_service_method_call]
+        assert_it_returns_group_as_json(
+            response, group=group_create_service.create_open_group.return_value
         )
 
     def test_it_with_groupid_request_param(
@@ -231,15 +329,23 @@ class TestUpdate:
                 {"description": sentinel.description},
                 call.update(sentinel.group, description=sentinel.description),
             ),
+            ({"type": "private"}, call.update(sentinel.group, type="private")),
             (
-                {"name": sentinel.name, "description": sentinel.description},
+                {
+                    "name": sentinel.name,
+                    "description": sentinel.description,
+                    "type": "private",
+                },
                 call.update(
-                    sentinel.group, name=sentinel.name, description=sentinel.description
+                    sentinel.group,
+                    name=sentinel.name,
+                    description=sentinel.description,
+                    type="private",
                 ),
             ),
         ],
     )
-    def test_update_private_group(
+    def test_update(
         self,
         context,
         pyramid_request,
@@ -361,6 +467,7 @@ class TestUpsert:
                     name=sentinel.name,
                     description="",
                     groupid=None,
+                    type="private",
                 ),
             ),
             (
@@ -370,11 +477,32 @@ class TestUpsert:
                     name=sentinel.name,
                     description=sentinel.description,
                     groupid=None,
+                    type="private",
+                ),
+            ),
+            (
+                {"name": sentinel.name, "type": "restricted"},
+                call.update(
+                    sentinel.group,
+                    name=sentinel.name,
+                    description="",
+                    groupid=None,
+                    type="restricted",
+                ),
+            ),
+            (
+                {"name": sentinel.name, "type": "open"},
+                call.update(
+                    sentinel.group,
+                    name=sentinel.name,
+                    description="",
+                    groupid=None,
+                    type="open",
                 ),
             ),
         ],
     )
-    def test_update_private_group(
+    def test_it_updates_an_existing_group(
         self,
         context,
         pyramid_request,
@@ -587,10 +715,7 @@ def CreateGroupAPISchema(mocker):
     CreateGroupAPISchema = mocker.patch(
         "h.views.api.groups.CreateGroupAPISchema", autospec=True, spec_set=True
     )
-    CreateGroupAPISchema.return_value.validate.return_value = {
-        "name": sentinel.name,
-        "description": sentinel.description,
-    }
+    CreateGroupAPISchema.return_value.validate.return_value = {"name": sentinel.name}
     return CreateGroupAPISchema
 
 
@@ -599,10 +724,7 @@ def UpdateGroupAPISchema(mocker):
     UpdateGroupAPISchema = mocker.patch(
         "h.views.api.groups.UpdateGroupAPISchema", autospec=True, spec_set=True
     )
-    UpdateGroupAPISchema.return_value.validate.return_value = {
-        "name": sentinel.name,
-        "description": sentinel.description,
-    }
+    UpdateGroupAPISchema.return_value.validate.return_value = {}
     return UpdateGroupAPISchema
 
 


### PR DESCRIPTION
Fixes https://github.com/hypothesis/h/issues/8896.

This adds a new `type` parameter to h's [create-group](https://h.readthedocs.io/en/latest/api-reference/v2/#tag/groups/paths/~1groups/post), [update-group](https://h.readthedocs.io/en/latest/api-reference/v2/#tag/groups/paths/~1groups~1{id}/patch) and [upsert-group](https://h.readthedocs.io/en/latest/api-reference/v2/#tag/groups/paths/~1groups~1{id}/put) APIs.

The type parameter is optional and defaults to `private`, so existing API calls that don't include the `type` parameter will continue to behave the same.

The group objects in responses from these APIs already include the group's `type` property, so I didn't have to make any changes to the API responses.

## Testing

### Testing the docs changes

Run `make docs`. You should see the new `type` parameter documented for the group create, update and upsert APIs in both v1 and v2 of the API:

* http://localhost:8000/api-reference/v1/#tag/groups/paths/~1groups/post
* http://localhost:8000/api-reference/v1/#tag/groups/paths/~1groups~1{id}/patch
* http://localhost:8000/api-reference/v1/#tag/groups/paths/~1groups~1{id}/put
* http://localhost:8000/api-reference/v2/#tag/groups/paths/~1groups/post
* http://localhost:8000/api-reference/v2/#tag/groups/paths/~1groups~1{id}/patch
* http://localhost:8000/api-reference/v2/#tag/groups/paths/~1groups~1{id}/put

### Creating and updating groups with the UI

Go to <http://localhost:5000/groups/new> and create a new group. Then click on **Edit group** and update the group. (You can only create/update private groups with the UI, the open and restricted options haven't been added yet.)

### Creating and updating groups with the API

Try the various ways of calling the create/update/upsert group APIs, and look closely at the API responses to make sure the created/updated groups have all the properties you expect.

Create a group with no `type` parameter, it'll default to `private`:

```
$ http --body POST 'http://localhost:5000/api/groups' Authorization:'Bearer 6879-***' name='Test Private Group 1'
{
    "groupid": null,
    "id": "Y23YQbbN",
    "links": {
        "html": "http://localhost:5000/groups/Y23YQbbN/test-private-group-1"
    },
    "name": "Test Private Group 1",
    "organization": null,
    "public": false,
    "scoped": false,
    "scopes": {
        "enforced": false,
        "uri_patterns": []
    },
    "type": "private"
}

```

Create a private group with the `type` parameter:

```
$ http --body POST 'http://localhost:5000/api/groups' Authorization:'Bearer 6879-***' name='Test Private Group 2' type=private
{
    "groupid": null,
    "id": "ReBaN7gW",
    "links": {
        "html": "http://localhost:5000/groups/ReBaN7gW/test-private-group-2"
    },
    "name": "Test Private Group 2",
    "organization": null,
    "public": false,
    "scoped": false,
    "scopes": {
        "enforced": false,
        "uri_patterns": []
    },
    "type": "private"
}

```

Create a restricted group:

```
$ http --body POST 'http://localhost:5000/api/groups' Authorization:'Bearer 6879-***' name='Test Restricted Group' type=restricted
{
    "groupid": null,
    "id": "qyJz3ybJ",
    "links": {
        "html": "http://localhost:5000/groups/qyJz3ybJ/test-restricted-group"
    },
    "name": "Test Restricted Group",
    "organization": null,
    "public": true,
    "scoped": false,
    "scopes": {
        "enforced": false,
        "uri_patterns": []
    },
    "type": "restricted"
}
```

Create an open group:

```
$ http --body POST 'http://localhost:5000/api/groups' Authorization:'Bearer 6879-***' name='Test Open Group' type=open
{
    "groupid": null,
    "id": "iMWNBx9Z",
    "links": {
        "html": "http://localhost:5000/groups/iMWNBx9Z/test-open-group"
    },
    "name": "Test Open Group",
    "organization": null,
    "public": true,
    "scoped": false,
    "scopes": {
        "enforced": false,
        "uri_patterns": []
    },
    "type": "open"
}
```

Change the type of an existing group:

```
$ http --body PATCH 'http://localhost:5000/api/groups/ID' Authorization:'Bearer 6879-***' type=restricted
```

Create a group using the upsert API with no `type`, it'll default to private:

```
$ http --body PUT 'http://localhost:5000/api/groups/CUSTOM_ID_THIS_WILL_BE_IGNORED' Authorization:'Bearer 6879-***' name='Upserted Group'
{
    "groupid": null,
    "id": "28nVMW42",
    "links": {
        "html": "http://localhost:5000/groups/28nVMW42/upserted-group"
    },
    "name": "Upserted Group",
    "organization": null,
    "public": false,
    "scoped": false,
    "scopes": {
        "enforced": false,
        "uri_patterns": []
    },
    "type": "private"
}
```

Upsert with `type`:

```
$ http --body PUT 'http://localhost:5000/api/groups/CUSTOM_ID_THIS_WILL_BE_IGNORED' Authorization:'Bearer 6879-***' name='Upserted Private Group' type=private
{
    "groupid": null,
    "id": "LieP21M5",
    "links": {
        "html": "http://localhost:5000/groups/LieP21M5/upserted-private-group"
    },
    "name": "Upserted Private Group",
    "organization": null,
    "public": false,
    "scoped": false,
    "scopes": {
        "enforced": false,
        "uri_patterns": []
    },
    "type": "private"
}


$ http --body PUT 'http://localhost:5000/api/groups/CUSTOM_ID_THIS_WILL_BE_IGNORED' Authorization:'Bearer 6879-***' name='Upserted Open Group' type=open
{
    "groupid": null,
    "id": "QkL3wkGM",
    "links": {
        "html": "http://localhost:5000/groups/QkL3wkGM/upserted-open-group"
    },
    "name": "Upserted Open Group",
    "organization": null,
    "public": true,
    "scoped": false,
    "scopes": {
        "enforced": false,
        "uri_patterns": []
    },
    "type": "open"
}


$ http --body PUT 'http://localhost:5000/api/groups/CUSTOM_ID_THIS_WILL_BE_IGNORED' Authorization:'Bearer 6879-***' name='Upserted Restriced Group' type=restricted
{
    "groupid": null,
    "id": "26q6gDx4",
    "links": {
        "html": "http://localhost:5000/groups/26q6gDx4/upserted-restriced-group"
    },
    "name": "Upserted Restriced Group",
    "organization": null,
    "public": true,
    "scoped": false,
    "scopes": {
        "enforced": false,
        "uri_patterns": []
    },
    "type": "restricted"
}
```

Use the upsert API to update the type of a group. You need to put the ID from the API response in the URL. Note that the `name` field is required when using the upsert API to update a group:

```
$ http --body PUT 'http://localhost:5000/api/groups/ID' Authorization:'Bearer 6879-***' name=Foo type=open
$ http --body PUT 'http://localhost:5000/api/groups/ID' Authorization:'Bearer 6879-***' name=Foo type=restriced
$ http --body PUT 'http://localhost:5000/api/groups/ID' Authorization:'Bearer 6879-***' name=Foo type=private
```

