### PR TITLE
Show members on open group home page

### DIFF
--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -51,15 +51,6 @@ class OpenGroup(Group):
     joinable_by = None
     readable_by = ReadableBy.world
     writeable_by = WriteableBy.authority
-    members = []
-
-    @factory.post_generation
-    def add_creator_as_member(  # pylint:disable=no-self-argument
-        _obj, _create, _extracted, **_kwargs
-    ):
-        # Open groups don't have members, so don't add group.creator to
-        # group.members for open groups.
-        pass
 
 
 class RestrictedGroup(Group):

--- a/tests/unit/h/services/group_members_test.py
+++ b/tests/unit/h/services/group_members_test.py
@@ -71,7 +71,7 @@ class TestAddMembers:
 
         group_members_service.add_members(group, userids)
 
-        assert group.members == users
+        assert all(user in group.members for user in users)
 
     def test_it_does_not_remove_existing_members(
         self, factories, group_members_service
@@ -132,7 +132,7 @@ class TestUpdateMembers:
         group_members_service.member_join = mock.Mock()
         group_members_service.member_leave = mock.Mock()
 
-        group = factories.OpenGroup()  # no members at outset
+        group = factories.OpenGroup()
         new_members = [factories.User(), factories.User()]
         group.members.append(new_members[0])
 
@@ -141,8 +141,11 @@ class TestUpdateMembers:
         group_members_service.member_join.assert_called_once_with(
             group, new_members[1].userid
         )
-        group_members_service.member_leave.assert_called_once_with(
-            group, new_members[0].userid
+        assert sorted(group_members_service.member_leave.call_args_list) == sorted(
+            [
+                mock.call(group, group.creator.userid),
+                mock.call(group, new_members[0].userid),
+            ]
         )
 
     def test_it_does_not_add_duplicate_members(self, factories, group_members_service):

--- a/tests/unit/h/views/activity_test.py
+++ b/tests/unit/h/views/activity_test.py
@@ -421,7 +421,7 @@ class TestGroupSearchController:
         result = controller.search()
 
         actual = {m["username"] for m in result["group_users_args"][1]}
-        expected = {test_group.creator.username}
+        expected = {member.username for member in test_group.members}
         assert actual == expected
 
     @pytest.mark.parametrize(
@@ -435,7 +435,7 @@ class TestGroupSearchController:
         result = controller.search()
 
         actual = {m["userid"] for m in result["group_users_args"][1]}
-        expected = {test_group.creator.userid}
+        expected = {member.userid for member in test_group.members}
         assert actual == expected
 
     @pytest.mark.parametrize(
@@ -675,18 +675,6 @@ class TestGroupSearchController:
         userids = [i["userid"] for i in info[1]]
         for member in test_group.members:
             assert member.userid in userids
-
-        search.reset_mock()
-
-    @pytest.mark.parametrize("test_group", [("open_group")], indirect=["test_group"])
-    def test_search_sets_display_members_for_open_group(
-        self, controller, test_group, search
-    ):
-        info = controller.search()["group_users_args"]
-        userids = [i["userid"] for i in info[1]]
-
-        # At the moment, for an open group we return the group creator as the moderator
-        assert userids == [test_group.creator.userid]
 
         search.reset_mock()
 


### PR DESCRIPTION
Show all of the group's members, not just the creator, in the "Members" list on an open group's home page. Same as we do on private and restricted group home pages.

Depends on https://github.com/hypothesis/h/pull/9005 and https://github.com/hypothesis/h/pull/9006.
