### PR TITLE
Use pagination in group members UI

### DIFF
--- a/h/schemas/pagination.py
+++ b/h/schemas/pagination.py
@@ -1,0 +1,16 @@
+from colander import Integer, Range, Schema, SchemaNode
+
+
+class PaginationQueryParamsSchema(Schema):
+    offset = SchemaNode(
+        Integer(),
+        name="page[offset]",
+        validator=Range(min=0),
+        missing=0,
+    )
+    limit = SchemaNode(
+        Integer(),
+        name="page[limit]",
+        validator=Range(min=1, max=500),
+        missing=200,
+    )

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -38,13 +38,14 @@ export type GroupMember = {
   roles: Role[];
 };
 
-export type PaginatedResponse<T> = {
+export type PaginatedResponse<Item> = {
   meta: {
     page: {
+      /** Total number of items in the collection. */
       total: number;
     };
   };
-  data: T[];
+  data: Item[];
 };
 
 /**

--- a/h/static/scripts/group-forms/utils/test/api-test.js
+++ b/h/static/scripts/group-forms/utils/test/api-test.js
@@ -124,6 +124,20 @@ describe('callAPI', () => {
     assert.equal(error.json, null);
   });
 
+  it('adds pagination params to URL', async () => {
+    const paginatedURL = new URL(url);
+    const offset = 5;
+    const limit = 10;
+    paginatedURL.searchParams.set('page[offset]', offset);
+    paginatedURL.searchParams.set('page[limit]', limit);
+    const response = new Response(JSON.stringify({}), { status: 200 });
+    fakeFetch.resolves(response);
+
+    await callAPI(url, { offset, limit });
+
+    assert.calledWith(fakeFetch, paginatedURL.toString());
+  });
+
   [
     {
       response: new Response(

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
     "@hypothesis/frontend-build": "^3.1.0",
-    "@hypothesis/frontend-shared": "^8.12.0",
+    "@hypothesis/frontend-shared": "^8.13.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",

--- a/tests/unit/h/schemas/pagination_test.py
+++ b/tests/unit/h/schemas/pagination_test.py
@@ -1,0 +1,51 @@
+import pytest
+from webob.multidict import NestedMultiDict
+
+from h.schemas import ValidationError
+from h.schemas.pagination import PaginationQueryParamsSchema
+from h.schemas.util import validate_query_params
+
+
+class TestPaginationQueryParamsSchema:
+    @pytest.mark.parametrize(
+        "input_,output",
+        [
+            ({}, {"page[offset]": 0, "page[limit]": 200}),
+            (
+                {"page[offset]": 150, "page[limit]": 50},
+                {"page[offset]": 150, "page[limit]": 50},
+            ),
+        ],
+    )
+    def test_valid(self, schema, input_, output):
+        input_ = NestedMultiDict(input_)
+
+        assert validate_query_params(schema, input_) == output
+
+    @pytest.mark.parametrize(
+        "input_,message",
+        [
+            (
+                {"page[offset]": -1},
+                r"^page\[offset\]: -1 is less than minimum value 0$",
+            ),
+            ({"page[limit]": 0}, r"^page\[limit\]: 0 is less than minimum value 1$"),
+            (
+                {"page[limit]": 501},
+                r"^page\[limit\]: 501 is greater than maximum value 500$",
+            ),
+            (
+                {"page[offset]": "foo", "page[limit]": "bar"},
+                r'^page\[offset\]: "foo" is not a number\npage\[limit\]: "bar" is not a number$',
+            ),
+        ],
+    )
+    def test_invalid(self, schema, input_, message):
+        input_ = NestedMultiDict(input_)
+
+        with pytest.raises(ValidationError, match=message):
+            validate_query_params(schema, input_)
+
+    @pytest.fixture
+    def schema(self):
+        return PaginationQueryParamsSchema()

--- a/tests/unit/h/services/group_members_test.py
+++ b/tests/unit/h/services/group_members_test.py
@@ -95,6 +95,33 @@ class TestGetMemberships:
             )
         ) == sorted(memberships, key=lambda membership: membership.user.username)
 
+    def test_offset_and_limit(self, group_members_service, db_session, factories):
+        group = factories.Group()
+        users = factories.User.build_batch(size=4)
+        memberships = [GroupMembership(group=group, user=user) for user in users]
+        db_session.add_all(memberships)
+
+        returned_memberships = group_members_service.get_memberships(
+            group, offset=1, limit=2
+        )
+
+        assert (
+            list(returned_memberships)
+            == sorted(memberships, key=lambda membership: membership.user.username)[1:3]
+        )
+
+
+class TestCountMemberships:
+    def test_it(self, group_members_service, factories):
+        group = factories.Group(
+            memberships=[
+                GroupMembership(user=user)
+                for user in factories.User.create_batch(size=2)
+            ]
+        )
+
+        assert group_members_service.count_memberships(group) == 2
+
 
 class TestMemberJoin:
     def test_it_adds_user_to_group(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,15 +1775,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^8.12.0":
-  version: 8.12.0
-  resolution: "@hypothesis/frontend-shared@npm:8.12.0"
+"@hypothesis/frontend-shared@npm:^8.13.0":
+  version: 8.13.0
+  resolution: "@hypothesis/frontend-shared@npm:8.13.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: 900be36b83fa0b73f1705ac6b774414b0ca8a6c779d0e3d96390212c2cb317071d5d8bbf1c771b11ff9e1e040c89972e8a716c3f5d0a0188b5ef6943eaab3c37
+  checksum: 5ac8ca16b1f58b09e917aef032bf3e7cfd5b665c4d29ab8803c1863f45d96d01e35c0b28b098ca7b2237836a4c05c405d2c213f86b06e0fd22c072e9ca22aecb
   languageName: node
   linkType: hard
 
@@ -6061,7 +6061,7 @@ __metadata:
     "@babel/preset-react": ^7.24.7
     "@babel/preset-typescript": ^7.24.7
     "@hypothesis/frontend-build": ^3.1.0
-    "@hypothesis/frontend-shared": ^8.12.0
+    "@hypothesis/frontend-shared": ^8.13.0
     "@hypothesis/frontend-testing": ^1.3.1
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^26.0.1


### PR DESCRIPTION
Use the new paginated API added in https://github.com/hypothesis/h/pull/9173 to paginate the members list. For testing purposes the page size can be configured by modifying the `pageSize` variable in `EditGroupMembersForm.tsx`. The design of the pagination control matches the one used in the client's notebook UI. Updating this control to match the mocks will happen in a subsequent update to @hypothesis/frontend-shared.

Note that no pagination controls are shown if there is only one page of members.

Preview with a page size of 1:

<img width="540" alt="paginated-members" src="https://github.com/user-attachments/assets/ddf79b8f-50b3-4e49-9f1d-77d56d108108">
