### PR TITLE
Make save state icon accessible

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -2,15 +2,14 @@ import { useEffect, useId, useMemo, useState } from 'preact/hooks';
 
 import {
   Button,
-  CheckIcon,
   CancelIcon,
   Input,
-  Spinner,
   Textarea,
 } from '@hypothesis/frontend-shared';
 import { readConfig } from '../config';
 import { callAPI, CreateUpdateGroupAPIResponse } from '../utils/api';
 import { setLocation } from '../utils/set-location';
+import SaveStateIcon from './SaveStateIcon';
 
 function Star() {
   return <span className="text-brand">*</span>;
@@ -254,8 +253,9 @@ export default function CreateEditGroupForm() {
             </div>
           )}
           <div className="grow" />
-          {saving && <Spinner data-testid="spinner" />}
-          {saved && <CheckIcon data-testid="check" />}
+          <SaveStateIcon
+            state={saving ? 'saving' : saved ? 'saved' : 'unsaved'}
+          />
           <Button
             type="submit"
             variant="primary"

--- a/h/static/scripts/group-forms/components/SaveStateIcon.tsx
+++ b/h/static/scripts/group-forms/components/SaveStateIcon.tsx
@@ -1,0 +1,29 @@
+import { SpinnerSpokesIcon, CheckIcon } from '@hypothesis/frontend-shared';
+
+export type SaveStateIconProps = {
+  state: 'unsaved' | 'saving' | 'saved';
+};
+
+/**
+ * An accessible save status icon.
+ *
+ * This can be in one of three states, set via the `state` prop:
+ *
+ *  - "unsaved" - There are no changes, or the changes are unsaved
+ *  - "saving" - Changes are currently being saved
+ *  - "saved" - Changes were successfully saved
+ */
+export default function SaveStateIcon({ state }: SaveStateIconProps) {
+  return (
+    <div role="status">
+      {state === 'saving' && (
+        // We use the `SpinnerSpokesIcon` component rather than `Spinner`
+        // because `Spinner` doesn't currently support aria-label. Also we want
+        // this component to have the same layout in the saving and saved
+        // states.
+        <SpinnerSpokesIcon aria-label="Saving changes..." />
+      )}
+      {state === 'saved' && <CheckIcon aria-label="Changes saved" />}
+    </div>
+  );
+}

--- a/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
@@ -377,9 +377,14 @@ async function assertInLoadingState(wrapper, inLoadingState) {
     wrapper,
     `button[data-testid="button"][disabled=${inLoadingState}]`,
   );
-  assert.equal(wrapper.exists('[data-testid="spinner"]'), inLoadingState);
+  const state = wrapper.find('SaveStateIcon').prop('state');
+  if (inLoadingState) {
+    assert.equal(state, 'saving');
+  } else {
+    assert.notEqual(state, 'saving');
+  }
 }
 
 function savedConfirmationShowing(wrapper) {
-  return wrapper.exists('[data-testid="check"]');
+  return wrapper.find('SaveStateIcon').prop('state') === 'saved';
 }

--- a/h/static/scripts/group-forms/components/test/SaveStateIcon-test.js
+++ b/h/static/scripts/group-forms/components/test/SaveStateIcon-test.js
@@ -1,0 +1,28 @@
+import { mount } from 'enzyme';
+import SaveStateIcon from '../SaveStateIcon';
+
+describe('SaveStateIcon', () => {
+  [
+    {
+      state: 'unsaved',
+      checkIcon: false,
+      spinnerIcon: false,
+    },
+    {
+      state: 'saving',
+      checkIcon: false,
+      spinnerIcon: true,
+    },
+    {
+      state: 'saved',
+      checkIcon: true,
+      spinnerIcon: false,
+    },
+  ].forEach(({ state, checkIcon, spinnerIcon }) => {
+    it(`shows expected icons in "${state}" state`, () => {
+      const wrapper = mount(<SaveStateIcon state={state} />);
+      assert.equal(wrapper.exists('CheckIcon'), checkIcon);
+      assert.equal(wrapper.exists('SpinnerSpokesIcon'), spinnerIcon);
+    });
+  });
+});


### PR DESCRIPTION
Extract the save status icons into a new component and make it accessible by:

 - Adding a `role="status"` container so that changes in labels are announced
 - Adding accessible labels to the saving / saved indicators

**Testing:**

1. Apply the diff below
2. Select a group in h and click the "Edit group" link
3. Activate screen reader
4. Click the "Save changes" button

You should hear "Saving changes..." being read out after clicking the button and then "Changes saved".

```diff
diff --git a/h/static/scripts/group-forms/utils/api.ts b/h/static/scripts/group-forms/utils/api.ts
index 273dc64ad..26ca218d5 100644
--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -109,5 +109,8 @@ export async function callAPI(
     });
   }
 
+  // TESTING
+  await new Promise(r => setTimeout(r, 2000));
+
   return responseJSON;
 }
```

**Known issues:**

I have noticed that when there is no save delay at all, Chrome does not always announce "Changes saved" if the form is edited again and re-saved after the first use of "Save changes". I'd like to investigate further, but I want to deploy this initial implementation first.