### PR TITLE
Move group membership views into their own file

### DIFF
--- a/h/views/api/group_members.py
+++ b/h/views/api/group_members.py
@@ -14,8 +14,8 @@ from h.views.api.config import api_config
     description="Fetch all members of a group",
     permission=Permission.Group.READ,
 )
-def read_members(context: GroupContext, _request):
-    """Fetch the members of a group."""
+def list_members(context: GroupContext, _request):
+    """Return a list of a group's members."""
     return [UserJSONPresenter(user).asdict() for user in context.group.members]
 
 

--- a/h/views/api/group_members.py
+++ b/h/views/api/group_members.py
@@ -11,7 +11,7 @@ from h.views.api.config import api_config
     route_name="api.group_members",
     request_method="GET",
     link_name="group.members.read",
-    description="Fetch all members of a group",
+    description="Fetch a list of all members of a group",
     permission=Permission.Group.READ,
 )
 def list_members(context: GroupContext, _request):
@@ -24,14 +24,13 @@ def list_members(context: GroupContext, _request):
     route_name="api.group_member",
     request_method="DELETE",
     link_name="group.member.delete",
-    description="Remove the current user from a group",
-    is_authenticated=True,
+    description="Remove a user from a group",
     permission=Permission.Group.MEMBER_REMOVE,
 )
 def remove_member(context: GroupMembershipContext, request):
-    """Remove a member from the given group."""
-
+    """Remove a member from a group."""
     group_members_service = request.find_service(name="group_members")
+
     group_members_service.member_leave(context.group, context.user.userid)
 
     return HTTPNoContent()
@@ -42,21 +41,16 @@ def remove_member(context: GroupMembershipContext, request):
     route_name="api.group_member",
     request_method="POST",
     link_name="group.member.add",
+    description="Add a user to a group",
     permission=Permission.Group.MEMBER_ADD,
-    description="Add the user in the request params to a group.",
 )
 def add_member(context: GroupMembershipContext, request):
-    """
-    Add a member to a given group.
-
-    :raise HTTPNotFound: if the user is not found or if the use and group
-      authorities don't match.
-    """
-    group_members_svc = request.find_service(name="group_members")
+    """Add a member to a group."""
+    group_members_service = request.find_service(name="group_members")
 
     if context.user.authority != context.group.authority:
         raise HTTPNotFound()
 
-    group_members_svc.member_join(context.group, context.user.userid)
+    group_members_service.member_join(context.group, context.user.userid)
 
     return HTTPNoContent()

--- a/h/views/api/group_members.py
+++ b/h/views/api/group_members.py
@@ -1,0 +1,62 @@
+from pyramid.httpexceptions import HTTPNoContent, HTTPNotFound
+
+from h.presenters import UserJSONPresenter
+from h.security import Permission
+from h.traversal import GroupContext, GroupMembershipContext
+from h.views.api.config import api_config
+
+
+@api_config(
+    versions=["v1", "v2"],
+    route_name="api.group_members",
+    request_method="GET",
+    link_name="group.members.read",
+    description="Fetch all members of a group",
+    permission=Permission.Group.READ,
+)
+def read_members(context: GroupContext, _request):
+    """Fetch the members of a group."""
+    return [UserJSONPresenter(user).asdict() for user in context.group.members]
+
+
+@api_config(
+    versions=["v1", "v2"],
+    route_name="api.group_member",
+    request_method="DELETE",
+    link_name="group.member.delete",
+    description="Remove the current user from a group",
+    is_authenticated=True,
+    permission=Permission.Group.MEMBER_REMOVE,
+)
+def remove_member(context: GroupMembershipContext, request):
+    """Remove a member from the given group."""
+
+    group_members_service = request.find_service(name="group_members")
+    group_members_service.member_leave(context.group, context.user.userid)
+
+    return HTTPNoContent()
+
+
+@api_config(
+    versions=["v1", "v2"],
+    route_name="api.group_member",
+    request_method="POST",
+    link_name="group.member.add",
+    permission=Permission.Group.MEMBER_ADD,
+    description="Add the user in the request params to a group.",
+)
+def add_member(context: GroupMembershipContext, request):
+    """
+    Add a member to a given group.
+
+    :raise HTTPNotFound: if the user is not found or if the use and group
+      authorities don't match.
+    """
+    group_members_svc = request.find_service(name="group_members")
+
+    if context.user.authority != context.group.authority:
+        raise HTTPNotFound()
+
+    group_members_svc.member_join(context.group, context.user.userid)
+
+    return HTTPNoContent()

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -1,10 +1,10 @@
-from pyramid.httpexceptions import HTTPConflict, HTTPNoContent, HTTPNotFound
+from pyramid.httpexceptions import HTTPConflict
 
 from h.i18n import TranslationString as _
-from h.presenters import GroupJSONPresenter, GroupsJSONPresenter, UserJSONPresenter
+from h.presenters import GroupJSONPresenter, GroupsJSONPresenter
 from h.schemas.api.group import CreateGroupAPISchema, UpdateGroupAPISchema
 from h.security import Permission
-from h.traversal import GroupContext, GroupMembershipContext
+from h.traversal import GroupContext
 from h.views.api.config import api_config
 from h.views.api.exceptions import PayloadError
 
@@ -133,62 +133,6 @@ def update(context: GroupContext, request):
     group = group_update_service.update(context.group, **appstruct)
 
     return GroupJSONPresenter(group, request).asdict(expand=["organization", "scopes"])
-
-
-@api_config(
-    versions=["v1", "v2"],
-    route_name="api.group_members",
-    request_method="GET",
-    link_name="group.members.read",
-    description="Fetch all members of a group",
-    permission=Permission.Group.READ,
-)
-def read_members(context: GroupContext, _request):
-    """Fetch the members of a group."""
-    return [UserJSONPresenter(user).asdict() for user in context.group.members]
-
-
-@api_config(
-    versions=["v1", "v2"],
-    route_name="api.group_member",
-    request_method="DELETE",
-    link_name="group.member.delete",
-    description="Remove the current user from a group",
-    is_authenticated=True,
-    permission=Permission.Group.MEMBER_REMOVE,
-)
-def remove_member(context: GroupMembershipContext, request):
-    """Remove a member from the given group."""
-
-    group_members_service = request.find_service(name="group_members")
-    group_members_service.member_leave(context.group, context.user.userid)
-
-    return HTTPNoContent()
-
-
-@api_config(
-    versions=["v1", "v2"],
-    route_name="api.group_member",
-    request_method="POST",
-    link_name="group.member.add",
-    permission=Permission.Group.MEMBER_ADD,
-    description="Add the user in the request params to a group.",
-)
-def add_member(context: GroupMembershipContext, request):
-    """
-    Add a member to a given group.
-
-    :raise HTTPNotFound: if the user is not found or if the use and group
-      authorities don't match.
-    """
-    group_members_svc = request.find_service(name="group_members")
-
-    if context.user.authority != context.group.authority:
-        raise HTTPNotFound()
-
-    group_members_svc.member_join(context.group, context.user.userid)
-
-    return HTTPNoContent()
 
 
 # @TODO This is a duplication of code in h.views.api — move to a util module

--- a/tests/unit/h/views/api/group_members_test.py
+++ b/tests/unit/h/views/api/group_members_test.py
@@ -17,7 +17,7 @@ class TestReadMembers:
             create_autospec(presenters.UserJSONPresenter, instance=True, spec_set=True),
         ]
 
-        response = views.read_members(context, pyramid_request)
+        response = views.list_members(context, pyramid_request)
 
         assert UserJSONPresenter.call_args_list == [
             call(sentinel.member_1),

--- a/tests/unit/h/views/api/group_members_test.py
+++ b/tests/unit/h/views/api/group_members_test.py
@@ -1,0 +1,89 @@
+from unittest.mock import call, create_autospec, sentinel
+
+import pytest
+from pyramid.httpexceptions import HTTPNoContent, HTTPNotFound
+
+import h.views.api.group_members as views
+from h import presenters
+from h.models import GroupMembership
+from h.traversal import GroupContext, GroupMembershipContext
+
+
+class TestReadMembers:
+    def test_it(self, context, pyramid_request, UserJSONPresenter):
+        context.group.members = [sentinel.member_1, sentinel.member_2]
+        presenter_instances = UserJSONPresenter.side_effect = [
+            create_autospec(presenters.UserJSONPresenter, instance=True, spec_set=True),
+            create_autospec(presenters.UserJSONPresenter, instance=True, spec_set=True),
+        ]
+
+        response = views.read_members(context, pyramid_request)
+
+        assert UserJSONPresenter.call_args_list == [
+            call(sentinel.member_1),
+            call(sentinel.member_2),
+        ]
+        presenter_instances[0].asdict.assert_called_once_with()
+        presenter_instances[1].asdict.assert_called_once_with()
+        assert response == [
+            presenter_instances[0].asdict.return_value,
+            presenter_instances[1].asdict.return_value,
+        ]
+
+    @pytest.fixture
+    def context(self):
+        return create_autospec(
+            GroupContext, instance=True, spec_set=True, group=sentinel.group
+        )
+
+
+class TestRemoveMember:
+    def test_it(self, context, pyramid_request, group_members_service):
+        response = views.remove_member(context, pyramid_request)
+
+        group_members_service.member_leave.assert_called_once_with(
+            context.group, context.user.userid
+        )
+        assert isinstance(response, HTTPNoContent)
+
+    @pytest.fixture
+    def context(self, factories):
+        group = factories.Group.build()
+        user = factories.User.build()
+        membership = GroupMembership(group=group, user=user)
+        return GroupMembershipContext(group=group, user=user, membership=membership)
+
+
+@pytest.mark.usefixtures("group_members_service")
+class TestAddMember:
+    def test_it(self, pyramid_request, group_members_service, context):
+        response = views.add_member(context, pyramid_request)
+
+        group_members_service.member_join.assert_called_once_with(
+            context.group, context.user.userid
+        )
+        assert isinstance(response, HTTPNoContent)
+
+    def test_it_with_authority_mismatch(self, pyramid_request, context):
+        context.group.authority = "other"
+
+        with pytest.raises(HTTPNotFound):
+            views.add_member(context, pyramid_request)
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.matchdict = {"userid": sentinel.userid}
+        return pyramid_request
+
+    @pytest.fixture
+    def context(self, factories):
+        group = factories.Group.build()
+        user = factories.User.build(authority=group.authority)
+        return GroupMembershipContext(group=group, user=user, membership=None)
+
+
+@pytest.fixture(autouse=True)
+def UserJSONPresenter(mocker):
+    return mocker.patch(
+        "h.views.api.group_members.UserJSONPresenter", autospec=True, spec_set=True
+    )

--- a/tests/unit/h/views/api/group_members_test.py
+++ b/tests/unit/h/views/api/group_members_test.py
@@ -9,7 +9,7 @@ from h.models import GroupMembership
 from h.traversal import GroupContext, GroupMembershipContext
 
 
-class TestReadMembers:
+class TestListMembers:
     def test_it(self, context, pyramid_request, UserJSONPresenter):
         context.group.members = [sentinel.member_1, sentinel.member_2]
         presenter_instances = UserJSONPresenter.side_effect = [

--- a/tests/unit/h/views/api/group_members_test.py
+++ b/tests/unit/h/views/api/group_members_test.py
@@ -71,11 +71,6 @@ class TestAddMember:
             views.add_member(context, pyramid_request)
 
     @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.matchdict = {"userid": sentinel.userid}
-        return pyramid_request
-
-    @pytest.fixture
     def context(self, factories):
         group = factories.Group.build()
         user = factories.User.build(authority=group.authority)


### PR DESCRIPTION
...plus a little tidy up.

I wanted to also tidy them up into a nice view class but I don't think that's going to be possible without first doing a bunch of work to remove h's custom `@api_config` decorator ([Slack thread](https://hypothes-is.slack.com/archives/C1MA4E9B9/p1732302467235899)). Not worth the effort right now, it's fine how it is. But if it wasn't for `@api_config` it would be possible to do something like this:

```python
@view_config(
    route_name="api.group_members",
    request_method="GET",
    permission=Permission.Group.READ,
)
def list_members(context: GroupContext, _request):
    return [UserJSONPresenter(user).asdict() for user in context.group.members]


@view_defaults(route_name="api.group_members")
class GroupMembershipAPIViews:
    def __init__(self, context: GroupMembershipContext, request: Request):
        self.context = context
        self.group_members_service = request.find_service(name="group_members")

    @view_config(request_method="DELETE", permission=Permission.Group.MEMBER_REMOVE)
    def delete(self):
        self.group_members_service.member_leave(context.group, context.user.userid)
        return HTTPNoContent()

    @view_config(request_method="POST", permission=Permission.Group.MEMBER_ADD)
    def post(self):
        if context.user.authority != context.group.authority:
            raise HTTPNotFound()

        self.group_members_service.member_join(context.group, context.user.userid)
        return HTTPNoContent()

    @view_config(request_method="PATCH", permission=Permission.Group.MEMBER_EDIT)
    def patch(self):
        ...

    @view_config(request_method="GET", permission=Permission.Group.READ)
    def get(self):
        ...
```