### PR TITLE
Suppress warning about `eval` usage by `syn` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
-    "@hypothesis/frontend-build": "^3.0.0",
+    "@hypothesis/frontend-build": "^3.1.0",
     "@hypothesis/frontend-shared": "^8.6.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^26.0.1",

--- a/rollup-tests.config.js
+++ b/rollup-tests.config.js
@@ -1,3 +1,4 @@
+import { log } from '@hypothesis/frontend-build';
 import { babel } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
@@ -57,4 +58,12 @@ export default {
       ],
     }),
   ],
+  onwarn: warning => {
+    // Suppress security warning about `eval` usage in syn, a test-only
+    // dependency.
+    if (warning.id.includes('node_modules/syn/') && warning.code === 'EVAL') {
+      return;
+    }
+    log.warn(`Rollup warning: ${warning} (${warning.url})`);
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,13 +1754,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-build@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@hypothesis/frontend-build@npm:3.0.0"
+"@hypothesis/frontend-build@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@hypothesis/frontend-build@npm:3.1.0"
   dependencies:
-    commander: ^11.0.0
+    commander: ^12.0.0
     fancy-log: ^2.0.0
-    glob: ^10.0.0
+    glob: ^11.0.0
   peerDependencies:
     autoprefixer: ^10.3.7
     karma: ^6.3.4
@@ -1771,7 +1771,7 @@ __metadata:
   peerDependenciesMeta:
     tailwindcss:
       optional: true
-  checksum: ea05f3c00bc9054cd37aaabb5bc391e39cf7c8abecfc002950a22a6fe61d13a28b89194d2bbba6619d234d37a1c8ca5874a191ad8e50485ed66e77805b8fe385
+  checksum: 56cdf9d33359c6f6663761a67fdb098afe86e3210fb286281e8865275a8c002747b06bd2aa36a121235c01d10416edad08c3b268e9025bf16ebec96b7994df6e
   languageName: node
   linkType: hard
 
@@ -3754,10 +3754,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^11.0.0":
-  version: 11.1.0
-  resolution: "commander@npm:11.1.0"
-  checksum: fd1a8557c6b5b622c89ecdfde703242ab7db3b628ea5d1755784c79b8e7cb0d74d65b4a262289b533359cd58e1bfc0bf50245dfbcd2954682a6f367c828b79ef
+"commander@npm:^12.0.0":
+  version: 12.1.0
+  resolution: "commander@npm:12.1.0"
+  checksum: 68e9818b00fc1ed9cdab9eb16905551c2b768a317ae69a5e3c43924c2b20ac9bb65b27e1cab36aeda7b6496376d4da908996ba2c0b5d79463e0fb1e77935d514
   languageName: node
   linkType: hard
 
@@ -5805,21 +5805,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.0.0":
-  version: 10.3.4
-  resolution: "glob@npm:10.3.4"
-  dependencies:
-    foreground-child: ^3.1.0
-    jackspeak: ^2.0.3
-    minimatch: ^9.0.1
-    minipass: ^5.0.0 || ^6.0.2 || ^7.0.0
-    path-scurry: ^1.10.1
-  bin:
-    glob: dist/cjs/src/bin.js
-  checksum: 176b97c124414401cb51329a93d2ba112cef8814adbed10348481916b9521b677773eee2691cb6b24d66632d8c8bb8913533f5ac4bfb2d0ef5454a1856082361
-  languageName: node
-  linkType: hard
-
 "glob@npm:^10.2.2":
   version: 10.3.3
   resolution: "glob@npm:10.3.3"
@@ -5848,6 +5833,22 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: bd7c0e30701136e936f414e5f6f82c7f04503f01df77408f177aa584927412f0bde0338e6ec541618cd21eacc57dde33e7b3c6c0a779cc1c6e6a0e14f3d15d9b
+  languageName: node
+  linkType: hard
+
+"glob@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "glob@npm:11.0.0"
+  dependencies:
+    foreground-child: ^3.1.0
+    jackspeak: ^4.0.1
+    minimatch: ^10.0.0
+    minipass: ^7.1.2
+    package-json-from-dist: ^1.0.0
+    path-scurry: ^2.0.0
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 8a2dd914d5776987be5244624d9491bbcaf19f2387e06783737003ff696ebfd2264190c47014f8709c1c02d8bc892f17660cf986c587b107e194c0a3151ab333
   languageName: node
   linkType: hard
 
@@ -6115,7 +6116,7 @@ __metadata:
     "@babel/preset-env": ^7.26.0
     "@babel/preset-react": ^7.24.7
     "@babel/preset-typescript": ^7.24.7
-    "@hypothesis/frontend-build": ^3.0.0
+    "@hypothesis/frontend-build": ^3.1.0
     "@hypothesis/frontend-shared": ^8.6.0
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
@@ -7141,6 +7142,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "jackspeak@npm:4.0.2"
+  dependencies:
+    "@isaacs/cliui": ^8.0.2
+  checksum: 210030029edfa1658328799ad88c3d0fc057c4cb8a069fc4137cc8d2cc4b65c9721c6e749e890f9ca77a954bb54f200f715b8896e50d330e5f3e902e72b40974
+  languageName: node
+  linkType: hard
+
 "jiti@npm:^1.21.0":
   version: 1.21.6
   resolution: "jiti@npm:1.21.6"
@@ -7591,6 +7601,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.0":
+  version: 11.0.2
+  resolution: "lru-cache@npm:11.0.2"
+  checksum: f9c27c58919a30f42834de9444de9f75bcbbb802c459239f96dd449ad880d8f9a42f51556d13659864dc94ab2dbded9c4a4f42a3e25a45b6da01bb86111224df
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -7757,6 +7774,15 @@ __metadata:
   bin:
     mime: cli.js
   checksum: dd3c93d433d41a09f6a1cfa969b653b769899f3bd573e7bfcea33bdc8b0cc4eba57daa2f95937369c2bd2b6d39d62389b11a4309fe40d1d3a1b736afdedad0ff
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "minimatch@npm:10.0.1"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: f5b63c2f30606091a057c5f679b067f84a2cd0ffbd2dbc9143bda850afd353c7be81949ff11ae0c86988f07390eeca64efd7143ee05a0dab37f6c6b38a2ebb6c
   languageName: node
   linkType: hard
 
@@ -8557,6 +8583,16 @@ __metadata:
     lru-cache: ^10.2.0
     minipass: ^5.0.0 || ^6.0.2 || ^7.0.0
   checksum: 890d5abcd593a7912dcce7cf7c6bf7a0b5648e3dee6caf0712c126ca0a65c7f3d7b9d769072a4d1baf370f61ce493ab5b038d59988688e0c5f3f646ee3c69023
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: ^11.0.0
+    minipass: ^7.1.2
+  checksum: 9953ce3857f7e0796b187a7066eede63864b7e1dfc14bf0484249801a5ab9afb90d9a58fc533ebb1b552d23767df8aa6a2c6c62caf3f8a65f6ce336a97bbb484
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/frontend-build/pull/634.

This suppresses these warnings when running `gulp test`:

```
[09:31:20] Rollup warning: node_modules/syn/dist/cjs/mouse.js (25:20): Use of eval in "node_modules/syn/dist/cjs/mouse.js" is strongly discouraged as it poses security risks and may cause issues with minification. (https://rollupjs.org/troubleshooting/#avoiding-eval)
[09:31:20] Rollup warning: node_modules/syn/dist/cjs/mouse.js (27:20): Use of eval in "node_modules/syn/dist/cjs/mouse.js" is strongly discouraged as it poses security risks and may cause issues with minification. (https://rollupjs.org/troubleshooting/#avoiding-eval)
```