### PR TITLE
Disable additional docs formats

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ sphinx:
   configuration: docs/conf.py
   builder: "dirhtml"
   fail_on_warning: true
-formats: all
+formats: []
 python:
   install:
     - requirements: requirements/docs.txt


### PR DESCRIPTION
Disable the addition HTMLZip, PDF and Epub documentation formats in the
readthedocs build. These are causing warnings that're causing the build
to fail, and they don't work anyway: various things like the table of
contents, API docs, etc don't work in the additional formats.
