### PR TITLE
Update Elasticsearch container in development to v7.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       elasticsearch:
-        image: hypothesis/elasticsearch:latest
+        image: hypothesis/elasticsearch:elasticsearch7.10
         ports:
         - 9200:9200
         env:
@@ -139,7 +139,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       elasticsearch:
-        image: hypothesis/elasticsearch:latest
+        image: hypothesis/elasticsearch:elasticsearch7.10
         ports:
         - 9200:9200
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     networks:
       - dbs
   elasticsearch:
-    image: hypothesis/elasticsearch:latest
+    image: hypothesis/elasticsearch:elasticsearch7.10
     ports:
       - '127.0.0.1:9200:9200'
     healthcheck:

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -156,7 +156,7 @@ class Search:
     @staticmethod
     def _get_total_hits(response):
         total = response["hits"]["total"]
-        if isinstance(total, int):
+        if isinstance(total, int):  # pragma: nocover
             # ES 6.x
             return total
 


### PR DESCRIPTION
This is the last 7.x version available in AWS OpenSearch. See https://github.com/hypothesis/elasticsearch_docker/pull/1.

The `elasticsearch` pip dependency remains on v6.8.2 for the time being. This is compatible with both ES 6 and ES 7 servers, at least for the functionality we use. Once the upgrade to an ES 7 server is complete, we can update this to the corresponding ES 7 version.

Elasticsearch v7 is compatible with an index created with v6. In development however the index data is currently part of the ES container rather than a separate volume. This means that upgrading the ES container will lose existing data. You can use the h admin UI to reindex existing data:

1. Make sure `h-periodic` is running
2. Go to http://localhost:5000/admin/search
3. Under "Process all annotations between two dates", enter a date range that covers all of the annotations you have created
4. Click "Process"
5. This will trigger `sync_annotations` tasks to reindex batches of data. Eventually these tasks will report there is no more outstanding activity by logging messages like `h.tasks.indexer.sync_annotations[06e69856-20ea-443e-81e5-8a2f7ab8c82a]: {}`. At that point reindexing is complete

To speed up the process, you can reduce the [scheduled interval](https://github.com/hypothesis/h-periodic/blob/6cc59ac74710d6813492eedb725f0077fa4b6a08/h_periodic/h_beat.py#L61) between `sync_annotations` tasks.

Fixes https://github.com/hypothesis/h/issues/7640.