### PR TITLE
Add `/group/:pubid/edit/members` route and placeholder page in frontend

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -212,6 +212,12 @@ def includeme(config):  # pylint: disable=too-many-statements
         factory="h.traversal.GroupRequiredRoot",
         traverse="/{pubid}",
     )
+    config.add_route(
+        "group_edit_members",
+        "/groups/{pubid}/edit/members",
+        factory="h.traversal.GroupRequiredRoot",
+        traverse="/{pubid}",
+    )
     # Match "/<pubid>/": we redirect to the version with the slug.
     config.add_route(
         "group_read",

--- a/h/static/scripts/group-forms/components/AppRoot.tsx
+++ b/h/static/scripts/group-forms/components/AppRoot.tsx
@@ -1,0 +1,48 @@
+import { Route, Switch } from 'wouter-preact';
+import { useMemo } from 'preact/hooks';
+
+import CreateEditGroupForm from './CreateEditGroupForm';
+import EditGroupMembersForm from './EditGroupMembersForm';
+import type { ConfigObject } from '../config';
+import { Config } from '../config';
+import { routes } from '../routes';
+
+export type AppRootProps = {
+  config: ConfigObject;
+};
+
+export default function AppRoot({ config }: AppRootProps) {
+  const stylesheetLinks = useMemo(
+    () =>
+      config.styles.map((stylesheetURL, index) => (
+        <link
+          key={`${stylesheetURL}${index}`}
+          rel="stylesheet"
+          href={stylesheetURL}
+        />
+      )),
+    [config],
+  );
+
+  return (
+    <>
+      {stylesheetLinks}
+      <Config.Provider value={config}>
+        <Switch>
+          <Route path={routes.groups.new}>
+            <CreateEditGroupForm />
+          </Route>
+          <Route path={routes.groups.edit}>
+            <CreateEditGroupForm />
+          </Route>
+          <Route path={routes.groups.editMembers}>
+            <EditGroupMembersForm />
+          </Route>
+          <Route>
+            <h1 data-testid="unknown-route">Page not found</h1>
+          </Route>
+        </Switch>
+      </Config.Provider>
+    </>
+  );
+}

--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useState } from 'preact/hooks';
+import { useContext, useEffect, useId, useState } from 'preact/hooks';
 
 import {
   Button,
@@ -6,7 +6,7 @@ import {
   RadioGroup,
   useWarnOnPageUnload,
 } from '@hypothesis/frontend-shared';
-import { readConfig } from '../config';
+import { Config } from '../config';
 import { callAPI } from '../utils/api';
 import type {
   CreateUpdateGroupAPIRequest,
@@ -15,9 +15,11 @@ import type {
 } from '../utils/api';
 import { pluralize } from '../utils/pluralize';
 import { setLocation } from '../utils/set-location';
+import FormContainer from './forms/FormContainer';
 import Star from './forms/Star';
 import Label from './forms/Label';
 import TextField from './forms/TextField';
+import GroupFormHeader from './GroupFormHeader';
 import SaveStateIcon from './SaveStateIcon';
 import WarningDialog from './WarningDialog';
 
@@ -84,7 +86,7 @@ function GroupTypeChangeWarning({
 }
 
 export default function CreateEditGroupForm() {
-  const config = useMemo(() => readConfig(), []);
+  const config = useContext(Config)!;
   const group = config.context.group;
 
   const [name, setName] = useState(group?.name ?? '');
@@ -217,11 +219,10 @@ export default function CreateEditGroupForm() {
   };
 
   return (
-    <div className="text-grey-6 text-sm/relaxed">
-      <h1 className="mt-14 mb-8 text-grey-7 text-xl/none" data-testid="header">
-        {heading}
-      </h1>
-
+    <FormContainer title={heading}>
+      {group && config.features.group_members && (
+        <GroupFormHeader group={group} />
+      )}
       <form onSubmit={onSubmit} data-testid="form">
         <TextField
           type="input"
@@ -327,6 +328,6 @@ export default function CreateEditGroupForm() {
           &nbsp;Required
         </div>
       </footer>
-    </div>
+    </FormContainer>
   );
 }

--- a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
+++ b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
@@ -1,0 +1,18 @@
+import { useContext } from 'preact/hooks';
+
+import { Config } from '../config';
+import FormContainer from './forms/FormContainer';
+import GroupFormHeader from './GroupFormHeader';
+
+export default function EditGroupMembersForm() {
+  const config = useContext(Config)!;
+  const group = config.context.group!;
+
+  return (
+    <FormContainer title="Edit group members">
+      <GroupFormHeader group={group} />
+      <hr />
+      <div className="my-2">Group members will appear here.</div>
+    </FormContainer>
+  );
+}

--- a/h/static/scripts/group-forms/components/GroupFormHeader.tsx
+++ b/h/static/scripts/group-forms/components/GroupFormHeader.tsx
@@ -1,0 +1,48 @@
+import classnames from 'classnames';
+import type { ComponentChildren } from 'preact';
+import { Link as RouterLink, useRoute } from 'wouter-preact';
+
+import type { Group } from '../config';
+import { routes } from '../routes';
+
+type TabLinkProps = {
+  href: string;
+  children: ComponentChildren;
+};
+
+function TabLink({ children, href }: TabLinkProps) {
+  const [selected] = useRoute(href);
+  return (
+    <RouterLink
+      href={href}
+      className={classnames({
+        'focus-visible-ring whitespace-nowrap flex items-center font-semibold rounded px-2 py-1 gap-x-2':
+          true,
+        'text-grey-1 bg-grey-7': selected,
+      })}
+    >
+      {children}
+    </RouterLink>
+  );
+}
+
+export type GroupFormHeaderProps = {
+  group: Group;
+};
+
+export default function GroupFormHeader({ group }: GroupFormHeaderProps) {
+  // This should be replaced with a proper URL generation function that handles
+  // escaping etc.
+  const editLink = routes.groups.edit.replace(':pubid', group.pubid);
+  const editMembersLinks = routes.groups.editMembers.replace(
+    ':pubid',
+    group.pubid,
+  );
+
+  return (
+    <div className="flex gap-x-2 justify-end py-2">
+      <TabLink href={editLink}>Settings</TabLink>
+      <TabLink href={editMembersLinks}>Members</TabLink>
+    </div>
+  );
+}

--- a/h/static/scripts/group-forms/components/forms/FormContainer.tsx
+++ b/h/static/scripts/group-forms/components/forms/FormContainer.tsx
@@ -1,0 +1,18 @@
+import type { ComponentChildren } from 'preact';
+
+export type FormContainerProps = {
+  title: string;
+  children: ComponentChildren;
+};
+
+/** A container for a form with a title. */
+export default function FormContainer({ children, title }: FormContainerProps) {
+  return (
+    <div className="text-grey-6 text-sm/relaxed">
+      <h1 className="mt-14 mb-8 text-grey-7 text-xl/none" data-testid="header">
+        {title}
+      </h1>
+      {children}
+    </div>
+  );
+}

--- a/h/static/scripts/group-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/group-forms/components/test/AppRoot-test.js
@@ -1,0 +1,79 @@
+import { mount } from 'enzyme';
+import { useContext } from 'preact/hooks';
+
+import { $imports, default as AppRoot } from '../AppRoot';
+import { Config } from '../../config';
+
+describe('AppRoot', () => {
+  let configContext;
+  const config = { styles: [] };
+
+  beforeEach(() => {
+    const mockComponent = name => {
+      function MockRoute() {
+        configContext = useContext(Config);
+        return null;
+      }
+      MockRoute.displayName = name;
+      return MockRoute;
+    };
+
+    configContext = null;
+
+    $imports.$mock({
+      './CreateEditGroupForm': mockComponent('CreateEditGroupForm'),
+      './EditGroupMembersForm': mockComponent('EditGroupMembersForm'),
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('renders style links', () => {
+    config.styles = ['/static/styles/foo.css'];
+    const links = mount(<AppRoot config={config} />).find('link');
+    assert.equal(links.length, 1);
+    assert.equal(links.at(0).prop('rel'), 'stylesheet');
+    assert.equal(links.at(0).prop('href'), '/static/styles/foo.css');
+  });
+
+  it('passes config to route', () => {
+    history.pushState({}, null, '/groups/new');
+    try {
+      mount(<AppRoot config={config} />);
+      assert.strictEqual(configContext, config);
+    } finally {
+      history.back();
+    }
+  });
+
+  [
+    {
+      path: '/groups/new',
+      selector: 'CreateEditGroupForm',
+    },
+    {
+      path: '/groups/1234/edit',
+      selector: 'CreateEditGroupForm',
+    },
+    {
+      path: '/groups/1234/edit/members',
+      selector: 'EditGroupMembersForm',
+    },
+    {
+      path: '/unknown',
+      selector: '[data-testid="unknown-route"]',
+    },
+  ].forEach(({ path, selector }) => {
+    it(`renders expected component for URL (${path})`, () => {
+      history.pushState({}, '', path);
+      try {
+        const wrapper = mount(<AppRoot config={config} />);
+        assert.isTrue(wrapper.exists(selector));
+      } finally {
+        history.back();
+      }
+    });
+  });
+});

--- a/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
@@ -7,9 +7,10 @@ import {
   default as CreateEditGroupForm,
 } from '../CreateEditGroupForm';
 
-let config;
+import { Config } from '../../config';
 
 describe('CreateEditGroupForm', () => {
+  let config;
   let fakeCallAPI;
   let fakeSetLocation;
   let fakeUseWarnOnPageUnload;
@@ -42,7 +43,6 @@ describe('CreateEditGroupForm', () => {
       '@hypothesis/frontend-shared': {
         useWarnOnPageUnload: fakeUseWarnOnPageUnload,
       },
-      '../config': { readConfig: () => config },
       '../utils/api': {
         callAPI: fakeCallAPI,
       },
@@ -89,7 +89,11 @@ describe('CreateEditGroupForm', () => {
   let wrappers;
 
   const createWrapper = () => {
-    const wrapper = mount(<CreateEditGroupForm />);
+    const wrapper = mount(
+      <Config.Provider value={config}>
+        <CreateEditGroupForm />
+      </Config.Provider>,
+    );
     wrappers.push(wrapper);
     const elements = getElements(wrapper);
     return { wrapper, elements };

--- a/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
+++ b/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
@@ -1,0 +1,31 @@
+import { mount } from 'enzyme';
+
+import { Config } from '../../config';
+import EditGroupMembersForm from '../EditGroupMembersForm';
+
+describe('EditGroupMembersForm', () => {
+  let config;
+
+  beforeEach(() => {
+    config = {
+      context: {
+        group: {
+          pubid: '1234',
+          name: 'Test group',
+        },
+      },
+    };
+  });
+
+  const createForm = (props = {}) => {
+    return mount(
+      <Config.Provider value={config}>
+        <EditGroupMembersForm {...props} />
+      </Config.Provider>,
+    );
+  };
+
+  it('renders', () => {
+    createForm();
+  });
+});

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -1,9 +1,19 @@
+import { createContext } from 'preact';
 import type { GroupType } from './utils/api';
 
 export type APIConfig = {
   method: string;
   url: string;
   headers: Record<PropertyKey, unknown>;
+};
+
+export type Group = {
+  pubid: string;
+  name: string;
+  description: string;
+  link: string;
+  type: GroupType;
+  num_annotations: number;
 };
 
 export type ConfigObject = {
@@ -14,16 +24,10 @@ export type ConfigObject = {
     updateGroup: APIConfig | null;
   };
   context: {
-    group: {
-      pubid: string;
-      name: string;
-      description: string;
-      link: string;
-      type: GroupType;
-      num_annotations: number;
-    } | null;
+    group: Group | null;
   };
   features: {
+    group_members: boolean;
     group_type: boolean;
   };
 };
@@ -36,3 +40,5 @@ export function readConfig(): ConfigObject {
     throw new Error('Failed to parse frontend configuration');
   }
 }
+
+export const Config = createContext<ConfigObject | null>(null);

--- a/h/static/scripts/group-forms/index.tsx
+++ b/h/static/scripts/group-forms/index.tsx
@@ -1,26 +1,13 @@
 import { render } from 'preact';
 
-import CreateEditGroupForm from './components/CreateEditGroupForm';
+import AppRoot from './components/AppRoot';
 import { readConfig } from './config';
 
 function init() {
-  const shadowHost = document.querySelector('#create-group-form')!;
+  const shadowHost = document.querySelector('#group-form')!;
   const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
   const config = readConfig();
-  const stylesheetLinks = config.styles.map((stylesheetURL, index) => (
-    <link
-      key={`${stylesheetURL}${index}`}
-      rel="stylesheet"
-      href={stylesheetURL}
-    />
-  ));
-  render(
-    <>
-      {stylesheetLinks}
-      <CreateEditGroupForm />
-    </>,
-    shadowRoot,
-  );
+  render(<AppRoot config={config} />, shadowRoot);
 }
 
 init();

--- a/h/static/scripts/group-forms/routes.ts
+++ b/h/static/scripts/group-forms/routes.ts
@@ -1,0 +1,13 @@
+/**
+ * URL patterns for routes that the frontend router needs to match or
+ * dynamically generate links for.
+ *
+ * These must be synchronized with h/routes.py.
+ */
+export const routes = {
+  groups: {
+    new: '/groups/new',
+    edit: '/groups/:pubid/edit',
+    editMembers: '/groups/:pubid/edit/members',
+  },
+};

--- a/h/templates/groups/create_edit.html.jinja2
+++ b/h/templates/groups/create_edit.html.jinja2
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block page_content %}
-  <div id="create-group-form"></div>
+  <div id="group-form"></div>
   <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
 {% endblock %}
 

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -60,6 +60,7 @@ class GroupCreateEditController:
             },
             "context": {"group": None},
             "features": {
+                "group_members": self.request.feature("group_members"),
                 "group_type": self.request.feature("group_type"),
             },
         }

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -34,6 +34,11 @@ class GroupCreateEditController:
     @view_config(
         route_name="group_edit", request_method="GET", permission=Permission.Group.EDIT
     )
+    @view_config(
+        route_name="group_edit_members",
+        request_method="GET",
+        permission=Permission.Group.EDIT,
+    )
     def edit(self):
         """Render the page for editing an existing group."""
         return {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "rollup": "^4.22.4",
     "sass": "^1.80.5",
     "scroll-into-view": "^1.16.2",
-    "tailwindcss": "^3.4.13"
+    "tailwindcss": "^3.4.13",
+    "wouter-preact": "^3.3.5"
   },
   "devDependencies": {
     "@hypothesis/frontend-testing": "^1.2.2",

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -195,6 +195,12 @@ def test_includeme():
             traverse="/{pubid}",
         ),
         call(
+            "group_edit_members",
+            "/groups/{pubid}/edit/members",
+            factory="h.traversal.GroupRequiredRoot",
+            traverse="/{pubid}",
+        ),
+        call(
             "group_read",
             "/groups/{pubid}/{slug:[^/]*}",
             factory="h.traversal.GroupRequiredRoot",

--- a/tests/unit/h/views/groups_test.py
+++ b/tests/unit/h/views/groups_test.py
@@ -13,6 +13,7 @@ class TestGroupCreateEditController:
     @pytest.mark.parametrize("group_type_flag", [True, False])
     def test_create(self, pyramid_request, assets_env, mocker, group_type_flag):
         pyramid_request.feature.flags["group_type"] = group_type_flag
+
         mocker.spy(views, "get_csrf_token")
 
         controller = views.GroupCreateEditController(sentinel.context, pyramid_request)
@@ -43,6 +44,7 @@ class TestGroupCreateEditController:
                 "context": {"group": None},
                 "features": {
                     "group_type": group_type_flag,
+                    "group_members": pyramid_request.feature.flags["group_members"],
                 },
             },
         }
@@ -99,6 +101,7 @@ class TestGroupCreateEditController:
                 },
                 "features": {
                     "group_type": pyramid_request.feature.flags["group_type"],
+                    "group_members": pyramid_request.feature.flags["group_members"],
                 },
             },
         }
@@ -115,6 +118,7 @@ class TestGroupCreateEditController:
     @pytest.fixture(autouse=True)
     def pyramid_request(self, pyramid_request):
         pyramid_request.feature.flags["group_type"] = True
+        pyramid_request.feature.flags["group_members"] = True
         return pyramid_request
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6166,6 +6166,7 @@ __metadata:
     tailwindcss: ^3.4.13
     typescript: ^5.6.3
     typescript-eslint: ^8.12.2
+    wouter-preact: ^3.3.5
   languageName: unknown
   linkType: soft
 
@@ -10958,6 +10959,18 @@ __metadata:
   peerDependencies:
     preact: ^10.0.0
   checksum: e23804152a953b89bdda3f04f31f60d2d5a3934e951da3a50a81fdd3aa2fd1de338778e99b249c2f80cd951c2cc9eb278afa5b650678f4a87a9f02a0310e2dc2
+  languageName: node
+  linkType: hard
+
+"wouter-preact@npm:^3.3.5":
+  version: 3.3.5
+  resolution: "wouter-preact@npm:3.3.5"
+  dependencies:
+    mitt: ^3.0.1
+    regexparam: ^3.0.0
+  peerDependencies:
+    preact: ^10.0.0
+  checksum: a3f201b0b21dbd939a19530d99095955e13195976c7a650ed16d9e9e65b23cc952fa2e3158310211c22a2cc40aea0815ada8b43a36ba2bf58427e87317d46063
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add a route for editing group members and a placeholder page in the frontend. When the `group_members` feature flag is enabled, the group forms display a tab bar that allows the user to switch between the pages for editing group settings and group members.

**Summary of changes:**

- Add a `/group/:pubid/edit/members` backend route
- Expose `group_members` feature flag to frontend
- Add a router component (`AppRoot`) to the frontend entry point which switches the displayed component based upon the URL. This uses the same router that we use in the LMS frontend. This component also reads the JSON configuration and exposes it to child components via Preact context.
- Add a `GroupFormHeader` component which contains the "Settings" and "Members" links. These links trigger client-side transitions. This component is rendered by `CreateEditGroupForm` component if the `group_members` flag is enabled.
- Add a placeholder page for the "Members" view

**Group edit view with new tab bar:**

<img width="550" alt="Edit group tab bar" src="https://github.com/user-attachments/assets/7c522f6c-acd0-464f-957a-cee36a9e9bb5">

**"Members" tab placeholder:**

<img width="565" alt="Edit group members placeholder" src="https://github.com/user-attachments/assets/79cbdadc-7bab-44cd-bb9d-53d0cf801687">

