### PR TITLE
Add creators to open groups as members

### DIFF
--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -36,7 +36,6 @@ class GroupCreateService:
             userid=userid,
             type_flags=GROUP_TYPE_FLAGS["private"],
             scopes=[],
-            add_creator_as_member=True,
             **kwargs,
         )
 
@@ -60,7 +59,6 @@ class GroupCreateService:
             userid=userid,
             type_flags=GROUP_TYPE_FLAGS["open"],
             scopes=scopes,
-            add_creator_as_member=False,
             **kwargs,
         )
 
@@ -85,13 +83,10 @@ class GroupCreateService:
             userid=userid,
             type_flags=GROUP_TYPE_FLAGS["restricted"],
             scopes=scopes,
-            add_creator_as_member=True,
             **kwargs,
         )
 
-    def _create(  # pylint: disable=too-many-arguments
-        self, name, userid, type_flags, scopes, add_creator_as_member, **kwargs
-    ):
+    def _create(self, name, userid, type_flags, scopes, **kwargs):
         """
         Create a group and save it to the DB.
 
@@ -100,7 +95,6 @@ class GroupCreateService:
         :param type_flags: the type of this group
         :param scopes: the list of scopes (URIs) that the group will be scoped to
         :type scopes: list(str)
-        :param add_creator_as_member: if the group creator should be added as a member
         :param kwargs: optional attributes to set on the group, as keyword
             arguments
         """
@@ -132,10 +126,8 @@ class GroupCreateService:
         # self.publish() or `return group`.
         self.db.flush()
 
-        if add_creator_as_member:
-            group.members.append(group.creator)
-
-            self.publish("group-join", group.pubid, group.creator.userid)
+        group.members.append(group.creator)
+        self.publish("group-join", group.pubid, group.creator.userid)
 
         return group
 

--- a/tests/unit/h/services/group_create_test.py
+++ b/tests/unit/h/services/group_create_test.py
@@ -152,10 +152,10 @@ class TestCreateOpenGroup:
 
         assert group.creator == creator
 
-    def test_it_does_not_add_group_creator_to_members(self, svc, creator, origins):
+    def test_it_adds_group_creator_to_members(self, svc, creator, origins):
         group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
 
-        assert creator not in group.members
+        assert creator in group.members
 
     @pytest.mark.parametrize(
         "flag,expected_value",
@@ -213,12 +213,12 @@ class TestCreateOpenGroup:
 
         assert group in db_session
 
-    def test_it_does_not_publish_join_event(self, svc, creator, publish, origins):
-        svc.create_open_group(
+    def test_it_publishes_join_event(self, svc, creator, publish, origins):
+        group = svc.create_open_group(
             "Dishwasher disassemblers", creator.userid, scopes=origins
         )
 
-        publish.assert_not_called()
+        publish.assert_called_once_with("group-join", group.pubid, creator.userid)
 
     @pytest.mark.parametrize(
         "origins",


### PR DESCRIPTION
When creating a new open group add the group's creator to the group as a member, as we do when creating a private or restricted group.

Will follow this up with a migration to add existing open group creators as members.