### PR TITLE
Add UI for changing a member's role within a group

### DIFF
--- a/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
+++ b/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
@@ -1,4 +1,5 @@
 import { mount, waitFor, waitForElement } from '@hypothesis/frontend-testing';
+import { Select } from '@hypothesis/frontend-shared';
 
 import { Config } from '../../config';
 import {
@@ -10,6 +11,37 @@ describe('EditGroupMembersForm', () => {
   let config;
   let fakeCallAPI;
 
+  const defaultMembers = [
+    {
+      userid: 'acct:bob@localhost',
+      username: 'bob',
+      actions: [
+        'delete',
+        'updates.roles.admin',
+        'updates.roles.moderator',
+        'updates.roles.member',
+      ],
+      roles: ['admin'],
+    },
+    {
+      userid: 'acct:johnsmith@localhost',
+      username: 'johnsmith',
+      actions: [],
+      roles: ['owner'],
+    },
+    {
+      userid: 'acct:jane@localhost',
+      username: 'jane',
+      actions: [
+        'delete',
+        'updates.roles.admin',
+        'updates.roles.moderator',
+        'updates.roles.member',
+      ],
+      roles: ['admin'],
+    },
+  ];
+
   beforeEach(() => {
     const headers = { 'Misc-Header': 'Some-Value' };
     config = {
@@ -17,6 +49,11 @@ describe('EditGroupMembersForm', () => {
         readGroupMembers: {
           url: '/api/groups/1234/members',
           method: 'GET',
+          headers,
+        },
+        editGroupMember: {
+          url: '/api/groups/1234/members/:userid',
+          method: 'PATCH',
           headers,
         },
         removeGroupMember: {
@@ -38,24 +75,7 @@ describe('EditGroupMembersForm', () => {
 
     fakeCallAPI = sinon.stub();
     fakeCallAPI.rejects(new Error('Unknown API call'));
-    fakeCallAPI.withArgs('/api/groups/1234/members').resolves([
-      {
-        userid: 'acct:bob@localhost',
-        username: 'bob',
-        actions: ['delete'],
-      },
-      {
-        userid: 'acct:johnsmith@localhost',
-        username: 'johnsmith',
-        actions: [],
-      },
-      {
-        userid: 'acct:jane@localhost',
-        username: 'jane',
-        actions: ['delete'],
-      },
-    ]);
-
+    fakeCallAPI.withArgs('/api/groups/1234/members').resolves(defaultMembers);
     fakeCallAPI
       .withArgs(
         `/api/groups/1234/members/${encodeURIComponent('acct:bob@localhost')}`,
@@ -64,6 +84,21 @@ describe('EditGroupMembersForm', () => {
         }),
       )
       .resolves({});
+
+    fakeCallAPI
+      .withArgs(
+        `/api/groups/1234/members/${encodeURIComponent('acct:bob@localhost')}`,
+        sinon.match({
+          method: 'PATCH',
+        }),
+      )
+      .callsFake(async (url, { json }) => {
+        const updatedMember = {
+          ...defaultMembers.find(m => m.username === 'bob'),
+        };
+        updatedMember.roles = [...json.roles];
+        return updatedMember;
+      });
 
     $imports.$mock({
       '../utils/api': {
@@ -97,6 +132,20 @@ describe('EditGroupMembersForm', () => {
     return wrapper.find(`IconButton[data-testid="remove-${username}"]`);
   };
 
+  const getRoleSelect = (wrapper, username) => {
+    return wrapper.find(`Select[data-testid="role-${username}"]`);
+  };
+
+  const getOptionValues = selectWrapper => {
+    return selectWrapper
+      .find(Select.Option)
+      .map(option => option.prop('value'));
+  };
+
+  const getRoleText = (wrapper, username) => {
+    return wrapper.find(`span[data-testid="role-${username}"]`);
+  };
+
   it('fetches and displays members', async () => {
     const wrapper = createForm();
     assert.calledWith(
@@ -112,6 +161,28 @@ describe('EditGroupMembersForm', () => {
 
     const users = getRenderedUsers(wrapper);
     assert.deepEqual(users, ['bob', 'johnsmith', 'jane']);
+  });
+
+  it('displays error if member fetch fails', async () => {
+    fakeCallAPI
+      .withArgs('/api/groups/1234/members')
+      .rejects(new Error('Permission denied'));
+
+    const wrapper = createForm();
+    await waitForError(wrapper);
+
+    const error = wrapper.find('ErrorNotice');
+    assert.equal(
+      error.prop('message'),
+      'Failed to fetch group members: Permission denied',
+    );
+  });
+
+  it('handles member fetch being canceled', () => {
+    const wrapper = createForm();
+    assert.calledWith(fakeCallAPI, '/api/groups/1234/members');
+    // Unmount while fetching. This should abort the request.
+    wrapper.unmount();
   });
 
   it('displays remove icon if member can be removed', async () => {
@@ -185,25 +256,89 @@ describe('EditGroupMembersForm', () => {
     assert.equal(error.prop('message'), 'User not found');
   });
 
-  it('displays error if member fetch fails', async () => {
-    fakeCallAPI
-      .withArgs('/api/groups/1234/members')
-      .rejects(new Error('Permission denied'));
-
+  it('displays current and available user roles', async () => {
     const wrapper = createForm();
-    await waitForError(wrapper);
+    await waitForTable(wrapper);
 
-    const error = wrapper.find('ErrorNotice');
-    assert.equal(
-      error.prop('message'),
-      'Failed to fetch group members: Permission denied',
+    // If the user's role can be changed, the current role and available options
+    // should be displayed in a Select.
+    const bobRole = getRoleSelect(wrapper, 'bob');
+    assert.isTrue(bobRole.exists());
+    assert.equal(bobRole.prop('value'), 'admin');
+    assert.deepEqual(getOptionValues(bobRole), [
+      'admin',
+      'moderator',
+      'member',
+    ]);
+
+    // If the user's role cannot be changed, the current role should be
+    // displayed as text.
+    const johnRoleSelect = getRoleSelect(wrapper, 'johnsmith');
+    assert.isFalse(johnRoleSelect.exists());
+    const johnRoleText = getRoleText(wrapper, 'johnsmith');
+    assert.equal(johnRoleText.text(), 'Owner');
+
+    // The role for the current user should be displayed as text, even if the
+    // API would allow changing our own role.
+    const janeRoleSelect = getRoleSelect(wrapper, 'jane');
+    assert.isFalse(janeRoleSelect.exists());
+    const janeRoleText = getRoleText(wrapper, 'jane');
+    assert.equal(janeRoleText.text(), 'Admin');
+  });
+
+  it('updates user role when select value is changed', async () => {
+    const wrapper = createForm();
+    await waitForTable(wrapper);
+    let bobRole = getRoleSelect(wrapper, 'bob');
+    bobRole.prop('onChange')('moderator');
+
+    // The displayed role should update immediately when the new role is
+    // selected.
+    wrapper.update();
+    bobRole = getRoleSelect(wrapper, 'bob');
+    assert.equal(bobRole.prop('value'), 'moderator');
+
+    assert.calledWith(
+      fakeCallAPI,
+      `/api/groups/1234/members/${encodeURIComponent('acct:bob@localhost')}`,
+      sinon.match({
+        method: 'PATCH',
+        json: {
+          roles: ['moderator'],
+        },
+      }),
     );
   });
 
-  it('handles member fetch being canceled', () => {
+  it('displays error if changing role fails', async () => {
+    fakeCallAPI
+      .withArgs(
+        `/api/groups/1234/members/${encodeURIComponent('acct:bob@localhost')}`,
+        sinon.match({
+          method: 'PATCH',
+        }),
+      )
+      .rejects(new Error('Invalid role'));
     const wrapper = createForm();
-    assert.calledWith(fakeCallAPI, '/api/groups/1234/members');
-    // Unmount while fetching. This should abort the request.
-    wrapper.unmount();
+    await waitForTable(wrapper);
+
+    // Attempt to change the role
+    let bobRole = getRoleSelect(wrapper, 'bob');
+    const originalRole = bobRole.prop('value');
+    bobRole.prop('onChange')('moderator');
+    wrapper.update();
+
+    // The role should briefly change to the new selection.
+    assert.equal(getRoleSelect(wrapper, 'bob').prop('value'), 'moderator');
+
+    // Wait for the role change to fail. An error should be displayed.
+    await waitForError(wrapper);
+    const error = wrapper.find('ErrorNotice');
+    assert.equal(error.prop('message'), 'Invalid role');
+
+    // The displayed role should revert to the original value.
+    wrapper.update();
+    bobRole = getRoleSelect(wrapper, 'bob');
+    assert.equal(bobRole.prop('value'), originalRole);
   });
 });

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -4,7 +4,7 @@
 export type GroupType = 'private' | 'restricted' | 'open';
 
 /** Member role within a group. */
-export type Role = 'owner' | 'admin' | 'member';
+export type Role = 'owner' | 'admin' | 'moderator' | 'member';
 
 /**
  * Request to create or update a group.


### PR DESCRIPTION
Add a "Role" column to the Members tab of the group settings UI. This displays a
dropdown with the different roles that the current user can assign to the target
user within the group. If the current user cannot change the role, the column
displays the current role as plain text.

We currently prevent the user from changing their own role since this has added
complexity. It may alter the user the actions the user can take on other users
and they could lose access to the group settings page entirely if they demote
themselves to a "Member".

Example group as user **robert** with _owner_ role:

<img width="550" alt="edit-role-as-first-user" src="https://github.com/user-attachments/assets/cce67644-301f-443b-bd9f-a0f854ef4fa9">

Same group as user **robert2** with _admin_ role:

<img width="526" alt="edit-role-as-second-user" src="https://github.com/user-attachments/assets/65b89548-9777-4350-9c26-61e1b6f447c4">

----

**TODO:**

- [x] Confirm how we should handle demoting yourself. If we decide this action should be possible, then we should show a confirmation prompt and refresh the member list afterwards, since the action will affect the other actions you can perform. If you downgrade yourself to a member, you also currently lose access to the settings page entirely. Alternatively we could decide to disable this action entirely, which will require a change on the backend to the available actions.