### PR TITLE
Remove legacy unpaginated list-group-members API

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -889,13 +889,6 @@ paths:
         To get the memberships of a private group the authenticated user must be a member of the group.
         Getting the memberships of an open or restricted group does not require authentication.
         The returned memberships are sorted by joining date, oldest first.
-
-        If the `page[number]` query param is included in the request then the response will be paginated.
-        If there's no `page[number]` query param in the request then a legacy,
-        un-paginated response format will be used. In the future this legacy
-        un-paginated response format will be removed and the paginated response
-        format will be used even when the `page[number]` query param is not
-        present.
       parameters:
         - $ref: '#/components/parameters/PageNumber'
         - $ref: '#/components/parameters/PageSize'
@@ -909,22 +902,16 @@ paths:
           content:
             application/*json:
               schema:
-                oneOf:
-                  - title: "Paginated"
+                type: object
+                properties:
+                  meta:
+                    description: "Metadata about this response."
                     type: object
                     properties:
-                      meta:
-                        description: "Metadata about this response."
-                        type: object
-                        properties:
-                          page:
-                            $ref: '#/components/schemas/PaginationMeta'
-                      data:
-                        description: "The list of memberships for the requested page."
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Membership'
-                  - title: "Unpaginated (deprecated)"
+                      page:
+                        $ref: '#/components/schemas/PaginationMeta'
+                  data:
+                    description: "The list of memberships for the requested page."
                     type: array
                     items:
                       $ref: '#/components/schemas/Membership'

--- a/docs/_extra/api-reference/hypothesis-v2.yaml
+++ b/docs/_extra/api-reference/hypothesis-v2.yaml
@@ -887,13 +887,6 @@ paths:
         To get the memberships of a private group the authenticated user must be a member of the group.
         Getting the memberships of an open or restricted group does not require authentication.
         The returned memberships are sorted by joining date, oldest first.
-
-        If the `page[number]` query param is included in the request then the response will be paginated.
-        If there's no `page[number]` query param in the request then a legacy,
-        un-paginated response format will be used. In the future this legacy
-        un-paginated response format will be removed and the paginated response
-        format will be used even when the `page[number]` query param is not
-        present.
       parameters:
         - $ref: '#/components/parameters/PageNumber'
         - $ref: '#/components/parameters/PageSize'
@@ -907,22 +900,16 @@ paths:
           content:
             application/*json:
               schema:
-                oneOf:
-                  - title: "Paginated"
+                type: object
+                properties:
+                  meta:
+                    description: "Metadata about this response."
                     type: object
                     properties:
-                      meta:
-                        description: "Metadata about this response."
-                        type: object
-                        properties:
-                          page:
-                            $ref: '#/components/schemas/PaginationMeta'
-                      data:
-                        description: "The list of memberships for the requested page."
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Membership'
-                  - title: "Unpaginated (deprecated)"
+                      page:
+                        $ref: '#/components/schemas/PaginationMeta'
+                  data:
+                    description: "The list of memberships for the requested page."
                     type: array
                     items:
                       $ref: '#/components/schemas/Membership'

--- a/h/views/api/group_members.py
+++ b/h/views/api/group_members.py
@@ -1,6 +1,5 @@
 import logging
 
-from pyramid.config import not_
 from pyramid.httpexceptions import HTTPConflict, HTTPNoContent, HTTPNotFound
 
 from h.presenters import GroupMembershipJSONPresenter
@@ -21,41 +20,14 @@ from h.views.api.helpers.json_payload import json_payload
 log = logging.getLogger(__name__)
 
 
-LIST_MEMBERS_API_CONFIG = {
-    "versions": ["v1", "v2"],
-    "route_name": "api.group_members",
-    "request_method": "GET",
-    "link_name": "group.members.read",
-    "description": "Fetch a list of all members of a group",
-    "permission": Permission.Group.READ,
-}
-
-
-@api_config(request_param=not_("page[number]"), **LIST_MEMBERS_API_CONFIG)
-def list_members_legacy(context: GroupContext, request):
-    """Legacy version of the list-members API, maintained for backwards-compatibility."""
-
-    log.info(
-        "list_members_legacy() was called. User-Agent: %s, Referer: %s, pubid: %s",
-        request.headers.get("User-Agent"),
-        request.headers.get("Referer"),
-        context.group.pubid,
-    )
-
-    # Get the list of memberships from GroupMembersService instead of just
-    # accessing `context.memberships` because GroupMembersService returns the
-    # memberships explictly sorted by creation date then username whereas
-    # `context.memberships` is unsorted.
-    group_members_service = request.find_service(name="group_members")
-    memberships = group_members_service.get_memberships(context.group)
-
-    return [
-        GroupMembershipJSONPresenter(request, membership).asdict()
-        for membership in memberships
-    ]
-
-
-@api_config(request_param="page[number]", **LIST_MEMBERS_API_CONFIG)
+@api_config(
+    versions=["v1", "v2"],
+    route_name="api.group_members",
+    request_method="GET",
+    link_name="group.members.read",
+    description="Fetch a list of all members of a group",
+    permission=Permission.Group.READ,
+)
 def list_members(context: GroupContext, request):
     group = context.group
     group_members_service = request.find_service(name="group_members")

--- a/tests/unit/h/views/api/group_members_test.py
+++ b/tests/unit/h/views/api/group_members_test.py
@@ -20,55 +20,6 @@ from h.traversal import (
 from h.views.api.exceptions import PayloadError
 
 
-class TestListMembersLegacy:
-    def test_it(
-        self,
-        context,
-        pyramid_request,
-        GroupMembershipJSONPresenter,
-        group_members_service,
-        caplog,
-    ):
-        pyramid_request.headers["User-Agent"] = sentinel.user_agent
-        pyramid_request.headers["Referer"] = sentinel.referer
-        group_members_service.get_memberships.return_value = [
-            sentinel.membership_1,
-            sentinel.membership_2,
-        ]
-
-        presenter_instances = GroupMembershipJSONPresenter.side_effect = [
-            create_autospec(
-                presenters.GroupMembershipJSONPresenter, instance=True, spec_set=True
-            ),
-            create_autospec(
-                presenters.GroupMembershipJSONPresenter, instance=True, spec_set=True
-            ),
-        ]
-
-        response = views.list_members_legacy(context, pyramid_request)
-
-        assert caplog.messages == [
-            f"list_members_legacy() was called. User-Agent: {sentinel.user_agent}, Referer: {sentinel.referer}, pubid: {context.group.pubid}"
-        ]
-        group_members_service.get_memberships.assert_called_once_with(context.group)
-        assert GroupMembershipJSONPresenter.call_args_list == [
-            call(pyramid_request, sentinel.membership_1),
-            call(pyramid_request, sentinel.membership_2),
-        ]
-        presenter_instances[0].asdict.assert_called_once_with()
-        presenter_instances[1].asdict.assert_called_once_with()
-        assert response == [
-            presenter_instances[0].asdict.return_value,
-            presenter_instances[1].asdict.return_value,
-        ]
-
-    @pytest.fixture
-    def context(self, factories):
-        return create_autospec(
-            GroupContext, instance=True, spec_set=True, group=factories.Group()
-        )
-
-
 class TestListMembers:
     def test_it(
         self,


### PR DESCRIPTION
Before merging this we should:

* Check if anyone appears to be using the API and consider if we want to contact them to let them know about the change. We should be able to use [this log message](https://github.com/hypothesis/h/blob/45f15ae0313d8d29338728388df9f673e33dc79f/h/views/api/group_members.py#L32-L37) to find usages