### PR TITLE
Warn when a client-side navigation will lose changes

### DIFF
--- a/h/static/scripts/group-forms/components/AppRoot.tsx
+++ b/h/static/scripts/group-forms/components/AppRoot.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'preact/hooks';
 
 import CreateEditGroupForm from './CreateEditGroupForm';
 import EditGroupMembersForm from './EditGroupMembersForm';
+import Router from './Router';
 import type { ConfigObject } from '../config';
 import { Config } from '../config';
 import { routes } from '../routes';
@@ -28,20 +29,22 @@ export default function AppRoot({ config }: AppRootProps) {
     <>
       {stylesheetLinks}
       <Config.Provider value={config}>
-        <Switch>
-          <Route path={routes.groups.new}>
-            <CreateEditGroupForm />
-          </Route>
-          <Route path={routes.groups.edit}>
-            <CreateEditGroupForm />
-          </Route>
-          <Route path={routes.groups.editMembers}>
-            <EditGroupMembersForm />
-          </Route>
-          <Route>
-            <h1 data-testid="unknown-route">Page not found</h1>
-          </Route>
-        </Switch>
+        <Router>
+          <Switch>
+            <Route path={routes.groups.new}>
+              <CreateEditGroupForm />
+            </Route>
+            <Route path={routes.groups.edit}>
+              <CreateEditGroupForm />
+            </Route>
+            <Route path={routes.groups.editMembers}>
+              <EditGroupMembersForm />
+            </Route>
+            <Route>
+              <h1 data-testid="unknown-route">Page not found</h1>
+            </Route>
+          </Switch>
+        </Router>
       </Config.Provider>
     </>
   );

--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -1,10 +1,6 @@
 import { useContext, useEffect, useId, useState } from 'preact/hooks';
 
-import {
-  Button,
-  RadioGroup,
-  useWarnOnPageUnload,
-} from '@hypothesis/frontend-shared';
+import { Button, RadioGroup } from '@hypothesis/frontend-shared';
 import { Config } from '../config';
 import { callAPI } from '../utils/api';
 import type {
@@ -14,6 +10,7 @@ import type {
 } from '../utils/api';
 import { pluralize } from '../utils/pluralize';
 import { setLocation } from '../utils/set-location';
+import { useUnsavedChanges } from '../utils/unsaved-changes';
 import ErrorNotice from './ErrorNotice';
 import FormContainer from './forms/FormContainer';
 import Star from './forms/Star';
@@ -109,7 +106,7 @@ export default function CreateEditGroupForm() {
   // Warn when leaving page if there are unsaved changes. We only do this when
   // editing a group because this hook lacks a way to disable the handler before
   // calling `setLocation` after a successful group creation.
-  useWarnOnPageUnload(!!group && ['unsaved', 'saving'].includes(saveState));
+  useUnsavedChanges(!!group && ['unsaved', 'saving'].includes(saveState));
 
   useEffect(() => {
     const listener = (e: PageTransitionEvent) => {

--- a/h/static/scripts/group-forms/components/Router.tsx
+++ b/h/static/scripts/group-forms/components/Router.tsx
@@ -1,0 +1,54 @@
+import { Router as BaseRouter } from 'wouter-preact';
+import { useBrowserLocation } from 'wouter-preact/use-browser-location';
+import type { ComponentChildren } from 'preact';
+import { useCallback, useState } from 'preact/hooks';
+
+import WarningDialog from './WarningDialog';
+import { hasUnsavedChanges } from '../utils/unsaved-changes';
+
+export type RouterProps = {
+  children: ComponentChildren;
+};
+
+/**
+ * A wrapper around Wouter's `Router` component which intercepts navigations
+ * triggered by router links and allows the user to cancel them if the
+ * navigation may lose unsaved changes.
+ */
+export default function Router({ children }: RouterProps) {
+  const [location, origSetLocation] = useBrowserLocation();
+  const [pendingURL, setPendingURL] = useState<string | null>(null);
+
+  const setLocation = useCallback(
+    (url: string) => {
+      if (!hasUnsavedChanges()) {
+        origSetLocation(url);
+        return;
+      }
+      setPendingURL(url);
+    },
+    [origSetLocation],
+  );
+  const hook: () => [string, typeof setLocation] = useCallback(
+    () => [location, setLocation],
+    [location, setLocation],
+  );
+
+  return (
+    <>
+      <BaseRouter hook={hook}>{children}</BaseRouter>
+      {pendingURL && (
+        <WarningDialog
+          title="Leave page?"
+          onCancel={() => setPendingURL(null)}
+          onConfirm={() => {
+            setPendingURL(null);
+            origSetLocation(pendingURL);
+          }}
+          confirmAction="Leave page"
+          message="This will lose unsaved changes."
+        />
+      )}
+    </>
+  );
+}

--- a/h/static/scripts/group-forms/components/test/Router-test.js
+++ b/h/static/scripts/group-forms/components/test/Router-test.js
@@ -1,0 +1,82 @@
+import { Link } from 'wouter-preact';
+import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
+
+import { $imports, default as Router } from '../Router';
+
+function App() {
+  return (
+    <Router>
+      <Link data-testid="link" href="/test/path">
+        Test link
+      </Link>
+    </Router>
+  );
+}
+
+describe('Router', () => {
+  let fakeHasUnsavedChanges;
+  let initialHistoryLen;
+
+  beforeEach(() => {
+    fakeHasUnsavedChanges = sinon.stub().returns(false);
+    initialHistoryLen = history.length;
+
+    $imports.$mock({
+      '../utils/unsaved-changes': {
+        hasUnsavedChanges: fakeHasUnsavedChanges,
+      },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+
+    const backSteps = history.length - initialHistoryLen;
+    if (backSteps > 0) {
+      history.go(-backSteps);
+    }
+  });
+
+  function clickLink(wrapper) {
+    act(() => {
+      wrapper.find('a').getDOMNode().click();
+    });
+    wrapper.update();
+  }
+
+  it('navigates without warning if there are no unsaved changes', () => {
+    const wrapper = mount(<App />);
+    clickLink(wrapper);
+    assert.isFalse(wrapper.exists('WarningDialog'));
+    assert.equal(location.pathname, '/test/path');
+  });
+
+  it('shows a warning if there are unsaved changes', () => {
+    // Click link when there are unsaved changes.
+    history.pushState({}, '', '/original/url');
+    fakeHasUnsavedChanges.returns(true);
+    const wrapper = mount(<App />);
+    clickLink(wrapper);
+
+    // The confirmation dialog should be shown.
+    const warning = wrapper.find('WarningDialog');
+    assert.isTrue(warning.exists());
+    assert.notEqual(location.pathname, '/test/path');
+
+    // Canceling the dialog should leave the location unchanged
+    warning.prop('onCancel')();
+    wrapper.update();
+    assert.isFalse(wrapper.exists('WarningDialog'));
+    assert.notEqual(location.pathname, '/test/path');
+
+    // Click the link again, but this time confirm the navigation.
+    clickLink(wrapper);
+    const warning2 = wrapper.find('WarningDialog');
+    warning2.prop('onConfirm')();
+    wrapper.update();
+
+    assert.isFalse(wrapper.exists('WarningDialog'));
+    assert.equal(location.pathname, '/test/path');
+  });
+});

--- a/h/static/scripts/group-forms/utils/test/unsaved-changes-test.js
+++ b/h/static/scripts/group-forms/utils/test/unsaved-changes-test.js
@@ -1,0 +1,60 @@
+import { mount } from 'enzyme';
+import { useUnsavedChanges, hasUnsavedChanges } from '../unsaved-changes';
+
+function TestUseUnsavedChanges({ unsaved, fakeWindow }) {
+  useUnsavedChanges(unsaved, fakeWindow);
+  return <div />;
+}
+
+describe('useUnsavedChanges', () => {
+  let fakeWindow;
+
+  function dispatchBeforeUnload() {
+    const event = new Event('beforeunload', { cancelable: true });
+    fakeWindow.dispatchEvent(event);
+    return event;
+  }
+
+  function createWidget(unsaved) {
+    return mount(
+      <TestUseUnsavedChanges fakeWindow={fakeWindow} unsaved={unsaved} />,
+    );
+  }
+
+  beforeEach(() => {
+    // Use a dummy window to avoid triggering any handlers that respond to
+    // "beforeunload" on the real window.
+    fakeWindow = new EventTarget();
+  });
+
+  it('does not increment unsaved-changes count if argument is false', () => {
+    const wrapper = createWidget(false);
+    assert.isFalse(hasUnsavedChanges());
+    wrapper.unmount();
+  });
+
+  it('does not register "beforeunload" handler if argument is false', () => {
+    const wrapper = createWidget(false);
+    const event = dispatchBeforeUnload();
+    assert.isFalse(event.defaultPrevented);
+    wrapper.unmount();
+  });
+
+  it('increments unsaved-changes count if argument is true', () => {
+    const wrapper = createWidget(true);
+    assert.isTrue(hasUnsavedChanges());
+    wrapper.unmount();
+    assert.isFalse(hasUnsavedChanges());
+  });
+
+  it('registers "beforeunload" handler if argument is true', () => {
+    const wrapper = createWidget(true);
+    const event = dispatchBeforeUnload();
+    assert.isTrue(event.defaultPrevented);
+
+    // Unmount the widget, this should remove the handler.
+    wrapper.unmount();
+    const event2 = dispatchBeforeUnload();
+    assert.isFalse(event2.defaultPrevented);
+  });
+});

--- a/h/static/scripts/group-forms/utils/unsaved-changes.ts
+++ b/h/static/scripts/group-forms/utils/unsaved-changes.ts
@@ -23,21 +23,24 @@ export function hasUnsavedChanges() {
  * @param hasUnsavedChanges - True if current component has unsaved changes
  * @param window_ - Test seam
  */
-export function useUnsavedChanges(hasUnsavedData: boolean, window_ = window) {
+export function useUnsavedChanges(
+  hasUnsavedChanges: boolean,
+  window_ = window,
+) {
   useEffect(() => {
-    if (hasUnsavedData) {
-      unsavedCount += 1;
-      if (unsavedCount === 1) {
-        window_.addEventListener('beforeunload', preventUnload);
-      }
+    if (!hasUnsavedChanges) {
+      return () => {};
+    }
+
+    unsavedCount += 1;
+    if (unsavedCount === 1) {
+      window_.addEventListener('beforeunload', preventUnload);
     }
     return () => {
-      if (hasUnsavedData) {
-        unsavedCount -= 1;
-        if (unsavedCount === 0) {
-          window_.removeEventListener('beforeunload', preventUnload);
-        }
+      unsavedCount -= 1;
+      if (unsavedCount === 0) {
+        window_.removeEventListener('beforeunload', preventUnload);
       }
     };
-  }, [hasUnsavedData, window_]);
+  }, [hasUnsavedChanges, window_]);
 }

--- a/h/static/scripts/group-forms/utils/unsaved-changes.ts
+++ b/h/static/scripts/group-forms/utils/unsaved-changes.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'preact/hooks';
+
+/** Count of components with unsaved changes. */
+let unsavedCount = 0;
+
+function preventUnload(e: BeforeUnloadEvent) {
+  e.preventDefault();
+  e.returnValue = '';
+}
+
+/**
+ * Return true if any active components have indicated they have unsaved changes
+ * using {@link useUnsavedChanges}.
+ */
+export function hasUnsavedChanges() {
+  return unsavedCount > 0;
+}
+
+/**
+ * Hook that registers the current component as having unsaved changes that
+ * would be lost in the event of a navigation.
+ *
+ * @param hasUnsavedChanges - True if current component has unsaved changes
+ * @param window_ - Test seam
+ */
+export function useUnsavedChanges(hasUnsavedData: boolean, window_ = window) {
+  useEffect(() => {
+    if (hasUnsavedData) {
+      unsavedCount += 1;
+      if (unsavedCount === 1) {
+        window_.addEventListener('beforeunload', preventUnload);
+      }
+    }
+    return () => {
+      if (hasUnsavedData) {
+        unsavedCount -= 1;
+        if (unsavedCount === 0) {
+          window_.removeEventListener('beforeunload', preventUnload);
+        }
+      }
+    };
+  }, [hasUnsavedData, window_]);
+}


### PR DESCRIPTION
Add infrastructure to register when a component has unsaved changes and show a confirmation dialog upon a client-side navigation in this case. Use this infrastructure to show a confirmation dialog when attempting to navigate from the "Settings" tab to the "Members" tab if there are unsaved changes.

<img width="621" alt="Client-side leave warning" src="https://github.com/user-attachments/assets/352531ab-aa43-478d-b99f-869fa82df4e5">

Fixes https://github.com/hypothesis/h/issues/9096.

---

**Testing:**

1. Go to the edit page for a group
2. Navigate between the Settings and Members tab, or to a different URL. There should be no confirmation.
3. Change one of the fields in the Settings tab but don't save.
4. Click the Members tab, you should see a confirmation dialog. Clicking "Leave page" / Cancel should confirm or cancel the navigation respectively.
5. Navigate to a different site when there are unsaved changes in the Settings tab. You should see the browser's warning about unsaved changes.

**Implementation notes:**

The implementation uses [Wouter's API](https://github.com/molefrog/wouter?tab=readme-ov-file#router-hookhook-parserfn-basebasepath-hrefsfn-) for customizing the location hook that is used by links that perform client-side navigations.