### PR TITLE
Add button to remove member in group members table

### DIFF
--- a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
+++ b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
@@ -1,4 +1,9 @@
-import { DataTable, Scroll } from '@hypothesis/frontend-shared';
+import {
+  DataTable,
+  Scroll,
+  TrashIcon,
+  IconButton,
+} from '@hypothesis/frontend-shared';
 import { useContext, useEffect, useState } from 'preact/hooks';
 
 import { Config } from '../config';
@@ -8,13 +13,23 @@ import FormContainer from './forms/FormContainer';
 import type { GroupMembersResponse } from '../utils/api';
 import { callAPI } from '../utils/api';
 import GroupFormHeader from './GroupFormHeader';
+import WarningDialog from './WarningDialog';
+
+type TableColumn<Row> = {
+  field: keyof Row;
+  label: string;
+  classes?: string;
+};
 
 type MemberRow = {
   username: string;
+  userid: string;
+  showDeleteAction: boolean;
 };
 
 async function fetchMembers(
   api: APIConfig,
+  currentUserid: string,
   signal: AbortSignal,
 ): Promise<MemberRow[]> {
   const { url, method, headers } = api;
@@ -24,8 +39,20 @@ async function fetchMembers(
     signal,
   });
   return members.map(member => ({
+    userid: member.userid,
     username: member.username,
+    showDeleteAction:
+      member.actions.includes('delete') && member.userid !== currentUserid,
   }));
+}
+
+async function removeMember(api: APIConfig, userid: string) {
+  const { url: urlTemplate, method, headers } = api;
+  const url = urlTemplate.replace(':userid', encodeURIComponent(userid));
+  await callAPI(url, {
+    method,
+    headers,
+  });
 }
 
 export type EditGroupMembersFormProps = {
@@ -37,6 +64,7 @@ export default function EditGroupMembersForm({
   group,
 }: EditGroupMembersFormProps) {
   const config = useContext(Config)!;
+  const userid = config.context.user.userid;
 
   // Fetch group members when the form loads.
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -48,7 +76,7 @@ export default function EditGroupMembersForm({
     }
     const abort = new AbortController();
     setErrorMessage(null);
-    fetchMembers(config.api.readGroupMembers, abort.signal)
+    fetchMembers(config.api.readGroupMembers, userid, abort.signal)
       .then(setMembers)
       .catch(err => {
         setErrorMessage(`Failed to fetch group members: ${err.message}`);
@@ -56,14 +84,43 @@ export default function EditGroupMembersForm({
     return () => {
       abort.abort();
     };
-  }, [config.api.readGroupMembers]);
+  }, [config.api.readGroupMembers, userid]);
 
-  const columns = [
+  const columns: TableColumn<MemberRow>[] = [
     {
-      field: 'username' as keyof MemberRow,
+      field: 'username',
       label: 'Username',
     },
+    {
+      field: 'showDeleteAction',
+      label: '',
+      classes: 'w-[55px]',
+    },
   ];
+
+  const [pendingRemoval, setPendingRemoval] = useState<string | null>(null);
+
+  const removeUserFromGroup = async (username: string) => {
+    // istanbul ignore next
+    if (!members || !config.api.removeGroupMember) {
+      return;
+    }
+    const member = members.find(m => m.username === username);
+    // istanbul ignore next
+    if (!member) {
+      return;
+    }
+    setPendingRemoval(null);
+
+    try {
+      await removeMember(config.api.removeGroupMember, member.userid);
+      setMembers(members =>
+        members ? members.filter(m => m.userid !== member.userid) : null,
+      );
+    } catch (err) {
+      setErrorMessage(err.message);
+    }
+  };
 
   const renderRow = (user: MemberRow, field: keyof MemberRow) => {
     switch (field) {
@@ -77,6 +134,15 @@ export default function EditGroupMembersForm({
             {user.username}
           </div>
         );
+      case 'showDeleteAction':
+        return user.showDeleteAction ? (
+          <IconButton
+            icon={TrashIcon}
+            title="Remove member"
+            data-testid={`remove-${user.username}`}
+            onClick={() => setPendingRemoval(user.username)}
+          />
+        ) : null;
       // istanbul ignore next
       default:
         return null;
@@ -84,19 +150,35 @@ export default function EditGroupMembersForm({
   };
 
   return (
-    <FormContainer title="Edit group members">
-      <GroupFormHeader group={group} />
-      <ErrorNotice message={errorMessage} />
-      <div className="w-full">
-        <Scroll>
-          <DataTable
-            title="Group members"
-            rows={members ?? []}
-            columns={columns}
-            renderItem={renderRow}
-          />
-        </Scroll>
-      </div>
-    </FormContainer>
+    <>
+      <FormContainer title="Edit group members">
+        <GroupFormHeader group={group} />
+        <ErrorNotice message={errorMessage} />
+        <div className="w-full">
+          <Scroll>
+            <DataTable
+              title="Group members"
+              rows={members ?? []}
+              columns={columns}
+              renderItem={renderRow}
+            />
+          </Scroll>
+        </div>
+      </FormContainer>
+      {pendingRemoval && (
+        <WarningDialog
+          title="Remove member?"
+          confirmAction="Remove member"
+          message={
+            <p>
+              Are you sure you want to remove <b>{pendingRemoval}</b> from the
+              group?
+            </p>
+          }
+          onConfirm={() => removeUserFromGroup(pendingRemoval)}
+          onCancel={() => setPendingRemoval(null)}
+        />
+      )}
+    </>
   );
 }

--- a/h/static/scripts/group-forms/components/WarningDialog.tsx
+++ b/h/static/scripts/group-forms/components/WarningDialog.tsx
@@ -1,11 +1,12 @@
 import { ModalDialog, Button } from '@hypothesis/frontend-shared';
+import type { ComponentChildren } from 'preact';
 
 export type WarningDialogProps = {
   /** Title of the dialog. */
   title: string;
 
   /** Message displayed in the dialog. */
-  message: string;
+  message: ComponentChildren;
 
   /** Label for the confirmation button. */
   confirmAction: string;

--- a/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
+++ b/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
@@ -11,12 +11,18 @@ describe('EditGroupMembersForm', () => {
   let fakeCallAPI;
 
   beforeEach(() => {
+    const headers = { 'Misc-Header': 'Some-Value' };
     config = {
       api: {
         readGroupMembers: {
           url: '/api/groups/1234/members',
           method: 'GET',
-          headers: { 'Misc-Header': 'Some-Value' },
+          headers,
+        },
+        removeGroupMember: {
+          url: '/api/groups/1234/members/:userid',
+          method: 'DELETE',
+          headers,
         },
       },
       context: {
@@ -24,18 +30,40 @@ describe('EditGroupMembersForm', () => {
           pubid: '1234',
           name: 'Test group',
         },
+        user: {
+          userid: 'acct:jane@localhost',
+        },
       },
     };
 
     fakeCallAPI = sinon.stub();
+    fakeCallAPI.rejects(new Error('Unknown API call'));
     fakeCallAPI.withArgs('/api/groups/1234/members').resolves([
       {
+        userid: 'acct:bob@localhost',
         username: 'bob',
+        actions: ['delete'],
       },
       {
+        userid: 'acct:johnsmith@localhost',
         username: 'johnsmith',
+        actions: [],
+      },
+      {
+        userid: 'acct:jane@localhost',
+        username: 'jane',
+        actions: ['delete'],
       },
     ]);
+
+    fakeCallAPI
+      .withArgs(
+        `/api/groups/1234/members/${encodeURIComponent('acct:bob@localhost')}`,
+        sinon.match({
+          method: 'DELETE',
+        }),
+      )
+      .resolves({});
 
     $imports.$mock({
       '../utils/api': {
@@ -65,6 +93,10 @@ describe('EditGroupMembersForm', () => {
     return wrapper.find('[data-testid="username"]').map(node => node.text());
   };
 
+  const getRemoveUserButton = (wrapper, username) => {
+    return wrapper.find(`IconButton[data-testid="remove-${username}"]`);
+  };
+
   it('fetches and displays members', async () => {
     const wrapper = createForm();
     assert.calledWith(
@@ -79,7 +111,78 @@ describe('EditGroupMembersForm', () => {
     await waitForTable(wrapper);
 
     const users = getRenderedUsers(wrapper);
-    assert.deepEqual(users, ['bob', 'johnsmith']);
+    assert.deepEqual(users, ['bob', 'johnsmith', 'jane']);
+  });
+
+  it('displays remove icon if member can be removed', async () => {
+    const wrapper = createForm();
+    await waitForTable(wrapper);
+
+    const expectRemovable = {
+      bob: true, // `delete` action present in `actions`
+      johnsmith: false, // `delete` action present in `actions`
+      jane: false, // `delete` action present, but this is the current user
+    };
+
+    for (const [username, removable] of Object.entries(expectRemovable)) {
+      const removeButton = getRemoveUserButton(wrapper, username);
+      assert.equal(removeButton.exists(), removable);
+    }
+  });
+
+  it('removes user with confirmation if remove button is clicked', async () => {
+    const wrapper = createForm();
+    await waitForTable(wrapper);
+    const removeBob = getRemoveUserButton(wrapper, 'bob');
+
+    removeBob.prop('onClick')();
+    wrapper.update();
+
+    // Confirmation prompt should be shown.
+    const warning = wrapper.find('WarningDialog');
+    assert.isTrue(warning.exists());
+
+    // Canceling the prompt should hide the dialog.
+    warning.prop('onCancel')();
+    wrapper.update();
+    assert.isFalse(wrapper.exists('WarningDialog'));
+
+    // Confirming the prompt should hide the dialog and trigger a call to
+    // remove the user.
+    removeBob.prop('onClick')();
+    wrapper.update();
+    warning.prop('onConfirm')();
+    wrapper.update();
+    assert.isFalse(wrapper.exists('WarningDialog'));
+
+    // Once the user is removed, their row should disappear.
+    await waitFor(() => {
+      wrapper.update();
+      return !getRemoveUserButton(wrapper, 'bob').exists();
+    });
+  });
+
+  it('shows error if removing user fails', async () => {
+    const userid = 'acct:bob@localhost';
+    fakeCallAPI
+      .withArgs(
+        `/api/groups/1234/members/${encodeURIComponent(userid)}`,
+        sinon.match({
+          method: 'DELETE',
+        }),
+      )
+      .rejects(new Error('User not found'));
+
+    const wrapper = createForm();
+    await waitForTable(wrapper);
+    const removeBob = getRemoveUserButton(wrapper, 'bob');
+    removeBob.prop('onClick')();
+    wrapper.update();
+    wrapper.find('WarningDialog').prop('onConfirm')();
+
+    await waitForError(wrapper);
+    const error = wrapper.find('ErrorNotice');
+    assert.equal(error.prop('message'), 'User not found');
   });
 
   it('displays error if member fetch fails', async () => {

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -23,9 +23,14 @@ export type ConfigObject = {
     createGroup: APIConfig;
     updateGroup?: APIConfig;
     readGroupMembers?: APIConfig;
+    editGroupMember?: APIConfig;
+    removeGroupMember?: APIConfig;
   };
   context: {
     group: Group | null;
+    user: {
+      userid: string;
+    };
   };
   features: {
     group_members: boolean;

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -3,6 +3,9 @@
  */
 export type GroupType = 'private' | 'restricted' | 'open';
 
+/** Member role within a group. */
+export type Role = 'owner' | 'admin' | 'member';
+
 /**
  * Request to create or update a group.
  *
@@ -28,7 +31,10 @@ export type CreateUpdateGroupAPIResponse = {
 };
 
 export type GroupMember = {
+  userid: string;
   username: string;
+  actions: string[];
+  roles: Role[];
 };
 
 /**
@@ -108,6 +114,10 @@ export async function callAPI<R = unknown>(
     throw new APIError('Network request failed.', {
       cause: err as Error,
     });
+  }
+
+  if (response.status === 204) {
+    return {} as R;
   }
 
   let responseJSON;

--- a/h/static/scripts/group-forms/utils/test/api-test.js
+++ b/h/static/scripts/group-forms/utils/test/api-test.js
@@ -70,6 +70,15 @@ describe('callAPI', () => {
       assert.deepEqual(result, responseBody);
     });
 
+    it('supports 204 (empty) responses', async () => {
+      const response = new Response(null, { status: 204 });
+      fakeFetch.withArgs(url).resolves(response);
+
+      const result = await callAPI(url);
+
+      assert.deepEqual(result, {});
+    });
+
     it("throws an error when the response body isn't valid json", async () => {
       const response = new Response('not valid JSON', { status: 200 });
       sinon.spy(response, 'json');


### PR DESCRIPTION
Add a "remove member" button to each row in the group members table where the `actions` field for that member indicates the current user can remove them from the group, and the user is not the current user. We currently do not allow the user to remove themselves this way because it has added complexity - the confirmation prompt would need to be different and the user loses access to the current page after they have removed themselves.

There isn't currently a loading indicator while the `DELETE` request is in-flight. I will address that separately.

<img width="530" alt="remove-member" src="https://github.com/user-attachments/assets/ce511859-498e-493b-a8c4-3cf0ce72c9df">

When this button is clicked, show a confirmation prompt:

<img width="619" alt="remove-member-confirmation-prompt" src="https://github.com/user-attachments/assets/cb91e2a9-dc66-419c-9517-b8168db27d3b">

When the action is confirmed, perform a `DELETE /api/groups/:groupid/members/:userid` API call to remove the member from the group. When that succeeds, the members list is updated to remove that row.

----

**TODO:**

- [x] Refine the text for the "Remove user" confirmation when removing a user other than you from the group
- [x] Refine the behavior / message when removing yourself from the group. There are two aspects to this: a) The confirmation prompt and b) What happens after the removal has been completed, since you no longer have access to edit the group's settings. We could for example redirect you to the group overview page. (_Update: We disallow the user from removing themselves from the group_)
- [x] Revise how the `EditGroupMembersForm` component gets the API URL and auth header for the `DELETE` request. Currently the code takes the headers from the `readGroupMembers` call and hardcodes the URL.