### PR TITLE
Add filter input to group members table

### DIFF
--- a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
+++ b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
@@ -1,5 +1,5 @@
-import { DataTable, Scroll } from '@hypothesis/frontend-shared';
-import { useEffect, useState } from 'preact/hooks';
+import { DataTable, Input, Scroll } from '@hypothesis/frontend-shared';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 
 import { routes } from '../routes';
 import type { Group } from '../config';
@@ -56,6 +56,8 @@ export default function EditGroupMembersForm({
     },
   ];
 
+  const [filter, setFilter] = useState('');
+
   const renderRow = (user: MemberRow, field: keyof MemberRow) => {
     switch (field) {
       case 'username':
@@ -75,12 +77,45 @@ export default function EditGroupMembersForm({
   };
 
   const memberText = pluralize(members?.length ?? 0, 'member', 'members');
+  const normalizedFilter = filter.toLowerCase();
+
+  const filteredMembers = useMemo(() => {
+    if (!normalizedFilter || !members) {
+      return members;
+    }
+    // nb. We can get away with lower-casing name and filter to do
+    // case-insensitive search because of the character set restrictions on
+    // usernames. This would be incorrect for Unicode text.
+    return members.filter(m =>
+      m.username.toLowerCase().includes(normalizedFilter),
+    );
+  }, [normalizedFilter, members]);
+
+  let emptyMessage;
+  if (members !== null && members.length > 0 && filter) {
+    emptyMessage = (
+      <div data-testid="no-filter-match">
+        No members match the filter {'"'}
+        <b>{filter}</b>
+        {'"'}
+      </div>
+    );
+  }
 
   return (
     <FormContainer title="Edit group members">
       <GroupFormHeader group={group} />
       <hr />
-      <div className="flex py-3">
+      <div className="flex py-3 items-center">
+        {/* Input has `w-full` style. Wrap in container to stop it stretching to full width of row. */}
+        <div>
+          <Input
+            aria-label="Search members"
+            data-testid="search-input"
+            placeholder="Search…"
+            onInput={e => setFilter((e.target as HTMLInputElement).value)}
+          />
+        </div>
         <div className="grow" />
         <div data-testid="member-count">
           {members?.length ?? '...'} {memberText}
@@ -91,9 +126,10 @@ export default function EditGroupMembersForm({
         <Scroll>
           <DataTable
             title="Group members"
-            rows={members ?? []}
+            rows={filteredMembers ?? []}
             columns={columns}
             renderItem={renderRow}
+            emptyMessage={emptyMessage}
           />
         </Scroll>
       </div>


### PR DESCRIPTION
Add a search box to filter group members. The filter currently only matches the username, is applied client-side and is case-insensitive.

Filter not applied:

<img width="530" alt="filter-empty" src="https://github.com/user-attachments/assets/ade5416c-376f-4e89-959a-c0187db5c54d">

Filter applied with match:

<img width="528" alt="filter-match" src="https://github.com/user-attachments/assets/7dd20dae-8b95-4cbd-9f2b-1c732ab95dbe">

Filter applied with no matches:

<img width="531" alt="filter-no-match" src="https://github.com/user-attachments/assets/457086af-3b41-4f3a-9e1a-28493df97da7">
