### PR TITLE
Reduce max and default pagination offsets

### DIFF
--- a/h/schemas/pagination.py
+++ b/h/schemas/pagination.py
@@ -11,6 +11,6 @@ class PaginationQueryParamsSchema(Schema):
     limit = SchemaNode(
         Integer(),
         name="page[limit]",
-        validator=Range(min=1, max=500),
-        missing=200,
+        validator=Range(min=1, max=100),
+        missing=20,
     )

--- a/tests/unit/h/schemas/pagination_test.py
+++ b/tests/unit/h/schemas/pagination_test.py
@@ -10,7 +10,7 @@ class TestPaginationQueryParamsSchema:
     @pytest.mark.parametrize(
         "input_,output",
         [
-            ({}, {"page[offset]": 0, "page[limit]": 200}),
+            ({}, {"page[offset]": 0, "page[limit]": 20}),
             (
                 {"page[offset]": 150, "page[limit]": 50},
                 {"page[offset]": 150, "page[limit]": 50},
@@ -31,8 +31,8 @@ class TestPaginationQueryParamsSchema:
             ),
             ({"page[limit]": 0}, r"^page\[limit\]: 0 is less than minimum value 1$"),
             (
-                {"page[limit]": 501},
-                r"^page\[limit\]: 501 is greater than maximum value 500$",
+                {"page[limit]": 101},
+                r"^page\[limit\]: 101 is greater than maximum value 100$",
             ),
             (
                 {"page[offset]": "foo", "page[limit]": "bar"},


### PR DESCRIPTION
Reduce the maximum and default values for the `page[limit]` query param
to the paginated list-group-members API. The frontend isn't going to be
using values greater than 100 anyway, and we may as well get rid of the
slower requests that're created by larger page sizes.
