### PR TITLE
Remove two unused `APICookiePolicy` methods

### DIFF
--- a/h/security/policy/_api_cookie.py
+++ b/h/security/policy/_api_cookie.py
@@ -1,10 +1,8 @@
 from pyramid.csrf import check_csrf_origin, check_csrf_token
 from pyramid.request import Request
-from pyramid.security import Allowed, Denied
 from webob.cookies import SignedCookieProfile
 
 from h.security.identity import Identity
-from h.security.permits import identity_permits
 from h.security.policy.helpers import AuthTicketCookieHelper
 
 COOKIE_AUTHENTICATABLE_API_REQUESTS = [
@@ -53,9 +51,3 @@ class APICookiePolicy:
         self.helper.add_vary_by_cookie(request)
 
         return identity
-
-    def authenticated_userid(self, request: Request) -> str | None:
-        return Identity.authenticated_userid(self.identity(request))
-
-    def permits(self, request: Request, context, permission: str) -> Allowed | Denied:
-        return identity_permits(self.identity(request), context, permission)

--- a/tests/unit/h/security/policy/_api_cookie_test.py
+++ b/tests/unit/h/security/policy/_api_cookie_test.py
@@ -55,34 +55,6 @@ class TestAPICookiePolicy:
         with pytest.raises(BadCSRFToken):
             api_cookie_policy.identity(pyramid_csrf_request)
 
-    def test_authenticated_userid(
-        self, api_cookie_policy, helper, pyramid_csrf_request, Identity
-    ):
-        authenticated_userid = api_cookie_policy.authenticated_userid(
-            pyramid_csrf_request
-        )
-
-        helper.add_vary_by_cookie.assert_called_once_with(pyramid_csrf_request)
-        helper.identity.assert_called_once_with(sentinel.cookie, pyramid_csrf_request)
-        Identity.authenticated_userid.assert_called_once_with(
-            helper.identity.return_value[0]
-        )
-        assert authenticated_userid == Identity.authenticated_userid.return_value
-
-    def test_permits(
-        self, api_cookie_policy, helper, pyramid_csrf_request, identity_permits
-    ):
-        permits = api_cookie_policy.permits(
-            pyramid_csrf_request, sentinel.context, sentinel.permission
-        )
-
-        helper.add_vary_by_cookie.assert_called_once_with(pyramid_csrf_request)
-        helper.identity.assert_called_once_with(sentinel.cookie, pyramid_csrf_request)
-        identity_permits.assert_called_once_with(
-            helper.identity.return_value[0], sentinel.context, sentinel.permission
-        )
-        assert permits == identity_permits.return_value
-
     @pytest.fixture
     def helper(self, factories):
         helper = create_autospec(AuthTicketCookieHelper, instance=True, spec_set=True)
@@ -101,13 +73,6 @@ class TestAPICookiePolicy:
 def Identity(mocker):
     return mocker.patch(
         "h.security.policy._api_cookie.Identity", autospec=True, spec_set=True
-    )
-
-
-@pytest.fixture(autouse=True)
-def identity_permits(mocker):
-    return mocker.patch(
-        "h.security.policy._api_cookie.identity_permits", autospec=True, spec_set=True
     )
 
 


### PR DESCRIPTION
`APIPolicy` doesn't call the `authenticated_userid()` and `permits()` methods of subpolicies like `APICookiePolicy`:

`APIPolicy` calls `Identity.authenticated_user()` itself directly:

https://github.com/hypothesis/h/blob/ff3d47fcbbf760937461a89f35453006e604b012/h/security/policy/_api.py#L22-L23

And `APIPolicy` calls `identity_permits()` itself directly:

https://github.com/hypothesis/h/blob/ff3d47fcbbf760937461a89f35453006e604b012/h/security/policy/_api.py#L29-L30