### PR TITLE
Fix admin pages when group has no organization

### DIFF
--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -105,7 +105,7 @@ class GroupCreateService:
 
         group_scopes = [GroupScope(scope=s) for s in scopes]
 
-        if "organization" in kwargs:
+        if kwargs.get("organization"):
             self._validate_authorities_match(
                 creator.authority, kwargs["organization"].authority
             )

--- a/tests/unit/h/schemas/forms/admin/group_test.py
+++ b/tests/unit/h/schemas/forms/admin/group_test.py
@@ -53,7 +53,7 @@ class TestAdminGroupSchema:
         with pytest.raises(colander.Invalid, match=f".*{required_field}.*"):
             bound_schema.deserialize(group_data)
 
-    @pytest.mark.parametrize("optional_field", ("description",))
+    @pytest.mark.parametrize("optional_field", ("description", "organization"))
     def test_it_allows_when_optional_field_missing(
         self, group_data, bound_schema, optional_field
     ):
@@ -162,6 +162,7 @@ class TestAdminGroupSchema:
 
         # pylint:disable=possibly-used-before-assignment
         assert org_node.widget.values == [
+            ("", "-- None --"),
             (org.pubid, f"{org.name} ({org.authority})"),
             (
                 third_party_org.pubid,

--- a/tests/unit/h/services/group_create_test.py
+++ b/tests/unit/h/services/group_create_test.py
@@ -69,8 +69,23 @@ class TestCreatePrivateGroup:
 
         assert getattr(group, flag) == expected_value
 
-    def test_it_creates_group_with_no_organization_by_default(self, creator, svc):
-        group = svc.create_private_group("Anteater fans", creator.userid)
+    @pytest.mark.parametrize("pass_kwarg", [True, False])
+    def test_it_creates_group_with_no_organization_by_default(
+        self, creator, svc, pass_kwarg
+    ):
+        """
+        If the caller passes no organization it creates a group with no organization.
+
+        This works both if the caller omits the `organization` kwarg entirely
+        and if the caller passes `organization=None`. It's convenient for the
+        caller to be able to do it either way.
+        """
+        if pass_kwarg:
+            kwargs = {"organization": None}
+        else:
+            kwargs = {}
+
+        group = svc.create_private_group("Anteater fans", creator.userid, **kwargs)
 
         assert group.organization is None
 
@@ -170,10 +185,25 @@ class TestCreateOpenGroup:
 
         assert getattr(group, flag) == expected_value
 
+    @pytest.mark.parametrize("pass_kwarg", [True, False])
     def test_it_creates_group_with_no_organization_by_default(
-        self, creator, svc, origins
+        self, creator, svc, origins, pass_kwarg
     ):
-        group = svc.create_open_group("Anteater fans", creator.userid, scopes=origins)
+        """
+        If the caller passes no organization it creates a group with no organization.
+
+        This works both if the caller omits the `organization` kwarg entirely
+        and if the caller passes `organization=None`. It's convenient for the
+        caller to be able to do it either way.
+        """
+        if pass_kwarg:
+            kwargs = {"organization": None}
+        else:
+            kwargs = {}
+
+        group = svc.create_open_group(
+            "Anteater fans", creator.userid, scopes=origins, **kwargs
+        )
 
         assert group.organization is None
 
@@ -319,11 +349,24 @@ class TestCreateRestrictedGroup:
 
         assert getattr(group, flag) == expected_value
 
+    @pytest.mark.parametrize("pass_kwarg", [True, False])
     def test_it_creates_group_with_no_organization_by_default(
-        self, creator, svc, origins
+        self, creator, svc, origins, pass_kwarg
     ):
+        """
+        If the caller passes no organization it creates a group with no organization.
+
+        This works both if the caller omits the `organization` kwarg entirely
+        and if the caller passes `organization=None`. It's convenient for the
+        caller to be able to do it either way.
+        """
+        if pass_kwarg:
+            kwargs = {"organization": None}
+        else:
+            kwargs = {}
+
         group = svc.create_restricted_group(
-            "Anteater fans", creator.userid, scopes=origins
+            "Anteater fans", creator.userid, scopes=origins, **kwargs
         )
 
         assert group.organization is None


### PR DESCRIPTION
Fix a crash on the admin page for editing an open or restricted group
when the group has no organization.

Fixes: https://github.com/hypothesis/h/issues/9009

Problem
-------

Open and restricted groups have admin pages that let Hypothesis admins
edit the group (type, name, organization, creator, description, scopes,
members). You go to https://hypothes.is/admin/groups, search for the
open or restricted group that you want, and click on that group's name
to go to the `https://hypothes.is/admin/groups/<PUBID>` admin page for
editing that group.

Private groups do not have admin pages, that's why many of the group
names on the the https://hypothes.is/admin/groups admin page aren't
linked: those are private groups.

Originally the only way to create an open or restricted group was via
the https://hypothes.is/admin/groups/new admin page, and that page
forces you to choose an organization for the open or restricted group to
belong to. The `https://hypothes.is/admin/groups/<PUBID>` page could
therefore assume that all open or restricted groups belong to an
organization.

Recently we've enabled users to create their own open or restricted
groups via the https://hypothes.is/groups/new page and groups created by
this page do not have organizations. Private groups created by this page
have never belonged to organizations. The open and restricted groups
that can now also be created don't have organizations either. A user
could also create a private group with no organization and then turn it
into an open or restricted group.

So for the first time it's now possible to have open and restricted
groups with no organizations. But the
`https://hypothes.is/admin/groups/<PUBID>` admin page for editing open
or restricted groups has two problems with this:

1. Loading the page crashes when the group has no organization
2. The form forces groups to belong to an organization, there's no
   option for a group to not have an organization. So when editing
   a group with no organization it'll force you to choose an
   organization before you can make any other changes

Solution
--------

This commit fixes the page to not crash when a group has no organization
and also adds a "-- None --" option to the form's organization dropdown
so that it no longer forces you to select an organization when creating
or editing a group.

As a side effect of these changes admins can now also use the
https://hypothes.is/admin/groups/new admin page to create open and
restricted groups with no organization, and some further fixes were
needed to prevent this from crashing.

Testing
-------

Use either http://localhost:5000/admin/groups/new or http://localhost:5000/groups/new to create a restricted or open group with no organization and then use `http://localhost:5000/admin/groups/<PUBID>` to edit the group.
