### PR TITLE
Set `gaMeasurementId` variable to meta tag value, not element

### DIFF
--- a/h/static/scripts/header.js
+++ b/h/static/scripts/header.js
@@ -11,7 +11,7 @@ window.envFlags.init();
 // See https://developers.google.com/analytics/devguides/migration/ua/analyticsjs-to-gtagjs
 const gaMeasurementId = document.querySelector(
   'meta[name="google-analytics-measurement-id"]',
-);
+)?.content;
 if (gaMeasurementId) {
   /* eslint-disable */
   window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
Fix an issue from https://github.com/hypothesis/h/pull/9014 (and the commit prior to that) where `gtag("config", tag_id)` was passed a DOM element instead of a tag ID.

🤦‍♂️ 