### PR TITLE
Read max_requets gunicorn settings from environment variables

### DIFF
--- a/conf/gunicorn.conf.py
+++ b/conf/gunicorn.conf.py
@@ -5,5 +5,5 @@ bind = "unix:/tmp/gunicorn-web.sock"
 worker_tmp_dir = "/dev/shm"
 workers = environ["WEB_NUM_WORKERS"]
 
-max_requests = 500_000
-max_requests_jitter = 100_000
+max_requests = environ.get("GUNICORN_MAX_REQUESTS", 500_000)
+max_requests_jitter = environ.get("GUNICORN_MAX_REQUESTS_JITTER", 100_000)


### PR DESCRIPTION
Allows to have different value in different environments like staging, prod-us and prod ca.