### PR TITLE
Add `created` and `updated` times to membership API responses

### DIFF
--- a/h/presenters/group_membership_json.py
+++ b/h/presenters/group_membership_json.py
@@ -4,6 +4,7 @@ from h.traversal.group_membership import (
     EditGroupMembershipContext,
     GroupMembershipContext,
 )
+from h.util.datetime import utc_iso8601
 
 
 class GroupMembershipJSONPresenter:
@@ -19,6 +20,8 @@ class GroupMembershipJSONPresenter:
             "display_name": self.membership.user.display_name,
             "roles": self.membership.roles,
             "actions": [],
+            "created": utc_iso8601(self.membership.created),
+            "updated": utc_iso8601(self.membership.updated),
         }
 
         if self.request.has_permission(

--- a/tests/functional/api/groups/members_test.py
+++ b/tests/functional/api/groups/members_test.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+from datetime import datetime
 
 import pytest
 from sqlalchemy import select
@@ -14,7 +15,11 @@ class TestListMembersLegacy:
     ):
         group = factories.RestrictedGroup(
             memberships=[
-                GroupMembership(user=user)
+                GroupMembership(
+                    user=user,
+                    created=datetime(1970, 1, 1, 0, 0, 0),
+                    updated=datetime(1970, 1, 1, 0, 0, 1),
+                )
                 for user in factories.User.create_batch(size=3)
             ]
         )
@@ -37,6 +42,8 @@ class TestListMembersLegacy:
                 "display_name": membership.user.display_name,
                 "roles": membership.roles,
                 "actions": [],
+                "created": "1970-01-01T00:00:00.000000+00:00",
+                "updated": "1970-01-01T00:00:01.000000+00:00",
             }
             for membership in sorted(
                 group.memberships, key=lambda membership: membership.user.username
@@ -50,7 +57,18 @@ class TestListMembersLegacy:
         user, other_user = factories.User.create_batch(size=2)
         token = factories.DeveloperToken(user=user)
         group.memberships.extend(
-            [GroupMembership(user=user), GroupMembership(user=other_user)]
+            [
+                GroupMembership(
+                    user=user,
+                    created=datetime(1970, 1, 1, 0, 0, 0),
+                    updated=datetime(1970, 1, 1, 0, 0, 1),
+                ),
+                GroupMembership(
+                    user=other_user,
+                    created=datetime(1971, 1, 1, 0, 0, 0),
+                    updated=datetime(1971, 1, 1, 0, 0, 1),
+                ),
+            ]
         )
         db_session.commit()
 
@@ -69,6 +87,8 @@ class TestListMembersLegacy:
                     "display_name": user.display_name,
                     "roles": [GroupMembershipRoles.MEMBER],
                     "actions": ["delete"],
+                    "created": "1970-01-01T00:00:00.000000+00:00",
+                    "updated": "1970-01-01T00:00:01.000000+00:00",
                 },
                 {
                     "authority": group.authority,
@@ -77,6 +97,8 @@ class TestListMembersLegacy:
                     "display_name": other_user.display_name,
                     "roles": [GroupMembershipRoles.MEMBER],
                     "actions": [],
+                    "created": "1971-01-01T00:00:00.000000+00:00",
+                    "updated": "1971-01-01T00:00:01.000000+00:00",
                 },
             ],
             key=lambda membership: membership["username"],
@@ -108,7 +130,11 @@ class TestListMembers:
     ):
         group = factories.RestrictedGroup(
             memberships=[
-                GroupMembership(user=user)
+                GroupMembership(
+                    user=user,
+                    created=datetime(1970, 1, 1, 0, 0, 0),
+                    updated=datetime(1970, 1, 1, 0, 0, 1),
+                )
                 for user in factories.User.create_batch(size=4)
             ]
         )
@@ -131,6 +157,8 @@ class TestListMembers:
                     "display_name": membership.user.display_name,
                     "roles": membership.roles,
                     "actions": [],
+                    "created": "1970-01-01T00:00:00.000000+00:00",
+                    "updated": "1970-01-01T00:00:01.000000+00:00",
                 }
                 for membership in sorted(
                     group.memberships, key=lambda membership: membership.user.username
@@ -145,7 +173,18 @@ class TestListMembers:
         user, other_user = factories.User.create_batch(size=2)
         token = factories.DeveloperToken(user=user)
         group.memberships.extend(
-            [GroupMembership(user=user), GroupMembership(user=other_user)]
+            [
+                GroupMembership(
+                    user=user,
+                    created=datetime(1970, 1, 1, 0, 0, 0),
+                    updated=datetime(1970, 1, 1, 0, 0, 1),
+                ),
+                GroupMembership(
+                    user=other_user,
+                    created=datetime(1971, 1, 1, 0, 0, 0),
+                    updated=datetime(1971, 1, 1, 0, 0, 1),
+                ),
+            ]
         )
         db_session.commit()
 
@@ -167,6 +206,8 @@ class TestListMembers:
                         "display_name": user.display_name,
                         "roles": [GroupMembershipRoles.MEMBER],
                         "actions": ["delete"],
+                        "created": "1970-01-01T00:00:00.000000+00:00",
+                        "updated": "1970-01-01T00:00:01.000000+00:00",
                     },
                     {
                         "authority": group.authority,
@@ -175,6 +216,8 @@ class TestListMembers:
                         "display_name": other_user.display_name,
                         "roles": [GroupMembershipRoles.MEMBER],
                         "actions": [],
+                        "created": "1971-01-01T00:00:00.000000+00:00",
+                        "updated": "1971-01-01T00:00:01.000000+00:00",
                     },
                 ],
                 key=lambda membership: membership["username"],

--- a/tests/unit/h/presenters/group_membership_json_test.py
+++ b/tests/unit/h/presenters/group_membership_json_test.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 
 from h.models import GroupMembership
@@ -17,6 +19,8 @@ class TestGroupMembershipJSONPresenter:
             "display_name": user.display_name,
             "roles": membership.roles,
             "actions": [],
+            "created": "1970-01-01T00:00:00.000000+00:00",
+            "updated": "1970-01-01T00:00:01.000000+00:00",
         }
 
     def test_it_with_permissive_securitypolicy(
@@ -39,7 +43,18 @@ class TestGroupMembershipJSONPresenter:
                 "updates.roles.admin",
                 "updates.roles.owner",
             ],
+            "created": "1970-01-01T00:00:00.000000+00:00",
+            "updated": "1970-01-01T00:00:01.000000+00:00",
         }
+
+    def test_it_with_no_created_or_updated_times(self, membership, pyramid_request):
+        membership.created = None
+        membership.updated = None
+
+        json = GroupMembershipJSONPresenter(pyramid_request, membership).asdict()
+
+        assert json["created"] is None
+        assert json["updated"] is None
 
     @pytest.fixture
     def user(self, factories):
@@ -51,4 +66,9 @@ class TestGroupMembershipJSONPresenter:
 
     @pytest.fixture
     def membership(self, user, group):
-        return GroupMembership(user=user, group=group)
+        return GroupMembership(
+            user=user,
+            group=group,
+            created=datetime(1970, 1, 1, 0, 0, 0),
+            updated=datetime(1970, 1, 1, 0, 0, 1),
+        )


### PR DESCRIPTION
Fixes https://github.com/hypothesis/h/issues/9137