### PR TITLE
Add missing `type` attribute to clipboard copy buttons

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -298,7 +298,8 @@
                value="{{ group.url }}">
         <button class="group-invite__clipboard-button"
                 data-ref="button"
-                title="Copy to clipboard">
+                title="Copy to clipboard"
+                type="button">
           {{ svg_icon('copy_to_clipboard', 'group-invite__clipboard-image') }}
         </button>
       </div>

--- a/h/templates/includes/share_widget.html.jinja2
+++ b/h/templates/includes/share_widget.html.jinja2
@@ -29,7 +29,8 @@
              readonly>
       <button class="share-widget-link__btn"
               data-ref="button"
-              title="Copy to clipboard">
+              title="Copy to clipboard"
+              type="button">
         {{ svg_icon('copy_to_clipboard', 'share-widget-link__btn--copy share-widget-action') }}
       </button>
   </div>


### PR DESCRIPTION
This fixes an issue where clicking the "Copy to clipboard" button for the group invite links would trigger a page reload.

**Testing:**

1. Go to the activity page for a group
2. Click the "Copy" button in the bottom right corner to copy the group's link

After step 2, the page should not reload.