### PR TITLE
Warn when closing tab if there are unsaved changes in groups form

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -253,13 +253,7 @@ export default function CreateEditGroupForm() {
           )}
           <div className="grow" />
           <SaveStateIcon
-            state={
-              saveState === 'saving'
-                ? 'saving'
-                : saveState === 'saved'
-                  ? 'saved'
-                  : 'unsaved'
-            }
+            state={saveState === 'unmodified' ? 'unsaved' : saveState}
           />
           <Button
             type="submit"

--- a/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
@@ -14,7 +14,7 @@ describe('CreateEditGroupForm', () => {
   let fakeUseWarnOnPageUnload;
 
   function pageUnloadWarningActive() {
-    return fakeUseWarnOnPageUnload.getCall(-1).args[0] === true;
+    return fakeUseWarnOnPageUnload.lastCall.args[0] === true;
   }
 
   beforeEach(() => {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^8.0.0",
+    "@hypothesis/frontend-shared": "^8.3.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,15 +1895,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@hypothesis/frontend-shared@npm:8.0.0"
+"@hypothesis/frontend-shared@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "@hypothesis/frontend-shared@npm:8.3.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 12f945d2d667926bc52dcba15164fb988a1c9f6f50fecffd676f507d29e3fcc365ea244b784b5a18e9b536ca050df50c5a4304e0f0757caea88424baa3cee9fd
+  checksum: e08dfe4c290f8c8aa3f18a64ca1dfca52180e1fe82fe4c3c45ea08a293fb59acdcc37d48d07ade6dd6179d694ea3fcc708b2a04fa2a8e0b92809ca291df56345
   languageName: node
   linkType: hard
 
@@ -5745,7 +5745,7 @@ __metadata:
     "@babel/preset-react": ^7.24.7
     "@babel/preset-typescript": ^7.24.7
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^8.0.0
+    "@hypothesis/frontend-shared": ^8.3.0
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^26.0.1


### PR DESCRIPTION
This adds logic to the groups form to warn when closing the tab if there are unsaved changes.

- Change the representation of the save status so we can differentiate between an unmodified form and an unsaved form
- Enable a warning using the `useWarnOnPageUnload` hook from `@hypothesis/frontend-shared` when the form has unsaved changes
- Handle the case where the form is edited while being saved. We could alternatively prevent this by disabling the input fields while saving.

**Testing:**

1. Open the form to edit an existing group, but don't make any changes
2. Close the tab. There should be no warning.
3. Open the form to edit the group again.
4. Make some changes.
5. Try to close the tab. You should get a warning about unsaved changes.
6. Save the changes and then close the tab. There should be no warning