### PR TITLE
Display icons next to group type names

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -1,6 +1,12 @@
 import { useContext, useEffect, useId, useState } from 'preact/hooks';
 
-import { Button, RadioGroup } from '@hypothesis/frontend-shared';
+import {
+  Button,
+  RadioGroup,
+  LockIcon,
+  GlobeAltIcon,
+  GlobeAltLockIcon,
+} from '@hypothesis/frontend-shared';
 import { Config } from '../config';
 import type { Group } from '../config';
 import { callAPI } from '../utils/api';
@@ -267,19 +273,19 @@ export default function CreateEditGroupForm({
                 value="private"
                 subtitle="Only members can create and read annotations."
               >
-                Private
+                <LockIcon /> Private
               </RadioGroup.Radio>
               <RadioGroup.Radio
                 value="restricted"
                 subtitle="Only members can create annotations, anyone can read them."
               >
-                Restricted
+                <GlobeAltLockIcon /> Restricted
               </RadioGroup.Radio>
               <RadioGroup.Radio
                 value="open"
                 subtitle="Anyone can create and read annotations."
               >
-                Open
+                <GlobeAltIcon /> Open
               </RadioGroup.Radio>
             </RadioGroup>
           </>


### PR DESCRIPTION
Add icons next to group type names that matches the icon used for that type in other contexts, such as the client's group menu.

<img width="566" alt="Group type icons" src="https://github.com/user-attachments/assets/b7c5b362-5333-4c41-adbb-b2e2b4dadaa1" />

In the current implementation the spacing is the same either side of the icon. In the [mocks](https://www.figma.com/design/jon1U01LGSLcx7PWtZ9TPZ/Hypothesis---Group-Management?node-id=2942-1928&node-type=frame&t=NPDV4Y62CUMkfEpq-0) the spacing is larger on the left side of the group type icon. The spacing here comes from the `RadioGroup.Radio` component in the shared library which we'll need to change to adjust that.