### PR TITLE
Don't use xdist when running a subset of unittests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -128,7 +128,7 @@ commands =
     tests: sh bin/create-testdb h_tests
     functests: sh bin/create-testdb h_functests
     {tests,functests}: python3 -m h.scripts.init_db --delete --create
-    tests: python -m pytest --cov --cov-report= --cov-fail-under=0 --numprocesses logical --dist loadgroup {posargs:tests/unit/}
+    tests: python -m pytest --cov --cov-report= --cov-fail-under=0 {posargs:--numprocesses logical --dist loadgroup tests/unit/}
     functests: python -m pytest {posargs:tests/functional/}
     docs: sphinx-autobuild -qT --open-browser -b dirhtml -d {envdir}/doctrees docs {envdir}/html
     checkdocs: sphinx-build -qTWn -b dirhtml -d {envdir}/doctrees docs {envdir}/html


### PR DESCRIPTION
If this turns out to work well in h we should make the same change in the cookiecutter so it'll get applied to LMS as well (or it would, if LMS wasn't still off-template).

Context:

When running `make test` or `tox` h uses pytest-xdist
(https://pytest-xdist.readthedocs.io/, activated by the `--numprocesses
logical` and `--dist loadgroup` options to `pytest`) to run the unit
tests in parallel (one worker per CPU core).

Running the tests in parallel is much faster when running a lot of
tests. But it adds extra startup time so it actually takes longer if
only running a few tests. This is why running the tests in parallel is
optional in the cookiecutter and has only been added to h and LMS: in
other projects it'd actually take longer.

Problem: when running only a subset of h's tests with a command like
`tox tests/unit/h/services/group_members_test.py` running them in
parallel actually takes longer due to the extra startup time.

Also if you've put any `breakpoints()` in the code they will not work:
pytest-xdist isn't compatible with pdb.

Solution: move the `--numprocesses logical --dist loadgroup` options
into the `{posargs:<default_value>}` in `tox.ini`. This means that when
you just run `make test` or `tox` the default `posargs` will apply and
`--numprocesses logical --dist loadgroup` will be included. But when you
override the default posargs with a command like `tox
tests/unit/h/services/group_members_test.py` pytest-xdist will not be
used.

You can still use xdist when running a subset of tests with a command
like this:

    tox -- --numprocesses logical --dist loadgroup tests/unit/h/services/group_members_test.py
