### PR TITLE
Add group type to `js-config`

### DIFF
--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -54,6 +54,7 @@ class GroupCreateEditController:
                 "pubid": group.pubid,
                 "name": group.name,
                 "description": group.description,
+                "type": group.type,
                 "link": self.request.route_url(
                     "group_read", pubid=group.pubid, slug=group.slug
                 ),

--- a/tests/unit/h/views/groups_test.py
+++ b/tests/unit/h/views/groups_test.py
@@ -75,6 +75,7 @@ class TestGroupCreateEditController:
                         "pubid": group.pubid,
                         "name": group.name,
                         "description": group.description,
+                        "type": group.type,
                         "link": pyramid_request.route_url(
                             "group_read", pubid=group.pubid, slug=group.slug
                         ),


### PR DESCRIPTION
Add the group's type to the `js-config` on the group-edit page. The frontend is going to need this for https://github.com/hypothesis/h/issues/8898.
