### PR TITLE
Pass the right `context` objects to `edit_member()` and `add_member()`

### DIFF
--- a/h/security/predicates.py
+++ b/h/security/predicates.py
@@ -221,6 +221,10 @@ def group_member_remove(identity, context: GroupMembershipContext):
 def group_member_edit(
     identity, context: EditGroupMembershipContext
 ):  # pylint:disable=too-many-return-statements,too-complex
+    assert (
+        context.new_roles is not None
+    ), "new_roles must be set before checking permissions"
+
     old_roles = context.membership.roles
     new_roles = context.new_roles
 

--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -63,6 +63,7 @@ shouldn't return model objects directly).
 from h.traversal.annotation import AnnotationContext, AnnotationRoot
 from h.traversal.group import GroupContext, GroupRequiredRoot, GroupRoot
 from h.traversal.group_membership import (
+    AddGroupMembershipContext,
     EditGroupMembershipContext,
     GroupMembershipContext,
     group_membership_api_factory,
@@ -82,6 +83,7 @@ __all__ = (
     "UserByIDRoot",
     "UserRoot",
     "GroupContext",
+    "AddGroupMembershipContext",
     "EditGroupMembershipContext",
     "GroupMembershipContext",
     "group_membership_api_factory",

--- a/h/views/api/group_members.py
+++ b/h/views/api/group_members.py
@@ -9,7 +9,12 @@ from h.schemas.pagination import PaginationQueryParamsSchema
 from h.schemas.util import validate_query_params
 from h.security import Permission
 from h.services.group_members import ConflictError
-from h.traversal import EditGroupMembershipContext, GroupContext, GroupMembershipContext
+from h.traversal import (
+    AddGroupMembershipContext,
+    EditGroupMembershipContext,
+    GroupContext,
+    GroupMembershipContext,
+)
 from h.views.api.config import api_config
 from h.views.api.helpers.json_payload import json_payload
 
@@ -108,7 +113,7 @@ def remove_member(context: GroupMembershipContext, request):
     description="Add a user to a group",
     permission=Permission.Group.MEMBER_ADD,
 )
-def add_member(context: GroupMembershipContext, request):
+def add_member(context: AddGroupMembershipContext, request):
     if context.user.authority != context.group.authority:
         raise HTTPNotFound()
 
@@ -139,21 +144,16 @@ def add_member(context: GroupMembershipContext, request):
     link_name="group.member.edit",
     description="Change a user's role in a group",
 )
-def edit_member(context: GroupMembershipContext, request):
+def edit_member(context: EditGroupMembershipContext, request):
     appstruct = EditGroupMembershipAPISchema().validate(json_payload(request))
-    new_roles = appstruct["roles"]
+    context.new_roles = appstruct["roles"]
 
-    if not request.has_permission(
-        Permission.Group.MEMBER_EDIT,
-        EditGroupMembershipContext(
-            context.group, context.user, context.membership, new_roles
-        ),
-    ):
+    if not request.has_permission(Permission.Group.MEMBER_EDIT, context):
         raise HTTPNotFound()
 
-    if context.membership.roles != new_roles:
+    if context.membership.roles != context.new_roles:
         old_roles = context.membership.roles
-        context.membership.roles = new_roles
+        context.membership.roles = context.new_roles
         log.info(
             "Changed group membership roles: %r (previous roles were: %r)",
             context.membership,
@@ -166,6 +166,6 @@ def edit_member(context: GroupMembershipContext, request):
         # Otherwise permissions checks will be based on the old roles.
         for membership in request.identity.user.memberships:
             if membership.group.id == context.group.id:
-                membership.roles = new_roles
+                membership.roles = context.new_roles
 
     return GroupMembershipJSONPresenter(request, context.membership).asdict()

--- a/tests/unit/h/security/predicates_test.py
+++ b/tests/unit/h/security/predicates_test.py
@@ -1027,6 +1027,20 @@ class TestGroupMemberEdit:
 
         assert predicates.group_member_edit(identity, context) == expected_result
 
+    def test_it_crashes_if_new_roles_is_not_set(self, identity):
+        context = EditGroupMembershipContext(
+            group=sentinel.group,
+            user=sentinel.user,
+            membership=sentinel.membership,
+            new_roles=None,
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="^new_roles must be set before checking permissions$",
+        ):
+            predicates.group_member_edit(identity, context)
+
     @pytest.fixture
     def authenticated_user(self, db_session, authenticated_user, factories):
         # Make the authenticated user a member of a *different* group,

--- a/tests/unit/h/traversal/group_membership_test.py
+++ b/tests/unit/h/traversal/group_membership_test.py
@@ -6,6 +6,8 @@ from pyramid.httpexceptions import HTTPNotFound
 
 from h.exceptions import InvalidUserId
 from h.traversal.group_membership import (
+    AddGroupMembershipContext,
+    EditGroupMembershipContext,
     GroupMembershipContext,
     group_membership_api_factory,
 )
@@ -13,9 +15,17 @@ from h.traversal.group_membership import (
 
 @pytest.mark.usefixtures("group_service", "user_service", "group_members_service")
 class TestGroupMembershipAPIFactory:
-    def test_it(
-        self, group_service, user_service, group_members_service, pyramid_request
+    @pytest.mark.parametrize("request_method", ["GET", "DELETE"])
+    def test_get_delete(
+        self,
+        group_service,
+        user_service,
+        group_members_service,
+        pyramid_request,
+        request_method,
     ):
+        pyramid_request.method = request_method
+
         context = group_membership_api_factory(pyramid_request)
 
         group_service.fetch.assert_called_once_with(sentinel.pubid)
@@ -28,25 +38,70 @@ class TestGroupMembershipAPIFactory:
         assert context.user == user_service.fetch.return_value
         assert context.membership == group_members_service.get_membership.return_value
 
-    def test_when_no_matching_group(self, group_service, pyramid_request):
+    def test_post(
+        self, group_service, user_service, group_members_service, pyramid_request
+    ):
+        pyramid_request.method = "POST"
+
+        context = group_membership_api_factory(pyramid_request)
+
+        group_service.fetch.assert_called_once_with(sentinel.pubid)
+        user_service.fetch.assert_called_once_with(sentinel.userid)
+        group_members_service.get_membership.assert_not_called()
+        assert isinstance(context, AddGroupMembershipContext)
+        assert context.group == group_service.fetch.return_value
+        assert context.user == user_service.fetch.return_value
+        assert context.new_roles is None
+
+    def test_patch(
+        self, group_service, user_service, group_members_service, pyramid_request
+    ):
+        pyramid_request.method = "PATCH"
+
+        context = group_membership_api_factory(pyramid_request)
+
+        group_service.fetch.assert_called_once_with(sentinel.pubid)
+        user_service.fetch.assert_called_once_with(sentinel.userid)
+        group_members_service.get_membership.assert_called_once_with(
+            group_service.fetch.return_value, user_service.fetch.return_value
+        )
+        assert isinstance(context, EditGroupMembershipContext)
+        assert context.group == group_service.fetch.return_value
+        assert context.user == user_service.fetch.return_value
+        assert context.membership == group_members_service.get_membership.return_value
+        assert context.new_roles is None
+
+    @pytest.mark.parametrize("request_method", ["GET", "POST", "PATCH", "DELETE"])
+    def test_when_no_matching_group(
+        self, group_service, pyramid_request, request_method
+    ):
+        pyramid_request.method = request_method
         group_service.fetch.return_value = None
 
         with pytest.raises(HTTPNotFound, match="Group not found: sentinel.pubid"):
             group_membership_api_factory(pyramid_request)
 
-    def test_when_no_matching_user(self, user_service, pyramid_request):
+    @pytest.mark.parametrize("request_method", ["GET", "POST", "PATCH", "DELETE"])
+    def test_when_no_matching_user(self, user_service, pyramid_request, request_method):
+        pyramid_request.method = request_method
         user_service.fetch.return_value = None
 
         with pytest.raises(HTTPNotFound, match="User not found: sentinel.userid"):
             group_membership_api_factory(pyramid_request)
 
-    def test_when_invalid_userid(self, user_service, pyramid_request):
+    @pytest.mark.parametrize("request_method", ["GET", "POST", "PATCH", "DELETE"])
+    def test_when_invalid_userid(self, user_service, pyramid_request, request_method):
+        pyramid_request.method = request_method
         user_service.fetch.side_effect = InvalidUserId(sentinel.userid)
 
         with pytest.raises(HTTPNotFound, match="User not found: sentinel.userid"):
             group_membership_api_factory(pyramid_request)
 
-    def test_when_no_matching_membership(self, group_members_service, pyramid_request):
+    @pytest.mark.parametrize("request_method", ["GET", "PATCH", "DELETE"])
+    def test_when_no_matching_membership(
+        self, group_members_service, pyramid_request, request_method
+    ):
+        pyramid_request.method = request_method
         group_members_service.get_membership.return_value = None
 
         with pytest.raises(
@@ -55,7 +110,11 @@ class TestGroupMembershipAPIFactory:
         ):
             group_membership_api_factory(pyramid_request)
 
-    def test_me_alias(self, pyramid_config, pyramid_request, user_service):
+    @pytest.mark.parametrize("request_method", ["GET", "POST", "PATCH", "DELETE"])
+    def test_me_alias(
+        self, pyramid_config, pyramid_request, user_service, request_method
+    ):
+        pyramid_request.method = request_method
         pyramid_config.testing_securitypolicy(userid=sentinel.userid)
         pyramid_request.matchdict["userid"] = "me"
 
@@ -63,7 +122,9 @@ class TestGroupMembershipAPIFactory:
 
         user_service.fetch.assert_called_once_with(sentinel.userid)
 
-    def test_me_alias_when_not_authenticated(self, pyramid_request):
+    @pytest.mark.parametrize("request_method", ["GET", "POST", "PATCH", "DELETE"])
+    def test_me_alias_when_not_authenticated(self, pyramid_request, request_method):
+        pyramid_request.method = request_method
         pyramid_request.matchdict["userid"] = "me"
 
         with pytest.raises(HTTPNotFound, match="User not found: me"):


### PR DESCRIPTION
Background
----------

Pyramid has the handy concept of a "context" object for a request, named `context`. The way the context object works is:

* `routes.py` defines the "factory" for the `"api.group_member"` route:

  ```python
  config.add_route(
      "api.group_member",
      "/api/groups/{pubid}/members/{userid}",
      factory="h.traversal.group_membership_api_factory",
  )
  ```

* The `factory="h.traversal.group_membership_api_factory"` means that whenever a request for `/api/groups/{pubid}/members/{userid}` comes in Pyramid will call [`group_membership_api_factory()`](https://github.com/hypothesis/h/blob/cfe86f0976524e9ec4e54b566578124759872601/h/traversal/group_membership.py#L24-L59) to get the context object.

* `group_membership_api_factory()` returns a `GroupMembershipContext` object for the `context`:

  ```python
  @dataclass
  class GroupMembershipContext:
      group: Group
      user: User
      membership: GroupMembership | None
  ```

* Pyramid then passes that object as the `context` argument to various layers in its [request processing cycle](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/router.html). For example:

  * The "predicate functions" in [`security/predicates.py`](https://github.com/hypothesis/h/blob/cfe86f0976524e9ec4e54b566578124759872601/h/security/predicates.py#L1-L313) (which make security decisions about whether to permit or deny a request) receive `context` as an argument. 
  * Views also receive `context` as an argument. There are [three views for the `"api.group_member"` route](https://github.com/hypothesis/h/blob/cfe86f0976524e9ec4e54b566578124759872601/h/views/api/group_members.py#L74-L145) (`remove_member()`, `edit_member()` and `add_member()`, https://github.com/hypothesis/h/pull/9197 will also add `get_member()`) that all receive `GroupMembershipContext` objects as the `context` argument.
  * The context object is also available in lots of other places, either passed into things as the `context` argument or available via the `request` object as `request.context`.

Problem
-------

`group_membership_api_factory()` is the context factory for all views that use the `"api.group_member"` route:

* [`remove_member()`](https://github.com/hypothesis/h/blob/cfe86f0976524e9ec4e54b566578124759872601/h/views/api/group_members.py#L74-L87) (`request_method="DELETE"`)
* [`add_member()`](https://github.com/hypothesis/h/blob/cfe86f0976524e9ec4e54b566578124759872601/h/views/api/group_members.py#L90-L106) (`request_method="POST"`)
* [`edit_member()`](https://github.com/hypothesis/h/blob/cfe86f0976524e9ec4e54b566578124759872601/h/views/api/group_members.py#L109-L145) (`request_method="PATCH"`)
* Add in https://github.com/hypothesis/h/pull/9197 also `get_member()` (`request_method="GET"`)

`group_membership_api_factory()` returns a `GroupMembershipContext` object but:

* `GroupMembershipContext` isn't the right context for `edit_member()`: it lacks the `context.new_roles` attribute for the new roles that the request wants to change `context.membership.roles` to.

* `GroupMembershipContext` isn't the right context for `add_member()`: it has an inappropriate `context.membership` attribute that has to be set to `None` (when adding a new membership there shouldn't be an existing membership in the context) and it lacks the `context.new_roles` attribute for the roles that the request wants to create a new membership with.

The context for the `edit_member()` view should be an `EditGroupMembershipContext` object, and for `add_member()` it should be an `AddGroupMembershipContext`.

As a result the `edit_member()` view has to create its own context object to pass to `request.has_permission()`:

https://github.com/hypothesis/h/blob/cfe86f0976524e9ec4e54b566578124759872601/h/views/api/group_members.py#L116-L126

When a future PR (https://github.com/hypothesis/h/pull/9200) enables users (not just auth clients) to call the add-membership API the `add_member()` view will have to do something
similar: constructing its own `AddGroupMembershipContext` object and passing it to `request.has_permission()`.

This means there are two different context objects in play for the `edit_member()` and `add_member()` views: the `context` that is passed to the view is a `GroupMembershipContext`, but the `context` that is passed to `request.has_permission()` is an `EditGroupMembershipContext` or `AddGroupMembershipContext` constructed by the view itself.

Solution
--------

This commit changes `group_membership_api_factory()` to return a `GroupMembershipContext` for `GET` and `DELETE` requests but return an `EditGroupMembershipContext` for `PATCH` requests and an `AddGroupMembershipContext` for `POST`s.

It's not possible for `group_membership_api_factory()` to set the context's `new_roles` attribute: the value for `new_roles` isn't available until later in the request processing cycle after the view has parsed and validated the request's JSON body. So the factory returns `context` objects with `context.new_roles=None` and the `edit_member()` view has to set `new_roles` before calling `has_permission()`:

```python
def edit_member(context: EditGroupMembershipContext, request):
    appstruct = EditGroupMembershipAPISchema().validate(json_payload(request))
    context.new_roles = appstruct["roles"]

    if not request.has_permission(Permission.Group.MEMBER_EDIT, context):
        raise HTTPNotFound()
```

In https://github.com/hypothesis/h/pull/9200 the `add_member()` view will have to do the same. So this is still a little weird, but I think it's better than having two different context objects for a single request.

Testing
-------

For now the add-member API can only be called by authclients, not users, so you'll have to create an authclient to test it:

1. [Log in](http://localhost:5000/login) as `devdata_admin` (password: `pass`).

2. Go to <http://localhost:5000/admin/oauthclients/new> and create a new authclient with these properties:

   Authority: localhost  
   Grant type: client_credentials  
   Trusted: yes  

3. Go to <http://localhost:5000/groups/new> and create a new group.

4. Use the authclient to authenticate a request to the add-member API:

   ```
   $ httpx http://localhost:5000/api/groups/{pubid}/members/acct:devdata_user@localhost --method POST --auth {client_id} {client_secret}
   ```

The edit-member and remove-member APIs can only be called by users, not authclients, so you'll have to go to http://localhost:5000/account/developer and create an API key to test them.

Now use the API key to authenticate a request to change `devdata_user`'s role:

```
$ httpx http://localhost:5000/api/groups/{pubid}/members/acct:devdata_user@localhost --method PATCH --headers Authorization 'Bearer {apitoken}' --json '{"roles": ["admin"]}'
```

Finally, use the API key to authenticate a request to delete `devdata_user`'s group membership:

```
$ httpx http://localhost:5000/api/groups/{pubid}/members/acct:devdata_user@localhost --method DELETE --headers Authorization 'Bearer {apitoken}'
```


