### PR TITLE
Group API `type` param 1/n: Enable setting `models.Group.type`

### DIFF
--- a/h/services/bulk_executor/_actions.py
+++ b/h/services/bulk_executor/_actions.py
@@ -14,7 +14,7 @@ from sqlalchemy.exc import IntegrityError, ProgrammingError
 from zope.sqlalchemy import mark_changed
 
 from h.models import Group, GroupMembership, User, UserIdentity
-from h.models.group import PRIVATE_GROUP_TYPE_FLAGS
+from h.models.group import GROUP_TYPE_FLAGS
 
 
 class DBAction:
@@ -92,7 +92,7 @@ class DBAction:
 class GroupUpsertAction(DBAction):
     """Perform a bulk group upsert."""
 
-    type_flags = PRIVATE_GROUP_TYPE_FLAGS
+    type_flags = GROUP_TYPE_FLAGS["private"]
 
     def execute(self, batch, effective_user_id=None, **_):
         if effective_user_id is None:

--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -2,11 +2,7 @@ from functools import partial
 
 from h import session
 from h.models import Group, GroupScope
-from h.models.group import (
-    OPEN_GROUP_TYPE_FLAGS,
-    PRIVATE_GROUP_TYPE_FLAGS,
-    RESTRICTED_GROUP_TYPE_FLAGS,
-)
+from h.models.group import GROUP_TYPE_FLAGS
 
 
 class GroupCreateService:
@@ -38,7 +34,7 @@ class GroupCreateService:
         return self._create(
             name=name,
             userid=userid,
-            type_flags=PRIVATE_GROUP_TYPE_FLAGS,
+            type_flags=GROUP_TYPE_FLAGS["private"],
             scopes=[],
             add_creator_as_member=True,
             **kwargs,
@@ -62,7 +58,7 @@ class GroupCreateService:
         return self._create(
             name=name,
             userid=userid,
-            type_flags=OPEN_GROUP_TYPE_FLAGS,
+            type_flags=GROUP_TYPE_FLAGS["open"],
             scopes=scopes,
             add_creator_as_member=False,
             **kwargs,
@@ -87,7 +83,7 @@ class GroupCreateService:
         return self._create(
             name=name,
             userid=userid,
-            type_flags=RESTRICTED_GROUP_TYPE_FLAGS,
+            type_flags=GROUP_TYPE_FLAGS["restricted"],
             scopes=scopes,
             add_creator_as_member=True,
             **kwargs,

--- a/tests/unit/h/models/group_test.py
+++ b/tests/unit/h/models/group_test.py
@@ -1,7 +1,12 @@
 import pytest
 
 from h import models
-from h.models.group import AUTHORITY_PROVIDED_ID_MAX_LENGTH, ReadableBy, WriteableBy
+from h.models.group import (
+    AUTHORITY_PROVIDED_ID_MAX_LENGTH,
+    GROUP_TYPE_FLAGS,
+    ReadableBy,
+    WriteableBy,
+)
 
 
 def test_init_sets_given_attributes():
@@ -153,11 +158,21 @@ def test_type_raises_for_unknown_type_of_group(factories):
         _ = group.type
 
 
-def test_you_cannot_set_type(factories):
-    group = factories.Group()
+@pytest.mark.parametrize("original_type", ["private", "restricted", "open"])
+@pytest.mark.parametrize("new_type", ["private", "restricted", "open"])
+def test_you_can_set_type(factories, original_type, new_type):
+    group = factories.Group(**GROUP_TYPE_FLAGS[original_type]._asdict())
 
-    with pytest.raises(AttributeError, match="object has no setter"):
-        group.type = "open"
+    group.type = new_type
+
+    assert group.type == new_type
+    for index, flag in enumerate(GROUP_TYPE_FLAGS[new_type]._fields):
+        assert getattr(group, flag) == GROUP_TYPE_FLAGS[new_type][index]
+
+
+def test_you_cant_set_type_to_an_invalid_value(factories):
+    with pytest.raises(ValueError):
+        factories.Group().type = "invalid"
 
 
 def test_repr(db_session, factories, organization):

--- a/tests/unit/h/services/bulk_executor/_actions_test.py
+++ b/tests/unit/h/services/bulk_executor/_actions_test.py
@@ -14,7 +14,7 @@ from h_matchers.matcher.object import AnyObject
 from sqlalchemy.exc import IntegrityError, ProgrammingError
 
 from h.models import Group, GroupMembership, User, UserIdentity
-from h.models.group import PRIVATE_GROUP_TYPE_FLAGS
+from h.models.group import GROUP_TYPE_FLAGS
 from h.services.bulk_executor._actions import (
     GroupMembershipCreateAction,
     GroupUpsertAction,
@@ -211,9 +211,9 @@ class TestBulkGroupUpsert:
 
         for group in groups:
             # Check the groups are private
-            assert group.joinable_by == PRIVATE_GROUP_TYPE_FLAGS.joinable_by
-            assert group.readable_by == PRIVATE_GROUP_TYPE_FLAGS.readable_by
-            assert group.writeable_by == PRIVATE_GROUP_TYPE_FLAGS.writeable_by
+            assert group.joinable_by == GROUP_TYPE_FLAGS["private"].joinable_by
+            assert group.readable_by == GROUP_TYPE_FLAGS["private"].readable_by
+            assert group.writeable_by == GROUP_TYPE_FLAGS["private"].writeable_by
 
             # Check they are owned by
             assert group.creator_id == user.id

--- a/tests/unit/h/services/group_update_test.py
+++ b/tests/unit/h/services/group_update_test.py
@@ -43,6 +43,14 @@ class TestGroupUpdate:
 
         assert updated_group.scopes == updated_scopes
 
+    @pytest.mark.parametrize("new_group_type", ["restricted", "open"])
+    def test_it_updates_the_type_of_a_group(self, factories, svc, new_group_type):
+        group = factories.Group()
+
+        updated_group = svc.update(group, type=new_group_type)
+
+        assert updated_group.type == new_group_type
+
     def test_it_does_not_protect_against_undefined_properties(self, factories, svc):
         group = factories.Group()
         data = {"some_random_field": "whatever"}


### PR DESCRIPTION
There is no group type column in the DB. Instead, the `group` table has three separate columns `joinable_by`, `readable_by` and `writeable_by`. [`models.Group.type`](https://github.com/hypothesis/h/blob/8f2997fff1f2929ff2360bbe1bfbf51b832f71ad/h/models/group.py#L189-L215) is a `@property` that returns `"private"`, `"restricted"` or `"open"` depending on the values of `joinable_by`, `readable_by` and `writeable_by`.

Currently `models.Group.type` isn't writeable: there's no setter for the property.

Add a setter for `models.Group.type` that accepts a simple type string `"private"`, `"restricted"` or `"open"` and sets the underlying `joinable_by`, `readable_by` and `writeable_by` attributes appropriately so that _reading_ the `type` property will now return the given `"private"`, `"restricted"` or `"open"` string.

So now you can change a group's type by just doing:

```python
some_group.type = "open"
```

Group type changes would normally be done via [`GroupUpdateService.update()`](https://github.com/hypothesis/h/blob/8f2997fff1f2929ff2360bbe1bfbf51b832f71ad/h/services/group_update.py#L15-L51). That service method just sets arbitrary kwargs on the `group` object so I didn't need to make any service-method changes to add support for the new `type` setter. Previously if you did `group_update_svc.update(group, type="open")` it would raise `TypeError` because it would try to set `group.type = "open"` but the property has no setter. Now it will work. I added a service test to prove this.