### PR TITLE
Remove an unnecessary optimization

### DIFF
--- a/h/services/auth_ticket.py
+++ b/h/services/auth_ticket.py
@@ -16,7 +16,6 @@ class AuthTicketService:
     def __init__(self, session, user_service):
         self._session = session
         self._user_service = user_service
-        self._user = None
 
     def verify_ticket(self, userid: str | None, ticket_id: str | None) -> User | None:
         """
@@ -25,11 +24,6 @@ class AuthTicketService:
         Verify that there is an unexpired AuthTicket in the DB matching the
         given `userid` and `ticket_id` and if so return the corresponding User.
         """
-
-        if self._user:
-            # We've already vetted the user!
-            return self._user
-
         if not userid or not ticket_id:
             return None
 
@@ -53,23 +47,19 @@ class AuthTicketService:
         if (datetime.utcnow() - ticket.updated) > self.TICKET_REFRESH_INTERVAL:
             ticket.expires = datetime.utcnow() + self.TICKET_TTL
 
-        # Update the user cache to allow quick checking if we are called again
-        self._user = ticket.user
-
-        return self._user
+        return ticket.user
 
     def add_ticket(self, userid: str, ticket_id: str) -> None:
         """Add a new auth ticket for the given userid and token_id to the DB."""
 
-        # Update the user cache to allow quick checking if we are called again
-        self._user = self._user_service.fetch(userid)
-        if self._user is None:
+        user = self._user_service.fetch(userid)
+        if user is None:
             raise ValueError(f"Cannot find user with userid {userid}")
 
         ticket = AuthTicket(
             id=ticket_id,
-            user=self._user,
-            user_userid=self._user.userid,
+            user=user,
+            user_userid=user.userid,
             expires=datetime.utcnow() + self.TICKET_TTL,
         )
         self._session.add(ticket)
@@ -78,9 +68,6 @@ class AuthTicketService:
         """Remove any ticket with the given ID from the DB."""
 
         self._session.query(AuthTicket).filter_by(id=ticket_id).delete()
-
-        # Empty the cached user to force revalidation.
-        self._user = None
 
 
 def factory(_context, request):

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -43,8 +43,8 @@ def ajax_payload(request, data):  # pragma: no cover
     return payload
 
 
-def _login_redirect_url(request):
-    return request.route_url("activity.user_search", username=request.user.username)
+def _login_redirect_url(request, user):
+    return request.route_url("activity.user_search", username=user.username)
 
 
 @view_config(
@@ -134,7 +134,7 @@ class AuthController:
         user = appstruct["user"]
         headers = self._login(user)
         return httpexceptions.HTTPFound(
-            location=self._login_redirect(), headers=headers
+            location=self._login_redirect(user), headers=headers
         )
 
     @view_config(route_name="logout", renderer=None, request_method="GET")
@@ -144,11 +144,13 @@ class AuthController:
         return httpexceptions.HTTPFound(location=self.logout_redirect, headers=headers)
 
     def _redirect_if_logged_in(self):
-        if self.request.authenticated_userid is not None:
-            raise httpexceptions.HTTPFound(location=self._login_redirect())
+        if self.request.user is not None:
+            raise httpexceptions.HTTPFound(
+                location=self._login_redirect(self.request.user)
+            )
 
-    def _login_redirect(self):
-        return self.request.params.get("next", _login_redirect_url(self.request))
+    def _login_redirect(self, user):
+        return self.request.params.get("next", _login_redirect_url(self.request, user))
 
     def _login(self, user):
         user.last_login_date = datetime.datetime.utcnow()

--- a/tests/unit/h/services/auth_ticket_test.py
+++ b/tests/unit/h/services/auth_ticket_test.py
@@ -19,17 +19,6 @@ class TestAuthTicketService:
             service.verify_ticket(auth_ticket.user.userid, auth_ticket.id)
             == auth_ticket.user
         )
-        # We also set the cache as a side effect
-
-        assert service._user == auth_ticket.user  # pylint: disable=protected-access
-
-    def test_verify_ticket_short_circuits_if_user_cache_is_set(self, service):
-        # pylint: disable=protected-access
-        service._user = sentinel.user
-
-        assert (
-            service.verify_ticket(sentinel.userid, sentinel.ticket_id) == service._user
-        )
 
     @pytest.mark.usefixtures("auth_ticket")
     def test_verify_ticket_returns_None_if_theres_no_matching_ticket(
@@ -88,7 +77,6 @@ class TestAuthTicketService:
         assert_nearly_equal(
             auth_ticket.expires, datetime.utcnow() + AuthTicketService.TICKET_TTL
         )
-        assert service._user == user  # pylint: disable=protected-access
 
     def test_add_ticket_raises_if_user_is_missing(self, service, user_service):
         user_service.fetch.return_value = None
@@ -101,7 +89,6 @@ class TestAuthTicketService:
     def test_remove_ticket(self, auth_ticket, service, db_session):
         service.remove_ticket(auth_ticket.id)
 
-        assert service._user is None  # pylint: disable=protected-access
         assert db_session.query(AuthTicket).first() is None
 
     @pytest.fixture

--- a/tests/unit/h/views/accounts_test.py
+++ b/tests/unit/h/views/accounts_test.py
@@ -143,7 +143,6 @@ class TestAuthController:
         pyramid_config.testing_securitypolicy(None)  # Logged out
         controller = views.AuthController(pyramid_request)
         user = factories.User(username="cara")
-        pyramid_request.user = user
         controller.form = form_validating_to({"user": user})
 
         result = controller.post()
@@ -156,9 +155,7 @@ class TestAuthController:
         pyramid_request.params = {"next": "/foo/bar"}
         pyramid_config.testing_securitypolicy(None)  # Logged out
         controller = views.AuthController(pyramid_request)
-        user = factories.User(username="cara")
-        pyramid_request.user = user
-        controller.form = form_validating_to({"user": user})
+        controller.form = form_validating_to({"user": factories.User()})
 
         result = controller.post()
 
@@ -178,7 +175,6 @@ class TestAuthController:
         pyramid_config.testing_securitypolicy(None)  # Logged out
         elephant = factories.User(username="avocado")
         controller = views.AuthController(pyramid_request)
-        pyramid_request.user = elephant
         controller.form = form_validating_to({"user": elephant})
 
         controller.post()


### PR DESCRIPTION
Remove an unnecessary optimization where
`AuthTicketService.verify_ticket()` caches the verified ticket's user
as `self._user` so that, if `verify_ticket()` is called again during the
same request, it can just return `self._user` and avoid re-verifying the
ticket (including querying the DB for the ticket).

This is an unnecessary optimization that adds a lot of code complexity
and is making future refactorings unnecessarily difficult. I doubt the
optimization is worth the maintenance difficulty.

`AuthTicketService.verify_ticket()` is only called by
`AuthTicketCookieHelper.identity()` which is only called by
`CookiePolicy.identity()` and `APICookiePolicy.identity()` and only one
of `CookiePolicy` or `APICookiePolicy` will be effective for a given
request. So the only way that `AuthTicketService.verify_ticket()` will
be called multiple times within the same request is if either
`CookiePolicy.identity()` or `APICookiePolicy.identity()` is called
multiple times within the same request. If an optimization was needed
here it would make more sense to do it higher up in
`AuthTicketCookieHelper.identity()` or in `CookiePolicy.identity()` and
`APICookiePolicy.identity()`.
