### PR TITLE
Add `num_annotations` to `js-config` group context

### DIFF
--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -5,6 +5,7 @@ from h.search.query import (
     AuthorityFilter,
     DeletedFilter,
     Limiter,
+    SharedAnnotationsFilter,
     TagsAggregation,
     TopLevelAnnotationsFilter,
     UserFilter,
@@ -22,6 +23,7 @@ __all__ = (
     "UsersAggregation",
     "get_client",
     "init",
+    "SharedAnnotationsFilter",
 )
 
 

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -193,6 +193,20 @@ class AuthFilter:
         )
 
 
+class SharedAnnotationsFilter:
+    """
+    A filter that selects only "shared" annotations and replies.
+
+    Only annotations and replies that have been shared
+    (`Annotation.shared=True`) will pass through this filter. "Only Me"
+    annotations (`Annotation.shared=False`) will be filtered out even if they
+    belong to the authenticated user.
+    """
+
+    def __call__(self, search, params):
+        return search.filter("term", shared=True)
+
+
 class GroupFilter:
     """
     Filter that limits which groups annotations are returned from.

--- a/h/services/annotation_stats.py
+++ b/h/services/annotation_stats.py
@@ -4,6 +4,7 @@ from h.search import (
     DeletedFilter,
     Limiter,
     Search,
+    SharedAnnotationsFilter,
     TopLevelAnnotationsFilter,
     UserFilter,
 )
@@ -47,6 +48,24 @@ class AnnotationStatsService:
         """Return the count of searchable top level annotations for this group."""
         params = MultiDict({"limit": 0, "group": pubid})
         return self._search(params)
+
+    def total_group_annotation_count(self, pubid, unshared=True):
+        """
+        Return the count of all annotations for a group.
+
+        This counts all of the group's annotations and replies from all users.
+
+        If `unshared=True` then "Only Me" annotations and replies in the group
+        (`Annotation.shared=False`) from *all* users (not just the
+        authenticated user) will be counted.
+
+        If `unshared=False` then no unshared annotations or replies will be
+        counted, not even ones from the authenticated user.
+        """
+        search = Search(self.request)
+        if not unshared:
+            search.append_modifier(SharedAnnotationsFilter())
+        return search.run(MultiDict({"limit": 0, "group": pubid})).total
 
     def _search(self, params):
         search = Search(self.request)

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -15,6 +15,7 @@ class GroupCreateEditController:
     def __init__(self, context, request):
         self.context = context
         self.request = request
+        self.annotation_stats_service = request.find_service(name="annotation_stats")
 
     @view_config(route_name="group_create", request_method="GET")
     def create(self):
@@ -57,6 +58,9 @@ class GroupCreateEditController:
                 "type": group.type,
                 "link": self.request.route_url(
                     "group_read", pubid=group.pubid, slug=group.slug
+                ),
+                "num_annotations": self.annotation_stats_service.total_group_annotation_count(
+                    group.pubid, unshared=False
                 ),
             }
             js_config["api"]["updateGroup"] = {


### PR DESCRIPTION
The frontend is going to need this in order to show a warning dialog when changing the type of a group: the warning only needs to be shown of there are shared annotations in the group. Also, the warning needs to include the number of annotations in the text. See https://github.com/hypothesis/h/issues/8898.

Testing
=======

1. Go to http://localhost:5000/groups/new and create a new group
2. Go to the group's edit page
3. View source and search for `"num_annotations"` in the `js-config` in the HTML. You should see `"num_annotations: 0"`
4. Go to http://localhost:5000/docs/help and create an annotation in the new group. Reload the view-source of the group edit page, you should see `"num_annotations": 1`
5. Create a reply, you should see `"num_annotations": 2`
6. Create an only-me annotation: `"num_annotations"` should not change
7. Delete annotations and `"num_annotations"` should decrease
8. In another browser log in as a different user, join the group, and create an annotation in the group: `"num_annotations"` should increase