### PR TITLE
Fix gulp tasks failing if invalid symlinks exist in repository

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,9 +44,14 @@ gulp.task('watch-css', () => {
 const fontFiles = 'h/static/styles/vendor/fonts/h.woff';
 
 gulp.task('build-fonts', () => {
+  const cwd = 'h/';
   const fontsDir = 'build/fonts';
   return gulp
-    .src(fontFiles, { encoding: false })
+    .src(fontFiles.slice(cwd.length), {
+      encoding: false,
+      // Prevent `gulp.src` from attempting to stat files outside of `cwd`
+      cwd,
+    })
     .pipe(changed(fontsDir))
     .pipe(gulp.dest(fontsDir));
 });
@@ -76,12 +81,15 @@ gulp.task('build-images', () => {
     ],
   };
 
+  const cwd = 'h/';
   const imagesDir = 'build/images';
   return gulp
-    .src(imageFiles, {
+    .src(imageFiles.slice(cwd.length), {
       // Treat all files as binary. Some of the images are SVGs which are text,
       // but `svgmin` is still able to process the files if passed as binary.
       encoding: false,
+      // Prevent `gulp.src` from attempting to stat files outside of `cwd`
+      cwd,
     })
     .pipe(changed(imagesDir))
     .pipe(gulpIf(shouldMinifySVG, svgmin(svgminConfig)))


### PR DESCRIPTION
`yarn build` tasks were failing in some CI jobs with errors like:

```
[01:29:49] 'build-fonts' errored after 8.57 s
[01:29:49] Error: ENOENT: no such file or directory, stat '/home/runner/work/h/h/.tox/.tox/bin/python'
```

Locally the problem can be reproduced by creating a broken symlink in the `.tox/.tox/bin` dir (or elsewhere in the source tree) and running `gulp build-images` or `gulp build-fonts`, even though this is a path which should be ignored by the globs used in these gulp tasks.

Resolve the issue, and make these tasks run faster, by setting the `cwd` used in `gulp.src` so files outside of the `h/` subdir are not stat-ed.

**Testing:**

1. Run `ln -s invalid symlink-to-invalid` locally to create a broken symlink
2. Run `gulp build-images build-fonts`. On main this command will fail. On this branch it should succeed.