### PR TITLE
Git ignore coverage directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ mail/
 .cache/
 .coverage
 .coverage.*
+coverage/*
 .hypothesis/
 .tox/
 


### PR DESCRIPTION
There seems to be a new `coverage/` directory now, add that to
`.gitignore`. (This looks like it may be new frontend coverage data).
