### PR TITLE
Automatically create the Docker network "dbs"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ help:
 .PHONY: services
 services: args?=up -d --wait
 services: python
+	@docker network create dbs 2>/dev/null || true
 	@docker compose $(args)
 
 .PHONY: db


### PR DESCRIPTION
I keep running into this error whenever running `make services`:

    Error response from daemon: network dbs not found

It's caused by this networks stuff that was added to h's `docker-compose.yml`:

https://github.com/hypothesis/h/blob/7cb19f4e08100641d316092a3f25f741a2c78dc2/docker-compose.yml#L29-L34

There was once a command added to h's Makefile to auto-create this
network:

https://github.com/hypothesis/h/pull/7673

But it got removed by:

https://github.com/hypothesis/h/commit/abbe35ccbb6c47c1038aaf9b15c304419c30b8f1.

Add the command back to get rid of the `network dbs not found` errors.

We'll probably have to add support for this to our cookiecutter but h
doesn't use the cookiecutter yet so for now this is fine.
