### PR TITLE
Display loading indicator in table when loading members

### DIFF
--- a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
+++ b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
@@ -307,6 +307,7 @@ export default function EditGroupMembersForm({
               rows={members ?? []}
               columns={columns}
               renderItem={renderRow}
+              loading={!members}
             />
           </Scroll>
         </div>

--- a/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
+++ b/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
@@ -168,9 +168,11 @@ describe('EditGroupMembersForm', () => {
         headers: config.api.readGroupMembers.headers,
       }),
     );
+    assert.isTrue(wrapper.find('DataTable').prop('loading'));
 
     await waitForTable(wrapper);
 
+    assert.isFalse(wrapper.find('DataTable').prop('loading'));
     const users = getRenderedUsers(wrapper);
     assert.deepEqual(users, ['bob', 'johnsmith', 'jane']);
   });


### PR DESCRIPTION
After h is updated to the next release of @hypothesis/frontend-shared, this will look like:

<img width="607" alt="members-loading-state" src="https://github.com/user-attachments/assets/18c2ac38-e784-46bf-8595-521c95c70587">
