### PR TITLE
Reduce max-requests value in production

### DIFF
--- a/conf/gunicorn.conf.py
+++ b/conf/gunicorn.conf.py
@@ -5,5 +5,5 @@ bind = "unix:/tmp/gunicorn-web.sock"
 worker_tmp_dir = "/dev/shm"
 workers = environ["WEB_NUM_WORKERS"]
 
-max_requests = 1_000_000
-max_requests_jitter = 250_000
+max_requests = 500_000
+max_requests_jitter = 100_000


### PR DESCRIPTION
This is a last-resort mechanism to avoid memory leak but we have not hit it in at least two weeks, maybe reduced to reduced season traffic.

Reduce the threshold to see the effects more clearly.