### PR TITLE
Add edit and remove-member APIs to js-config

### DIFF
--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -49,10 +49,10 @@ class GroupCreateEditController:
     def _js_config(self):
         csrf_token = get_csrf_token(self.request)
 
-        def api_config(route_name: str, method: str, **params):
+        def api_config(route_name: str, method: str, **kw):
             return {
                 "method": method,
-                "url": self.request.route_url(route_name, **params),
+                "url": self.request.route_url(route_name, **kw),
                 "headers": {"X-CSRF-Token": csrf_token},
             }
 
@@ -61,7 +61,12 @@ class GroupCreateEditController:
             "api": {
                 "createGroup": api_config("api.groups", "POST"),
             },
-            "context": {"group": None},
+            "context": {
+                "group": None,
+                "user": {
+                    "userid": self.request.authenticated_userid,
+                },
+            },
             "features": {
                 "group_members": self.request.feature("group_members"),
                 "group_type": self.request.feature("group_type"),
@@ -86,6 +91,15 @@ class GroupCreateEditController:
                     "updateGroup": api_config("api.group", "PATCH", id=group.pubid),
                     "readGroupMembers": api_config(
                         "api.group_members", "GET", pubid=group.pubid
+                    ),
+                    "editGroupMember": api_config(
+                        "api.group_member", "PATCH", pubid=group.pubid, userid=":userid"
+                    ),
+                    "removeGroupMember": api_config(
+                        "api.group_member",
+                        "DELETE",
+                        pubid=group.pubid,
+                        userid=":userid",
                     ),
                 }
             )

--- a/tests/unit/h/views/groups_test.py
+++ b/tests/unit/h/views/groups_test.py
@@ -41,7 +41,10 @@ class TestGroupCreateEditController:
                         },
                     }
                 },
-                "context": {"group": None},
+                "context": {
+                    "group": None,
+                    "user": {"userid": sentinel.authenticated_userid},
+                },
                 "features": {
                     "group_type": group_type_flag,
                     "group_members": pyramid_request.feature.flags["group_members"],
@@ -88,6 +91,24 @@ class TestGroupCreateEditController:
                             "X-CSRF-Token": views.get_csrf_token.spy_return  # pylint:disable=no-member
                         },
                     },
+                    "editGroupMember": {
+                        "method": "PATCH",
+                        "url": pyramid_request.route_url(
+                            "api.group_member", pubid=group.pubid, userid=":userid"
+                        ),
+                        "headers": {
+                            "X-CSRF-Token": views.get_csrf_token.spy_return  # pylint:disable=no-member
+                        },
+                    },
+                    "removeGroupMember": {
+                        "method": "DELETE",
+                        "url": pyramid_request.route_url(
+                            "api.group_member", pubid=group.pubid, userid=":userid"
+                        ),
+                        "headers": {
+                            "X-CSRF-Token": views.get_csrf_token.spy_return  # pylint:disable=no-member
+                        },
+                    },
                     "updateGroup": {
                         "method": "PATCH",
                         "url": pyramid_request.route_url("api.group", id=group.pubid),
@@ -106,7 +127,8 @@ class TestGroupCreateEditController:
                             "group_read", pubid=group.pubid, slug=group.slug
                         ),
                         "num_annotations": annotation_stats_service.total_group_annotation_count.return_value,
-                    }
+                    },
+                    "user": {"userid": sentinel.authenticated_userid},
                 },
                 "features": {
                     "group_type": pyramid_request.feature.flags["group_type"],
@@ -122,6 +144,7 @@ class TestGroupCreateEditController:
     @pytest.fixture(autouse=True)
     def pyramid_config(self, pyramid_config, assets_env):
         pyramid_config.registry["assets_env"] = assets_env
+        pyramid_config.testing_securitypolicy(sentinel.authenticated_userid)
         return pyramid_config
 
     @pytest.fixture(autouse=True)
@@ -146,4 +169,5 @@ def routes(pyramid_config):
     pyramid_config.add_route("group_read", "/g/{pubid}/{slug}")
     pyramid_config.add_route("api.group", "/api/group/{id}")
     pyramid_config.add_route("api.group_members", "/api/groups/{pubid}/members")
+    pyramid_config.add_route("api.group_member", "/api/groups/{pubid}/members/{userid}")
     pyramid_config.add_route("api.groups", "/api/groups")


### PR DESCRIPTION
Add some extra information to the js-config on the edit-group page:

1. Add details of the PATCH API call for editing a membership
2. Add details of the DELETE API call for removing a membership
3. Add the userid of the authenticated user.
   This is needed because deleting or editing the authenticated user's
   own membership has different consequences and needs to be treated
   differently by the UX.

The URLs for the PATCH and DELETE APIs have ":userid" in place of the
user ID. The frontend needs to replace this with the userid it wants to
act on. This follows the syntax of the URL Pattern API:
https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API
