### PR TITLE
Center Pagination rather than stretching to fill container width

### DIFF
--- a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
+++ b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
@@ -397,7 +397,7 @@ export default function EditGroupMembersForm({
           </Scroll>
         </div>
         {typeof totalPages === 'number' && totalPages > 1 && (
-          <div className="mt-4">
+          <div className="mt-4 flex justify-center">
             <Pagination
               currentPage={pageIndex + 1}
               onChangePage={page => setPageIndex(page - 1)}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
     "@hypothesis/frontend-build": "^3.1.0",
-    "@hypothesis/frontend-shared": "^8.14.0",
+    "@hypothesis/frontend-shared": "^8.15.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,15 +1775,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^8.14.0":
-  version: 8.14.0
-  resolution: "@hypothesis/frontend-shared@npm:8.14.0"
+"@hypothesis/frontend-shared@npm:^8.15.0":
+  version: 8.15.0
+  resolution: "@hypothesis/frontend-shared@npm:8.15.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: a8646ecc395150e79245c39062130bc8a362749d525640468cb27bd33104959a4e47970089db34316fb44dfa7891b19cdf74fe5642fb5ccf547adca689f525d6
+  checksum: 7489c92e3f0887a01ad541983a097e717fb57155bbaea1c83caaf26476c98f17061e4b195331b8a800790a523ed801e0fe93c0aa65b58d6918bdaca932691b79
   languageName: node
   linkType: hard
 
@@ -6061,7 +6061,7 @@ __metadata:
     "@babel/preset-react": ^7.24.7
     "@babel/preset-typescript": ^7.24.7
     "@hypothesis/frontend-build": ^3.1.0
-    "@hypothesis/frontend-shared": ^8.14.0
+    "@hypothesis/frontend-shared": ^8.15.0
     "@hypothesis/frontend-testing": ^1.3.1
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^26.0.1


### PR DESCRIPTION
Now that the Pagination component has a consistent width regardless of current page, we can center it without causing the Prev/Next page buttons to move around (at least, not too much) while navigating through pages. Previously the Pagination was stretched to fill the parent, so that the Prev/Next buttons were aligned with the edges of the table above.

Example (nb. page size and page count have been altered manually here):

<img width="695" alt="Page numbers" src="https://github.com/user-attachments/assets/510f0a5d-a73e-47dd-8c63-a98a873df818" />
