### PR TITLE
Replace `Group.members` and `User.members` with `memberships`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,6 @@ omit =
 show_missing = True
 precision = 2
 fail_under = 100
-
 skip_covered = True
+exclude_also =
+    if TYPE_CHECKING:

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -11,7 +11,7 @@ from h.exceptions import InvalidUserId
 from h.util.user import format_userid, split_user
 
 if TYPE_CHECKING:
-    from models.group import Group  # pragma: nocover
+    from models.group import Group
 
 
 USERNAME_MIN_LENGTH = 3

--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -126,7 +126,7 @@ class GroupCreateService:
         # self.publish() or `return group`.
         self.db.flush()
 
-        group.memberships.append(GroupMembership(user=group.creator, roles=["owner"]))
+        self.db.add(GroupMembership(group=group, user=group.creator, roles=["owner"]))
         self.publish("group-join", group.pubid, group.creator.userid)
 
         return group

--- a/h/services/group_create.py
+++ b/h/services/group_create.py
@@ -126,9 +126,7 @@ class GroupCreateService:
         # self.publish() or `return group`.
         self.db.flush()
 
-        self.db.add(
-            GroupMembership(user_id=creator.id, group_id=group.id, roles=["owner"])
-        )
+        group.memberships.append(GroupMembership(user=group.creator, roles=["owner"]))
         self.publish("group-join", group.pubid, group.creator.userid)
 
         return group

--- a/h/services/group_members.py
+++ b/h/services/group_members.py
@@ -78,17 +78,15 @@ class GroupMembersService:
         """Remove `userid` from the member list of `group`."""
         user = self.user_fetcher(userid)
 
-        matching_memberships = [
-            membership for membership in group.memberships if membership.user == user
-        ]
+        matching_memberships = self.db.scalars(
+            select(GroupMembership).where(GroupMembership.user == user)
+        ).all()
 
         if not matching_memberships:
             return
 
         for membership in matching_memberships:
             self.db.delete(membership)
-            group.memberships.remove(membership)
-            user.memberships.remove(membership)
 
         self.publish("group-leave", group.pubid, userid)
 

--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -20,7 +20,6 @@ class Group(ModelFactory):
     joinable_by = JoinableBy.authority
     readable_by = ReadableBy.members
     writeable_by = WriteableBy.members
-    members = factory.LazyFunction(list)
     authority_provided_id = Faker("hexify", text="^" * 30)
     enforce_scope = True
 

--- a/tests/functional/api/bulk/annotation_test.py
+++ b/tests/functional/api/bulk/annotation_test.py
@@ -2,6 +2,8 @@ import json
 
 import pytest
 
+from h.models import GroupMembership
+
 
 @pytest.mark.usefixtures("with_clean_db")
 class TestBulkAnnotation:
@@ -23,7 +25,7 @@ class TestBulkAnnotation:
         group = factories.Group(
             authority="lms.hypothes.is",
             authority_provided_id="1234567890",
-            members=[user],
+            memberships=[GroupMembership(user=user)],
         )
         annotation_slim = factories.AnnotationSlim(
             user=user,

--- a/tests/functional/api/groups/read_test.py
+++ b/tests/functional/api/groups/read_test.py
@@ -21,10 +21,8 @@ class TestReadGroups:
         self, app, factories, db_session, user_with_token, token_auth_header
     ):
         user, _ = user_with_token
-        group1 = factories.Group()
-        db_session.add(GroupMembership(group_id=group1.id, user_id=user.id))
-        group2 = factories.Group()
-        db_session.add(GroupMembership(group_id=group2.id, user_id=user.id))
+        group1 = factories.Group(memberships=[GroupMembership(user=user)])
+        group2 = factories.Group(memberships=[GroupMembership(user=user)])
         db_session.commit()
 
         res = app.get("/api/groups", headers=token_auth_header)
@@ -38,8 +36,9 @@ class TestReadGroups:
         self, app, factories, db_session, user_with_token, token_auth_header
     ):
         user, _ = user_with_token
-        group1 = factories.Group(authority=user.authority)
-        db_session.add(GroupMembership(group_id=group1.id, user_id=user.id))
+        group1 = factories.Group(
+            authority=user.authority, memberships=[GroupMembership(user=user)]
+        )
         db_session.commit()
 
         res = app.get("/api/groups?authority=whatever.com", headers=token_auth_header)
@@ -94,8 +93,7 @@ class TestReadGroup:
         self, app, user_with_token, token_auth_header, factories, db_session
     ):
         user, _ = user_with_token
-        group = factories.Group(creator=user)
-        db_session.add(GroupMembership(group_id=group.id, user_id=user.id))
+        group = factories.Group(creator=user, memberships=[GroupMembership(user=user)])
         db_session.commit()
 
         res = app.get(
@@ -109,7 +107,7 @@ class TestReadGroup:
     ):
         user, _ = user_with_token
         group = factories.Group()
-        group.members.append(user)
+        group.memberships.append(GroupMembership(user=user))
         db_session.commit()
 
         res = app.get(

--- a/tests/functional/api/profile_test.py
+++ b/tests/functional/api/profile_test.py
@@ -1,5 +1,7 @@
 import pytest
 
+from h.models import GroupMembership
+
 
 class TestGetProfile:
     def test_it_returns_profile_with_single_group_when_not_authd(self, app):
@@ -147,8 +149,9 @@ def groups(factories):
 
 @pytest.fixture
 def user(groups, db_session, factories):
-    user = factories.User()
-    user.groups = groups
+    user = factories.User(
+        memberships=[GroupMembership(group=group) for group in groups]
+    )
     db_session.commit()
     return user
 

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -75,6 +75,13 @@ disable = [
 
     # h-matchers triggers this when called without brackets
     "no-value-for-parameter",
+
+    # This is intermittently causing a false-positive:
+    # tests/unit/h/models/document/_uri_test.py:17:15: W0143: Comparing against a callable, did you omit the parenthesis? (comparison-with-callable)
+    # ...if we add a # pylint:disable comment for it then it starts intermittently causing:
+    # tests/unit/h/models/document/_uri_test.py:17:0: I0021: Useless suppression of 'comparison-with-callable' (useless-suppression)
+    # Just disable the whole rule globally.
+    "comparison-with-callable",
 ]
 
 # Just disable PyLint's name style checking for the tests, because we

--- a/tests/unit/h/models/document/_uri_test.py
+++ b/tests/unit/h/models/document/_uri_test.py
@@ -14,6 +14,7 @@ class TestDocumentURI:
     def test_it_normalizes_the_uri(self):
         document_uri = DocumentURI(uri="http://example.com/")
 
+        # pylint:disable=comparison-with-callable
         assert document_uri.uri_normalized == "httpx://example.com"
 
     def test_type_defaults_to_empty_string(self, db_session, document_uri, factories):

--- a/tests/unit/h/models/document/_uri_test.py
+++ b/tests/unit/h/models/document/_uri_test.py
@@ -14,7 +14,6 @@ class TestDocumentURI:
     def test_it_normalizes_the_uri(self):
         document_uri = DocumentURI(uri="http://example.com/")
 
-        # pylint:disable=comparison-with-callable
         assert document_uri.uri_normalized == "httpx://example.com"
 
     def test_type_defaults_to_empty_string(self, db_session, document_uri, factories):

--- a/tests/unit/h/models/group_test.py
+++ b/tests/unit/h/models/group_test.py
@@ -219,6 +219,38 @@ def test_non_public_group():
     assert not group.is_public
 
 
+def test_members(factories):
+    users = factories.User.build_batch(size=2)
+    group = factories.Group.build(
+        memberships=[
+            models.GroupMembership(user=users[0]),
+            models.GroupMembership(user=users[1]),
+        ]
+    )
+
+    assert group.members == tuple(users)
+
+
+def test_members_is_readonly(factories):
+    group = factories.Group.build()
+    new_members = (factories.User.build(),)
+
+    with pytest.raises(
+        AttributeError, match="^property 'members' of 'Group' object has no setter$"
+    ):
+        group.members = new_members
+
+
+def test_members_is_immutable(factories):
+    group = factories.Group.build()
+    new_member = factories.User.build()
+
+    with pytest.raises(
+        AttributeError, match="^'tuple' object has no attribute 'append'$"
+    ):
+        group.members.append(new_member)
+
+
 class TestGroupMembership:
     def test_defaults(self, db_session, user, group):
         membership = models.GroupMembership(user_id=user.id, group_id=group.id)

--- a/tests/unit/h/security/identity_test.py
+++ b/tests/unit/h/security/identity_test.py
@@ -3,6 +3,7 @@ from unittest.mock import sentinel
 import pytest
 from h_matchers import Any
 
+from h.models import GroupMembership
 from h.security.identity import (
     Identity,
     LongLivedAuthClient,
@@ -25,7 +26,7 @@ class TestLongLivedGroup:
 class TestLongLivedUser:
     def test_from_models(self, factories, LongLivedGroup):
         group = factories.Group.build()
-        user = factories.User.build(groups=[group])
+        user = factories.User.build(memberships=[GroupMembership(group=group)])
 
         model = LongLivedUser.from_model(user)
 

--- a/tests/unit/h/security/permits_test.py
+++ b/tests/unit/h/security/permits_test.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, sentinel
 import pytest
 from pyramid.security import Allowed, Denied
 
+from h.models import GroupMembership
 from h.security import Identity, Permission
 from h.security.permits import PERMISSION_MAP, identity_permits
 from h.traversal import AnnotationContext
@@ -92,7 +93,7 @@ class TestIdentityPermitsIntegrated:
 
     @pytest.fixture
     def user(self, factories, group):
-        return factories.User(groups=[group])
+        return factories.User(memberships=[GroupMembership(group=group)])
 
     @pytest.fixture
     def group(self, factories):

--- a/tests/unit/h/services/bulk_api/annotation_test.py
+++ b/tests/unit/h/services/bulk_api/annotation_test.py
@@ -3,6 +3,7 @@ from unittest.mock import sentinel
 import pytest
 from h_matchers import Any
 
+from h.models import GroupMembership
 from h.services.bulk_api.annotation import (
     BulkAnnotation,
     BulkAnnotationService,
@@ -48,7 +49,9 @@ class TestBulkAnnotationService:
         author = factories.User(
             authority=self.AUTHORITY, nipsa=values["nipsad"], username=username
         )
-        group = factories.Group(members=[author, viewer])
+        group = factories.Group(
+            memberships=[GroupMembership(user=author), GroupMembership(user=viewer)]
+        )
         anno_slim = factories.AnnotationSlim(
             user=author,
             group=group,
@@ -86,7 +89,9 @@ class TestBulkAnnotationService:
         annotations = [
             factories.AnnotationSlim(
                 user=author,
-                group=factories.Group(members=group_members),
+                group=factories.Group(
+                    memberships=[GroupMembership(user=user) for user in group_members]
+                ),
                 shared=True,
                 deleted=False,
             )

--- a/tests/unit/h/services/group_list_test.py
+++ b/tests/unit/h/services/group_list_test.py
@@ -39,7 +39,7 @@ class TestAssociatedGroups:
 
     def test_it_returns_restricted_groups_if_user_is_member(self, svc, factories, user):
         restricted_group = factories.RestrictedGroup(
-            members=[user], authority=user.authority
+            memberships=[GroupMembership(user=user)], authority=user.authority
         )
         groups = svc.associated_groups(user)
 
@@ -64,11 +64,6 @@ class TestAssociatedGroups:
         # with this user in some form—but we want to make sure it does not appear
         # in these results.
         private_group = factories.Group(creator=user, authority=user.authority)
-        # Remove `private_group.creator` from `private_group.members`.
-        # The creator is still attached to `private_group` as `private_group.creator`.
-        private_group.members = [
-            user for user in private_group.members if user is not private_group.creator
-        ]
 
         groups = svc.associated_groups(user)
 
@@ -85,7 +80,9 @@ class TestAssociatedGroups:
         # This user is both a member of and a creator of this group; make sure it only
         # comes back once
         restricted_group = factories.RestrictedGroup(
-            members=[user], authority=user.authority, creator=user
+            memberships=[GroupMembership(user=user)],
+            authority=user.authority,
+            creator=user,
         )
 
         groups = svc_no_sample_groups.associated_groups(user)
@@ -159,9 +156,11 @@ class TestListGroupsRequestGroups:
 
 class TestUserGroups:
     def test_it_returns_all_user_groups_sorted_by_group_name(
-        self, svc, user, user_groups
+        self, db_session, svc, user, user_groups
     ):
-        user.groups = user_groups
+
+        with db_session.no_autoflush:
+            user.memberships = [GroupMembership(group=group) for group in user_groups]
 
         u_groups = svc.user_groups(user)
 
@@ -191,12 +190,16 @@ class TestPrivateGroups:
 
         svc.user_groups.assert_called_once_with(user)
 
-    def test_it_returns_only_private_groups(self, svc, user, factories):
+    def test_it_returns_only_private_groups(self, db_session, svc, user, factories):
         private_group = factories.Group()
         open_group = factories.OpenGroup()
         restricted_group = factories.RestrictedGroup()
 
-        user.groups = [private_group, open_group, restricted_group]
+        with db_session.no_autoflush:
+            user.memberships = [
+                GroupMembership(group=group)
+                for group in [private_group, open_group, restricted_group]
+            ]
 
         p_groups = svc.private_groups(user)
 
@@ -331,9 +334,7 @@ def document_uri():
 
 
 @pytest.fixture
-def sample_groups(
-    factories, other_authority, document_uri, default_authority, user, db_session
-):
+def sample_groups(factories, other_authority, document_uri, default_authority, user):
     sample_groups = {
         "open": factories.OpenGroup(
             name="sample open",
@@ -356,10 +357,8 @@ def sample_groups(
         "private": factories.Group(creator=user),
     }
 
-    # Make `user` a member of the sample_groups["private"].
-    db_session.add(
-        GroupMembership(user_id=user.id, group_id=sample_groups["private"].id)
-    )
+    # Make `user` a member of sample_groups["private"].
+    sample_groups["private"].memberships.append(GroupMembership(user=user))
 
     return sample_groups
 

--- a/tests/unit/h/services/group_members_test.py
+++ b/tests/unit/h/services/group_members_test.py
@@ -94,7 +94,7 @@ class TestUpdateMembers:
         assert group.members == new_members
 
     def test_it_removes_members_not_present_in_userids(
-        self, factories, group_members_service, creator
+        self, db_session, factories, group_members_service, creator
     ):
         group = factories.Group(
             creator=creator,

--- a/tests/unit/h/services/group_test.py
+++ b/tests/unit/h/services/group_test.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 from h_matchers import Any
 
-from h.models import Group
+from h.models import Group, GroupMembership
 from h.models.group import ReadableBy
 from h.services.group import GroupService, groups_factory
 
@@ -140,7 +140,7 @@ class TestGroupServiceGroupIds:
         user = factories.User()
 
         group = factories.Group(readable_by=ReadableBy.members)
-        group.members.append(user)
+        group.memberships.append(GroupMembership(user=user))
 
         db_session.flush()
 
@@ -168,7 +168,7 @@ class TestGroupServiceGroupIds:
     def test_created_by_excludes_other_groups(self, svc, db_session, factories):
         user = factories.User()
         private_group = factories.Group()
-        private_group.members.append(user)
+        private_group.memberships.append(GroupMembership(user=user))
         factories.Group(readable_by=ReadableBy.world)
         db_session.flush()
 

--- a/tests/unit/h/services/user_delete_test.py
+++ b/tests/unit/h/services/user_delete_test.py
@@ -354,11 +354,18 @@ class TestUserPurger:
         other_user = factories.User()
         groups = [
             # A group that `user` created.
-            factories.Group(creator=user, members=[other_user]),
+            factories.Group(
+                creator=user, memberships=[GroupMembership(user=other_user)]
+            ),
             # A group that `user` is a member of but didn't create.
-            factories.Group(members=[user, other_user]),
+            factories.Group(
+                memberships=[
+                    GroupMembership(user=user),
+                    GroupMembership(user=other_user),
+                ]
+            ),
             # A group that `user` is neither a creator or member of.
-            factories.Group(members=[other_user]),
+            factories.Group(memberships=[GroupMembership(user=other_user)]),
         ]
 
         purger.delete_group_memberships(user)

--- a/tests/unit/h/views/activity_test.py
+++ b/tests/unit/h/views/activity_test.py
@@ -8,6 +8,7 @@ from pyramid import httpexceptions
 from webob.multidict import MultiDict
 
 from h.activity.query import ActivityResults
+from h.models import GroupMembership
 from h.security import Permission
 from h.traversal import UserContext
 from h.traversal.group import GroupContext
@@ -390,7 +391,7 @@ class TestGroupSearchController:
     ):
         user_1 = factories.User()
         user_2 = factories.User()
-        group.members = [user_1, user_2]
+        group.memberships = [GroupMembership(user=user_1), GroupMembership(user=user_2)]
 
         pyramid_request.user = group.members[-1]
 
@@ -1189,36 +1190,51 @@ class TestGroupAndUserSearchController:
 @pytest.fixture
 def group(factories):
     group = factories.Group()
-    group.members.extend([group.creator, factories.User(), factories.User()])
+    group.memberships.extend(
+        [
+            GroupMembership(user=user)
+            for user in [group.creator, factories.User(), factories.User()]
+        ]
+    )
     return group
 
 
 @pytest.fixture
 def no_creator_group(factories):
     group = factories.Group(creator=None)
-    group.members.extend([factories.User(), factories.User()])
+    group.memberships.extend(
+        [GroupMembership(user=factories.User()), GroupMembership(user=factories.User())]
+    )
     return group
 
 
 @pytest.fixture
 def no_organization_group(factories):
     group = factories.Group(organization=None)
-    group.members.extend([group.creator, factories.User(), factories.User()])
+    group.memberships.extend(
+        [
+            GroupMembership(user=user)
+            for user in [group.creator, factories.User(), factories.User()]
+        ]
+    )
     return group
 
 
 @pytest.fixture
 def open_group(factories):
     open_group = factories.OpenGroup()
-    open_group.members.append(open_group.creator)
+    open_group.memberships.append(GroupMembership(user=open_group.creator))
     return open_group
 
 
 @pytest.fixture
 def restricted_group(factories):
     restricted_group = factories.RestrictedGroup()
-    restricted_group.members.extend(
-        [restricted_group.creator, factories.User(), factories.User()]
+    restricted_group.memberships.extend(
+        [
+            GroupMembership(user=user)
+            for user in [restricted_group.creator, factories.User(), factories.User()]
+        ]
     )
     return restricted_group
 


### PR DESCRIPTION
Now that `GroupMembership`'s are going to have roles via the (not-yet-merged) `GroupMembership.roles` column it's no longer sufficient for code to speak in terms of "members", for example a group having a list of users as `group.members`. Code instead needs to speak of "memberships" so that it can refer to the role of the membership.

For example when adding a user to a group, this won't work because there's no way to specify the membership role:

```python
group.members.append(user)
```

Instead code now needs to do this:

```python
group.memberships.append(GroupMembership(group=group, user=user, roles=roles))
```

And similarly when *reading* a group's memberships, we need to read a list of `GroupMembership`'s with their roles rather than reading a list of `User`'s. We need `Group.memberships` not `Group.members`.

So this PR replaces the SQLAlchemy relationships `Group.members` and `User.groups` with new `Group.memberships` and `User.memberships` relationships and updates lots of code and tests to work with memberships instead of working with members and groups directly.

The approach that we're taking here where we have three ORM classes `User`, `Group` and `GroupMembership` for the association table is called the "association object" pattern and has [its own section in the SQLAlchemy docs](https://docs.sqlalchemy.org/en/20/orm/basic_relationships.html#association-object). It's the pattern that you're supposed to use when the association class has its own extra attributes like the upcoming `GroupMembership.roles` attribute.

## Testing

1. `GroupCreateService` was changed so go to <http://localhost:5000/admin/features> and enable the `group_type` feature flag then go to <http://localhost:5000/groups/new> and test creating each of the three types of group. The group's creator should be added to the group as a member.
2. `GroupMembersService.member_join()` was changed so test visiting a private group's page as a user who isn't a member of the group and joining the group.
3. `GroupMembersService.member_leave()` was changed so test visiting a private group's page and clicking the **Leave this group** link.