### PR TITLE
Update @hypothesis/frontend-shared

### DIFF
--- a/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
+++ b/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
@@ -112,6 +112,7 @@ describe('EditGroupMembersForm', () => {
       <Config.Provider value={config}>
         <EditGroupMembersForm group={config.context.group} {...props} />
       </Config.Provider>,
+      { connected: true },
     );
   };
 
@@ -136,6 +137,14 @@ describe('EditGroupMembersForm', () => {
     return wrapper.find(`Select[data-testid="role-${username}"]`);
   };
 
+  const openRoleSelect = (wrapper, username) => {
+    getRoleSelect(wrapper, username).find('button').simulate('click');
+  };
+
+  /**
+   * Return the roles listed in a given select. Note that the select must be
+   * open for the options to be rendered.
+   */
   const getOptionValues = selectWrapper => {
     return selectWrapper
       .find(Select.Option)
@@ -280,6 +289,8 @@ describe('EditGroupMembersForm', () => {
   it('displays current and available user roles', async () => {
     const wrapper = createForm();
     await waitForTable(wrapper);
+
+    openRoleSelect(wrapper, 'bob');
 
     // If the user's role can be changed, the current role and available options
     // should be displayed in a Select.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
     "@hypothesis/frontend-build": "^3.1.0",
-    "@hypothesis/frontend-shared": "^8.6.0",
+    "@hypothesis/frontend-shared": "^8.11.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,15 +1775,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^8.6.0":
-  version: 8.6.0
-  resolution: "@hypothesis/frontend-shared@npm:8.6.0"
+"@hypothesis/frontend-shared@npm:^8.11.0":
+  version: 8.11.0
+  resolution: "@hypothesis/frontend-shared@npm:8.11.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 9332d7d39e9bfa3f4ad2f312be5d6a4180a3faa8662b54a9f44f3d754fda8fd6c3cc3eb19d176a48aa31e8aecd136105237d30a37c7563a73553be58e802376c
+  checksum: d42d765e59ff658d5b4320b117e6ab74a1f007ee026d88395e2152b7c8f4aa84178f382062d641cde12049b8c9b61b3cca2634938f97e7e857d56a06f075d950
   languageName: node
   linkType: hard
 
@@ -6117,7 +6117,7 @@ __metadata:
     "@babel/preset-react": ^7.24.7
     "@babel/preset-typescript": ^7.24.7
     "@hypothesis/frontend-build": ^3.1.0
-    "@hypothesis/frontend-shared": ^8.6.0
+    "@hypothesis/frontend-shared": ^8.11.0
     "@hypothesis/frontend-testing": ^1.3.1
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^26.0.1


### PR DESCRIPTION
This required a change in tests for `EditGroupMembersForm` as `Select` controls have been optimized to avoid rendering their options until opened.