### PR TITLE
Un-pin `upload-artifact` action and enable `include-hidden-files` option for coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,11 @@ jobs:
         env:
           COVERAGE_FILE: .coverage.${{ matrix.python-version }}
       - name: Upload coverage file
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v3
         with:
           name: coverage
           path: .coverage.*
+          include-hidden-files: true
   Coverage:
     needs: tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
This resolves an issue where the `.coverage.{python_version}` file was not uploaded.

See https://github.com/actions/upload-artifact/issues/602 and https://hypothes-is.slack.com/archives/C4K6M7P5E/p1725285976308269.