### PR TITLE
Add "Joined" column to group members table

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -229,7 +229,7 @@ export default function CreateEditGroupForm({
   };
 
   return (
-    <FormContainer title={heading}>
+    <FormContainer title={heading} classes="max-w-[530px] mx-auto">
       {group && config.features.group_members && (
         <GroupFormHeader group={group} />
       )}

--- a/h/static/scripts/group-forms/components/forms/FormContainer.tsx
+++ b/h/static/scripts/group-forms/components/forms/FormContainer.tsx
@@ -1,14 +1,20 @@
+import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 
 export type FormContainerProps = {
   title: string;
   children: ComponentChildren;
+  classes?: string;
 };
 
 /** A container for a form with a title. */
-export default function FormContainer({ children, title }: FormContainerProps) {
+export default function FormContainer({
+  children,
+  classes,
+  title,
+}: FormContainerProps) {
   return (
-    <div className="text-grey-6 text-sm/relaxed">
+    <div className={classnames('text-grey-6 text-sm/relaxed', classes)}>
       <h1 className="mt-14 mb-8 text-grey-7 text-xl/none" data-testid="header">
         {title}
       </h1>

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -6,6 +6,9 @@ export type GroupType = 'private' | 'restricted' | 'open';
 /** Member role within a group. */
 export type Role = 'owner' | 'admin' | 'moderator' | 'member';
 
+/** A date and time in ISO format (eg. "2024-12-09T07:17:52+00:00") */
+export type ISODateTime = string;
+
 /**
  * Request to create or update a group.
  *
@@ -36,6 +39,12 @@ export type GroupMember = {
   username: string;
   actions: string[];
   roles: Role[];
+
+  /** Timestamp when user joined group. `null` if before Dec 2024. */
+  created: ISODateTime | null;
+
+  /** Timestamp when membership was last updated. `null` if before Dec 2024. */
+  updated: ISODateTime | null;
 };
 
 export type PaginatedResponse<Item> = {

--- a/h/static/styles/components/_form-container.scss
+++ b/h/static/styles/components/_form-container.scss
@@ -18,6 +18,10 @@
     padding-right: $h-padding;
   }
 
+  .form-container--wide {
+    max-width: 700px;
+  }
+
   .form-container--popup {
     max-width: #{340px + ($h-padding * 2)};
   }

--- a/h/templates/groups/create_edit.html.jinja2
+++ b/h/templates/groups/create_edit.html.jinja2
@@ -11,8 +11,10 @@
 {% endblock %}
 
 {% block page_content %}
+<div class="form-container form-container--wide">
   <div id="group-form"></div>
   <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
+</div>
 {% endblock %}
 
 {% block scripts %}

--- a/h/templates/groups/join.html.jinja2
+++ b/h/templates/groups/join.html.jinja2
@@ -3,6 +3,7 @@
 {% set page_title = group.name %}
 
 {% block page_content %}
+<div class="form-container">
   <div class="join-group-form">
     <h1 class="form-header">Group invitation</h1>
 
@@ -37,4 +38,5 @@
   <footer class="form-footer">
     What is Hypothesis? <a class="link--footer" href="https://hypothes.is/about">Learn more</a>
   </footer>
+</div>
 {% endblock page_content %}

--- a/h/templates/layouts/group.html.jinja2
+++ b/h/templates/layouts/group.html.jinja2
@@ -8,9 +8,7 @@
 
 {% block content %}
   <div class="content paper">
-    <div class="form-container">
-      {% include "h:templates/includes/flash-messages.html.jinja2" %}
-      {{ self.page_content() }}
-    </div>
+    {% include "h:templates/includes/flash-messages.html.jinja2" %}
+    {{ self.page_content() }}
   </div>
 {% endblock content %}


### PR DESCRIPTION
Make the group members table wider so it has space for an additional column and can also display longer usernames / display names before eliding. Add a "Joined" column to the table that displays the user's join date if known, or ~~placeholder text~~ (_nothing_) if they joined before we started recording this information (~ 5th Dec 2024).

_Edit:_ After discussion this has been changed to show nothing in the Joined column if the join date is unknown.

<img width="733" alt="Joined date column" src="https://github.com/user-attachments/assets/be1deb3c-0141-4ad3-b68f-4948b6e0b5c1">
