### PR TITLE
Use ArrowLeftIcon for groups back arrow

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useMemo, useState } from 'preact/hooks';
 
 import {
+  ArrowLeftIcon,
   Button,
   CancelIcon,
   Input,
@@ -275,7 +276,8 @@ export default function CreateEditGroupForm() {
         <div className="flex">
           {group && (
             <a href={group.link} data-testid="back-link">
-              ← Back to group overview page
+              <ArrowLeftIcon className="inline scale-75" />
+              Back to group overview page
             </a>
           )}
           <div className="grow" />


### PR DESCRIPTION
Use `ArrowLeftIcon` from frontend-shared for the groups form back arrow, and make it more vertically aligned via flex utilities.

Before:

![image](https://github.com/user-attachments/assets/14041036-0215-4cb1-b1e5-a1701c687f65)

After:

![image](https://github.com/user-attachments/assets/89f3c64c-0d52-4c0b-af27-1e0969b75526)
