### PR TITLE
Remove deprecated `get_html_theme_path` call

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,9 +109,7 @@ def setup(app):
 
 # -- Options for HTML output ---------------------------------------------------
 
-import sphinx_rtd_theme
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
The readthedocs.org build of h docs was failing due to a deprecation warning being treated as an error. Fix the warning by following its advice:

```
$ make docs
[sphinx-autobuild] Starting initial build
[sphinx-autobuild] > python -m sphinx build -qT -b dirhtml -d .tox/docs/doctrees docs .tox/docs/html
WARNING: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.
```

See also the Deprecations section of
https://github.com/readthedocs/sphinx_rtd_theme/blob/master/docs/changelog.rst#300rc1.

----

**Testing:**

- Run `make checkdocs`. There should be no errors or warnings.
- Run `make docs` and visit http://localhost:8000. There should be no warnings and the docs should render.