### PR TITLE
Persist group details changes when switching tabs

### DIFF
--- a/h/static/scripts/group-forms/components/AppRoot.tsx
+++ b/h/static/scripts/group-forms/components/AppRoot.tsx
@@ -1,5 +1,5 @@
 import { Route, Switch } from 'wouter-preact';
-import { useMemo } from 'preact/hooks';
+import { useMemo, useState } from 'preact/hooks';
 
 import CreateEditGroupForm from './CreateEditGroupForm';
 import EditGroupMembersForm from './EditGroupMembersForm';
@@ -25,6 +25,10 @@ export default function AppRoot({ config }: AppRootProps) {
     [config],
   );
 
+  // Saved group details. Extracted out of `config` so we can update them after
+  // saving changes to the backend.
+  const [group, setGroup] = useState(config.context.group);
+
   return (
     <>
       {stylesheetLinks}
@@ -32,13 +36,13 @@ export default function AppRoot({ config }: AppRootProps) {
         <Router>
           <Switch>
             <Route path={routes.groups.new}>
-              <CreateEditGroupForm />
+              <CreateEditGroupForm group={group} onUpdateGroup={setGroup} />
             </Route>
             <Route path={routes.groups.edit}>
-              <CreateEditGroupForm />
+              <CreateEditGroupForm group={group} onUpdateGroup={setGroup} />
             </Route>
             <Route path={routes.groups.editMembers}>
-              <EditGroupMembersForm />
+              <EditGroupMembersForm group={group!} />
             </Route>
             <Route>
               <h1 data-testid="unknown-route">Page not found</h1>

--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect, useId, useState } from 'preact/hooks';
 
 import { Button, RadioGroup } from '@hypothesis/frontend-shared';
 import { Config } from '../config';
+import type { Group } from '../config';
 import { callAPI } from '../utils/api';
 import type {
   CreateUpdateGroupAPIRequest,
@@ -82,9 +83,19 @@ function GroupTypeChangeWarning({
   );
 }
 
-export default function CreateEditGroupForm() {
+export type CreateEditGroupFormProps = {
+  /** The saved group details, or `null` if the group has not been saved yet. */
+  group: Group | null;
+
+  /** Update the saved group details in the frontend's local state. */
+  onUpdateGroup?: (g: Group) => void;
+};
+
+export default function CreateEditGroupForm({
+  group,
+  onUpdateGroup,
+}: CreateEditGroupFormProps) {
   const config = useContext(Config)!;
-  const group = config.context.group;
 
   const [name, setName] = useState(group?.name ?? '');
   const [description, setDescription] = useState(group?.description ?? '');
@@ -178,6 +189,8 @@ export default function CreateEditGroupForm() {
 
       // Mark form as saved, unless user edited it while saving.
       setSaveState(state => (state === 'saving' ? 'saved' : state));
+
+      onUpdateGroup?.({ ...group!, name, description, type: groupType });
     } catch (apiError) {
       setSaveState('unsaved');
       setErrorMessage(apiError.message);

--- a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
+++ b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
@@ -1,8 +1,8 @@
 import { DataTable, Scroll } from '@hypothesis/frontend-shared';
-import { useContext, useEffect, useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 
-import { Config } from '../config';
 import { routes } from '../routes';
+import type { Group } from '../config';
 import ErrorNotice from './ErrorNotice';
 import FormContainer from './forms/FormContainer';
 import type { GroupMembersResponse } from '../utils/api';
@@ -25,10 +25,14 @@ async function fetchMembers(
   }));
 }
 
-export default function EditGroupMembersForm() {
-  const config = useContext(Config)!;
-  const group = config.context.group!;
+export type EditGroupMembersFormProps = {
+  /** The saved group details. */
+  group: Group;
+};
 
+export default function EditGroupMembersForm({
+  group,
+}: EditGroupMembersFormProps) {
   // Fetch group members when the form loads.
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [members, setMembers] = useState<MemberRow[] | null>(null);

--- a/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
+++ b/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
@@ -38,7 +38,7 @@ describe('EditGroupMembersForm', () => {
   const createForm = (props = {}) => {
     return mount(
       <Config.Provider value={config}>
-        <EditGroupMembersForm {...props} />
+        <EditGroupMembersForm group={config.context.group} {...props} />
       </Config.Provider>,
     );
   };


### PR DESCRIPTION
When switching from the "Settings" tab to "Members" and back, persist changes to group settings.

This is done by extracting the saved group details from the config into a state value in the `AppRoot` component which is then passed down to the current route as a prop. The `CreateEditGroupForm` component then updates this value via a callback after changes are saved.

An alternative way to achieve this would be for the "Settings" tab to fetch the group details from the backend every time it is rendered via an API call, which is how the "Members" tab works. As an optimization, this could be skipped on the initial load if the details have been provided as part of the config.

Fixes https://github.com/hypothesis/h/issues/9087

**Testing:**

1. In activity pages, go to an existing group and select "Edit group"
2. Edit the name, description or type and click "Save changes"
3. Navigate to the "Members" tab and then back to "Settings". The changes made in Step 2 should be persisted. Note the Members tab only works for open groups until https://github.com/hypothesis/h/pull/9085 lands.