### PR TITLE
Add "Group type" field to group creation form

### DIFF
--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -1,3 +1,5 @@
+import type { GroupType } from './utils/api';
+
 export type APIConfig = {
   method: string;
   url: string;
@@ -17,6 +19,7 @@ export type ConfigObject = {
       name: string;
       description: string;
       link: string;
+      type: GroupType;
     } | null;
   };
   features: {

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -1,4 +1,21 @@
 /**
+ * Values for `type` field when creating or updating groups.
+ */
+export type GroupType = 'private' | 'restricted' | 'open';
+
+/**
+ * Request to create or update a group.
+ *
+ * See https://h.readthedocs.io/en/latest/api-reference/v2/#tag/groups/paths/~1groups/post
+ */
+export type CreateUpdateGroupAPIRequest = {
+  id?: string;
+  name: string;
+  description?: string;
+  type?: GroupType;
+};
+
+/**
  * A successful response from either h's create-new-group API or its update-group API:
  *
  * https://h.readthedocs.io/en/latest/api-reference/v2/#tag/groups/paths/~1groups/post


### PR DESCRIPTION
This allows setting the group type to "private", "restricted" or "open" when creating or editing a group.

This PR does not implement the part of the design where a warning is shown when changing the type of an existing group.

See https://github.com/hypothesis/h/issues/8898.

**Testing:**

1. Enable the `group_type` feature flag
2. Go to http://localhost:5000/groups/new
3. You should see new UI options to set the group type
4. Pick one of the group types other than "Private" and create the group
5. Go to edit the group and you should see the chosen group type selected
6. Change the group type in the edit form and click "Save changes"
7. Refresh the page and the group type should persist