### PR TITLE
Don't show error if user navigates while fetching members

### DIFF
--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -87,6 +87,14 @@ export class APIError extends Error {
     this.response = response;
     this.json = json;
   }
+
+  /**
+   * Property that is true if the API call failed because the operation was
+   * aborted.
+   */
+  get aborted() {
+    return this.cause?.name === 'AbortError';
+  }
 }
 
 export type APIOptions = {

--- a/h/static/scripts/group-forms/utils/test/api-test.js
+++ b/h/static/scripts/group-forms/utils/test/api-test.js
@@ -9,7 +9,7 @@ describe('callAPI', () => {
   });
 
   afterEach(() => {
-    window.fetch.restore();
+    window.fetch.restore?.();
   });
 
   context('when the API responds successfully', () => {
@@ -136,6 +136,23 @@ describe('callAPI', () => {
     await callAPI(url, { offset, limit });
 
     assert.calledWith(fakeFetch, paginatedURL.toString());
+  });
+
+  it('rejects with aborted APIError if request is aborted', async () => {
+    window.fetch.restore();
+
+    const ac = new AbortController();
+    ac.abort();
+
+    let error;
+    try {
+      await callAPI(url, { signal: ac.signal });
+    } catch (e) {
+      error = e;
+    }
+
+    assert.instanceOf(error, APIError);
+    assert.isTrue(error.aborted);
   });
 
   [


### PR DESCRIPTION
Don't show error messages when requests fail due to being canceled from the client end while in flight. This can happen when navigating (eg. changing page) while members are being fetched.

An alternative solution here would be to disable the pagination controls while members are loading, but this reduces how quickly the user can flip through pages.

**Testing:**

1. Apply this diff to reduce the members page size and simulate a slow fetch:

```diff
diff --git a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
index 5aeaaa9d7..cc4e83464 100644
--- a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
+++ b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
@@ -163,7 +163,7 @@ function RoleSelect({
   );
 }
 
-export const pageSize = 20;
+export const pageSize = 1;
 
 export type EditGroupMembersFormProps = {
   /** The saved group details. */
diff --git a/h/static/scripts/group-forms/utils/api.ts b/h/static/scripts/group-forms/utils/api.ts
index f095a943d..c47fa0bc9 100644
--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -140,6 +140,8 @@ export async function callAPI<R = unknown>(
     requestURL.searchParams.set(param, value.toString());
   }
 
+  await new Promise(r => setTimeout(r, 2000));
+
   let response;
   try {
     // Converting `requestURL` to a string is not necessary, but it makes
```

2. Go to a group with at least 2 members and navigate back and forth between pages. On main, you should see an error notice after navigating while a request is in flight. On this branch, you shouldn't.