### PR TITLE
Revert "Use a separate auth cookie for API requests (fixed version)"

### DIFF
--- a/h/security/policy/_api_cookie.py
+++ b/h/security/policy/_api_cookie.py
@@ -29,7 +29,7 @@ class APICookiePolicy:
         ) in COOKIE_AUTHENTICATABLE_API_REQUESTS
 
     def identity(self, request: Request) -> Identity | None:
-        identity, _ = self.helper.identity(self.cookie, request)
+        identity = self.helper.identity(self.cookie, request)
 
         if identity is None:
             return identity

--- a/h/security/policy/_cookie.py
+++ b/h/security/policy/_cookie.py
@@ -30,7 +30,7 @@ class CookiePolicy:
 
     def identity(self, request):
         self.helper.add_vary_by_cookie(request)
-        identity, ticket_id = self.helper.identity(self.html_authcookie, request)
+        identity = self.helper.identity(self.html_authcookie, request)
 
         # If a request was successfully authenticated using the HTML auth
         # cookie and that request did *not* also contain the API auth cookie,
@@ -47,7 +47,7 @@ class CookiePolicy:
         # this won't happen but it could happen if the API auth cookie (but not
         # the HTML one) was deleted somehow, for example by the user manually
         # deleting the cookie in the browser's developer tools, or another way.
-        self._issue_api_authcookie(identity, request, ticket_id)
+        self._issue_api_authcookie(identity, request)
 
         return identity
 
@@ -76,11 +76,9 @@ class CookiePolicy:
         # would set the same cookie twice.
         request.h_api_authcookie_headers_added = True
 
-        ticket_id = self.helper.add_ticket(request, userid)
-
         return [
-            *self.helper.remember(self.html_authcookie, userid, ticket_id),
-            *self.helper.remember(self.api_authcookie, userid, ticket_id),
+            *self.helper.remember(self.html_authcookie, request, userid),
+            *self.helper.remember(self.api_authcookie, request, userid),
         ]
 
     def forget(self, request):
@@ -93,7 +91,7 @@ class CookiePolicy:
     def permits(self, request, context, permission) -> Allowed | Denied:
         return identity_permits(self.identity(request), context, permission)
 
-    def _issue_api_authcookie(self, identity, request, ticket_id):
+    def _issue_api_authcookie(self, identity, request):
         if not identity:
             return
 
@@ -107,7 +105,7 @@ class CookiePolicy:
             return
 
         headers = self.helper.remember(
-            self.api_authcookie, identity.user.userid, ticket_id
+            self.api_authcookie, request, identity.user.userid
         )
 
         def add_api_authcookie_headers(

--- a/h/security/policy/helpers.py
+++ b/h/security/policy/helpers.py
@@ -16,29 +16,19 @@ def is_api_request(request) -> bool:
 class AuthTicketCookieHelper:
     def identity(
         self, cookie: SignedCookieProfile, request: Request
-    ) -> tuple[Identity, AuthTicket] | tuple[None, None]:
+    ) -> Identity | None:
         userid, ticket_id = self.get_cookie_value(cookie)
 
-        ticket = request.find_service(AuthTicketService).verify_ticket(
-            userid, ticket_id
-        )
+        user = request.find_service(AuthTicketService).verify_ticket(userid, ticket_id)
 
-        if (not ticket) or ticket.user.deleted:
-            return (None, None)
+        if (not user) or user.deleted:
+            return None
 
-        return (Identity.from_models(user=ticket.user), ticket)
+        return Identity.from_models(user=user)
 
-    def add_ticket(self, request: Request, userid):
-        """
-        Add a new auth ticket for the given user to the DB.
-
-        Returns the ID of the newly-created auth ticket.
-        """
+    def remember(self, cookie: SignedCookieProfile, request: Request, userid: str):
         ticket_id = AuthTicket.generate_ticket_id()
         request.find_service(AuthTicketService).add_ticket(userid, ticket_id)
-        return ticket_id
-
-    def remember(self, cookie: SignedCookieProfile, userid: str, ticket_id):
         return cookie.get_headers([userid, ticket_id])
 
     def forget(self, cookie: SignedCookieProfile, request: Request):

--- a/h/security/policy/top_level.py
+++ b/h/security/policy/top_level.py
@@ -50,7 +50,7 @@ def get_subpolicy(request):
     api_authcookie = webob.cookies.SignedCookieProfile(
         secret=request.registry.settings["h_api_auth_cookie_secret"],
         salt=request.registry.settings["h_api_auth_cookie_salt"],
-        cookie_name="h_api_authcookie.v2",
+        cookie_name="h_api_authcookie",
         httponly=True,
         secure=request.scheme == "https",
         samesite="strict",
@@ -60,15 +60,6 @@ def get_subpolicy(request):
         max_age=HTML_AUTHCOOKIE_MAX_AGE + int(timedelta(hours=1).total_seconds()),
     )
     api_authcookie = api_authcookie.bind(request)
-
-    if is_api_request(request):
-        return APIPolicy(
-            [
-                BearerTokenPolicy(),
-                AuthClientPolicy(),
-                APICookiePolicy(api_authcookie, AuthTicketCookieHelper()),
-            ]
-        )
 
     # The cookie that's used to authenticate HTML page requests.
     html_authcookie = webob.cookies.SignedCookieProfile(
@@ -80,4 +71,22 @@ def get_subpolicy(request):
         secure=request.scheme == "https",
     )
     html_authcookie = html_authcookie.bind(request)
+
+    if is_api_request(request):
+        return APIPolicy(
+            [
+                BearerTokenPolicy(),
+                AuthClientPolicy(),
+                APICookiePolicy(
+                    # Use html_authcookie rather than api_authcookie to
+                    # authenticate API requests, at least for now. This is a
+                    # hopefully temporary workaround for an undiagnosed issue
+                    # we've been seeing in production, see:
+                    # https://hypothes-is.slack.com/archives/C2BLQDKHA/p1725041696040459
+                    html_authcookie,
+                    AuthTicketCookieHelper(),
+                ),
+            ]
+        )
+
     return CookiePolicy(html_authcookie, api_authcookie, AuthTicketCookieHelper())

--- a/h/services/auth_ticket.py
+++ b/h/services/auth_ticket.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 import sqlalchemy as sa
 
-from h.models import AuthTicket
+from h.models import AuthTicket, User
 
 
 class AuthTicketService:
@@ -16,21 +16,19 @@ class AuthTicketService:
     def __init__(self, session, user_service):
         self._session = session
         self._user_service = user_service
-        self._ticket = None
+        self._user = None
 
-    def verify_ticket(
-        self, userid: str | None, ticket_id: str | None
-    ) -> AuthTicket | None:
+    def verify_ticket(self, userid: str | None, ticket_id: str | None) -> User | None:
         """
-        Return the AuthTicket matching the given userid and ticket_id, or None.
+        Return the User object matching the given userid and ticket_id, or None.
 
         Verify that there is an unexpired AuthTicket in the DB matching the
-        given `userid` and `ticket_id` and if so return the AuthTicket.
+        given `userid` and `ticket_id` and if so return the corresponding User.
         """
 
-        if self._ticket:
-            # We've already verified this request's ticket.
-            return self._ticket
+        if self._user:
+            # We've already vetted the user!
+            return self._user
 
         if not userid or not ticket_id:
             return None
@@ -55,40 +53,34 @@ class AuthTicketService:
         if (datetime.utcnow() - ticket.updated) > self.TICKET_REFRESH_INTERVAL:
             ticket.expires = datetime.utcnow() + self.TICKET_TTL
 
-        # Update the cache to allow quick checking if we are called again
-        self._ticket = ticket
+        # Update the user cache to allow quick checking if we are called again
+        self._user = ticket.user
 
-        return self._ticket
+        return self._user
 
     def add_ticket(self, userid: str, ticket_id: str) -> None:
         """Add a new auth ticket for the given userid and token_id to the DB."""
 
-        user = self._user_service.fetch(userid)
-
-        if user is None:
+        # Update the user cache to allow quick checking if we are called again
+        self._user = self._user_service.fetch(userid)
+        if self._user is None:
             raise ValueError(f"Cannot find user with userid {userid}")
 
         ticket = AuthTicket(
             id=ticket_id,
-            user=user,
-            user_userid=user.userid,
+            user=self._user,
+            user_userid=self._user.userid,
             expires=datetime.utcnow() + self.TICKET_TTL,
         )
-
         self._session.add(ticket)
-
-        # Update the cache to allow quick checking if we are called again.
-        self._ticket = ticket
-
-        return ticket
 
     def remove_ticket(self, ticket_id: str) -> None:
         """Remove any ticket with the given ID from the DB."""
 
         self._session.query(AuthTicket).filter_by(id=ticket_id).delete()
 
-        # Empty the cache to force revalidation.
-        self._ticket = None
+        # Empty the cached user to force revalidation.
+        self._user = None
 
 
 def factory(_context, request):

--- a/tests/unit/h/security/policy/_api_cookie_test.py
+++ b/tests/unit/h/security/policy/_api_cookie_test.py
@@ -4,7 +4,6 @@ import pytest
 from pyramid.csrf import SessionCSRFStoragePolicy
 from pyramid.exceptions import BadCSRFOrigin, BadCSRFToken
 
-from h.security.identity import Identity as Identity_
 from h.security.policy._api_cookie import APICookiePolicy
 from h.security.policy.helpers import AuthTicketCookieHelper
 
@@ -32,12 +31,12 @@ class TestAPICookiePolicy:
 
         helper.add_vary_by_cookie.assert_called_once_with(pyramid_csrf_request)
         helper.identity.assert_called_once_with(sentinel.cookie, pyramid_csrf_request)
-        assert identity == helper.identity.return_value[0]
+        assert identity == helper.identity.return_value
 
     def test_identity_with_no_auth_cookie(
         self, api_cookie_policy, helper, pyramid_request
     ):
-        helper.identity.return_value = (None, None)
+        helper.identity.return_value = None
 
         assert api_cookie_policy.identity(pyramid_request) is None
 
@@ -65,7 +64,7 @@ class TestAPICookiePolicy:
         helper.add_vary_by_cookie.assert_called_once_with(pyramid_csrf_request)
         helper.identity.assert_called_once_with(sentinel.cookie, pyramid_csrf_request)
         Identity.authenticated_userid.assert_called_once_with(
-            helper.identity.return_value[0]
+            helper.identity.return_value
         )
         assert authenticated_userid == Identity.authenticated_userid.return_value
 
@@ -79,18 +78,13 @@ class TestAPICookiePolicy:
         helper.add_vary_by_cookie.assert_called_once_with(pyramid_csrf_request)
         helper.identity.assert_called_once_with(sentinel.cookie, pyramid_csrf_request)
         identity_permits.assert_called_once_with(
-            helper.identity.return_value[0], sentinel.context, sentinel.permission
+            helper.identity.return_value, sentinel.context, sentinel.permission
         )
         assert permits == identity_permits.return_value
 
     @pytest.fixture
-    def helper(self, factories):
-        helper = create_autospec(AuthTicketCookieHelper, instance=True, spec_set=True)
-        helper.identity.return_value = (
-            create_autospec(Identity_, instance=True, spec_set=True),
-            factories.AuthTicket(),
-        )
-        return helper
+    def helper(self):
+        return create_autospec(AuthTicketCookieHelper, instance=True, spec_set=True)
 
     @pytest.fixture
     def api_cookie_policy(self, helper):

--- a/tests/unit/h/security/policy/top_level_test.py
+++ b/tests/unit/h/security/policy/top_level_test.py
@@ -70,10 +70,16 @@ class TestGetSubpolicy:
         AuthTicketCookieHelper,
     ):
         is_api_request.return_value = True
+        html_authcookie = create_autospec(
+            SignedCookieProfile, instance=True, spec_set=True
+        )
         api_authcookie = create_autospec(
             SignedCookieProfile, instance=True, spec_set=True
         )
-        webob.cookies.SignedCookieProfile.return_value = api_authcookie
+        webob.cookies.SignedCookieProfile.side_effect = [
+            api_authcookie,
+            html_authcookie,
+        ]
 
         policy = get_subpolicy(pyramid_request)
 
@@ -83,17 +89,26 @@ class TestGetSubpolicy:
             call(
                 secret="test_h_api_auth_cookie_secret",
                 salt="test_h_api_auth_cookie_salt",
-                cookie_name="h_api_authcookie.v2",
+                cookie_name="h_api_authcookie",
                 max_age=31539600,
                 httponly=True,
                 secure=True,
                 samesite="strict",
-            )
+            ),
+            call(
+                secret="test_h_auth_cookie_secret",
+                salt="authsanity",
+                cookie_name="auth",
+                max_age=31536000,
+                httponly=True,
+                secure=True,
+            ),
         ]
         api_authcookie.bind.assert_called_once_with(pyramid_request)
+        html_authcookie.bind.assert_called_once_with(pyramid_request)
         AuthTicketCookieHelper.assert_called_once_with()
         APICookiePolicy.assert_called_once_with(
-            api_authcookie.bind.return_value,
+            html_authcookie.bind.return_value,
             AuthTicketCookieHelper.return_value,
         )
         APIPolicy.assert_called_once_with(
@@ -131,7 +146,7 @@ class TestGetSubpolicy:
             call(
                 secret="test_h_api_auth_cookie_secret",
                 salt="test_h_api_auth_cookie_salt",
-                cookie_name="h_api_authcookie.v2",
+                cookie_name="h_api_authcookie",
                 max_age=31539600,
                 httponly=True,
                 secure=True,


### PR DESCRIPTION
Reverts hypothesis/h#8946. This seems to have broken staging: https://hypothesis.sentry.io/issues/5906066249/