### PR TITLE
Add tsbuildinfo files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ tests/py3-actual-failures.txt
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# TypeScript cache
+*.tsbuildinfo


### PR DESCRIPTION
These files started appearing after updating to TypeScript 5.6. See https://devblogs.microsoft.com/typescript/announcing-typescript-5-6-beta/#.tsbuildinfo-is-always-written.