### PR TITLE
Group API `type` param 2/n: set `group.pubid` before returning open groups

### DIFF
--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -128,11 +128,12 @@ class GroupCreateService:
         )
         self.db.add(group)
 
+        # Flush the DB to generate `group.pubid` before passing `group` to
+        # self.publish() or `return group`.
+        self.db.flush()
+
         if add_creator_as_member:
             group.members.append(group.creator)
-
-            # Flush the DB to generate group.pubid before publish()ing it.
-            self.db.flush()
 
             self.publish("group-join", group.pubid, group.creator.userid)
 

--- a/tests/unit/h/services/group_create_test.py
+++ b/tests/unit/h/services/group_create_test.py
@@ -14,6 +14,7 @@ class TestCreatePrivateGroup:
         group = svc.create_private_group("Anteater fans", creator.userid)
 
         assert isinstance(group, Group)
+        assert group.pubid
 
     def test_it_sets_group_name(self, creator, svc):
         group = svc.create_private_group("Anteater fans", creator.userid)
@@ -118,6 +119,7 @@ class TestCreateOpenGroup:
         group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
         assert isinstance(group, Group)
+        assert group.pubid
 
     @pytest.mark.parametrize(
         "group_attr,expected_value",
@@ -258,6 +260,7 @@ class TestCreateRestrictedGroup:
         )
 
         assert isinstance(group, Group)
+        assert group.pubid
 
     @pytest.mark.parametrize(
         "group_attr,expected_value",


### PR DESCRIPTION
`GroupCreateService.create_private_group()` and `GroupCreateService.create_restricted_group()` both return `models.Group` objects whose `pubid` attribute has already been generated, but `GroupCreateService.create_open_group()` returns groups with `pubid=None` because the value for `pubid` won't be generated until the group is flushed to the DB.

This is a likely source of errors (for example the API returning `id: null` in the JSON response when creating an open group) so fix `GroupCreateService` to generate `pubid`'s also for open groups before returning the group to the caller.
