### PR TITLE
Add better logging to `UserDeleteService`

### DIFF
--- a/h/models/annotation_slim.py
+++ b/h/models/annotation_slim.py
@@ -3,6 +3,7 @@ import datetime
 import sqlalchemy as sa
 
 from h.db import Base, types
+from h.models import helpers
 
 
 class AnnotationSlim(Base):
@@ -94,3 +95,6 @@ class AnnotationSlim(Base):
         index=True,
     )
     group = sa.orm.relationship("Group")
+
+    def __repr__(self):
+        return helpers.repr_(self, ["id"])

--- a/h/models/auth_ticket.py
+++ b/h/models/auth_ticket.py
@@ -5,6 +5,7 @@ import sqlalchemy as sa
 
 from h.db import Base
 from h.db.mixins import Timestamps
+from h.models import helpers
 
 
 class AuthTicket(Base, Timestamps):
@@ -48,3 +49,6 @@ class AuthTicket(Base, Timestamps):
         generate ids for most cases.
         """
         return urlsafe_b64encode(urandom(32)).rstrip(b"=").decode("ascii")
+
+    def __repr__(self):
+        return helpers.repr_(self, ["user_id", "expires"])

--- a/h/models/feature_cohort.py
+++ b/h/models/feature_cohort.py
@@ -1,6 +1,7 @@
 import sqlalchemy as sa
 
 from h.db import Base, mixins
+from h.models import helpers
 
 
 class FeatureCohort(Base, mixins.Timestamps):
@@ -29,6 +30,9 @@ class FeatureCohortUser(Base):
     id = sa.Column(sa.Integer, nullable=False, autoincrement=True, primary_key=True)
     cohort_id = sa.Column(sa.Integer, sa.ForeignKey("featurecohort.id"), nullable=False)
     user_id = sa.Column(sa.Integer, sa.ForeignKey("user.id"), nullable=False)
+
+    def __repr__(self):
+        return helpers.repr_(self, ["id", "cohort_id", "user_id"])
 
 
 FEATURECOHORT_FEATURE_TABLE = sa.Table(

--- a/h/models/flag.py
+++ b/h/models/flag.py
@@ -2,6 +2,7 @@ import sqlalchemy as sa
 
 from h.db import Base, types
 from h.db.mixins import Timestamps
+from h.models import helpers
 
 
 class Flag(Base, Timestamps):
@@ -37,4 +38,4 @@ class Flag(Base, Timestamps):
     user = sa.orm.relationship("User")
 
     def __repr__(self):
-        return f"<Flag annotation_id={self.annotation_id} user_id={self.user_id}>"
+        return helpers.repr_(self, ["id", "annotation_id", "user_id"])

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -280,7 +280,7 @@ class Group(Base, mixins.Timestamps):
         return self.readable_by == ReadableBy.world
 
     def __repr__(self):
-        return f"<Group: {self.slug}>"
+        return helpers.repr_(self, ["id"])
 
 
 TypeFlags = namedtuple("TypeFlags", "joinable_by readable_by writeable_by")

--- a/h/models/job.py
+++ b/h/models/job.py
@@ -85,6 +85,5 @@ class Job(Base):
                 "expires_at",
                 "priority",
                 "tag",
-                "kwargs",
             ],
         )

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -5,6 +5,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Mapped
 
 from h.db import Base, mixins
+from h.models import helpers
 
 
 class Token(Base, mixins.Timestamps):
@@ -89,3 +90,6 @@ class Token(Base, mixins.Timestamps):
         # For example 2.3 beccomes 2, but 2.9 also becomes 2.
         ttl_in_seconds_truncated = int(ttl_in_seconds)
         return ttl_in_seconds_truncated
+
+    def __repr__(self):
+        return helpers.repr_(self, ["id", "user_id", "_authclient_id"])

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.hybrid import Comparator, hybrid_property
 
 from h.db import Base
 from h.exceptions import InvalidUserId
+from h.models import helpers
 from h.util.user import format_userid, split_user
 
 if TYPE_CHECKING:
@@ -378,4 +379,4 @@ class User(Base):
         )
 
     def __repr__(self):
-        return f"<User: {self.username}>"
+        return helpers.repr_(self, ["id"])

--- a/tests/unit/h/models/annotation_slim_test.py
+++ b/tests/unit/h/models/annotation_slim_test.py
@@ -1,0 +1,5 @@
+def test_repr(db_session, factories):
+    annotation_slim = factories.AnnotationSlim()
+    db_session.flush()
+
+    assert repr(annotation_slim) == f"AnnotationSlim(id={annotation_slim.id!r})"

--- a/tests/unit/h/models/auth_ticket_test.py
+++ b/tests/unit/h/models/auth_ticket_test.py
@@ -12,3 +12,12 @@ class TestAuthTicket:
         urandom.assert_called_once_with(32)
         urlsafe_b64encode.assert_called_once_with(urandom.spy_return)
         assert ticket_id == urlsafe_b64encode.spy_return.rstrip(b"=").decode("ascii")
+
+    def test_repr(self, db_session, factories):
+        authticket = factories.AuthTicket()
+        db_session.flush()
+
+        assert (
+            repr(authticket)
+            == f"AuthTicket(user_id={authticket.user_id!r}, expires={authticket.expires!r})"
+        )

--- a/tests/unit/h/models/feature_cohort_test.py
+++ b/tests/unit/h/models/feature_cohort_test.py
@@ -1,0 +1,16 @@
+from h.models.feature_cohort import FeatureCohortUser
+
+
+class TestFeatureCohortUser:
+    def test_repr(self, db_session, factories):
+        cohort = factories.FeatureCohort()
+        user = factories.User()
+        db_session.flush()
+        feature_cohort_user = FeatureCohortUser(cohort_id=cohort.id, user_id=user.id)
+        db_session.add(feature_cohort_user)
+        db_session.flush()
+
+        assert (
+            repr(feature_cohort_user)
+            == f"FeatureCohortUser(id={feature_cohort_user.id!r}, cohort_id={cohort.id!r}, user_id={user.id!r})"
+        )

--- a/tests/unit/h/models/flag_test.py
+++ b/tests/unit/h/models/flag_test.py
@@ -1,8 +1,8 @@
-from h.models.flag import Flag
-
-
 class TestFlag:
-    def test___repr__(self):
-        flag = Flag(annotation_id=123, user_id=456)
+    def test___repr__(self, factories):
+        flag = factories.Flag()
 
-        assert repr(flag) == "<Flag annotation_id=123 user_id=456>"
+        assert (
+            repr(flag)
+            == f"Flag(id={flag.id!r}, annotation_id={flag.annotation_id!r}, user_id={flag.user_id!r})"
+        )

--- a/tests/unit/h/models/group_test.py
+++ b/tests/unit/h/models/group_test.py
@@ -189,7 +189,7 @@ def test_repr(db_session, factories, organization):
     db_session.add(group)
     db_session.flush()
 
-    assert repr(group) == "<Group: my-hypothesis-group>"
+    assert repr(group) == f"Group(id={group.id!r})"
 
 
 def test_group_organization(db_session):

--- a/tests/unit/h/models/job_test.py
+++ b/tests/unit/h/models/job_test.py
@@ -15,7 +15,6 @@ def test___repr__(factories, helpers):
             "expires_at",
             "priority",
             "tag",
-            "kwargs",
         ],
     )
     assert repr_ == helpers.repr_.return_value

--- a/tests/unit/h/models/token_test.py
+++ b/tests/unit/h/models/token_test.py
@@ -46,3 +46,12 @@ class TestToken:
         token = Token(refresh_token_expires=refresh_token_expires)
 
         assert token.refresh_token_expired is True
+
+    def test_repr(self, factories):
+        token = factories.DeveloperToken()
+
+        # pylint:disable=protected-access
+        assert (
+            repr(token)
+            == f"Token(id={token.id!r}, user_id={token.user_id!r}, _authclient_id={token._authclient_id!r})"
+        )

--- a/tests/unit/h/models/user_test.py
+++ b/tests/unit/h/models/user_test.py
@@ -213,7 +213,7 @@ class TestUserModel:
         assert getattr(User(), "privacy_accepted") is None
 
     def test_repr(self, user):
-        assert repr(user) == "<User: kiki>"
+        assert repr(user) == f"User(id={user.id})"
 
     @pytest.fixture
     def user(self, db_session):


### PR DESCRIPTION
Demo:

```
Purging User(id=1) - marked user as deleted
Purging User(id=1) - added purge_user job: Job(id=3, name=<JobName.PURGE_USER: 'purge_user'>, enqueued_at=datetime.datetime(2024, 11, 20, 17, 54, 14, 532500), scheduled_at=datetime.datetime(2024, 11, 20, 17, 54, 14, 532500), expires_at=datetime.datetime(2024, 12, 20, 17, 54, 14, 532500), priority=0, tag='UserDeleteService.delete_user')
Purging User(id=1) - added record of user deletion: UserDeletion(id=1, userid='acct:devdata_user@localhost', requested_at=datetime.datetime(2024, 11, 20, 17, 54, 14, 532500), requested_by='acct:devdata_admin@localhost', tag='admin.users_delete', registered_date=datetime.datetime(2024, 11, 20, 17, 51, 45, 532818), num_annotations=2)
Purging User(id=1) - deleted 1 rows from authticket
Purging User(id=1) - deleted 2 rows from token: 1, 2
Purging User(id=1) - marked annotations as deleted: ZTAldqdoEe-rRre0o_POkw, ZyjywqdoEe-rRsdA2rr4SA
Purging User(id=1) - marked annotation_slims as deleted: 1, 2
Purging User(id=1) - enqueued jobs to delete annotations from Elasticsearch: ZTAldqdoEe-rRre0o_POkw, ZyjywqdoEe-rRsdA2rr4SA
Purging User(id=1) - deleted 1 rows from group: 5
Purging User(id=1) - deleted 1 rows from user: 1
Purging User(id=1) - completed job: Job(id=3, name='purge_user', enqueued_at=datetime.datetime(2024, 11, 20, 17, 54, 14, 532500), scheduled_at=datetime.datetime(2024, 11, 20, 17, 54, 14, 532500), expires_at=datetime.datetime(2024, 12, 20, 17, 54, 14, 532500), priority=0, tag='UserDeleteService.delete_user')

```

The aim is to add good enough logging to `UserDeleteService` such that if a user was accidentally deleted (or if a bug caused `UserDeleteService` to delete stuff that it shouldn't, etc) we'd have enough information in the logs to assess what happened and to recover the accidentally deleted data from a backup of the DB.

The logging should also incidentally make monitoring and debugging generally easier.

Notes:

* `__repr__()`'s on all model classes that're nice and short, include the primary key, and don't include any sensitive information. And then log model objects with `%r` or `{obj!r}` so that `__repr__()` is used not `__str__()`.

* When rendering lists of things from the DB into log message strings it's good to sort the things. This makes the app's behaviour more predictable: always logging things in alphabetical order. And makes it easier to write non-flakey test assertions.

* It can be useful to have helper functions to log things in a consistent way. For example all the `UserDeleteService` log messages in this PR start with `"Purging {user!r} - "` and when DB rows have been deleted or updated there's always a comma-separated list of the IDs of the affected rows.