### PR TITLE
Set up frontend code coverage reporting and resolve coverage gaps

### DIFF
--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -33,12 +33,14 @@ export class Controller {
    */
   constructor(element, options = {}) {
     if (!element) {
+      // istanbul ignore next
       throw new Error(
         'Controllers require an element passed to the constructor',
       );
     } else if (!element.controllers) {
       element.controllers = [this];
     } else {
+      // istanbul ignore next
       element.controllers.push(this);
     }
 

--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -52,6 +52,7 @@ export function upgradeElements(root, controllers) {
     removeControllers(element);
 
     if (typeof html !== 'string') {
+      // istanbul ignore next
       throw new Error('Replacement markup must be a string');
     }
     const container = document.createElement('div');
@@ -74,6 +75,7 @@ export function upgradeElements(root, controllers) {
         upgradedElements.push(el);
         markReady(el);
       } catch (err) {
+        // istanbul ignore next
         console.error(
           'Failed to upgrade element %s with controller',
           el,
@@ -83,6 +85,7 @@ export function upgradeElements(root, controllers) {
         );
 
         // Re-raise error so that Sentry can capture and report it
+        // istanbul ignore next
         throw err;
       }
     });

--- a/h/static/scripts/controllers/autosuggest-dropdown-controller.js
+++ b/h/static/scripts/controllers/autosuggest-dropdown-controller.js
@@ -41,18 +41,21 @@ export class AutosuggestDropdownController extends Controller {
     super(inputElement, configOptions);
 
     if (!configOptions.renderListItem) {
+      // istanbul ignore next
       throw new Error(
         'Missing renderListItem callback in AutosuggestDropdownController constructor',
       );
     }
 
     if (!configOptions.listFilter) {
+      // istanbul ignore next
       throw new Error(
         'Missing listFilter function in AutosuggestDropdownController constructor',
       );
     }
 
     if (!configOptions.onSelect) {
+      // istanbul ignore next
       throw new Error(
         'Missing onSelect callback in AutosuggestDropdownController constructor',
       );
@@ -165,6 +168,7 @@ export class AutosuggestDropdownController extends Controller {
    */
   _setList(list) {
     if (!Array.isArray(list)) {
+      // istanbul ignore next
       throw new TypeError('setList requires an array first argument');
     }
 
@@ -242,6 +246,7 @@ export class AutosuggestDropdownController extends Controller {
     const target = event.currentTarget;
 
     if (hovering && currentActive && currentActive.contains(target)) {
+      // istanbul ignore next
       return;
     }
 
@@ -332,6 +337,7 @@ export class AutosuggestDropdownController extends Controller {
     if (HTMLElement.prototype.insertAdjacentElement) {
       this._input.insertAdjacentElement('afterend', this._suggestionContainer);
     } else {
+      // istanbul ignore next
       this._input.parentNode.insertBefore(
         this._suggestionContainer,
         this._input.nextSibling,

--- a/h/static/scripts/controllers/form-controller.js
+++ b/h/static/scripts/controllers/form-controller.js
@@ -87,6 +87,7 @@ export class FormController extends Controller {
       // inputs. Since we auto-submit when such inputs change, don't mark the
       // field as dirty.
       if (shouldAutosubmit(event.target.type)) {
+        // istanbul ignore next
         return;
       }
       this.setState({ dirty: true });
@@ -268,6 +269,7 @@ export class FormController extends Controller {
       field => field.container,
     );
     if (fieldContainers.length === 0) {
+      // istanbul ignore next
       return null;
     }
 

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -76,6 +76,7 @@ export class SearchBarController extends Controller {
         try {
           tagSuggestions = JSON.parse(tagSuggestionJSON.innerHTML.trim());
         } catch (e) {
+          // istanbul ignore next
           console.error('Could not parse .js-tag-suggestions JSON content', e);
         }
       }
@@ -100,6 +101,7 @@ export class SearchBarController extends Controller {
         try {
           groupSuggestions = JSON.parse(groupSuggestionJSON.innerHTML.trim());
         } catch (e) {
+          // istanbul ignore next
           console.error(
             'Could not parse .js-group-suggestions JSON content',
             e,
@@ -338,6 +340,7 @@ export class SearchBarController extends Controller {
           listItem.title,
         )} </span>`;
         if (listItem.type === GROUP_TYPE && listItem.relationship) {
+          // istanbul ignore next
           itemContents += `<span class="search-bar__dropdown-menu-relationship"> ${escapeHtml(
             listItem.relationship,
           )} </span>`;

--- a/h/static/scripts/controllers/share-widget-controller.js
+++ b/h/static/scripts/controllers/share-widget-controller.js
@@ -29,6 +29,7 @@ class ShareWidget {
   constructor(containerElement) {
     // we only attach one to the dom since it's a global listener
     if (shareWidgetAttached) {
+      // istanbul ignore next
       return;
     }
     shareWidgetAttached = true;
@@ -46,6 +47,7 @@ class ShareWidget {
 
       // do nothing if we are clicking inside of the widget
       if (this._container.contains(target)) {
+        // istanbul ignore next
         return;
       }
 
@@ -133,6 +135,7 @@ class ShareWidget {
    */
   showForNode(node, config) {
     if (!node || !config) {
+      // istanbul ignore next
       throw new Error('showForNode did not recieve both arguments');
     }
 

--- a/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
@@ -295,6 +295,21 @@ describe('CreateEditGroupForm', () => {
       assert.isTrue(pageUnloadWarningActive());
     });
 
+    it('clears modified state when page is loaded from cache', () => {
+      const { elements } = createWrapper();
+      act(() => {
+        elements.nameField.prop('onChangeValue')('modified');
+      });
+      assert.isTrue(pageUnloadWarningActive());
+
+      act(() => {
+        window.dispatchEvent(
+          new PageTransitionEvent('pageshow', { persisted: true }),
+        );
+      });
+      assert.isFalse(pageUnloadWarningActive());
+    });
+
     it('updates the group', async () => {
       const { wrapper, elements } = createWrapper();
       const { nameField, descriptionField } = elements;

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -30,5 +30,9 @@ export type ConfigObject = {
 
 /** Return the frontend config from the page's <script class="js-config">. */
 export function readConfig(): ConfigObject {
-  return JSON.parse(document.querySelector('.js-config')!.textContent!);
+  try {
+    return JSON.parse(document.querySelector('.js-config')!.textContent!);
+  } catch {
+    throw new Error('Failed to parse frontend configuration');
+  }
 }

--- a/h/static/scripts/group-forms/test/config-test.js
+++ b/h/static/scripts/group-forms/test/config-test.js
@@ -1,0 +1,40 @@
+import { readConfig } from '../config';
+
+describe('readConfig', () => {
+  let expectedConfig;
+  let configEl;
+
+  beforeEach(() => {
+    expectedConfig = {
+      styles: ['/static/foo.css'],
+    };
+    configEl = document.createElement('script');
+    configEl.className = 'js-config';
+    configEl.type = 'application/json';
+    configEl.textContent = JSON.stringify(expectedConfig);
+    document.body.appendChild(configEl);
+  });
+
+  afterEach(() => {
+    configEl.remove();
+  });
+
+  it('should throw if the .js-config object is missing', () => {
+    configEl.remove();
+    assert.throws(() => {
+      readConfig();
+    }, 'Failed to parse frontend configuration');
+  });
+
+  it('should throw if the config cannot be parsed', () => {
+    configEl.textContent = 'not valid JSON';
+    assert.throws(() => {
+      readConfig();
+    }, 'Failed to parse frontend configuration');
+  });
+
+  it('should return the parsed configuration', () => {
+    const config = readConfig();
+    assert.deepEqual(config, expectedConfig);
+  });
+});

--- a/h/static/scripts/group-forms/utils/set-location.ts
+++ b/h/static/scripts/group-forms/utils/set-location.ts
@@ -1,3 +1,7 @@
+/**
+ * Test seam for updating {@link location.href}.
+ */
+// istanbul ignore next
 export function setLocation(newLocation: string): void {
   window.location.href = newLocation;
 }

--- a/h/static/scripts/karma.config.cjs
+++ b/h/static/scripts/karma.config.cjs
@@ -38,6 +38,11 @@ module.exports = function (config) {
       'report-config': {
         json: { subdir: './' },
       },
+      thresholds: {
+        global: {
+          statements: 100,
+        },
+      },
     },
 
     // Use https://www.npmjs.com/package/karma-mocha-reporter

--- a/h/static/scripts/karma.config.cjs
+++ b/h/static/scripts/karma.config.cjs
@@ -1,4 +1,7 @@
-/* global module */
+/* global __dirname module require */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require('path');
 
 module.exports = function (config) {
   config.set({
@@ -29,9 +32,17 @@ module.exports = function (config) {
       output: 'minimal',
     },
 
+    coverageIstanbulReporter: {
+      dir: path.join(__dirname, '../../../coverage'),
+      reports: ['json', 'html'],
+      'report-config': {
+        json: { subdir: './' },
+      },
+    },
+
     // Use https://www.npmjs.com/package/karma-mocha-reporter
     // for more helpful rendering of test failures
-    reporters: ['mocha'],
+    reporters: ['progress', 'mocha', 'coverage-istanbul'],
 
     // web server port
     port: 9876,

--- a/h/static/scripts/util/dom.js
+++ b/h/static/scripts/util/dom.js
@@ -63,6 +63,7 @@ function firstElementChild(node) {
       return node.childNodes[i];
     }
   }
+  // istanbul ignore next
   return null;
 }
 

--- a/h/static/scripts/util/search-text-parser.js
+++ b/h/static/scripts/util/search-text-parser.js
@@ -71,6 +71,7 @@ export function shouldLozengify(phrase) {
     const queryTerm = getLozengeFacetNameAndValue(phrase);
 
     if (!canLozengify(queryTerm.facetName)) {
+      // istanbul ignore next
       return false;
     }
     if (

--- a/h/static/scripts/util/string.js
+++ b/h/static/scripts/util/string.js
@@ -42,6 +42,7 @@ export function unhyphenate(name) {
  */
 export function normalize(str) {
   if (!String.prototype.normalize) {
+    // istanbul ignore next
     return str;
   }
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@hypothesis/frontend-testing": "^1.2.2",
+    "babel-plugin-istanbul": "^7.0.0",
     "babel-plugin-mockable-imports": "^2.0.1",
     "chai": "^5.1.2",
     "diff": "^7.0.0",
@@ -59,6 +60,7 @@
     "globals": "^15.11.0",
     "karma": "^6.4.4",
     "karma-chrome-launcher": "^3.2.0",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-source-map-support": "^1.4.0",

--- a/rollup-tests.config.js
+++ b/rollup-tests.config.js
@@ -46,7 +46,15 @@ export default {
           },
         ],
       ],
-      plugins: ['mockable-imports'],
+      plugins: [
+        'mockable-imports',
+        [
+          'babel-plugin-istanbul',
+          {
+            exclude: ['**/test/**/*.js', '**/test-util/**'],
+          },
+        ],
+      ],
     }),
   ],
 };

--- a/rollup-tests.config.js
+++ b/rollup-tests.config.js
@@ -51,7 +51,7 @@ export default {
         [
           'babel-plugin-istanbul',
           {
-            exclude: ['**/test/**/*.js', '**/test-util/**'],
+            exclude: ['**/test/**/*.js', '**/tests/**/*.js', '**/test-util/**'],
           },
         ],
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,7 +64,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.26.0":
+"@babel/core@npm:^7.23.9, @babel/core@npm:^7.26.0":
   version: 7.26.0
   resolution: "@babel/core@npm:7.26.0"
   dependencies:
@@ -596,16 +596,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.24.7":
-  version: 7.24.7
-  resolution: "@babel/parser@npm:7.24.7"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: fc9d2c4c8712f89672edc55c0dc5cf640dcec715b56480f111f85c2bc1d507e251596e4110d65796690a96ac37a4b60432af90b3e97bb47e69d4ef83872dbbd6
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.25.9, @babel/parser@npm:^7.26.0, @babel/parser@npm:^7.26.2":
+"@babel/parser@npm:^7.23.9, @babel/parser@npm:^7.25.9, @babel/parser@npm:^7.26.0, @babel/parser@npm:^7.26.2":
   version: 7.26.2
   resolution: "@babel/parser@npm:7.26.2"
   dependencies:
@@ -613,6 +604,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: c88b5ea0adf357ef909cdc2c31e284a154943edc59f63f6e8a4c20bf773a1b2f3d8c2205e59c09ca7cdad91e7466300114548876529277a80651b6436a48d5d9
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/parser@npm:7.24.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: fc9d2c4c8712f89672edc55c0dc5cf640dcec715b56480f111f85c2bc1d507e251596e4110d65796690a96ac37a4b60432af90b3e97bb47e69d4ef83872dbbd6
   languageName: node
   linkType: hard
 
@@ -1812,6 +1812,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@istanbuljs/load-nyc-config@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@istanbuljs/load-nyc-config@npm:1.1.0"
+  dependencies:
+    camelcase: ^5.3.1
+    find-up: ^4.1.0
+    get-package-type: ^0.1.0
+    js-yaml: ^3.13.1
+    resolve-from: ^5.0.0
+  checksum: d578da5e2e804d5c93228450a1380e1a3c691de4953acc162f387b717258512a3e07b83510a936d9fab03eac90817473917e24f5d16297af3867f59328d58568
+  languageName: node
+  linkType: hard
+
+"@istanbuljs/schema@npm:^0.1.2, @istanbuljs/schema@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@istanbuljs/schema@npm:0.1.3"
+  checksum: 5282759d961d61350f33d9118d16bcaed914ebf8061a52f4fa474b2cb08720c9c81d165e13b82f2e5a8a212cc5af482f0c6fc1ac27b9e067e5394c9a6ed186c9
+  languageName: node
+  linkType: hard
+
 "@jridgewell/gen-mapping@npm:^0.1.0":
   version: 0.1.1
   resolution: "@jridgewell/gen-mapping@npm:0.1.1"
@@ -2870,6 +2890,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"argparse@npm:^1.0.7":
+  version: 1.0.10
+  resolution: "argparse@npm:1.0.10"
+  dependencies:
+    sprintf-js: ~1.0.2
+  checksum: 7ca6e45583a28de7258e39e13d81e925cfa25d7d4aacbf806a382d3c02fcb13403a07fb8aeef949f10a7cfe4a62da0e2e807b348a5980554cc28ee573ef95945
+  languageName: node
+  linkType: hard
+
 "argparse@npm:^2.0.1":
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
@@ -3150,6 +3179,19 @@ __metadata:
   version: 4.1.0
   resolution: "axobject-query@npm:4.1.0"
   checksum: 7d1e87bf0aa7ae7a76cd39ab627b7c48fda3dc40181303d9adce4ba1d5b5ce73b5e5403ee6626ec8e91090448c887294d6144e24b6741a976f5be9347e3ae1df
+  languageName: node
+  linkType: hard
+
+"babel-plugin-istanbul@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "babel-plugin-istanbul@npm:7.0.0"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.0.0
+    "@istanbuljs/load-nyc-config": ^1.0.0
+    "@istanbuljs/schema": ^0.1.3
+    istanbul-lib-instrument: ^6.0.2
+    test-exclude: ^6.0.0
+  checksum: fd3048d793897502510267a076df54b47f0cc721afc830edd95d009622e992d84e9753acf69daeb117df64b7dcfd742749738912f4957ee0c194b43f070a0318
   languageName: node
   linkType: hard
 
@@ -3456,6 +3498,13 @@ __metadata:
   version: 2.0.1
   resolution: "camelcase-css@npm:2.0.1"
   checksum: 1cec2b3b3dcb5026688a470b00299a8db7d904c4802845c353dbd12d9d248d3346949a814d83bfd988d4d2e5b9904c07efe76fecd195a1d4f05b543e7c0b56b1
+  languageName: node
+  linkType: hard
+
+"camelcase@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "camelcase@npm:5.3.1"
+  checksum: e6effce26b9404e3c0f301498184f243811c30dfe6d0b9051863bd8e4034d09c8c2923794f280d6827e5aa055f6c434115ff97864a16a963366fb35fd673024b
   languageName: node
   linkType: hard
 
@@ -5139,6 +5188,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esprima@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "esprima@npm:4.0.1"
+  bin:
+    esparse: ./bin/esparse.js
+    esvalidate: ./bin/esvalidate.js
+  checksum: b45bc805a613dbea2835278c306b91aff6173c8d034223fa81498c77dcbce3b2931bf6006db816f62eacd9fd4ea975dfd85a5b7f3c6402cfd050d4ca3c13a628
+  languageName: node
+  linkType: hard
+
 "esquery@npm:^1.5.0":
   version: 1.6.0
   resolution: "esquery@npm:1.6.0"
@@ -5332,6 +5391,16 @@ __metadata:
     statuses: ~1.5.0
     unpipe: ~1.0.0
   checksum: 617880460c5138dd7ccfd555cb5dde4d8f170f4b31b8bd51e4b646bb2946c30f7db716428a1f2882d730d2b72afb47d1f67cc487b874cb15426f95753a88965e
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "find-up@npm:4.1.0"
+  dependencies:
+    locate-path: ^5.0.0
+    path-exists: ^4.0.0
+  checksum: 4c172680e8f8c1f78839486e14a43ef82e9decd0e74145f40707cc42e7420506d5ec92d9a11c22bd2c48fb0c384ea05dd30e10dd152fefeec6f2f75282a8b844
   languageName: node
   linkType: hard
 
@@ -5660,6 +5729,13 @@ __metadata:
     has-symbols: ^1.0.3
     hasown: ^2.0.0
   checksum: 414e3cdf2c203d1b9d7d33111df746a4512a1aa622770b361dadddf8ed0b5aeb26c560f49ca077e24bfafb0acb55ca908d1f709216ccba33ffc548ec8a79a951
+  languageName: node
+  linkType: hard
+
+"get-package-type@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "get-package-type@npm:0.1.0"
+  checksum: bba0811116d11e56d702682ddef7c73ba3481f114590e705fc549f4d868972263896af313c57a25c076e3c0d567e11d919a64ba1b30c879be985fc9d44f96148
   languageName: node
   linkType: hard
 
@@ -6048,6 +6124,7 @@ __metadata:
     "@rollup/plugin-terser": ^0.4.4
     "@sentry/browser": ^8.36.0
     autoprefixer: ^10.4.20
+    babel-plugin-istanbul: ^7.0.0
     babel-plugin-mockable-imports: ^2.0.1
     bootstrap: ^4.6.2
     chai: ^5.1.2
@@ -6071,6 +6148,7 @@ __metadata:
     jquery: ^3.7.1
     karma: ^6.4.4
     karma-chrome-launcher: ^3.2.0
+    karma-coverage-istanbul-reporter: ^3.0.3
     karma-mocha: ^2.0.1
     karma-mocha-reporter: ^2.2.5
     karma-source-map-support: ^1.4.0
@@ -6249,6 +6327,13 @@ __metadata:
     array.prototype.filter: ^1.0.0
     call-bind: ^1.0.2
   checksum: 7408da008d37bfa76b597e298ae0ed530258065deb29fbd73d40f7cbd123b654d1022a7a8cfbe713e57d90c5bef844399f5c8a46cde7d55c91d305024c921d08
+  languageName: node
+  linkType: hard
+
+"html-escaper@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: d2df2da3ad40ca9ee3a39c5cc6475ef67c8f83c234475f24d8e9ce0dc80a2c82df8e1d6fa78ddd1e9022a586ea1bd247a615e80a5cd9273d90111ddda7d9e974
   languageName: node
   linkType: hard
 
@@ -6942,6 +7027,67 @@ __metadata:
   languageName: node
   linkType: hard
 
+"istanbul-lib-coverage@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "istanbul-lib-coverage@npm:2.0.5"
+  checksum: c83bf39dc722d2a3e7c98b16643f2fef719fd59adf23441ad8a1e6422bb1f3367ac7d4c42ac45d0d87413476891947b6ffbdecf2184047436336aa0c28bbfc15
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
+  version: 3.2.2
+  resolution: "istanbul-lib-coverage@npm:3.2.2"
+  checksum: 2367407a8d13982d8f7a859a35e7f8dd5d8f75aae4bb5484ede3a9ea1b426dc245aff28b976a2af48ee759fdd9be374ce2bd2669b644f31e76c5f46a2e29a831
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-instrument@npm:^6.0.2":
+  version: 6.0.3
+  resolution: "istanbul-lib-instrument@npm:6.0.3"
+  dependencies:
+    "@babel/core": ^7.23.9
+    "@babel/parser": ^7.23.9
+    "@istanbuljs/schema": ^0.1.3
+    istanbul-lib-coverage: ^3.2.0
+    semver: ^7.5.4
+  checksum: 74104c60c65c4fa0e97cc76f039226c356123893929f067bfad5f86fe839e08f5d680354a68fead3bc9c1e2f3fa6f3f53cded70778e821d911e851d349f3545a
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-report@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "istanbul-lib-report@npm:3.0.1"
+  dependencies:
+    istanbul-lib-coverage: ^3.0.0
+    make-dir: ^4.0.0
+    supports-color: ^7.1.0
+  checksum: fd17a1b879e7faf9bb1dc8f80b2a16e9f5b7b8498fe6ed580a618c34df0bfe53d2abd35bf8a0a00e628fb7405462576427c7df20bbe4148d19c14b431c974b21
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-source-maps@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "istanbul-lib-source-maps@npm:3.0.6"
+  dependencies:
+    debug: ^4.1.1
+    istanbul-lib-coverage: ^2.0.5
+    make-dir: ^2.1.0
+    rimraf: ^2.6.3
+    source-map: ^0.6.1
+  checksum: 1c6ebc81331ab4d831910db3e98da1ee4e3e96f64c2fb533e1b73516305f020b44765fa2937f24eee4adb11be22a1fa42c04786e0d697d4893987a1a5180a541
+  languageName: node
+  linkType: hard
+
+"istanbul-reports@npm:^3.0.2":
+  version: 3.1.7
+  resolution: "istanbul-reports@npm:3.1.7"
+  dependencies:
+    html-escaper: ^2.0.0
+    istanbul-lib-report: ^3.0.0
+  checksum: 2072db6e07bfbb4d0eb30e2700250636182398c1af811aea5032acb219d2080f7586923c09fa194029efd6b92361afb3dcbe1ebcc3ee6651d13340f7c6c4ed95
+  languageName: node
+  linkType: hard
+
 "iterator.prototype@npm:^1.1.2":
   version: 1.1.2
   resolution: "iterator.prototype@npm:1.1.2"
@@ -7014,6 +7160,18 @@ __metadata:
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
   checksum: 8a95213a5a77deb6cbe94d86340e8d9ace2b93bc367790b260101d2f36a2eaf4e4e22d9fa9cf459b38af3a32fb4190e638024cf82ec95ef708680e405ea7cc78
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^3.13.1":
+  version: 3.14.1
+  resolution: "js-yaml@npm:3.14.1"
+  dependencies:
+    argparse: ^1.0.7
+    esprima: ^4.0.0
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: bef146085f472d44dee30ec34e5cf36bf89164f5d585435a3d3da89e52622dff0b188a580e4ad091c3341889e14cb88cac6e4deb16dc5b1e9623bb0601fc255c
   languageName: node
   linkType: hard
 
@@ -7133,6 +7291,19 @@ __metadata:
   dependencies:
     which: ^1.2.1
   checksum: e1119e4f95dbcdaec937e5d15a9ffea1b7e5c1d7566f7074ff140161983d4a0821ad274d3dcc34aacfb792caf842a39c459ba9c263723faa6a060cca8692d9b7
+  languageName: node
+  linkType: hard
+
+"karma-coverage-istanbul-reporter@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "karma-coverage-istanbul-reporter@npm:3.0.3"
+  dependencies:
+    istanbul-lib-coverage: ^3.0.0
+    istanbul-lib-report: ^3.0.0
+    istanbul-lib-source-maps: ^3.0.6
+    istanbul-reports: ^3.0.2
+    minimatch: ^3.0.4
+  checksum: 34b5b102a0759572481739300a1748df2ab6ebb34253ce212ddaa68f560a90c2a6ca8255bd5335db8d34f662b4130ab1cd418f84d16e6d9c44fc6dea67e45c07
   languageName: node
   linkType: hard
 
@@ -7283,6 +7454,15 @@ __metadata:
   version: 1.2.4
   resolution: "lines-and-columns@npm:1.2.4"
   checksum: 0c37f9f7fa212b38912b7145e1cd16a5f3cd34d782441c3e6ca653485d326f58b3caccda66efce1c5812bde4961bbde3374fae4b0d11bf1226152337f3894aa5
+  languageName: node
+  linkType: hard
+
+"locate-path@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "locate-path@npm:5.0.0"
+  dependencies:
+    p-locate: ^4.1.0
+  checksum: 83e51725e67517287d73e1ded92b28602e3ae5580b301fe54bfb76c0c723e3f285b19252e375712316774cf52006cb236aed5704692c32db0d5d089b69696e30
   languageName: node
   linkType: hard
 
@@ -7448,6 +7628,25 @@ __metadata:
   dependencies:
     "@jridgewell/sourcemap-codec": ^1.4.15
   checksum: da10fecff0c0a7d3faf756913ce62bd6d5e7b0402be48c3b27bfd651b90e29677e279069a63b764bcdc1b8ecdcdb898f29a5c5ec510f2323e8d62ee057a6eb18
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "make-dir@npm:2.1.0"
+  dependencies:
+    pify: ^4.0.1
+    semver: ^5.6.0
+  checksum: 043548886bfaf1820323c6a2997e6d2fa51ccc2586ac14e6f14634f7458b4db2daf15f8c310e2a0abd3e0cddc64df1890d8fc7263033602c47bb12cbfcf86aab
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "make-dir@npm:4.0.0"
+  dependencies:
+    semver: ^7.5.3
+  checksum: bf0731a2dd3aab4db6f3de1585cea0b746bb73eb5a02e3d8d72757e376e64e6ada190b1eddcde5b2f24a81b688a9897efd5018737d05e02e2a671dda9cff8a8a
   languageName: node
   linkType: hard
 
@@ -8184,12 +8383,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-limit@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "p-limit@npm:2.3.0"
+  dependencies:
+    p-try: ^2.0.0
+  checksum: 84ff17f1a38126c3314e91ecfe56aecbf36430940e2873dadaa773ffe072dc23b7af8e46d4b6485d302a11673fe94c6b67ca2cfbb60c989848b02100d0594ac1
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^3.0.2":
   version: 3.1.0
   resolution: "p-limit@npm:3.1.0"
   dependencies:
     yocto-queue: ^0.1.0
   checksum: 7c3690c4dbf62ef625671e20b7bdf1cbc9534e83352a2780f165b0d3ceba21907e77ad63401708145ca4e25bfc51636588d89a8c0aeb715e6c37d1c066430360
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "p-locate@npm:4.1.0"
+  dependencies:
+    p-limit: ^2.2.0
+  checksum: 513bd14a455f5da4ebfcb819ef706c54adb09097703de6aeaa5d26fe5ea16df92b48d1ac45e01e3944ce1e6aa2a66f7f8894742b8c9d6e276e16cd2049a2b870
   languageName: node
   linkType: hard
 
@@ -8208,6 +8425,13 @@ __metadata:
   dependencies:
     aggregate-error: ^3.0.0
   checksum: cb0ab21ec0f32ddffd31dfc250e3afa61e103ef43d957cc45497afe37513634589316de4eb88abdfd969fe6410c22c0b93ab24328833b8eb1ccc087fc0442a1c
+  languageName: node
+  linkType: hard
+
+"p-try@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "p-try@npm:2.2.0"
+  checksum: f8a8e9a7693659383f06aec604ad5ead237c7a261c18048a6e1b5b85a5f8a067e469aa24f5bc009b991ea3b058a87f5065ef4176793a200d4917349881216cae
   languageName: node
   linkType: hard
 
@@ -8395,6 +8619,13 @@ __metadata:
   version: 2.3.0
   resolution: "pify@npm:2.3.0"
   checksum: 9503aaeaf4577acc58642ad1d25c45c6d90288596238fb68f82811c08104c800e5a7870398e9f015d82b44ecbcbef3dc3d4251a1cbb582f6e5959fe09884b2ba
+  languageName: node
+  linkType: hard
+
+"pify@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "pify@npm:4.0.1"
+  checksum: 9c4e34278cb09987685fa5ef81499c82546c033713518f6441778fbec623fc708777fe8ac633097c72d88470d5963094076c7305cafc7ad340aae27cfacd856b
   languageName: node
   linkType: hard
 
@@ -8947,6 +9178,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-from@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "resolve-from@npm:5.0.0"
+  checksum: 4ceeb9113e1b1372d0cd969f3468fa042daa1dd9527b1b6bb88acb6ab55d8b9cd65dbf18819f9f9ddf0db804990901dcdaade80a215e7b2c23daae38e64f5bdf
+  languageName: node
+  linkType: hard
+
 "resolve-options@npm:^2.0.0":
   version: 2.0.0
   resolution: "resolve-options@npm:2.0.0"
@@ -9059,6 +9297,17 @@ __metadata:
   version: 1.3.0
   resolution: "rfdc@npm:1.3.0"
   checksum: fb2ba8512e43519983b4c61bd3fa77c0f410eff6bae68b08614437bc3f35f91362215f7b4a73cbda6f67330b5746ce07db5dd9850ad3edc91271ad6deea0df32
+  languageName: node
+  linkType: hard
+
+"rimraf@npm:^2.6.3":
+  version: 2.7.1
+  resolution: "rimraf@npm:2.7.1"
+  dependencies:
+    glob: ^7.1.3
+  bin:
+    rimraf: ./bin.js
+  checksum: cdc7f6eacb17927f2a075117a823e1c5951792c6498ebcce81ca8203454a811d4cf8900314154d3259bb8f0b42ab17f67396a8694a54cae3283326e57ad250cd
   languageName: node
   linkType: hard
 
@@ -9245,6 +9494,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^5.6.0":
+  version: 5.7.2
+  resolution: "semver@npm:5.7.2"
+  bin:
+    semver: bin/semver
+  checksum: fb4ab5e0dd1c22ce0c937ea390b4a822147a9c53dbd2a9a0132f12fe382902beef4fbf12cf51bb955248d8d15874ce8cd89532569756384f994309825f10b686
+  languageName: node
+  linkType: hard
+
 "semver@npm:^6.3.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
@@ -9265,7 +9523,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.6.0":
+"semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0":
   version: 7.6.3
   resolution: "semver@npm:7.6.3"
   bin:
@@ -9534,6 +9792,13 @@ __metadata:
   version: 2.1.0
   resolution: "sparkles@npm:2.1.0"
   checksum: 5243c388b3060762ac3ded676528be486e835c64996512a7e61e1be059c7da48ddf32d244b11b457c4dec2f5227da44963b59f51f772aa503c968f00aa19362d
+  languageName: node
+  linkType: hard
+
+"sprintf-js@npm:~1.0.2":
+  version: 1.0.3
+  resolution: "sprintf-js@npm:1.0.3"
+  checksum: 19d79aec211f09b99ec3099b5b2ae2f6e9cdefe50bc91ac4c69144b6d3928a640bb6ae5b3def70c2e85a2c3d9f5ec2719921e3a59d3ca3ef4b2fd1a4656a0df3
   languageName: node
   linkType: hard
 
@@ -10006,6 +10271,17 @@ __metadata:
   bin:
     terser: bin/terser
   checksum: e059177775b4d4f4cff219ad89293175aefbd1b081252270444dc83e42a2c5f07824eb2a85eae6e22ef6eb7ef04b21af36dd7d1dd7cfb93912310e57d416a205
+  languageName: node
+  linkType: hard
+
+"test-exclude@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "test-exclude@npm:6.0.0"
+  dependencies:
+    "@istanbuljs/schema": ^0.1.2
+    glob: ^7.1.4
+    minimatch: ^3.0.4
+  checksum: 3b34a3d77165a2cb82b34014b3aba93b1c4637a5011807557dc2f3da826c59975a5ccad765721c4648b39817e3472789f9b0fa98fc854c5c1c7a1e632aacdc28
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add code coverage reporting for JS, using essentially the same configuration we use in the lms app. This requires all statements to be either executed or explicitly ignored for coverage in order for frontend tests to pass.

- Add frontend code coverage using Istanbul
- Enable test execution progress reporter in Karma config
- Add missing tests for `readConfig` function and "pageshow" event handling, in tests for new group forms
- Suppress coverage gaps in legacy JS