### PR TITLE
Show display names in the group members table

### DIFF
--- a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
+++ b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
@@ -23,8 +23,10 @@ type TableColumn<Row> = {
 };
 
 type MemberRow = {
-  username: string;
   userid: string;
+
+  username: string;
+  displayName?: string;
 
   /** Whether to show the button to remove this member from the group? */
   showDeleteAction: boolean;
@@ -61,6 +63,7 @@ function memberToRow(member: GroupMember, currentUserid: string): MemberRow {
       : [role];
   return {
     userid: member.userid,
+    displayName: member.display_name,
     username: member.username,
     showDeleteAction:
       member.actions.includes('delete') && member.userid !== currentUserid,
@@ -253,18 +256,30 @@ export default function EditGroupMembersForm({
     switch (field) {
       case 'username':
         return (
-          <div
-            data-testid="username"
-            className="truncate"
-            title={user.username}
-          >
-            {user.username}
+          <div className="truncate" title={user.username}>
+            <span data-testid="username" className="font-bold text-grey-7">
+              @{user.username}
+            </span>
+            {user.displayName && (
+              <span data-testid="display-name">
+                {
+                  // Create space using a separate element, rather than eg.
+                  // `inline-block ml-3` on the display name container because
+                  // that would cause the entire display name to be hidden if
+                  // truncated.
+                  <span className="inline-block w-3" />
+                }
+                {user.displayName}
+              </span>
+            )}
           </div>
         );
       case 'role':
         if (user.availableRoles.length <= 1) {
           return (
-            <span data-testid={`role-${user.username}`}>
+            // Left padding here aligns the static role label in this row with
+            // the current role in dropdowns in other rows.
+            <span className="pl-2" data-testid={`role-${user.username}`}>
               {roleStrings[user.role]}
             </span>
           );
@@ -303,6 +318,8 @@ export default function EditGroupMembersForm({
         <div className="w-full">
           <Scroll>
             <DataTable
+              grid
+              striped={false}
               title="Group members"
               rows={members ?? []}
               columns={columns}

--- a/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
+++ b/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
@@ -15,6 +15,7 @@ describe('EditGroupMembersForm', () => {
     {
       userid: 'acct:bob@localhost',
       username: 'bob',
+      display_name: 'Bob Jones',
       actions: [
         'delete',
         'updates.roles.admin',
@@ -26,6 +27,7 @@ describe('EditGroupMembersForm', () => {
     {
       userid: 'acct:johnsmith@localhost',
       username: 'johnsmith',
+      display_name: 'John Smith',
       actions: [],
       roles: ['owner'],
     },
@@ -125,8 +127,14 @@ describe('EditGroupMembersForm', () => {
       return wrapper.find('ErrorNotice').prop('message') !== null;
     });
 
-  const getRenderedUsers = wrapper => {
+  const getRenderedUsernames = wrapper => {
     return wrapper.find('[data-testid="username"]').map(node => node.text());
+  };
+
+  const getRenderedDisplayNames = wrapper => {
+    return wrapper
+      .find('[data-testid="display-name"]')
+      .map(node => node.text());
   };
 
   const getRemoveUserButton = (wrapper, username) => {
@@ -182,8 +190,11 @@ describe('EditGroupMembersForm', () => {
     await waitForTable(wrapper);
 
     assert.isFalse(wrapper.find('DataTable').prop('loading'));
-    const users = getRenderedUsers(wrapper);
-    assert.deepEqual(users, ['bob', 'johnsmith', 'jane']);
+    const usernames = getRenderedUsernames(wrapper);
+    assert.deepEqual(usernames, ['@bob', '@johnsmith', '@jane']);
+
+    const displayNames = getRenderedDisplayNames(wrapper);
+    assert.deepEqual(displayNames, ['Bob Jones', 'John Smith']);
   });
 
   it('displays error if member fetch fails', async () => {
@@ -282,7 +293,7 @@ describe('EditGroupMembersForm', () => {
     assert.equal(error.prop('message'), 'User not found');
 
     // Controls should be re-enabled after saving fails.
-    assert.include(getRenderedUsers(wrapper), 'bob');
+    assert.include(getRenderedUsernames(wrapper), '@bob');
     assert.isFalse(controlsDisabled(wrapper, 'bob'));
   });
 

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -32,6 +32,7 @@ export type CreateUpdateGroupAPIResponse = {
 
 export type GroupMember = {
   userid: string;
+  display_name?: string;
   username: string;
   actions: string[];
   roles: Role[];


### PR DESCRIPTION
Show display names in the members table if available, per [designs](https://www.figma.com/design/jon1U01LGSLcx7PWtZ9TPZ/Hypothesis---Group-Management?node-id=2677-127&node-type=canvas&t=p84JLIdPL59QN4tT-0).

 - Show display names next to username in table if present
 - Prefix username with '@' and make them bold and darker
 - Change table to use grid lines and non-striped rows, to align with the designs.

**Before:**

<img width="550" alt="group-members-before" src="https://github.com/user-attachments/assets/46ed4be1-490a-4391-83f1-361890b4d811">

**After:**

<img width="583" alt="group-members-after" src="https://github.com/user-attachments/assets/205a8e0a-974d-41b7-9785-9ef2a767c24b">

Compared to the designs the role select has a lot more padding around it. I will address this separately.