### PR TITLE
Add actions to group membership APIs

### DIFF
--- a/h/presenters/group_membership_json.py
+++ b/h/presenters/group_membership_json.py
@@ -1,12 +1,41 @@
+from h.models import GroupMembershipRoles
+from h.security import Permission
+from h.traversal.group_membership import (
+    EditGroupMembershipContext,
+    GroupMembershipContext,
+)
+
+
 class GroupMembershipJSONPresenter:
-    def __init__(self, membership):
+    def __init__(self, request, membership):
+        self.request = request
         self.membership = membership
 
     def asdict(self):
-        return {
+        membership_dict = {
             "authority": self.membership.group.authority,
             "userid": self.membership.user.userid,
             "username": self.membership.user.username,
             "display_name": self.membership.user.display_name,
             "roles": self.membership.roles,
+            "actions": [],
         }
+
+        if self.request.has_permission(
+            Permission.Group.MEMBER_REMOVE,
+            GroupMembershipContext(
+                self.membership.group, self.membership.user, self.membership
+            ),
+        ):
+            membership_dict["actions"].append("delete")
+
+        for role in GroupMembershipRoles:
+            if self.request.has_permission(
+                Permission.Group.MEMBER_EDIT,
+                EditGroupMembershipContext(
+                    self.membership.group, self.membership.user, self.membership, [role]
+                ),
+            ):
+                membership_dict["actions"].append(f"updates.roles.{role}")
+
+        return membership_dict

--- a/tests/unit/h/presenters/group_membership_json_test.py
+++ b/tests/unit/h/presenters/group_membership_json_test.py
@@ -1,14 +1,14 @@
+import pytest
+
 from h.models import GroupMembership
 from h.presenters.group_membership_json import GroupMembershipJSONPresenter
 
 
 class TestGroupMembershipJSONPresenter:
-    def test_it(self, factories):
-        user = factories.User.build()
-        group = factories.Group.build()
-        membership = GroupMembership(user=user, group=group)
+    def test_it(self, user, group, membership, pyramid_request, pyramid_config):
+        pyramid_config.testing_securitypolicy(permissive=False)
 
-        json = GroupMembershipJSONPresenter(membership).asdict()
+        json = GroupMembershipJSONPresenter(pyramid_request, membership).asdict()
 
         assert json == {
             "authority": group.authority,
@@ -16,4 +16,39 @@ class TestGroupMembershipJSONPresenter:
             "username": user.username,
             "display_name": user.display_name,
             "roles": membership.roles,
+            "actions": [],
         }
+
+    def test_it_with_permissive_securitypolicy(
+        self, user, group, membership, pyramid_request, pyramid_config
+    ):
+        pyramid_config.testing_securitypolicy(permissive=True)
+
+        json = GroupMembershipJSONPresenter(pyramid_request, membership).asdict()
+
+        assert json == {
+            "authority": group.authority,
+            "userid": user.userid,
+            "username": user.username,
+            "display_name": user.display_name,
+            "roles": membership.roles,
+            "actions": [
+                "delete",
+                "updates.roles.member",
+                "updates.roles.moderator",
+                "updates.roles.admin",
+                "updates.roles.owner",
+            ],
+        }
+
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User.build()
+
+    @pytest.fixture
+    def group(self, factories):
+        return factories.Group.build()
+
+    @pytest.fixture
+    def membership(self, user, group):
+        return GroupMembership(user=user, group=group)


### PR DESCRIPTION
Add a new `actions` field to the list-group-memberships and edit-group-membership API's responses that tells the frontend what actions the authenticated user can take against each membership.