### PR TITLE
Add paginated group members API

### DIFF
--- a/h/schemas/pagination.py
+++ b/h/schemas/pagination.py
@@ -1,0 +1,16 @@
+from colander import Integer, Range, Schema, SchemaNode
+
+
+class PaginationQueryParamsSchema(Schema):
+    offset = SchemaNode(
+        Integer(),
+        name="page[offset]",
+        validator=Range(min=0),
+        missing=0,
+    )
+    limit = SchemaNode(
+        Integer(),
+        name="page[limit]",
+        validator=Range(min=1, max=500),
+        missing=200,
+    )

--- a/tests/unit/h/schemas/pagination_test.py
+++ b/tests/unit/h/schemas/pagination_test.py
@@ -1,0 +1,51 @@
+import pytest
+from webob.multidict import NestedMultiDict
+
+from h.schemas import ValidationError
+from h.schemas.pagination import PaginationQueryParamsSchema
+from h.schemas.util import validate_query_params
+
+
+class TestPaginationQueryParamsSchema:
+    @pytest.mark.parametrize(
+        "input_,output",
+        [
+            ({}, {"page[offset]": 0, "page[limit]": 200}),
+            (
+                {"page[offset]": 150, "page[limit]": 50},
+                {"page[offset]": 150, "page[limit]": 50},
+            ),
+        ],
+    )
+    def test_valid(self, schema, input_, output):
+        input_ = NestedMultiDict(input_)
+
+        assert validate_query_params(schema, input_) == output
+
+    @pytest.mark.parametrize(
+        "input_,message",
+        [
+            (
+                {"page[offset]": -1},
+                r"^page\[offset\]: -1 is less than minimum value 0$",
+            ),
+            ({"page[limit]": 0}, r"^page\[limit\]: 0 is less than minimum value 1$"),
+            (
+                {"page[limit]": 501},
+                r"^page\[limit\]: 501 is greater than maximum value 500$",
+            ),
+            (
+                {"page[offset]": "foo", "page[limit]": "bar"},
+                r'^page\[offset\]: "foo" is not a number\npage\[limit\]: "bar" is not a number$',
+            ),
+        ],
+    )
+    def test_invalid(self, schema, input_, message):
+        input_ = NestedMultiDict(input_)
+
+        with pytest.raises(ValidationError, match=message):
+            validate_query_params(schema, input_)
+
+    @pytest.fixture
+    def schema(self):
+        return PaginationQueryParamsSchema()

--- a/tests/unit/h/services/group_members_test.py
+++ b/tests/unit/h/services/group_members_test.py
@@ -95,6 +95,33 @@ class TestGetMemberships:
             )
         ) == sorted(memberships, key=lambda membership: membership.user.username)
 
+    def test_offset_and_limit(self, group_members_service, db_session, factories):
+        group = factories.Group()
+        users = factories.User.build_batch(size=4)
+        memberships = [GroupMembership(group=group, user=user) for user in users]
+        db_session.add_all(memberships)
+
+        returned_memberships = group_members_service.get_memberships(
+            group, offset=1, limit=2
+        )
+
+        assert (
+            list(returned_memberships)
+            == sorted(memberships, key=lambda membership: membership.user.username)[1:3]
+        )
+
+
+class TestCountMemberships:
+    def test_it(self, group_members_service, factories):
+        group = factories.Group(
+            memberships=[
+                GroupMembership(user=user)
+                for user in factories.User.create_batch(size=2)
+            ]
+        )
+
+        assert group_members_service.count_memberships(group) == 2
+
 
 class TestMemberJoin:
     def test_it_adds_user_to_group(


### PR DESCRIPTION
Add a new, paginated version of the list-group-memberships API. Fixes https://github.com/hypothesis/h/issues/9133.

We can merge and deploy this without breaking anything because the new pagination stuff is only used if the `page[offset]` query param is present.

For discussion of the paginated API design see: https://github.com/hypothesis/h/discussions/9172.

There was a request to add `first`, `last`, `next` and `prev` links into the paginated responses, I'll add those in a follow-up PR.

Updating the API docs will also be a follow-up PR.

Testing
=======

Without the new `page[offset]` query param the old, non-paginated API is used:

```terminal
$ httpx http://localhost:5000/api/groups/{id}/members --method GET --headers Authorization 'Bearer {token}'
[
  {...},
  {...},
  {...}
]
```

If you include the `page[offset]` param you'll get the paginated version:

```terminal
$ httpx http://localhost:5000/api/groups/{id}/members --method GET --headers Authorization 'Bearer {token}' --params page[offset] 0
{
    "meta": {
        "page": {
            "total": 3
        }
    },
    "data": [
        {...},
        {...},
        {...}
    ]
```

You can also use `page[limit]`:

```terminal
$ httpx http://localhost:5000/api/groups/{id}/members --method GET --headers Authorization 'Bearer {token}' --params page[offset] 0 --params page[limit] 1
```

If you use a `page[offset]` that's larger than the number of memberships in the group you'll get an empty list in the response.

Error messages for invalid offset and limit query params:

```terminal
$ httpx http://localhost:5000/api/groups/{id}/members --method GET --headers Authorization 'Bearer {token}' --params page[offset] -1 --params page[limit] 0
{
    "status": "failure",
    "reason": "page[offset]: -1 is less than minimum value 0\npage[limit]: 0 is less than minimum value 1"
}
```