### PR TITLE
Allow groups with no scopes in admin pages

### DIFF
--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -206,10 +206,7 @@ class AdminGroupSchema(CSRFSchema):
             "Define where this group appears. A document's URL must start with one or more"
             " of the entered scope strings (e.g. 'http://www.example.com')"
         ),
-        widget=SequenceWidget(add_subitem_text_template=_("Add scope"), min_len=1),
-        validator=colander.Length(
-            min=1, min_err=_("At least one scope must be specified")
-        ),
+        widget=SequenceWidget(add_subitem_text_template=_("Add scope")),
     )
 
     members = colander.SequenceSchema(

--- a/tests/unit/h/schemas/forms/admin/group_test.py
+++ b/tests/unit/h/schemas/forms/admin/group_test.py
@@ -69,10 +69,10 @@ class TestAdminGroupSchema:
         with pytest.raises(colander.Invalid, match="scope.*must be a complete URL"):
             bound_schema.deserialize(group_data)
 
-    def test_it_raises_if_no_origins(self, group_data, bound_schema):
+    def test_it_allows_no_scopes(self, group_data, bound_schema):
         group_data["scopes"] = []
-        with pytest.raises(colander.Invalid, match="At least one scope"):
-            bound_schema.deserialize(group_data)
+
+        bound_schema.deserialize(group_data)
 
     def test_it_raises_if_group_type_changed(
         self, group_data, pyramid_csrf_request, org, user_service


### PR DESCRIPTION
Problem
-------

Previously the only way to create open or restricted groups was via the
https://hypothes.is/admin/groups/new admin page and that page forced you
to enter at least one scope for the group.

It's now possible to use the https://hypothes.is/groups/new page to
create open and restricted groups with no scopes.

But the `https://hypothes.is/admin/groups/<PUBID>` page for editing an
existing open or restricted group forces the group to have at least one
scope.

This means that if you create an unscoped group via
https://hypothes.is/groups/new and then try to edit the group via
`https://hypothes.is/admin/groups/<PUBID>` it'll force you to enter at
least one scope for the group before you can save any changes (even to
other fields, e.g. the group's name).

Solution
--------

Remove the admin pages validation requirement that groups must have at
least one scope. Now you can edit unscoped groups without having to add
a scope to them.

As a side-effect https://hypothes.is/admin/groups/new can now be used to
create unscoped groups as well.

Testing
-------

Go to either https://hypothes.is/admin/groups/new or
https://hypothes.is/groups/new, create an open or restricted group, then
go to `https://hypothes.is/admin/groups/<PUBID>` and edit the group
without adding any scopes to it.
