### PR TITLE
Revert "Bump newrelic from 10.2.0 to 10.3.0"

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -160,7 +160,7 @@ markupsafe==2.1.5
     #   pyramid-jinja2
 matplotlib-inline==0.1.6
     # via ipython
-newrelic==10.3.0
+newrelic==10.2.0
     # via -r requirements/prod.txt
 oauthlib==3.2.2
     # via -r requirements/prod.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -148,7 +148,7 @@ markupsafe==2.1.5
     #   jinja2
     #   mako
     #   pyramid-jinja2
-newrelic==10.3.0
+newrelic==10.2.0
     # via -r requirements/prod.txt
 oauthlib==3.2.2
     # via -r requirements/prod.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -238,7 +238,7 @@ markupsafe==2.1.5
     #   pyramid-jinja2
 mccabe==0.7.0
     # via pylint
-newrelic==10.3.0
+newrelic==10.2.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -109,7 +109,7 @@ markupsafe==2.1.5
     #   jinja2
     #   mako
     #   pyramid-jinja2
-newrelic==10.3.0
+newrelic==10.2.0
     # via -r requirements/prod.in
 oauthlib==3.2.2
     # via -r requirements/prod.in

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -157,7 +157,7 @@ markupsafe==2.1.5
     #   jinja2
     #   mako
     #   pyramid-jinja2
-newrelic==10.3.0
+newrelic==10.2.0
     # via -r requirements/prod.txt
 oauthlib==3.2.2
     # via -r requirements/prod.txt


### PR DESCRIPTION
Reverts hypothesis/h#9118. This seems to be causing the WebSocket app to crash, [Slack thread](https://hypothes-is.slack.com/archives/CR3E3S7K8/p1732724193901549)