### PR TITLE
Fix warning when group creation form redirects

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -136,7 +136,10 @@ export default function CreateEditGroupForm() {
     'unmodified' | 'unsaved' | 'saving' | 'saved'
   >('unmodified');
 
-  useWarnOnPageUnload(['unsaved', 'saving'].includes(saveState));
+  // Warn when leaving page if there are unsaved changes. We only do this when
+  // editing a group because this hook lacks a way to disable the handler before
+  // calling `setLocation` after a successful group creation.
+  useWarnOnPageUnload(!!group && ['unsaved', 'saving'].includes(saveState));
 
   useEffect(() => {
     const listener = (e: PageTransitionEvent) => {

--- a/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
@@ -204,6 +204,18 @@ describe('CreateEditGroupForm', () => {
     assert.isFalse(savedConfirmationShowing(wrapper));
   });
 
+  it('does not warn when leaving page if there are unsaved changes', () => {
+    const { elements } = createWrapper();
+    const nameEl = elements.name.fieldEl;
+
+    nameEl.getDOMNode().value = 'modified';
+    nameEl.simulate('input');
+
+    // Warnings about unsaved changes are only enabled when editing a group.
+    // See notes in the implementation.
+    assert.isFalse(pageUnloadWarningActive());
+  });
+
   it('shows a loading state when the create-group API request is in-flight', async () => {
     const { wrapper } = createWrapper();
     fakeCallAPI.resolves(new Promise(() => {}));


### PR DESCRIPTION
We need to disable the `useWarnOnPageUnload` hook before redirecting.  The hook doesn't provide a convenient API for doing this without re-rendering, so just disable this behavior for the group creation form.