### PR TITLE
Display read-only list of group members in "Members" tab

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -2,7 +2,6 @@ import { useContext, useEffect, useId, useState } from 'preact/hooks';
 
 import {
   Button,
-  CancelIcon,
   RadioGroup,
   useWarnOnPageUnload,
 } from '@hypothesis/frontend-shared';
@@ -15,6 +14,7 @@ import type {
 } from '../utils/api';
 import { pluralize } from '../utils/pluralize';
 import { setLocation } from '../utils/set-location';
+import ErrorNotice from './ErrorNotice';
 import FormContainer from './forms/FormContainer';
 import Star from './forms/Star';
 import Label from './forms/Label';
@@ -276,17 +276,7 @@ export default function CreateEditGroupForm() {
         )}
 
         <div className="flex items-center gap-x-4 mt-2">
-          <div data-testid="error-container" role="alert">
-            {errorMessage && (
-              <div
-                className="text-red-error font-bold flex items-center gap-x-2"
-                data-testid="error-message"
-              >
-                <CancelIcon />
-                {errorMessage}
-              </div>
-            )}
-          </div>
+          <ErrorNotice message={errorMessage} />
           <div className="grow" />
           <SaveStateIcon
             state={saveState === 'unmodified' ? 'unsaved' : saveState}

--- a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
+++ b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
@@ -1,18 +1,98 @@
-import { useContext } from 'preact/hooks';
+import { DataTable, Scroll } from '@hypothesis/frontend-shared';
+import { useContext, useEffect, useState } from 'preact/hooks';
 
 import { Config } from '../config';
+import { routes } from '../routes';
+import ErrorNotice from './ErrorNotice';
 import FormContainer from './forms/FormContainer';
+import type { GroupMembersResponse } from '../utils/api';
+import { callAPI } from '../utils/api';
+import { pluralize } from '../utils/pluralize';
 import GroupFormHeader from './GroupFormHeader';
+
+type MemberRow = {
+  username: string;
+};
+
+async function fetchMembers(
+  groupid: string,
+  signal: AbortSignal,
+): Promise<MemberRow[]> {
+  const membersURL = routes.api.group.members.replace(':pubid', groupid);
+  const members: GroupMembersResponse = await callAPI(membersURL, { signal });
+  return members.map(member => ({
+    username: member.username,
+  }));
+}
 
 export default function EditGroupMembersForm() {
   const config = useContext(Config)!;
   const group = config.context.group!;
 
+  // Fetch group members when the form loads.
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [members, setMembers] = useState<MemberRow[] | null>(null);
+  useEffect(() => {
+    const abort = new AbortController();
+    setErrorMessage(null);
+    fetchMembers(group.pubid, abort.signal)
+      .then(setMembers)
+      .catch(err => {
+        setErrorMessage(`Failed to fetch group members: ${err.message}`);
+      });
+    return () => {
+      abort.abort();
+    };
+  }, [group.pubid]);
+
+  const columns = [
+    {
+      field: 'username' as keyof MemberRow,
+      label: 'Username',
+    },
+  ];
+
+  const renderRow = (user: MemberRow, field: keyof MemberRow) => {
+    switch (field) {
+      case 'username':
+        return (
+          <div
+            data-testid="username"
+            className="truncate"
+            title={user.username}
+          >
+            {user.username}
+          </div>
+        );
+      // istanbul ignore next
+      default:
+        return null;
+    }
+  };
+
+  const memberText = pluralize(members?.length ?? 0, 'member', 'members');
+
   return (
     <FormContainer title="Edit group members">
       <GroupFormHeader group={group} />
       <hr />
-      <div className="my-2">Group members will appear here.</div>
+      <div className="flex py-3">
+        <div className="grow" />
+        <div data-testid="member-count">
+          {members?.length ?? '...'} {memberText}
+        </div>
+      </div>
+      <ErrorNotice message={errorMessage} />
+      <div className="w-full">
+        <Scroll>
+          <DataTable
+            title="Group members"
+            rows={members ?? []}
+            columns={columns}
+            renderItem={renderRow}
+          />
+        </Scroll>
+      </div>
     </FormContainer>
   );
 }

--- a/h/static/scripts/group-forms/components/ErrorNotice.tsx
+++ b/h/static/scripts/group-forms/components/ErrorNotice.tsx
@@ -1,0 +1,28 @@
+import { CancelIcon } from '@hypothesis/frontend-shared';
+
+export type ErrorNoticeProps = {
+  message: string | null;
+};
+
+/**
+ * A live region which displays an error message.
+ *
+ * If there is no error, the container should be rendered with a null `message`.
+ * This will cause any error message that is displayed later to be announced
+ * to screen readers.
+ */
+export default function ErrorNotice({ message }: ErrorNoticeProps) {
+  return (
+    <div data-testid="error-container" role="alert">
+      {message && (
+        <div
+          className="text-red-error font-bold flex items-center gap-x-2"
+          data-testid="error-message"
+        >
+          <CancelIcon />
+          {message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
+++ b/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
@@ -1,10 +1,15 @@
+import { waitFor, waitForElement } from '@hypothesis/frontend-testing';
 import { mount } from 'enzyme';
 
 import { Config } from '../../config';
-import EditGroupMembersForm from '../EditGroupMembersForm';
+import {
+  $imports,
+  default as EditGroupMembersForm,
+} from '../EditGroupMembersForm';
 
 describe('EditGroupMembersForm', () => {
   let config;
+  let fakeCallAPI;
 
   beforeEach(() => {
     config = {
@@ -15,6 +20,19 @@ describe('EditGroupMembersForm', () => {
         },
       },
     };
+
+    fakeCallAPI = sinon.stub();
+    fakeCallAPI.withArgs('/api/groups/1234/members').resolves([
+      {
+        username: 'bob',
+      },
+    ]);
+
+    $imports.$mock({
+      '../utils/api': {
+        callAPI: fakeCallAPI,
+      },
+    });
   });
 
   const createForm = (props = {}) => {
@@ -25,7 +43,55 @@ describe('EditGroupMembersForm', () => {
     );
   };
 
-  it('renders', () => {
-    createForm();
+  const waitForTable = wrapper =>
+    waitForElement(wrapper, '[data-testid="username"]');
+
+  const waitForError = wrapper =>
+    waitFor(() => {
+      wrapper.update();
+      return wrapper.find('ErrorNotice').prop('message') !== null;
+    });
+
+  it('fetches and displays members', async () => {
+    const wrapper = createForm();
+    assert.calledWith(fakeCallAPI, '/api/groups/1234/members');
+
+    await waitForTable(wrapper);
+
+    const users = wrapper.find('[data-testid="username"]');
+    assert.equal(users.length, 1);
+    assert.equal(users.at(0).text(), 'bob');
+  });
+
+  it('displays member count', async () => {
+    const wrapper = createForm();
+    const memberCount = wrapper.find('[data-testid="member-count"]');
+    assert.equal(memberCount.text(), '... members');
+
+    await waitForTable(wrapper);
+
+    assert.equal(memberCount.text(), '1 member');
+  });
+
+  it('displays error if member fetch fails', async () => {
+    fakeCallAPI
+      .withArgs('/api/groups/1234/members')
+      .rejects(new Error('Permission denied'));
+
+    const wrapper = createForm();
+    await waitForError(wrapper);
+
+    const error = wrapper.find('ErrorNotice');
+    assert.equal(
+      error.prop('message'),
+      'Failed to fetch group members: Permission denied',
+    );
+  });
+
+  it('handles member fetch being canceled', () => {
+    const wrapper = createForm();
+    assert.calledWith(fakeCallAPI, '/api/groups/1234/members');
+    // Unmount while fetching. This should abort the request.
+    wrapper.unmount();
   });
 });

--- a/h/static/scripts/group-forms/routes.ts
+++ b/h/static/scripts/group-forms/routes.ts
@@ -5,6 +5,11 @@
  * These must be synchronized with h/routes.py.
  */
 export const routes = {
+  api: {
+    group: {
+      members: '/api/groups/:pubid/members',
+    },
+  },
   groups: {
     new: '/groups/new',
     edit: '/groups/:pubid/edit',

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -27,6 +27,17 @@ export type CreateUpdateGroupAPIResponse = {
   };
 };
 
+export type GroupMember = {
+  username: string;
+};
+
+/**
+ * Response to group members API.
+ *
+ * https://h.readthedocs.io/en/latest/api-reference/v2/#tag/groups/paths/~1groups~1{id}~1members/get
+ */
+export type GroupMembersResponse = GroupMember[];
+
 /** An error response from the h API:
  * https://h.readthedocs.io/en/latest/api-reference/v2/#section/Hypothesis-API/Errors
  */

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -62,24 +62,27 @@ export class APIError extends Error {
 }
 
 /* Make an API call and return the parsed JSON body or throw APIError. */
-export async function callAPI(
+export async function callAPI<R = unknown>(
   url: string,
   {
     method = 'GET',
     json = null,
     headers = {},
+    signal,
   }: {
     method?: string;
     json?: object | null;
     headers?: Record<PropertyKey, unknown>;
+    signal?: AbortSignal;
   } = {},
-): Promise<object> {
+): Promise<R> {
   const options: RequestInit = {
     method,
     headers: {
       ...headers,
       'Content-Type': 'application/json; charset=UTF-8',
     },
+    signal,
   };
 
   if (json) {

--- a/h/static/scripts/group-forms/utils/test/api-test.js
+++ b/h/static/scripts/group-forms/utils/test/api-test.js
@@ -25,12 +25,15 @@ describe('callAPI', () => {
       await callAPI(url);
 
       assert.ok(
-        fakeFetch.calledOnceWith(url, {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json; charset=UTF-8',
-          },
-        }),
+        fakeFetch.calledOnceWith(
+          url,
+          sinon.match({
+            method: 'GET',
+            headers: {
+              'Content-Type': 'application/json; charset=UTF-8',
+            },
+          }),
+        ),
       );
     });
 


### PR DESCRIPTION
This commit adds initial infrastructure to fetch and display group members in the "Members" tab of the group settings form.

The only useful field currently available in the response is the username, so that is the only column in the table.

<img width="541" alt="Group members table" src="https://github.com/user-attachments/assets/c126b396-adf5-407b-8d4f-aeaa015d490e">

**Known issues:**

- Fetching the member list only works for open and restricted groups, as the group members API call does not yet allow cookie authentication
- If you change group settings, navigate to the members tab and then navigate back, the group settings will reset to what they were when the form originally loaded. This is because edits are not yet overlaid onto the original settings after the `CreateEditGroupForm` component unmounts.
- Error message styling and wording needs refinement
- There is no progress indicator when fetching members. You just see an empty table.