### PR TITLE
Show warning when changing existing group between private and public types

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -16,6 +16,7 @@ import type {
   CreateUpdateGroupAPIResponse,
   GroupType,
 } from '../utils/api';
+import { pluralize } from '../utils/pluralize';
 import { setLocation } from '../utils/set-location';
 import SaveStateIcon from './SaveStateIcon';
 import WarningDialog from './WarningDialog';
@@ -167,9 +168,9 @@ function GroupTypeChangeWarning({
   let confirmAction;
   let message;
   if (newTypeIsPrivate) {
-    title = `Make ${count} annotations private?`;
+    title = `Make ${count} ${pluralize(count, 'annotation', 'annotations')} private?`;
     confirmAction = 'Make annotations private';
-    message = `Are you sure you want to make "${name}" a private group? ${count} annotations that are publicly visible will become visible only to members of "${name}".`;
+    message = `Are you sure you want to make "${name}" a private group? ${count} ${pluralize(count, 'annotation that is', 'annotations that are')} publicly visible will become visible only to members of "${name}".`;
   } else {
     let groupDescription = 'a public group';
     switch (newType) {
@@ -181,9 +182,9 @@ function GroupTypeChangeWarning({
         break;
     }
 
-    title = `Make ${count} annotations public?`;
+    title = `Make ${count} ${pluralize(count, 'annotation', 'annotations')} public?`;
     confirmAction = 'Make annotations public';
-    message = `Are you sure you want to make "${name}" ${groupDescription}? ${count} annotations that are visible only to members of "${name}" will become publicly visible.`;
+    message = `Are you sure you want to make "${name}" ${groupDescription}? ${count} ${pluralize(count, 'annotation that is', 'annotations that are')} visible only to members of "${name}" will become publicly visible.`;
   }
 
   return (

--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -329,6 +329,8 @@ export default function CreateEditGroupForm() {
     } else {
       setPendingGroupType(newType);
     }
+
+    setSaveState('unsaved');
   };
 
   return (

--- a/h/static/scripts/group-forms/components/WarningDialog.tsx
+++ b/h/static/scripts/group-forms/components/WarningDialog.tsx
@@ -1,0 +1,52 @@
+import { ModalDialog, Button } from '@hypothesis/frontend-shared';
+
+export type WarningDialogProps = {
+  /** Title of the dialog. */
+  title: string;
+
+  /** Message displayed in the dialog. */
+  message: string;
+
+  /** Label for the confirmation button. */
+  confirmAction: string;
+
+  /** Callback invoked when the user confirms the action. */
+  onConfirm: () => void;
+
+  /** Callback invoked when the user aborts the action. */
+  onCancel: () => void;
+};
+
+/**
+ * A modal dialog that warns users about a potentially destructive action.
+ */
+export default function WarningDialog({
+  title,
+  message,
+  confirmAction,
+  onConfirm,
+  onCancel,
+}: WarningDialogProps) {
+  return (
+    <ModalDialog
+      buttons={
+        <>
+          <Button data-testid="cancel-button" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            data-testid="confirm-button"
+            onClick={onConfirm}
+          >
+            {confirmAction}
+          </Button>
+        </>
+      }
+      title={title}
+      onClose={onCancel}
+    >
+      {message}
+    </ModalDialog>
+  );
+}

--- a/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
@@ -462,15 +462,19 @@ describe('CreateEditGroupForm', () => {
       assert.isFalse(savedConfirmationShowing(wrapper));
     });
 
-    ['name', 'description'].forEach(field => {
+    ['name', 'description', 'type'].forEach(field => {
       it('clears the confirmation if fields are edited again', async () => {
         const { wrapper, elements } = createWrapper();
-        const fieldEl = elements[field].fieldEl;
         fakeCallAPI.resolves();
         await wrapper.find('form[data-testid="form"]').simulate('submit');
 
-        fieldEl.getDOMNode().value = 'new text';
-        fieldEl.simulate('input');
+        if (field === 'type') {
+          setSelectedGroupType(wrapper, 'open');
+        } else {
+          const fieldEl = elements[field].fieldEl;
+          fieldEl.getDOMNode().value = 'new text';
+          fieldEl.simulate('input');
+        }
 
         await assertInLoadingState(wrapper, false);
         assert.isFalse(savedConfirmationShowing(wrapper));

--- a/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
@@ -504,6 +504,18 @@ describe('CreateEditGroupForm', () => {
       },
     },
     {
+      // Warn when making annotations public (singular)
+      oldType: 'private',
+      newType: 'open',
+      annotationCount: 1,
+      expectedWarning: {
+        title: 'Make 1 annotation public?',
+        message:
+          'Are you sure you want to make "Test Name" an open group? 1 annotation that is visible only to members of "Test Name" will become publicly visible.',
+        confirmAction: 'Make annotations public',
+      },
+    },
+    {
       // Warn when making annotations public (restricted group)
       oldType: 'private',
       newType: 'restricted',
@@ -524,6 +536,18 @@ describe('CreateEditGroupForm', () => {
         title: 'Make 3 annotations private?',
         message:
           'Are you sure you want to make "Test Name" a private group? 3 annotations that are publicly visible will become visible only to members of "Test Name".',
+        confirmAction: 'Make annotations private',
+      },
+    },
+    {
+      // Warn when making annotations private (singular)
+      oldType: 'open',
+      newType: 'private',
+      annotationCount: 1,
+      expectedWarning: {
+        title: 'Make 1 annotation private?',
+        message:
+          'Are you sure you want to make "Test Name" a private group? 1 annotation that is publicly visible will become visible only to members of "Test Name".',
         confirmAction: 'Make annotations private',
       },
     },

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -20,6 +20,7 @@ export type ConfigObject = {
       description: string;
       link: string;
       type: GroupType;
+      num_annotations: number;
     } | null;
   };
   features: {

--- a/h/static/scripts/group-forms/utils/pluralize.ts
+++ b/h/static/scripts/group-forms/utils/pluralize.ts
@@ -1,0 +1,3 @@
+export function pluralize(count: number, singular: string, plural: string) {
+  return count === 1 ? singular : plural;
+}


### PR DESCRIPTION
Show a warning when changing an existing group from a private type to a public type and vice-versa.

A caveat with the current implementation is that once a change is confirmed, it becomes the new "current type" that is used when deciding whether to show the warning in future, even though the type isn't actually changed until "Save changes" is clicked. This made the implementation simpler.

See https://github.com/hypothesis/h/issues/8898.

**Warning when making annotations private:**

<img width="636" alt="Make private v2" src="https://github.com/user-attachments/assets/dd29fc55-05ab-477d-ab4f-e41d0fc1e95b">

**Warning when making annotations public:**

<img width="620" alt="Make public v2" src="https://github.com/user-attachments/assets/1bfaac20-4609-4a0f-8763-7f92c2ac5327">

**Testing:**

1. Enable the `group_type` feature flag
2. Create a new private group
3. Go to http://localhost:5000/docs/help and add some annotations in the new group
4. Edit the new group and click the "Open" or "Restricted" group types. You should see a warning. Canceling should abort the change, confirming should perform the change.
5. Click "Save changes"
6. Change the group back to "Private". You should see a different warning. Canceling / confirming should work as before.
