### PR TITLE
Fix h's readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+sphinx:
+  configuration: docs/conf.py
+  builder: "dirhtml"
+  fail_on_warning: true
+formats: all
+python:
+  install:
+    - requirements: requirements/docs.txt


### PR DESCRIPTION
h's readthedocs build has been failing for over eleven months, see:

https://readthedocs.org/projects/h/builds/

> Error
>
> The required .readthedocs.yaml configuration file was not found at
> repository's root. Learn how to use this file in our
> [configuration file tutorial](https://docs.readthedocs.io/en/stable/config-file/index.html).

The linked tutorial explains that we need to add a `.readthedocs.yaml`
configuration file, which must be in the root of the repo.
