### PR TITLE
Change from offset & limit to number and size

### DIFF
--- a/h/schemas/pagination.py
+++ b/h/schemas/pagination.py
@@ -2,15 +2,15 @@ from colander import Integer, Range, Schema, SchemaNode
 
 
 class PaginationQueryParamsSchema(Schema):
-    offset = SchemaNode(
+    page = SchemaNode(
         Integer(),
-        name="page[offset]",
-        validator=Range(min=0),
-        missing=0,
+        name="page[number]",
+        validator=Range(min=1),
+        missing=1,
     )
-    limit = SchemaNode(
+    size = SchemaNode(
         Integer(),
-        name="page[limit]",
+        name="page[size]",
         validator=Range(min=1, max=100),
         missing=20,
     )

--- a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
+++ b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
@@ -84,17 +84,17 @@ async function fetchMembers(
   currentUserid: string,
   options: {
     signal: AbortSignal;
-    offset: number;
-    limit: number;
+    pageNumber: number;
+    pageSize: number;
   },
 ): Promise<{ total: number; members: MemberRow[] }> {
-  const { offset, limit, signal } = options;
+  const { pageNumber, pageSize, signal } = options;
   const { url, method, headers } = api;
   const { meta, data }: GroupMembersResponse = await callAPI(url, {
     headers,
-    limit,
+    pageSize,
     method,
-    offset,
+    pageNumber,
     signal,
   });
 
@@ -191,7 +191,7 @@ export default function EditGroupMembersForm({
   const config = useContext(Config)!;
   const currentUserid = config.context.user.userid;
 
-  const [pageIndex, setPageIndex] = useState(0);
+  const [pageNumber, setPageNumber] = useState(1);
   const [totalMembers, setTotalMembers] = useState<number | null>(null);
   const totalPages =
     totalMembers !== null ? Math.ceil(totalMembers / pageSize) : null;
@@ -216,8 +216,8 @@ export default function EditGroupMembersForm({
     const abort = new AbortController();
     setErrorMessage(null);
     fetchMembers(config.api.readGroupMembers, currentUserid, {
-      offset: pageIndex * pageSize,
-      limit: pageSize,
+      pageNumber,
+      pageSize,
       signal: abort.signal,
     })
       .then(({ total, members }) => {
@@ -230,7 +230,7 @@ export default function EditGroupMembersForm({
     return () => {
       abort.abort();
     };
-  }, [config.api.readGroupMembers, currentUserid, pageIndex, setError]);
+  }, [config.api.readGroupMembers, currentUserid, pageNumber, setError]);
 
   const columns: TableColumn<MemberRow>[] = [
     {
@@ -399,8 +399,8 @@ export default function EditGroupMembersForm({
         {typeof totalPages === 'number' && totalPages > 1 && (
           <div className="mt-4 flex justify-center">
             <Pagination
-              currentPage={pageIndex + 1}
-              onChangePage={page => setPageIndex(page - 1)}
+              currentPage={pageNumber}
+              onChangePage={setPageNumber}
               totalPages={totalPages}
             />
           </div>

--- a/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
+++ b/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
@@ -307,8 +307,8 @@ describe('EditGroupMembersForm', () => {
       fakeCallAPI,
       '/api/groups/1234/members',
       sinon.match({
-        offset: pageSize,
-        limit: pageSize,
+        pageNumber: 2,
+        pageSize: pageSize,
       }),
     );
 

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -112,11 +112,11 @@ export type APIOptions = {
   headers?: Record<PropertyKey, unknown>;
   signal?: AbortSignal;
 
-  /** Index of first item to return in paginated APIs. */
-  offset?: number;
+  /** 1-based number of first page to return in paginated APIs. */
+  pageNumber?: number;
 
   /** Maximum number of items to return in response for a paginated API. */
-  limit?: number;
+  pageSize?: number;
 };
 
 /** Make an API call and return the parsed JSON body or throw APIError. */
@@ -125,9 +125,9 @@ export async function callAPI<R = unknown>(
   {
     headers = {},
     json = null,
-    limit,
+    pageSize,
     method = 'GET',
-    offset,
+    pageNumber,
     signal,
   }: APIOptions = {},
 ): Promise<R> {
@@ -145,11 +145,11 @@ export async function callAPI<R = unknown>(
   }
 
   const queryParams: Record<string, string | number> = {};
-  if (typeof offset === 'number') {
-    queryParams['page[offset]'] = offset;
+  if (typeof pageNumber === 'number') {
+    queryParams['page[number]'] = pageNumber;
   }
-  if (typeof limit === 'number') {
-    queryParams['page[limit]'] = limit;
+  if (typeof pageSize === 'number') {
+    queryParams['page[size]'] = pageSize;
   }
 
   const requestURL = new URL(url);

--- a/h/static/scripts/group-forms/utils/test/api-test.js
+++ b/h/static/scripts/group-forms/utils/test/api-test.js
@@ -126,14 +126,14 @@ describe('callAPI', () => {
 
   it('adds pagination params to URL', async () => {
     const paginatedURL = new URL(url);
-    const offset = 5;
-    const limit = 10;
-    paginatedURL.searchParams.set('page[offset]', offset);
-    paginatedURL.searchParams.set('page[limit]', limit);
+    const pageNumber = 5;
+    const pageSize = 10;
+    paginatedURL.searchParams.set('page[number]', pageNumber);
+    paginatedURL.searchParams.set('page[size]', pageSize);
     const response = new Response(JSON.stringify({}), { status: 200 });
     fakeFetch.resolves(response);
 
-    await callAPI(url, { offset, limit });
+    await callAPI(url, { pageNumber, pageSize });
 
     assert.calledWith(fakeFetch, paginatedURL.toString());
   });

--- a/h/views/api/group_members.py
+++ b/h/views/api/group_members.py
@@ -31,7 +31,7 @@ LIST_MEMBERS_API_CONFIG = {
 }
 
 
-@api_config(request_param=not_("page[offset]"), **LIST_MEMBERS_API_CONFIG)
+@api_config(request_param=not_("page[number]"), **LIST_MEMBERS_API_CONFIG)
 def list_members_legacy(context: GroupContext, request):
     """Legacy version of the list-members API, maintained for backwards-compatibility."""
 
@@ -55,14 +55,16 @@ def list_members_legacy(context: GroupContext, request):
     ]
 
 
-@api_config(request_param="page[offset]", **LIST_MEMBERS_API_CONFIG)
+@api_config(request_param="page[number]", **LIST_MEMBERS_API_CONFIG)
 def list_members(context: GroupContext, request):
     group = context.group
     group_members_service = request.find_service(name="group_members")
 
     params = validate_query_params(PaginationQueryParamsSchema(), request.params)
-    offset = params["page[offset]"]
-    limit = params["page[limit]"]
+    page_number = params["page[number]"]
+    page_size = params["page[size]"]
+    offset = page_size * (page_number - 1)
+    limit = page_size
 
     total = group_members_service.count_memberships(group)
     memberships = group_members_service.get_memberships(

--- a/tests/unit/h/schemas/pagination_test.py
+++ b/tests/unit/h/schemas/pagination_test.py
@@ -10,10 +10,10 @@ class TestPaginationQueryParamsSchema:
     @pytest.mark.parametrize(
         "input_,output",
         [
-            ({}, {"page[offset]": 0, "page[limit]": 20}),
+            ({}, {"page[number]": 1, "page[size]": 20}),
             (
-                {"page[offset]": 150, "page[limit]": 50},
-                {"page[offset]": 150, "page[limit]": 50},
+                {"page[number]": 150, "page[size]": 50},
+                {"page[number]": 150, "page[size]": 50},
             ),
         ],
     )
@@ -26,17 +26,17 @@ class TestPaginationQueryParamsSchema:
         "input_,message",
         [
             (
-                {"page[offset]": -1},
-                r"^page\[offset\]: -1 is less than minimum value 0$",
+                {"page[number]": 0},
+                r"^page\[number\]: 0 is less than minimum value 1$",
             ),
-            ({"page[limit]": 0}, r"^page\[limit\]: 0 is less than minimum value 1$"),
+            ({"page[size]": 0}, r"^page\[size\]: 0 is less than minimum value 1$"),
             (
-                {"page[limit]": 101},
-                r"^page\[limit\]: 101 is greater than maximum value 100$",
+                {"page[size]": 101},
+                r"^page\[size\]: 101 is greater than maximum value 100$",
             ),
             (
-                {"page[offset]": "foo", "page[limit]": "bar"},
-                r'^page\[offset\]: "foo" is not a number\npage\[limit\]: "bar" is not a number$',
+                {"page[number]": "foo", "page[size]": "bar"},
+                r'^page\[number\]: "foo" is not a number\npage\[size\]: "bar" is not a number$',
             ),
         ],
     )

--- a/tests/unit/h/views/api/group_members_test.py
+++ b/tests/unit/h/views/api/group_members_test.py
@@ -20,7 +20,7 @@ from h.traversal import (
 from h.views.api.exceptions import PayloadError
 
 
-class TestListMembersLegacyLegacy:
+class TestListMembersLegacy:
     def test_it(
         self,
         context,
@@ -80,8 +80,8 @@ class TestListMembers:
         validate_query_params,
     ):
         pyramid_request.params = validate_query_params.return_value = {
-            "page[offset]": sentinel.offset,
-            "page[limit]": sentinel.limit,
+            "page[number]": 3,
+            "page[size]": 2,
         }
         group_members_service.get_memberships.return_value = [
             sentinel.membership_1,
@@ -104,7 +104,7 @@ class TestListMembers:
         )
         group_members_service.count_memberships.assert_called_once_with(context.group)
         group_members_service.get_memberships.assert_called_once_with(
-            context.group, offset=sentinel.offset, limit=sentinel.limit
+            context.group, offset=4, limit=2
         )
         assert GroupMembershipJSONPresenter.call_args_list == [
             call(pyramid_request, sentinel.membership_1),


### PR DESCRIPTION
Change the list-memberships API's pagination query params from
`page[offset]` and `page[limit]` to `page[number]` and `page[size]`.

This is a better API design because it doesn't enable the client to send
nonsensical values. For example `page[offset]=2` and `page[size]=10`
is nonsensical because `offset` isn't a multiple of `limit`: what would
the `offset` and `limit` for the previous page link be?

With `page` and `size` this class of nonsensical requests is no longer
possible.

This will make it easier to add first, last, prev and next page links to
the backend's API responses, as was attempted in this PR (not merged):
https://github.com/hypothesis/h/pull/9181

If the client supplies a page number that is beyond the end of the
group's list of memberships, rather than an error the server simply
responds with empty data:

    {
        "meta": {
            "page": {
                "total": 101
            }
        },
        "data": []
    }

The client can use the `meta.page.total` value to figure out how many
pages there should be and re-render its pagination controls.

(This can happen for example if members leave the group after pagination
controls are rendered: the pagination controls may contain links to
pages that no longer exist.)

Testing
-------

### Creating a group with lots of members

1. [Log in](http://localhost:5000/login) as devdata_admin
2. [Create a new group](http://localhost:5000/groups/new)
3. [Create an auth client](http://localhost:5000/admin/oauthclients/new) with:  
   Authority: localhost  
   Grant type: client_credentials  
   Trusted: yes
4. Run this script to add 100 members to the group:

   ```python
   #!/usr/bin/env python3
   import httpx

   auth = ("CLIENT_ID", "CLIENT_SECRET")
   pubid = "GROUP_PUBID"

   for i in range(100):
       httpx.post(
           "http://localhost:5000/api/users",
           auth=auth,
           json={
               "authority": "localhost",
               "username": f"user{i}",
               "email": f"user{i}@example.com",
           },
       )
       httpx.post(
           f"http://localhost:5000/api/groups/{pubid}/members/acct:user{i}@localhost",
           auth=auth,
       )
   ```

   The script requires `httpx` so:

   ```
   python3 -m venv /tmp/venv
   /tmp/venv/bin/pip install httpx
   /tmp/venv/bin/python script.py
   ```

### Testing the API

[Create an API key](http://localhost:5000/account/developer) then:

```
$ httpx http://localhost:5000/api/groups/{PUBID}/members --method GET --headers Authorization 'Bearer {APIKEY}' --params page[number] 1 --params page[size] 10
```

### Testing the UI

Go to <http://localhost:5000/admin/features> and enable the `group_members` feature flag, then go to the group's edit page and test the pagination controls at the bottom.