### PR TITLE
enable users to call add member API

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -265,6 +265,8 @@ components:
       $ref: './schemas/user-new.yaml#/User'
     UserUpdate:
       $ref: './schemas/user-update.yaml#/User'
+    Membership:
+      $ref: './schemas/membership.yaml#/Membership'
 
 # -----------------------------------------------------------------------------
 # API OPERATIONS
@@ -895,8 +897,12 @@ paths:
         - $ref: '#/components/parameters/GroupID'
         - $ref: '#/components/parameters/UserID'
       responses:
-        '204':
-          $ref: '#/components/responses/NoContent'
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Membership'
 
     # ----------------------------------------------------------
     # DELETE groups/{id}/members/{user} - Remove user from group

--- a/docs/_extra/api-reference/hypothesis-v2.yaml
+++ b/docs/_extra/api-reference/hypothesis-v2.yaml
@@ -263,6 +263,8 @@ components:
       $ref: './schemas/user-new.yaml#/User'
     UserUpdate:
       $ref: './schemas/user-update.yaml#/User'
+    Membership:
+      $ref: './schemas/membership.yaml#/Membership'
 
 # -----------------------------------------------------------------------------
 # API OPERATIONS
@@ -893,8 +895,12 @@ paths:
         - $ref: '#/components/parameters/GroupID'
         - $ref: '#/components/parameters/UserID'
       responses:
-        '204':
-          $ref: '#/components/responses/NoContent'
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Membership'
 
     # ----------------------------------------------------------
     # DELETE groups/{id}/members/{user} - Remove user from group

--- a/docs/_extra/api-reference/schemas/membership.yaml
+++ b/docs/_extra/api-reference/schemas/membership.yaml
@@ -1,0 +1,41 @@
+Membership:
+  type: object
+  properties:
+    authority:
+      type: string
+      example: "hypothes.is"
+    userid:
+      type: string
+      description: "The member's unique ID"
+      example: "acct:felicity_nunsun@hypothes.is"
+    username:
+      type: string
+      description: "The member's username"
+      example: "felicity_nunsun"
+    display_name:
+      type: string
+      description: "The member's display name"
+      example: "Felicity Nunsun"
+    roles:
+      type: array
+      items:
+        type: string
+      description: "The member's roles in the group"
+      example: ["moderator"]
+    actions:
+      type: array
+      items:
+        type: string
+      description: "The actions that the authenticated user can take against this membership"
+      example: ["delete", "updates.roles.member"]
+    created:
+      type: string
+      format: date-time
+      description: "When the member joined the group"
+      example: "1970-01-01T00:00:00.000000+00:00"
+    updated:
+      type: string
+      format: date-time
+      description: "When this membership was last updated (for example to change the role)"
+      example: "1970-01-01T00:00:00.000000+00:00"
+

--- a/h/security/permission_map.py
+++ b/h/security/permission_map.py
@@ -66,7 +66,10 @@ PERMISSION_MAP = {
         [p.group_has_user_as_admin],
         [p.group_has_user_as_moderator],
     ],
-    Permission.Group.MEMBER_ADD: [[p.group_matches_authenticated_client_authority]],
+    Permission.Group.MEMBER_ADD: [
+        [p.group_member_add],
+        [p.group_matches_authenticated_client_authority],
+    ],
     Permission.Group.MEMBER_REMOVE: [[p.group_member_remove]],
     Permission.Group.MEMBER_EDIT: [[p.group_member_edit]],
     Permission.Group.MODERATE: GROUP_MODERATE_PREDICATES.values(),

--- a/h/security/predicates.py
+++ b/h/security/predicates.py
@@ -13,7 +13,11 @@ group.
 from itertools import chain
 
 from h.models.group import GroupMembershipRoles, JoinableBy, ReadableBy, WriteableBy
-from h.traversal import EditGroupMembershipContext, GroupMembershipContext
+from h.traversal import (
+    AddGroupMembershipContext,
+    EditGroupMembershipContext,
+    GroupMembershipContext,
+)
 
 
 def requires(*parent_predicates):
@@ -215,6 +219,32 @@ def group_member_remove(identity, context: GroupMembershipContext):
         or "admin" in authenticated_users_membership.roles
         or "moderator" in authenticated_users_membership.roles
     )
+
+
+@requires(authenticated_user, group_found)
+def group_member_add(identity, context: AddGroupMembershipContext):
+    def get_authenticated_users_roles():
+        """Return the authenticated users roles in the target group."""
+        for membership in identity.user.memberships:
+            if membership.group.id == context.group.id:
+                return membership.roles
+
+        return []
+
+    authenticated_users_roles = get_authenticated_users_roles()
+
+    if GroupMembershipRoles.OWNER in authenticated_users_roles:
+        # Owners can add members with any roles.
+        return True
+
+    if GroupMembershipRoles.ADMIN in authenticated_users_roles:
+        # Admins can add members with any role below admin.
+        return (
+            GroupMembershipRoles.OWNER not in context.roles
+            and GroupMembershipRoles.ADMIN not in context.roles
+        )
+
+    return False
 
 
 @requires(authenticated_user, group_found)

--- a/h/services/group_members.py
+++ b/h/services/group_members.py
@@ -111,7 +111,7 @@ class GroupMembersService:
         for userid in userids_for_removal:
             self.member_leave(group, userid)
 
-    def member_join(self, group, userid):
+    def member_join(self, group, userid) -> GroupMembership:
         """Add `userid` to the member list of `group`."""
         user = self.user_fetcher(userid)
 
@@ -119,7 +119,7 @@ class GroupMembersService:
 
         if existing_membership:
             # The user is already a member of the group.
-            return
+            return existing_membership
 
         membership = GroupMembership(group=group, user=user)
         self.db.add(membership)
@@ -129,6 +129,8 @@ class GroupMembersService:
 
         log.info("Added group membership: %r", membership)
         self.publish("group-join", group.pubid, userid)
+
+        return membership
 
     def member_leave(self, group, userid):
         """Remove `userid` from the member list of `group`."""

--- a/h/services/group_members.py
+++ b/h/services/group_members.py
@@ -111,8 +111,9 @@ class GroupMembersService:
         for userid in userids_for_removal:
             self.member_leave(group, userid)
 
-    def member_join(self, group, userid) -> GroupMembership:
+    def member_join(self, group, userid, roles=None) -> GroupMembership:
         """Add `userid` to the member list of `group`."""
+
         user = self.user_fetcher(userid)
 
         existing_membership = self.get_membership(group, user)
@@ -121,7 +122,12 @@ class GroupMembersService:
             # The user is already a member of the group.
             return existing_membership
 
-        membership = GroupMembership(group=group, user=user)
+        kwargs = {"group": group, "user": user}
+
+        if roles is not None:
+            kwargs["roles"] = roles
+
+        membership = GroupMembership(**kwargs)
         self.db.add(membership)
 
         # Flush the DB to generate SQL defaults for `membership` before logging it.

--- a/h/services/group_members.py
+++ b/h/services/group_members.py
@@ -9,6 +9,10 @@ from h.models import Group, GroupMembership, GroupMembershipRoles, User
 log = logging.getLogger(__name__)
 
 
+class ConflictError(Exception):
+    """A conflicting group membership already exists in the DB."""
+
+
 class GroupMembersService:
     """A service for manipulating group membership."""
 
@@ -112,22 +116,33 @@ class GroupMembersService:
             self.member_leave(group, userid)
 
     def member_join(self, group, userid, roles=None) -> GroupMembership:
-        """Add `userid` to the member list of `group`."""
+        """
+        Add `userid` to `group` with `roles` and return the resulting membership.
+
+        If `roles=None` it will default to `[GroupMembershipRoles.MEMBER]`.
+
+        If a membership matching `group`, `userid` and `roles` already exists
+        in the DB it will just be returned.
+
+        :raise ConflictError: if a membership already exists with the given
+            group and userid but different roles
+        """
+        roles = roles or [GroupMembershipRoles.MEMBER]
 
         user = self.user_fetcher(userid)
 
-        existing_membership = self.get_membership(group, user)
+        kwargs = {"roles": roles}
 
-        if existing_membership:
-            # The user is already a member of the group.
+        if existing_membership := self.get_membership(group, user):
+            for key, value in kwargs.items():
+                if getattr(existing_membership, key) != value:
+                    raise ConflictError(
+                        "The user is already a member of the group, with conflicting membership attributes"
+                    )
+
             return existing_membership
 
-        kwargs = {"group": group, "user": user}
-
-        if roles is not None:
-            kwargs["roles"] = roles
-
-        membership = GroupMembership(**kwargs)
+        membership = GroupMembership(group=group, user=user, **kwargs)
         self.db.add(membership)
 
         # Flush the DB to generate SQL defaults for `membership` before logging it.

--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -63,6 +63,7 @@ shouldn't return model objects directly).
 from h.traversal.annotation import AnnotationContext, AnnotationRoot
 from h.traversal.group import GroupContext, GroupRequiredRoot, GroupRoot
 from h.traversal.group_membership import (
+    AddGroupMembershipContext,
     EditGroupMembershipContext,
     GroupMembershipContext,
     group_membership_api_factory,
@@ -82,6 +83,7 @@ __all__ = (
     "UserByIDRoot",
     "UserRoot",
     "GroupContext",
+    "AddGroupMembershipContext",
     "EditGroupMembershipContext",
     "GroupMembershipContext",
     "group_membership_api_factory",

--- a/h/traversal/group_membership.py
+++ b/h/traversal/group_membership.py
@@ -14,6 +14,13 @@ class GroupMembershipContext:
 
 
 @dataclass
+class AddGroupMembershipContext:
+    group: Group
+    user: User
+    roles: list[GroupMembershipRoles]
+
+
+@dataclass
 class EditGroupMembershipContext:
     group: Group
     user: User

--- a/h/views/api/group_members.py
+++ b/h/views/api/group_members.py
@@ -96,14 +96,14 @@ def remove_member(context: GroupMembershipContext, request):
     permission=Permission.Group.MEMBER_ADD,
 )
 def add_member(context: GroupMembershipContext, request):
-    group_members_service = request.find_service(name="group_members")
-
     if context.user.authority != context.group.authority:
         raise HTTPNotFound()
 
-    group_members_service.member_join(context.group, context.user.userid)
+    group_members_service = request.find_service(name="group_members")
 
-    return HTTPNoContent()
+    membership = group_members_service.member_join(context.group, context.user.userid)
+
+    return GroupMembershipJSONPresenter(request, membership).asdict()
 
 
 @api_config(

--- a/h/views/api/group_members.py
+++ b/h/views/api/group_members.py
@@ -1,13 +1,14 @@
 import logging
 
 from pyramid.config import not_
-from pyramid.httpexceptions import HTTPNoContent, HTTPNotFound
+from pyramid.httpexceptions import HTTPConflict, HTTPNoContent, HTTPNotFound
 
 from h.presenters import GroupMembershipJSONPresenter
 from h.schemas.api.group_membership import EditGroupMembershipAPISchema
 from h.schemas.pagination import PaginationQueryParamsSchema
 from h.schemas.util import validate_query_params
 from h.security import Permission
+from h.services.group_members import ConflictError
 from h.traversal import EditGroupMembershipContext, GroupContext, GroupMembershipContext
 from h.views.api.config import api_config
 from h.views.api.helpers.json_payload import json_payload
@@ -104,14 +105,17 @@ def add_member(context: GroupMembershipContext, request):
         roles = appstruct["roles"]
     else:
         # This doesn't mean the membership will be created with no roles:
-        # there's a server_default in the DB schema that will be applied.
+        # default roles will be applied by the service.
         roles = None
 
     group_members_service = request.find_service(name="group_members")
 
-    membership = group_members_service.member_join(
-        context.group, context.user.userid, roles
-    )
+    try:
+        membership = group_members_service.member_join(
+            context.group, context.user.userid, roles
+        )
+    except ConflictError as err:
+        raise HTTPConflict(str(err)) from err
 
     return GroupMembershipJSONPresenter(request, membership).asdict()
 

--- a/h/views/api/group_members.py
+++ b/h/views/api/group_members.py
@@ -99,9 +99,19 @@ def add_member(context: GroupMembershipContext, request):
     if context.user.authority != context.group.authority:
         raise HTTPNotFound()
 
+    if request.body:
+        appstruct = EditGroupMembershipAPISchema().validate(json_payload(request))
+        roles = appstruct["roles"]
+    else:
+        # This doesn't mean the membership will be created with no roles:
+        # there's a server_default in the DB schema that will be applied.
+        roles = None
+
     group_members_service = request.find_service(name="group_members")
 
-    membership = group_members_service.member_join(context.group, context.user.userid)
+    membership = group_members_service.member_join(
+        context.group, context.user.userid, roles
+    )
 
     return GroupMembershipJSONPresenter(request, membership).asdict()
 

--- a/h/views/api/group_members.py
+++ b/h/views/api/group_members.py
@@ -3,13 +3,19 @@ import logging
 from pyramid.config import not_
 from pyramid.httpexceptions import HTTPConflict, HTTPNoContent, HTTPNotFound
 
+from h.models import GroupMembershipRoles
 from h.presenters import GroupMembershipJSONPresenter
 from h.schemas.api.group_membership import EditGroupMembershipAPISchema
 from h.schemas.pagination import PaginationQueryParamsSchema
 from h.schemas.util import validate_query_params
 from h.security import Permission
 from h.services.group_members import ConflictError
-from h.traversal import EditGroupMembershipContext, GroupContext, GroupMembershipContext
+from h.traversal import (
+    AddGroupMembershipContext,
+    EditGroupMembershipContext,
+    GroupContext,
+    GroupMembershipContext,
+)
 from h.views.api.config import api_config
 from h.views.api.helpers.json_payload import json_payload
 
@@ -94,7 +100,6 @@ def remove_member(context: GroupMembershipContext, request):
     request_method="POST",
     link_name="group.member.add",
     description="Add a user to a group",
-    permission=Permission.Group.MEMBER_ADD,
 )
 def add_member(context: GroupMembershipContext, request):
     if context.user.authority != context.group.authority:
@@ -104,9 +109,13 @@ def add_member(context: GroupMembershipContext, request):
         appstruct = EditGroupMembershipAPISchema().validate(json_payload(request))
         roles = appstruct["roles"]
     else:
-        # This doesn't mean the membership will be created with no roles:
-        # default roles will be applied by the service.
-        roles = None
+        roles = [GroupMembershipRoles.MEMBER]
+
+    if not request.has_permission(
+        Permission.Group.MEMBER_ADD,
+        AddGroupMembershipContext(context.group, context.user, roles),
+    ):
+        raise HTTPNotFound()
 
     group_members_service = request.find_service(name="group_members")
 

--- a/tests/functional/api/groups/members_test.py
+++ b/tests/functional/api/groups/members_test.py
@@ -357,7 +357,7 @@ class TestAddMember:
 
     @pytest.fixture
     def do_request(self, db_session, app, group, user, headers):
-        def do_request(pubid=group.pubid, userid=user.userid, status=204):
+        def do_request(pubid=group.pubid, userid=user.userid, status=200):
             db_session.commit()
             return app.post_json(
                 f"/api/groups/{pubid}/members/{userid}", headers=headers, status=status

--- a/tests/functional/api/groups/members_test.py
+++ b/tests/functional/api/groups/members_test.py
@@ -287,6 +287,22 @@ class TestAddMember:
 
         assert user in group.members
 
+    def test_it_when_a_conflicting_membership_already_exists(
+        self, do_request, group, user
+    ):
+        group.memberships.append(
+            GroupMembership(user=user, roles=[GroupMembershipRoles.MEMBER])
+        )
+
+        response = do_request(
+            json={"roles": [GroupMembershipRoles.MODERATOR]}, status=409
+        )
+
+        assert (
+            response.json["reason"]
+            == "The user is already a member of the group, with conflicting membership attributes"
+        )
+
     def test_it_errors_if_the_pubid_is_unknown(self, do_request):
         do_request(pubid="UNKNOWN_PUBID", status=404)
 

--- a/tests/functional/api/groups/members_test.py
+++ b/tests/functional/api/groups/members_test.py
@@ -261,10 +261,22 @@ class TestListMembers:
 
 
 class TestAddMember:
-    def test_it(self, do_request, group, user):
-        do_request()
+    @pytest.mark.parametrize(
+        "json,expected_roles",
+        [
+            ({"roles": ["owner"]}, ["owner"]),
+            (None, ["member"]),
+        ],
+    )
+    def test_it(self, do_request, group, user, json, expected_roles):
+        do_request(json=json)
 
-        assert user in group.members
+        for membership in group.memberships:
+            if membership.user == user:
+                assert membership.roles == expected_roles
+                break
+        else:
+            assert False, "No membership was created"
 
     def test_it_does_nothing_if_the_user_is_already_a_member_of_the_group(
         self, do_request, group, user
@@ -357,11 +369,14 @@ class TestAddMember:
 
     @pytest.fixture
     def do_request(self, db_session, app, group, user, headers):
-        def do_request(pubid=group.pubid, userid=user.userid, status=200):
+        def do_request(pubid=group.pubid, userid=user.userid, status=200, json=None):
             db_session.commit()
-            return app.post_json(
-                f"/api/groups/{pubid}/members/{userid}", headers=headers, status=status
-            )
+            path = f"/api/groups/{pubid}/members/{userid}"
+
+            if json is None:
+                return app.post(path, headers=headers, status=status)
+            else:
+                return app.post_json(path, json, headers=headers, status=status)
 
         return do_request
 

--- a/tests/unit/h/security/predicates_test.py
+++ b/tests/unit/h/security/predicates_test.py
@@ -13,6 +13,7 @@ from h.models.group import (
 from h.security import Identity, predicates
 from h.security.identity import LongLivedGroup, LongLivedMembership
 from h.traversal import (
+    AddGroupMembershipContext,
     AnnotationContext,
     EditGroupMembershipContext,
     GroupMembershipContext,
@@ -533,6 +534,89 @@ class TestGroupMemberRemove:
         return GroupMembershipContext(
             group=group, user=user, membership=GroupMembership(group=group, user=user)
         )
+
+
+class TestGroupMemberAdd:
+    @pytest.mark.parametrize(
+        "authenticated_users_roles,target_users_roles,expected_result",
+        [
+            ([GroupMembershipRoles.OWNER], [GroupMembershipRoles.OWNER], True),
+            ([GroupMembershipRoles.OWNER], [GroupMembershipRoles.ADMIN], True),
+            ([GroupMembershipRoles.OWNER], [GroupMembershipRoles.MODERATOR], True),
+            ([GroupMembershipRoles.OWNER], [GroupMembershipRoles.MEMBER], True),
+            ([GroupMembershipRoles.ADMIN], [GroupMembershipRoles.OWNER], False),
+            ([GroupMembershipRoles.ADMIN], [GroupMembershipRoles.ADMIN], False),
+            ([GroupMembershipRoles.ADMIN], [GroupMembershipRoles.MODERATOR], True),
+            ([GroupMembershipRoles.ADMIN], [GroupMembershipRoles.MEMBER], True),
+            ([GroupMembershipRoles.MODERATOR], [GroupMembershipRoles.OWNER], False),
+            ([GroupMembershipRoles.MODERATOR], [GroupMembershipRoles.ADMIN], False),
+            ([GroupMembershipRoles.MODERATOR], [GroupMembershipRoles.MODERATOR], False),
+            ([GroupMembershipRoles.MODERATOR], [GroupMembershipRoles.MEMBER], False),
+            ([GroupMembershipRoles.MEMBER], [GroupMembershipRoles.OWNER], False),
+            ([GroupMembershipRoles.MEMBER], [GroupMembershipRoles.ADMIN], False),
+            ([GroupMembershipRoles.MEMBER], [GroupMembershipRoles.MODERATOR], False),
+            ([GroupMembershipRoles.MEMBER], [GroupMembershipRoles.MEMBER], False),
+            (None, [GroupMembershipRoles.OWNER], False),
+            (None, [GroupMembershipRoles.ADMIN], False),
+            (None, [GroupMembershipRoles.MODERATOR], False),
+            (None, [GroupMembershipRoles.MEMBER], False),
+        ],
+    )
+    def test_it(
+        self,
+        db_session,
+        factories,
+        identity,
+        group,
+        authenticated_users_roles,
+        target_users_roles,
+        expected_result,
+    ):
+        target_user = factories.User()
+        if authenticated_users_roles:
+            identity.user.memberships.append(
+                LongLivedMembership(
+                    group=LongLivedGroup.from_model(group),
+                    user=identity.user,
+                    roles=authenticated_users_roles,
+                )
+            )
+        context = AddGroupMembershipContext(
+            group=group, user=target_user, roles=target_users_roles
+        )
+        db_session.commit()
+
+        assert predicates.group_member_add(identity, context) == expected_result
+
+    @pytest.fixture
+    def authenticated_user(self, db_session, authenticated_user, factories):
+        # Make the authenticated user a member of a *different* group,
+        # to make sure that unrelated memberships don't accidentally allow or
+        # deny permissions.
+        db_session.add(
+            GroupMembership(
+                user=authenticated_user,
+                group=factories.Group(),
+                roles=[GroupMembershipRoles.OWNER],
+            )
+        )
+
+        return authenticated_user
+
+    @pytest.fixture
+    def group(self, db_session, factories):
+        group = factories.Group()
+
+        # Make a *different* user a member of the target group
+        # to make sure that unrelated memberships don't accidentally allow or
+        # deny permissions.
+        db_session.add(
+            GroupMembership(
+                group=group, user=factories.User(), roles=[GroupMembershipRoles.OWNER]
+            )
+        )
+
+        return group
 
 
 class TestGroupMemberEdit:

--- a/tests/unit/h/services/group_members_test.py
+++ b/tests/unit/h/services/group_members_test.py
@@ -7,7 +7,11 @@ import pytest
 from sqlalchemy import select
 
 from h.models import GroupMembership, GroupMembershipRoles, User
-from h.services.group_members import GroupMembersService, group_members_factory
+from h.services.group_members import (
+    ConflictError,
+    GroupMembersService,
+    group_members_factory,
+)
 
 
 class TestGetMembership:
@@ -210,7 +214,9 @@ class TestMemberJoin:
         ).one_or_none()
         assert membership.roles == [GroupMembershipRoles.MEMBER]
 
-    def test_it_is_idempotent(self, group_members_service, factories):
+    def test_it_when_a_matching_membership_already_exists(
+        self, group_members_service, factories
+    ):
         user = factories.User()
         group = factories.Group()
         existing_membership = group_members_service.member_join(group, user.userid)
@@ -219,6 +225,20 @@ class TestMemberJoin:
 
         assert returned == existing_membership
         assert group.members.count(user) == 1
+
+    def test_it_when_a_conflicting_membership_already_exists(
+        self, group_members_service, factories
+    ):
+        user = factories.User()
+        group = factories.Group()
+        group_members_service.member_join(
+            group, user.userid, roles=[GroupMembershipRoles.MEMBER]
+        )
+
+        with pytest.raises(ConflictError):
+            group_members_service.member_join(
+                group, user.userid, roles=[GroupMembershipRoles.MODERATOR]
+            )
 
     def test_it_publishes_join_event(self, group_members_service, factories, publish):
         group = factories.Group()

--- a/tests/unit/h/services/group_members_test.py
+++ b/tests/unit/h/services/group_members_test.py
@@ -183,16 +183,32 @@ class TestMemberJoin:
         caplog.set_level(logging.INFO)
         user = factories.User()
         group = factories.Group()
-        returned = group_members_service.member_join(group, user.userid)
+
+        returned = group_members_service.member_join(
+            group, user.userid, roles=[GroupMembershipRoles.OWNER]
+        )
 
         membership = db_session.scalars(
             select(GroupMembership)
             .where(GroupMembership.user == user)
             .where(GroupMembership.group == group)
         ).one_or_none()
-        assert membership
+        assert membership.roles == [GroupMembershipRoles.OWNER]
         assert returned == membership
         assert caplog.messages == [f"Added group membership: {membership!r}"]
+
+    def test_it_with_no_role(self, group_members_service, factories, db_session):
+        user = factories.User()
+        group = factories.Group()
+
+        group_members_service.member_join(group, user.userid)
+
+        membership = db_session.scalars(
+            select(GroupMembership)
+            .where(GroupMembership.user == user)
+            .where(GroupMembership.group == group)
+        ).one_or_none()
+        assert membership.roles == [GroupMembershipRoles.MEMBER]
 
     def test_it_is_idempotent(self, group_members_service, factories):
         user = factories.User()

--- a/tests/unit/h/views/api/group_members_test.py
+++ b/tests/unit/h/views/api/group_members_test.py
@@ -141,13 +141,23 @@ class TestRemoveMember:
 
 @pytest.mark.usefixtures("group_members_service")
 class TestAddMember:
-    def test_it(self, pyramid_request, group_members_service, context):
+    def test_it(
+        self,
+        pyramid_request,
+        group_members_service,
+        context,
+        GroupMembershipJSONPresenter,
+    ):
         response = views.add_member(context, pyramid_request)
 
         group_members_service.member_join.assert_called_once_with(
             context.group, context.user.userid
         )
-        assert isinstance(response, HTTPNoContent)
+        GroupMembershipJSONPresenter.assert_called_once_with(
+            pyramid_request, group_members_service.member_join.return_value
+        )
+        GroupMembershipJSONPresenter.return_value.asdict.assert_called_once_with()
+        assert response == GroupMembershipJSONPresenter.return_value.asdict.return_value
 
     def test_it_with_authority_mismatch(self, pyramid_request, context):
         context.group.authority = "other"

--- a/tests/unit/h/views/api/group_members_test.py
+++ b/tests/unit/h/views/api/group_members_test.py
@@ -147,17 +147,54 @@ class TestAddMember:
         group_members_service,
         context,
         GroupMembershipJSONPresenter,
+        EditGroupMembershipAPISchema,
     ):
         response = views.add_member(context, pyramid_request)
 
+        EditGroupMembershipAPISchema.assert_called_once_with()
+        EditGroupMembershipAPISchema.return_value.validate.assert_called_once_with(
+            sentinel.json_body
+        )
         group_members_service.member_join.assert_called_once_with(
-            context.group, context.user.userid
+            context.group, context.user.userid, roles=sentinel.roles
         )
         GroupMembershipJSONPresenter.assert_called_once_with(
             pyramid_request, group_members_service.member_join.return_value
         )
         GroupMembershipJSONPresenter.return_value.asdict.assert_called_once_with()
         assert response == GroupMembershipJSONPresenter.return_value.asdict.return_value
+
+    def test_it_with_no_request_body(
+        self,
+        pyramid_request,
+        group_members_service,
+        context,
+        EditGroupMembershipAPISchema,
+    ):
+        pyramid_request.body = b""
+
+        views.add_member(context, pyramid_request)
+
+        EditGroupMembershipAPISchema.assert_not_called()
+        group_members_service.member_join.assert_called_once_with(
+            context.group, context.user.userid, roles=None
+        )
+
+    def test_it_errors_if_the_request_isnt_valid_JSON(
+        self, context, pyramid_request, mocker
+    ):
+        value_error = ValueError()
+        mocker.patch.object(
+            type(pyramid_request),
+            "json_body",
+            PropertyMock(side_effect=value_error),
+            create=True,
+        )
+
+        with pytest.raises(PayloadError) as exc_info:
+            views.add_member(context, pyramid_request)
+
+        assert exc_info.value.__cause__ == value_error
 
     def test_it_with_authority_mismatch(self, pyramid_request, context):
         context.group.authority = "other"
@@ -170,6 +207,19 @@ class TestAddMember:
         group = factories.Group.build()
         user = factories.User.build(authority=group.authority)
         return GroupMembershipContext(group=group, user=user, membership=None)
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.body = sentinel.body
+        pyramid_request.json_body = sentinel.json_body
+        return pyramid_request
+
+    @pytest.fixture
+    def EditGroupMembershipAPISchema(self, EditGroupMembershipAPISchema):
+        EditGroupMembershipAPISchema.return_value.validate.return_value = {
+            "roles": sentinel.roles
+        }
+        return EditGroupMembershipAPISchema
 
 
 class TestEditMember:

--- a/tests/unit/h/views/api/group_members_test.py
+++ b/tests/unit/h/views/api/group_members_test.py
@@ -2,13 +2,14 @@ import logging
 from unittest.mock import PropertyMock, call, create_autospec, sentinel
 
 import pytest
-from pyramid.httpexceptions import HTTPNoContent, HTTPNotFound
+from pyramid.httpexceptions import HTTPConflict, HTTPNoContent, HTTPNotFound
 
 import h.views.api.group_members as views
 from h import presenters
 from h.models import GroupMembership
 from h.schemas.base import ValidationError
 from h.security.identity import Identity, LongLivedGroup, LongLivedMembership
+from h.services.group_members import ConflictError
 from h.traversal import GroupContext, GroupMembershipContext
 from h.views.api.exceptions import PayloadError
 
@@ -179,6 +180,16 @@ class TestAddMember:
         group_members_service.member_join.assert_called_once_with(
             context.group, context.user.userid, roles=None
         )
+
+    def test_it_when_a_conflicting_membership_already_exists(
+        self, pyramid_request, group_members_service, context
+    ):
+        group_members_service.member_join.side_effect = ConflictError(
+            "test_error_message"
+        )
+
+        with pytest.raises(HTTPConflict, match="^test_error_message$"):
+            views.add_member(context, pyramid_request)
 
     def test_it_errors_if_the_request_isnt_valid_JSON(
         self, context, pyramid_request, mocker

--- a/tests/unit/h/views/api/group_members_test.py
+++ b/tests/unit/h/views/api/group_members_test.py
@@ -6,7 +6,7 @@ from pyramid.httpexceptions import HTTPConflict, HTTPNoContent, HTTPNotFound
 
 import h.views.api.group_members as views
 from h import presenters
-from h.models import GroupMembership
+from h.models import GroupMembership, GroupMembershipRoles
 from h.schemas.base import ValidationError
 from h.security.identity import Identity, LongLivedGroup, LongLivedMembership
 from h.services.group_members import ConflictError
@@ -165,6 +165,14 @@ class TestAddMember:
         GroupMembershipJSONPresenter.return_value.asdict.assert_called_once_with()
         assert response == GroupMembershipJSONPresenter.return_value.asdict.return_value
 
+    def test_it_errors_if_the_user_doesnt_have_permission(
+        self, context, pyramid_request, pyramid_config
+    ):
+        pyramid_config.testing_securitypolicy(permissive=False)
+
+        with pytest.raises(HTTPNotFound):
+            views.add_member(context, pyramid_request)
+
     def test_it_with_no_request_body(
         self,
         pyramid_request,
@@ -178,7 +186,7 @@ class TestAddMember:
 
         EditGroupMembershipAPISchema.assert_not_called()
         group_members_service.member_join.assert_called_once_with(
-            context.group, context.user.userid, roles=None
+            context.group, context.user.userid, roles=[GroupMembershipRoles.MEMBER]
         )
 
     def test_it_when_a_conflicting_membership_already_exists(


### PR DESCRIPTION
- **Add response body to add-member API**
- **Support setting role in add-member API requests**
- **409 if a conflicting membership already exists**
- **Allow users to call the add-membership API**
