### PR TITLE
Add response body to add-member API

### DIFF
--- a/h/services/group_members.py
+++ b/h/services/group_members.py
@@ -111,7 +111,7 @@ class GroupMembersService:
         for userid in userids_for_removal:
             self.member_leave(group, userid)
 
-    def member_join(self, group, userid):
+    def member_join(self, group, userid) -> GroupMembership:
         """Add `userid` to the member list of `group`."""
         user = self.user_fetcher(userid)
 
@@ -119,7 +119,7 @@ class GroupMembersService:
 
         if existing_membership:
             # The user is already a member of the group.
-            return
+            return existing_membership
 
         membership = GroupMembership(group=group, user=user)
         self.db.add(membership)
@@ -129,6 +129,8 @@ class GroupMembersService:
 
         log.info("Added group membership: %r", membership)
         self.publish("group-join", group.pubid, userid)
+
+        return membership
 
     def member_leave(self, group, userid):
         """Remove `userid` from the member list of `group`."""

--- a/h/views/api/group_members.py
+++ b/h/views/api/group_members.py
@@ -96,14 +96,14 @@ def remove_member(context: GroupMembershipContext, request):
     permission=Permission.Group.MEMBER_ADD,
 )
 def add_member(context: GroupMembershipContext, request):
-    group_members_service = request.find_service(name="group_members")
-
     if context.user.authority != context.group.authority:
         raise HTTPNotFound()
 
-    group_members_service.member_join(context.group, context.user.userid)
+    group_members_service = request.find_service(name="group_members")
 
-    return HTTPNoContent()
+    membership = group_members_service.member_join(context.group, context.user.userid)
+
+    return GroupMembershipJSONPresenter(request, membership).asdict()
 
 
 @api_config(

--- a/tests/functional/api/groups/members_test.py
+++ b/tests/functional/api/groups/members_test.py
@@ -357,7 +357,7 @@ class TestAddMember:
 
     @pytest.fixture
     def do_request(self, db_session, app, group, user, headers):
-        def do_request(pubid=group.pubid, userid=user.userid, status=204):
+        def do_request(pubid=group.pubid, userid=user.userid, status=200):
             db_session.commit()
             return app.post_json(
                 f"/api/groups/{pubid}/members/{userid}", headers=headers, status=status

--- a/tests/unit/h/views/api/group_members_test.py
+++ b/tests/unit/h/views/api/group_members_test.py
@@ -141,13 +141,23 @@ class TestRemoveMember:
 
 @pytest.mark.usefixtures("group_members_service")
 class TestAddMember:
-    def test_it(self, pyramid_request, group_members_service, context):
+    def test_it(
+        self,
+        pyramid_request,
+        group_members_service,
+        context,
+        GroupMembershipJSONPresenter,
+    ):
         response = views.add_member(context, pyramid_request)
 
         group_members_service.member_join.assert_called_once_with(
             context.group, context.user.userid
         )
-        assert isinstance(response, HTTPNoContent)
+        GroupMembershipJSONPresenter.assert_called_once_with(
+            pyramid_request, group_members_service.member_join.return_value
+        )
+        GroupMembershipJSONPresenter.return_value.asdict.assert_called_once_with()
+        assert response == GroupMembershipJSONPresenter.return_value.asdict.return_value
 
     def test_it_with_authority_mismatch(self, pyramid_request, context):
         context.group.authority = "other"


### PR DESCRIPTION
Change the add-group-membership API's response from a 204 No Content to a 200 OK with a JSON representation of the newly-added membership as the body.

Fixes https://github.com/hypothesis/h/issues/9141.

Testing:

1. Log in as `devdata_admin`
2. Go to <http://localhost:5000/groups/new> and create a new group
3. Go to <http://localhost:5000/admin/oauthclients/new> and create an authclient with these properties:

   Authority: localhost  
   Grant type: client_credentials  
   Trusted: yes

4. Use the authclient to authenticate an API request to add `devdata_user` to the group:

   ```
   $ httpx http://localhost:5000/api/groups/{pubid}/members/acct:devdata_user@localhost --method POST --auth {client_id} {client_secret}
   HTTP/1.1 200 OK

   {
       "authority": "localhost",
       "userid": "acct:devdata_user@localhost",
       "username": "devdata_user",
       "display_name": null,
       "roles": [
           "member"
       ],
       "actions": [],
       "created": "2024-12-06T12:54:27.790391+00:00",
       "updated": "2024-12-06T12:54:27.790394+00:00"
   }
   ```