### PR TITLE
Support listing members of private groups in the group form

### DIFF
--- a/h/security/policy/_api_cookie.py
+++ b/h/security/policy/_api_cookie.py
@@ -8,6 +8,7 @@ from h.security.policy.helpers import AuthTicketCookieHelper
 COOKIE_AUTHENTICATABLE_API_REQUESTS = [
     ("api.groups", "POST"),  # Create a new group.
     ("api.group", "PATCH"),  # Edit an existing group.
+    ("api.group_members", "GET"),  # List group members
 ]
 
 

--- a/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
+++ b/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
@@ -13,6 +13,13 @@ describe('EditGroupMembersForm', () => {
 
   beforeEach(() => {
     config = {
+      api: {
+        readGroupMembers: {
+          url: '/api/groups/1234/members',
+          method: 'GET',
+          headers: { 'Misc-Header': 'Some-Value' },
+        },
+      },
       context: {
         group: {
           pubid: '1234',
@@ -67,7 +74,14 @@ describe('EditGroupMembersForm', () => {
 
   it('fetches and displays members', async () => {
     const wrapper = createForm();
-    assert.calledWith(fakeCallAPI, '/api/groups/1234/members');
+    assert.calledWith(
+      fakeCallAPI,
+      '/api/groups/1234/members',
+      sinon.match({
+        method: config.api.readGroupMembers.method,
+        headers: config.api.readGroupMembers.headers,
+      }),
+    );
 
     await waitForTable(wrapper);
 

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -21,7 +21,8 @@ export type ConfigObject = {
   styles: string[];
   api: {
     createGroup: APIConfig;
-    updateGroup: APIConfig | null;
+    updateGroup?: APIConfig;
+    readGroupMembers?: APIConfig;
   };
   context: {
     group: Group | null;

--- a/h/static/scripts/group-forms/routes.ts
+++ b/h/static/scripts/group-forms/routes.ts
@@ -5,11 +5,6 @@
  * These must be synchronized with h/routes.py.
  */
 export const routes = {
-  api: {
-    group: {
-      members: '/api/groups/:pubid/members',
-    },
-  },
   groups: {
     new: '/groups/new',
     edit: '/groups/:pubid/edit',

--- a/tests/unit/h/views/groups_test.py
+++ b/tests/unit/h/views/groups_test.py
@@ -79,6 +79,15 @@ class TestGroupCreateEditController:
                             "X-CSRF-Token": views.get_csrf_token.spy_return  # pylint:disable=no-member
                         },
                     },
+                    "readGroupMembers": {
+                        "method": "GET",
+                        "url": pyramid_request.route_url(
+                            "api.group_members", pubid=group.pubid
+                        ),
+                        "headers": {
+                            "X-CSRF-Token": views.get_csrf_token.spy_return  # pylint:disable=no-member
+                        },
+                    },
                     "updateGroup": {
                         "method": "PATCH",
                         "url": pyramid_request.route_url("api.group", id=group.pubid),
@@ -136,4 +145,5 @@ def test_read_noslug_redirects(pyramid_request, factories):
 def routes(pyramid_config):
     pyramid_config.add_route("group_read", "/g/{pubid}/{slug}")
     pyramid_config.add_route("api.group", "/api/group/{id}")
+    pyramid_config.add_route("api.group_members", "/api/groups/{pubid}/members")
     pyramid_config.add_route("api.groups", "/api/groups")


### PR DESCRIPTION
https://github.com/hypothesis/h/pull/9079 added an initial read-only list of members to the "Members" tab in the group form. That iteration only supported listing members of open groups because the call to list members was unauthenticated.

This PR changes the call to work the same way as the (authenticated) API calls the forms use to create and edit groups. This enables the members list to work for private groups as well.

**Summary of changes:**

- Add the `api.group_members` route to the list of routes that allow API cookie auth
- Change the backend to add API configuration for making the call to list group members
- Change the frontend to use this API configuration instead of generating the URL itself

**Testing:**

1. Select a private group in activity pages and click "Edit group".
2. Click the "Members" link and you should see the group's members listed.