### PR TITLE
Do not clear group form save state until changes are confirmed

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -327,11 +327,10 @@ export default function CreateEditGroupForm() {
 
     if (count === 0 || oldTypeIsPrivate === newTypeIsPrivate) {
       setGroupType(newType);
+      setSaveState('unsaved');
     } else {
       setPendingGroupType(newType);
     }
-
-    setSaveState('unsaved');
   };
 
   return (
@@ -429,6 +428,7 @@ export default function CreateEditGroupForm() {
           onCancel={() => setPendingGroupType(null)}
           onConfirm={() => {
             setGroupType(pendingGroupType);
+            setSaveState('unsaved');
             setPendingGroupType(null);
           }}
         />

--- a/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
@@ -273,7 +273,7 @@ describe('CreateEditGroupForm', () => {
     const { wrapper } = createWrapper();
     fakeCallAPI.resolves({ links: { html: 'https://example.com/group/foo' } });
 
-    await wrapper.find('form[data-testid="form"]').simulate('submit');
+    wrapper.find('form[data-testid="form"]').simulate('submit');
 
     await assertInLoadingState(wrapper, true);
     assert.isFalse(savedConfirmationShowing(wrapper));
@@ -309,7 +309,8 @@ describe('CreateEditGroupForm', () => {
       descriptionEl.simulate('input');
       setSelectedGroupType(wrapper, type);
 
-      await wrapper.find('form[data-testid="form"]').simulate('submit');
+      wrapper.find('form[data-testid="form"]').simulate('submit');
+      await delay(0);
 
       assert.calledOnceWithExactly(fakeCallAPI, config.api.createGroup.url, {
         method: config.api.createGroup.method,
@@ -420,7 +421,7 @@ describe('CreateEditGroupForm', () => {
       descriptionEl.simulate('input');
       wrapper.find(`[data-value="${newGroupType}"]`).simulate('click');
 
-      await wrapper.find('form[data-testid="form"]').simulate('submit');
+      wrapper.find('form[data-testid="form"]').simulate('submit');
 
       assert.isTrue(
         fakeCallAPI.calledOnceWithExactly(config.api.updateGroup.url, {
@@ -449,7 +450,7 @@ describe('CreateEditGroupForm', () => {
       const { wrapper } = createWrapper();
       fakeCallAPI.resolves();
 
-      await wrapper.find('form[data-testid="form"]').simulate('submit');
+      wrapper.find('form[data-testid="form"]').simulate('submit');
 
       await assertInLoadingState(wrapper, false);
       assert.isTrue(savedConfirmationShowing(wrapper));
@@ -475,7 +476,7 @@ describe('CreateEditGroupForm', () => {
       it('clears the confirmation if fields are edited again', async () => {
         const { wrapper, elements } = createWrapper();
         fakeCallAPI.resolves();
-        await wrapper.find('form[data-testid="form"]').simulate('submit');
+        wrapper.find('form[data-testid="form"]').simulate('submit');
 
         if (field === 'type') {
           // nb. Since the group has no annotations, the type will change


### PR DESCRIPTION
If changing the group type triggers a warning, do not clear the form's save state until the user confirms the change.

In the process I cleaned up some unnecessary uses of `await` in the tests (see second commit).

**Testing:**

1. Create a new private group
2. Add at least one annotation to the group
3. Go to the group edit form, change the description and click "Save". You should see a tick next to "Save changes"
4. Click a radio button to change the group type from private to public, but Cancel the warning. The tick next to "Save changes" should remain.
5. Repeat step 4, but this time Confirm the warning. The tick next to "Save changes" should disappear