### PR TITLE
Remove created indices on migration downgrade

### DIFF
--- a/h/migrations/versions/9c0efdf762a6_add_user_group_created_and_updated_.py
+++ b/h/migrations/versions/9c0efdf762a6_add_user_group_created_and_updated_.py
@@ -13,5 +13,7 @@ def upgrade():
 
 
 def downgrade():
+    op.drop_index(op.f("ix__user_group_updated"), table_name="user_group")
+    op.drop_index(op.f("ix__user_group_created"), table_name="user_group")
     op.drop_column("user_group", "updated")
     op.drop_column("user_group", "created")


### PR DESCRIPTION
We don't expect to run this on production but it helps to bring the local base up to date if switching between branches and ending up on a inconsistent state.


## Testing

- On this branch

downgrade, executing the new code:

tox -e dev --run-command 'alembic downgrade -1'


upgrade again:

 tox -e dev --run-command 'alembic upgrade head'





