### PR TITLE
Suppress a warning in rollup due to the use of

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,6 +20,13 @@ function bundleConfig(name, entryFile) {
       chunkFileNames: '[name].bundle.js',
       entryFileNames: '[name].bundle.js',
     },
+
+    // Suppress a warning (https://rollupjs.org/guide/en/#error-this-is-undefined)
+    // due to https://github.com/babel/babel/issues/9149.
+    //
+    // Any code string other than "undefined" which evaluates to `undefined` will work here.
+    context: 'void(0)',
+
     plugins: [
       babel({
         babelHelpers: 'bundled',


### PR DESCRIPTION
This PR adds a workaround to suppress a warning thrown by rollup. The warning in question is documented here https://rollupjs.org/guide/en/#error-this-is-undefined

The way it's fixed here is the same approach we used in the rest of the projects where rollup is used:

* [Client](https://github.com/hypothesis/client/blob/9dfb7e1dead988931b9b326cf26603f81a522d57/rollup.config.js#L70-L74)
* [LMS](https://github.com/hypothesis/lms/blob/a02651cac9eaed5fd4613244b16584a6fb30b3ea/rollup.config.js#L32-L36)
* [Frontend shared](https://github.com/hypothesis/frontend-shared/blob/38be2a55c995415b0338b289c7172cee99c76cb6/rollup.config.js#L19-L23)

### Testing steps

In `main` branch, when running `make dev` you should see the assets output include a couple lines like `Rollup warning: [...]: The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten (https://rollupjs.org/troubleshooting/#error-this-is-undefined)`

In this branch, those warnings should not be printed.