### PR TITLE
Attempt to fix our Sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,12 +109,9 @@ def setup(app):
 
 # -- Options for HTML output ---------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-if not on_rtd:
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+import sphinx_rtd_theme
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
h's docs use `sphinx-rtd-theme` (https://sphinx-rtd-theme.readthedocs.io/)
when run locally with `make docs` and used to use that theme in
production also but at some point the production docs theme changed to
Alabaster. I think readthedocs may have changed their default theme. Try
to set the theme back to sphinx-rtd-theme in production.
