### PR TITLE
Add an API for editing a group membership's role

### DIFF
--- a/h/presenters/__init__.py
+++ b/h/presenters/__init__.py
@@ -5,6 +5,7 @@ from h.presenters.document_html import DocumentHTMLPresenter
 from h.presenters.document_json import DocumentJSONPresenter
 from h.presenters.document_searchindex import DocumentSearchIndexPresenter
 from h.presenters.group_json import GroupJSONPresenter, GroupsJSONPresenter
+from h.presenters.group_membership_json import GroupMembershipJSONPresenter
 from h.presenters.user_json import TrustedUserJSONPresenter, UserJSONPresenter
 
 __all__ = (
@@ -17,5 +18,6 @@ __all__ = (
     "GroupJSONPresenter",
     "GroupsJSONPresenter",
     "UserJSONPresenter",
+    "GroupMembershipJSONPresenter",
     "TrustedUserJSONPresenter",
 )

--- a/h/presenters/group_membership_json.py
+++ b/h/presenters/group_membership_json.py
@@ -1,0 +1,12 @@
+class GroupMembershipJSONPresenter:
+    def __init__(self, membership):
+        self.membership = membership
+
+    def asdict(self):
+        return {
+            "authority": self.membership.group.authority,
+            "userid": self.membership.user.userid,
+            "username": self.membership.user.username,
+            "display_name": self.membership.user.display_name,
+            "roles": self.membership.roles,
+        }

--- a/h/schemas/api/group_membership.py
+++ b/h/schemas/api/group_membership.py
@@ -1,0 +1,18 @@
+from h.schemas.base import JSONSchema
+
+
+class EditGroupMembershipAPISchema(JSONSchema):
+    schema = {
+        "type": "object",
+        "properties": {
+            "roles": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 1,
+                "items": {
+                    "enum": ["member", "moderator", "admin", "owner"],
+                },
+            }
+        },
+        "required": ["roles"],
+    }

--- a/h/security/permission_map.py
+++ b/h/security/permission_map.py
@@ -68,6 +68,7 @@ PERMISSION_MAP = {
     ],
     Permission.Group.MEMBER_ADD: [[p.group_matches_authenticated_client_authority]],
     Permission.Group.MEMBER_REMOVE: [[p.group_member_remove]],
+    Permission.Group.MEMBER_EDIT: [[p.group_member_edit]],
     Permission.Group.MODERATE: GROUP_MODERATE_PREDICATES.values(),
     # --------------------------------------------------------------------- #
     # Annotations

--- a/h/security/permissions.py
+++ b/h/security/permissions.py
@@ -43,6 +43,9 @@ class Permission:
         MEMBER_REMOVE = "group:member:remove"
         """Remove a member from the group."""
 
+        MEMBER_EDIT = "group:member:edit"
+        """Change a member's role in a group."""
+
     class Annotation(Enum):
         """Permissions relating to annotations."""
 

--- a/h/security/predicates.py
+++ b/h/security/predicates.py
@@ -243,7 +243,7 @@ def group_member_edit(
             return True
 
         if GroupMembershipRoles.ADMIN in authenticated_users_roles:
-            # Admins can change their own role to anything but admin.
+            # Admins can change their own role to anything but owner.
             return GroupMembershipRoles.OWNER not in new_roles
 
         if GroupMembershipRoles.MODERATOR in authenticated_users_roles:

--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -63,6 +63,7 @@ shouldn't return model objects directly).
 from h.traversal.annotation import AnnotationContext, AnnotationRoot
 from h.traversal.group import GroupContext, GroupRequiredRoot, GroupRoot
 from h.traversal.group_membership import (
+    EditGroupMembershipContext,
     GroupMembershipContext,
     group_membership_api_factory,
 )
@@ -81,6 +82,7 @@ __all__ = (
     "UserByIDRoot",
     "UserRoot",
     "GroupContext",
+    "EditGroupMembershipContext",
     "GroupMembershipContext",
     "group_membership_api_factory",
 )

--- a/h/traversal/group_membership.py
+++ b/h/traversal/group_membership.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from pyramid.httpexceptions import HTTPNotFound
 
 from h.exceptions import InvalidUserId
-from h.models import Group, GroupMembership, User
+from h.models import Group, GroupMembership, GroupMembershipRoles, User
 
 
 @dataclass
@@ -11,6 +11,14 @@ class GroupMembershipContext:
     group: Group
     user: User
     membership: GroupMembership | None
+
+
+@dataclass
+class EditGroupMembershipContext:
+    group: Group
+    user: User
+    membership: GroupMembership
+    new_roles: list[GroupMembershipRoles]
 
 
 def group_membership_api_factory(request) -> GroupMembershipContext:

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -29,7 +29,7 @@ from h.schemas.util import validate_query_params
 from h.security import Permission
 from h.services import AnnotationWriteService
 from h.views.api.config import api_config
-from h.views.api.exceptions import PayloadError
+from h.views.api.helpers.json_payload import json_payload
 
 _ = i18n.TranslationStringFactory(__package__)
 
@@ -77,7 +77,7 @@ def search(request):
 def create(request):
     """Create an annotation from the POST payload."""
     schema = CreateAnnotationSchema(request)
-    appstruct = schema.validate(_json_payload(request))
+    appstruct = schema.validate(json_payload(request))
 
     annotation = request.find_service(AnnotationWriteService).create_annotation(
         data=appstruct
@@ -136,7 +136,7 @@ def update(context, request):
     schema = UpdateAnnotationSchema(
         request, context.annotation.target_uri, context.annotation.groupid
     )
-    appstruct = schema.validate(_json_payload(request))
+    appstruct = schema.validate(json_payload(request))
 
     annotation = request.find_service(AnnotationWriteService).update_annotation(
         context.annotation, data=appstruct
@@ -164,18 +164,6 @@ def delete(context, request):
 
     # TODO: Track down why we don't return an HTTP 204 like other DELETEs
     return {"id": context.annotation.id, "deleted": True}
-
-
-def _json_payload(request):
-    """
-    Return a parsed JSON payload for the request.
-
-    :raises PayloadError: if the body has no valid JSON body
-    """
-    try:
-        return request.json_body
-    except ValueError as err:
-        raise PayloadError() from err
 
 
 def _publish_annotation_event(request, annotation, action):

--- a/h/views/api/helpers/json_payload.py
+++ b/h/views/api/helpers/json_payload.py
@@ -1,0 +1,13 @@
+from h.views.api.exceptions import PayloadError
+
+
+def json_payload(request):
+    """
+    Return the parsed JSON payload from `request`.
+
+    :raise PayloadError: if the request has no valid JSON body
+    """
+    try:
+        return request.json_body
+    except ValueError as err:
+        raise PayloadError() from err

--- a/tests/unit/h/presenters/group_membership_json_test.py
+++ b/tests/unit/h/presenters/group_membership_json_test.py
@@ -1,0 +1,19 @@
+from h.models import GroupMembership
+from h.presenters.group_membership_json import GroupMembershipJSONPresenter
+
+
+class TestGroupMembershipJSONPresenter:
+    def test_it(self, factories):
+        user = factories.User.build()
+        group = factories.Group.build()
+        membership = GroupMembership(user=user, group=group)
+
+        json = GroupMembershipJSONPresenter(membership).asdict()
+
+        assert json == {
+            "authority": group.authority,
+            "userid": user.userid,
+            "username": user.username,
+            "display_name": user.display_name,
+            "roles": membership.roles,
+        }

--- a/tests/unit/h/schemas/api/group_membership_test.py
+++ b/tests/unit/h/schemas/api/group_membership_test.py
@@ -1,0 +1,36 @@
+import pytest
+
+from h.schemas import ValidationError
+from h.schemas.api.group_membership import EditGroupMembershipAPISchema
+
+
+class TestEditGroupMembershipAPISchema:
+    @pytest.mark.parametrize(
+        "data,expected_appstruct",
+        [
+            ({"roles": ["member"]}, {"roles": ["member"]}),
+            ({"roles": ["moderator"]}, {"roles": ["moderator"]}),
+            ({"roles": ["admin"]}, {"roles": ["admin"]}),
+            ({"roles": ["owner"]}, {"roles": ["owner"]}),
+        ],
+    )
+    def test_valid(self, schema, data, expected_appstruct):
+        assert schema.validate(data) == expected_appstruct
+
+    @pytest.mark.parametrize(
+        "data,error_message",
+        [
+            ({"roles": ["unknown"]}, r"^roles\.0: 'unknown' is not one of \[[^]]*\]$"),
+            ({"roles": []}, r"^roles: \[\] should be non-empty$"),
+            ({"roles": ["member", "moderator"]}, r"^roles: \[[^]]*\] is too long$"),
+            ({"roles": 42}, r"^roles: 42 is not of type 'array'$"),
+            ({}, r"^'roles' is a required property$"),
+        ],
+    )
+    def test_invalid(self, schema, data, error_message):
+        with pytest.raises(ValidationError, match=error_message):
+            schema.validate(data)
+
+    @pytest.fixture
+    def schema(self):
+        return EditGroupMembershipAPISchema()

--- a/tests/unit/h/views/api/group_members_test.py
+++ b/tests/unit/h/views/api/group_members_test.py
@@ -1,4 +1,5 @@
-from unittest.mock import call, create_autospec, sentinel
+import logging
+from unittest.mock import PropertyMock, call, create_autospec, sentinel
 
 import pytest
 from pyramid.httpexceptions import HTTPNoContent, HTTPNotFound
@@ -6,22 +7,28 @@ from pyramid.httpexceptions import HTTPNoContent, HTTPNotFound
 import h.views.api.group_members as views
 from h import presenters
 from h.models import GroupMembership
+from h.schemas.base import ValidationError
 from h.traversal import GroupContext, GroupMembershipContext
+from h.views.api.exceptions import PayloadError
 
 
 class TestListMembers:
-    def test_it(self, context, pyramid_request, UserJSONPresenter):
-        context.group.members = [sentinel.member_1, sentinel.member_2]
-        presenter_instances = UserJSONPresenter.side_effect = [
-            create_autospec(presenters.UserJSONPresenter, instance=True, spec_set=True),
-            create_autospec(presenters.UserJSONPresenter, instance=True, spec_set=True),
+    def test_it(self, context, pyramid_request, GroupMembershipJSONPresenter):
+        context.group.memberships = [sentinel.membership_1, sentinel.membership_2]
+        presenter_instances = GroupMembershipJSONPresenter.side_effect = [
+            create_autospec(
+                presenters.GroupMembershipJSONPresenter, instance=True, spec_set=True
+            ),
+            create_autospec(
+                presenters.GroupMembershipJSONPresenter, instance=True, spec_set=True
+            ),
         ]
 
         response = views.list_members(context, pyramid_request)
 
-        assert UserJSONPresenter.call_args_list == [
-            call(sentinel.member_1),
-            call(sentinel.member_2),
+        assert GroupMembershipJSONPresenter.call_args_list == [
+            call(sentinel.membership_1),
+            call(sentinel.membership_2),
         ]
         presenter_instances[0].asdict.assert_called_once_with()
         presenter_instances[1].asdict.assert_called_once_with()
@@ -77,8 +84,112 @@ class TestAddMember:
         return GroupMembershipContext(group=group, user=user, membership=None)
 
 
+class TestEditMember:
+    def test_it(
+        self,
+        context,
+        pyramid_request,
+        EditGroupMembershipAPISchema,
+        GroupMembershipJSONPresenter,
+        caplog,
+    ):
+        response = views.edit_member(context, pyramid_request)
+
+        EditGroupMembershipAPISchema.return_value.validate.assert_called_once_with(
+            sentinel.json_body
+        )
+        assert context.membership.roles == sentinel.new_roles
+        GroupMembershipJSONPresenter.assert_called_once_with(context.membership)
+        assert response == GroupMembershipJSONPresenter.return_value.asdict.return_value
+        assert caplog.messages == [
+            f"Changed group membership roles: {context.membership!r} (previous roles were: {sentinel.old_roles!r})",
+        ]
+
+    def test_noop(self, context, pyramid_request, EditGroupMembershipAPISchema, caplog):
+        EditGroupMembershipAPISchema.return_value.validate.return_value["roles"] = (
+            sentinel.old_roles
+        )
+
+        views.edit_member(context, pyramid_request)
+
+        assert not caplog.messages
+
+    def test_it_errors_if_the_user_doesnt_have_permission(
+        self, context, pyramid_request, pyramid_config
+    ):
+        pyramid_config.testing_securitypolicy(permissive=False)
+
+        with pytest.raises(HTTPNotFound):
+            views.edit_member(context, pyramid_request)
+
+    def test_it_errors_if_the_request_isnt_valid_JSON(
+        self, context, pyramid_request, mocker
+    ):
+        value_error = ValueError()
+        mocker.patch.object(
+            type(pyramid_request),
+            "json_body",
+            PropertyMock(side_effect=value_error),
+            create=True,
+        )
+
+        with pytest.raises(PayloadError) as exc_info:
+            views.edit_member(context, pyramid_request)
+
+        assert exc_info.value.__cause__ == value_error
+
+    def test_it_errors_if_the_request_is_invalid(
+        self, context, pyramid_request, EditGroupMembershipAPISchema
+    ):
+        EditGroupMembershipAPISchema.return_value.validate.side_effect = ValidationError
+
+        with pytest.raises(ValidationError):
+            views.edit_member(context, pyramid_request)
+
+    @pytest.fixture
+    def context(self, factories):
+        group = factories.Group.build()
+        user = factories.User.build(authority=group.authority)
+        membership = GroupMembership(group=group, user=user, roles=sentinel.old_roles)
+
+        return GroupMembershipContext(group=group, user=user, membership=membership)
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.json_body = sentinel.json_body
+        return pyramid_request
+
+    @pytest.fixture
+    def EditGroupMembershipAPISchema(self, EditGroupMembershipAPISchema):
+        EditGroupMembershipAPISchema.return_value.validate.return_value = {
+            "roles": sentinel.new_roles
+        }
+        return EditGroupMembershipAPISchema
+
+    @pytest.fixture(autouse=True)
+    def pyramid_config(self, pyramid_config):
+        pyramid_config.testing_securitypolicy(permissive=True)
+        return pyramid_config
+
+    @pytest.fixture
+    def caplog(self, caplog):
+        caplog.set_level(logging.INFO)
+        return caplog
+
+
 @pytest.fixture(autouse=True)
-def UserJSONPresenter(mocker):
+def EditGroupMembershipAPISchema(mocker):
     return mocker.patch(
-        "h.views.api.group_members.UserJSONPresenter", autospec=True, spec_set=True
+        "h.views.api.group_members.EditGroupMembershipAPISchema",
+        autospec=True,
+        spec_set=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def GroupMembershipJSONPresenter(mocker):
+    return mocker.patch(
+        "h.views.api.group_members.GroupMembershipJSONPresenter",
+        autospec=True,
+        spec_set=True,
     )


### PR DESCRIPTION
Add an API for editing a group member's role:

    PATCH /api/groups/{pubid}/members/{userid}
    {"roles": ["<new_role>"]}
 
Testing:
 
1. Log in as devdata_admin (http://localhost:5000/login)
2. Create an API token (http://localhost:5000/account/developer)
3. Create a group (http://localhost:5000/groups/new)
4. Log in as a devdata_user and join the group
5. Use devdata_admin's API token to promote devdata_user to admin: `httpx http://localhost:5000/api/groups/{pubid}/members/acct:devdata_user@localhost --method PATCH --headers Authorization 'Bearer {apitoken}' --json '{"roles": ["admin"]}'`
6. Use the "me" alias to demote yourself to a plain member: `httpx http://localhost:5000/api/groups/{pubid}/members/me --method PATCH --headers Authorization 'Bearer {apitoken}' --json '{"roles": ["admin"]}'`
7. Now that you're just a plain member if you try to promote yourself again or try to change devdata_user's role you'll get 404s.
8. If you try to use an invalid role you'll get a validation error, for example: `httpx http://localhost:5000/api/groups/{pubid}/members/me --method PATCH --headers Authorization 'Bearer {apitoken}' --json '{"roles": ["INVALID"]}'`