### PR TITLE
Wrap group form error message in `alert` region

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -242,15 +242,17 @@ export default function CreateEditGroupForm() {
         />
 
         <div className="flex items-center gap-x-4">
-          {errorMessage && (
-            <div
-              className="text-red-error font-bold flex items-center gap-x-2"
-              data-testid="error-message"
-            >
-              <CancelIcon />
-              {errorMessage}
-            </div>
-          )}
+          <div data-testid="error-container" role="alert">
+            {errorMessage && (
+              <div
+                className="text-red-error font-bold flex items-center gap-x-2"
+                data-testid="error-message"
+              >
+                <CancelIcon />
+                {errorMessage}
+              </div>
+            )}
+          </div>
           <div className="grow" />
           <SaveStateIcon
             state={saveState === 'unmodified' ? 'unsaved' : saveState}


### PR DESCRIPTION
This causes the error to be read out after an unsuccessful save. This will likely be wrapped up into a shared component in future.

**Testing:**

With a screen reader active:

1. Edit an existing group
2. Change the group name to "   a     ", including whitespace
3. Click "Save changes". The error message that appears after saving fails should be announced.