### PR TITLE
Add `created` to group membership model

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -1,3 +1,4 @@
+import datetime
 import enum
 import re
 from collections import namedtuple
@@ -76,6 +77,15 @@ class GroupMembership(Base):
         ),
         server_default=sa.text("""'["member"]'::jsonb"""),
         nullable=False,
+    )
+
+    created = sa.Column(sa.DateTime, default=datetime.datetime.utcnow, index=True)
+
+    updated = sa.Column(
+        sa.DateTime,
+        default=datetime.datetime.utcnow,
+        onupdate=datetime.datetime.utcnow,
+        index=True,
     )
 
     def __repr__(self):


### PR DESCRIPTION
Add a `created` column to `models.GroupMembership`.

Fixes https://github.com/hypothesis/h/issues/9103. This should automatically mean that new group memberships get their created and updated times tracked, without any further changes.

Before we can merge this PR we'll need a migration to add the new columns.

Then after merging this PR we'll need another PR to add the created date to the responses from various APIs.

While we're doing this, might as well add `updated` as well.

There's a desire for this column to be nullable so that pre-existing
memberships can have `NULL` in this column, see:
https://hypothes-is.slack.com/archives/C4K6M7P5E/p1733330444569829

For that reason we can't use `h.db.mixins.Timestamps` because that mixin
adds *non-nullable* `created` and `updated` columns.

I don't think it really matters but if we did change the
`GroupMembership` model to inherit from the `Timestamps` mixin that
would add the `created` and `updated` columns to the _start_ of the
table, whereas in the staging and production DBs a migration is going to
add the new columns to the _end_ of the table. Meaning that DBs created
from the models (e.g. in dev and on CI) would actually have the columns
in a different order than staging and production. Not sure if there
would be a way to fix the column order while using `mixins.Timestamps`.
Moot point anyway since we need them to be nullable.
