### PR TITLE
Add logging to `GroupMembersService`

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import relationship
 
 from h import pubid
 from h.db import Base, mixins
+from h.models import helpers
 from h.models.user import User
 from h.util.group import split_groupid
 
@@ -76,6 +77,12 @@ class GroupMembership(Base):
         server_default=sa.text("""'["member"]'::jsonb"""),
         nullable=False,
     )
+
+    def __repr__(self):
+        return helpers.repr_(
+            self,
+            ["id", "user_id", "group_id", "roles"],
+        )
 
 
 class Group(Base, mixins.Timestamps):

--- a/h/services/group_members.py
+++ b/h/services/group_members.py
@@ -1,9 +1,12 @@
+import logging
 from functools import partial
 
 from sqlalchemy import select
 
 from h import session
 from h.models import GroupMembership
+
+log = logging.getLogger(__name__)
 
 
 class GroupMembersService:
@@ -70,8 +73,10 @@ class GroupMembersService:
             # The user is already a member of the group.
             return
 
-        self.db.add(GroupMembership(group=group, user=user))
+        membership = GroupMembership(group=group, user=user)
+        self.db.add(membership)
 
+        log.info("Added group membership: %r", membership)
         self.publish("group-join", group.pubid, userid)
 
     def member_leave(self, group, userid):
@@ -89,6 +94,7 @@ class GroupMembersService:
 
         self.db.delete(membership)
 
+        log.info("Deleted group membership: %r", membership)
         self.publish("group-leave", group.pubid, userid)
 
 


### PR DESCRIPTION
Add logging to `GroupMembersService` whenever creating or deleting a
group membership. I think we should start doing this as a matter of good
practice: each view or service method that creates, updates or deletes
something in the DB should log the changes it makes. This could have
helped with a recent bug (https://github.com/hypothesis/h/pull/9080) in
a number of ways:

1. Logging helps with writing unittests: tests can assert that expected
   messages were logged, which helps to ensure that the test is going
   down the code path that it expects to.

2. Logging can also help with manual testing either locally or on
   staging or production: you can look at the logs being produced and
   are more likely to notice if it's doing something wrong (e.g.
   deleting too many objects)

3. Logging can help with analysing the impact of a bug and with data
   recovery.

   For example with the bug above it actually wasn't possible to figure
   for certain which group memberships had been erroneously deleted and
   restore them. The logging included in this commit would have made
   complete recovery easy: we actually could have restored the deleted
   memberships from the log messages alone, without even needing a DB
   snapshot.

   For more complex objects (e.g. annotations, users, groups) it's not
   possible to include all attributes of the object in a single log line
   so you couldn't recover deleted objects from the logs alone. But if
   the logs include enough information to identify the deleted objects
   in a DB snapshot (e.g. if they included the primary key) they can
   help ensure that full recovery is both possible and quick and easy to
   do.
