### PR TITLE
Allow to add annotations to the job queue by ID

### DIFF
--- a/h/services/job_queue.py
+++ b/h/services/job_queue.py
@@ -10,7 +10,8 @@ class Priority:
     SINGLE_ITEM = 1
     SINGLE_USER = 100
     SINGLE_GROUP = 100
-    BETWEEN_TIMES = 1000
+    BETWEEN_TIMES = 1_000
+    BY_IDS = 1_000
 
 
 class JobQueueService:
@@ -59,6 +60,20 @@ class JobQueueService:
         """
         where = [Annotation.id == annotation_id]
         self.add_where(name, where, tag, Priority.SINGLE_ITEM, force, schedule_in)
+
+    def add_by_ids(
+        self, name, annotation_ids: list[str], tag, force=False, schedule_in=None
+    ):
+        """
+        Queue annotations by ID.
+
+        :param annotation_ids: List of annotation IDs to be queued, in the
+            application-level URL-safe format
+        """
+        where = [Annotation.id.in_(annotation_ids)]
+        self.add_where(
+            name, where, tag, Priority.BY_IDS, force=force, schedule_in=schedule_in
+        )
 
     def add_by_user(self, name, userid: str, tag, force=False, schedule_in=None):
         """

--- a/h/tasks/job_queue.py
+++ b/h/tasks/job_queue.py
@@ -25,3 +25,12 @@ def add_annotations_from_group(name, groupid, tag, force=False, schedule_in=None
     celery.request.find_service(name="queue_service").add_by_group(
         name, groupid, tag, force=force, schedule_in=schedule_in
     )
+
+
+@celery.task
+def add_annotations_by_ids(
+    name, annotation_ids: list[str], tag, force=False, schedule_in=None
+):
+    celery.request.find_service(name="queue_service").add_by_ids(
+        name, annotation_ids, tag, force=force, schedule_in=schedule_in
+    )

--- a/h/templates/admin/search.html.jinja2
+++ b/h/templates/admin/search.html.jinja2
@@ -64,5 +64,13 @@
 
     {{ force_checkbox("reindex_group_force") }}
   {% endcall %}
+
+  {% call reindex_form(heading="Process all by ID", action="reindex_ids") %}
+    <div class="form-group">
+      <label for="annotation_ids">Annotation IDs (one per line)</label>
+      <textarea required class="form-control" name="annotation_ids" id="annotation_ids"></textarea>
+    </div>
+    {{ force_checkbox("reindex_ids_force") }}
+  {% endcall %}
 {% endblock %}
 

--- a/tests/unit/h/services/job_queue_test.py
+++ b/tests/unit/h/services/job_queue_test.py
@@ -121,6 +121,27 @@ class TestQueueService:
         where = add_where.call_args[0][1]
         assert where[0].compare(Annotation.id == sentinel.annotation_id)
 
+    def test_add_annotations_by_ids(self, svc, add_where):
+        svc.add_by_ids(
+            sentinel.name,
+            [sentinel.id_1, sentinel.id_2],
+            sentinel.tag,
+            schedule_in=sentinel.schedule_in,
+            force=sentinel.force,
+        )
+
+        add_where.assert_called_once_with(
+            sentinel.name,
+            [Any.instance_of(BinaryExpression)],
+            sentinel.tag,
+            Priority.BY_IDS,
+            force=sentinel.force,
+            schedule_in=sentinel.schedule_in,
+        )
+
+        where = add_where.call_args[0][1]
+        assert where[0].compare(Annotation.id.in_([sentinel.id_1, sentinel.id_2]))
+
     def test_add_annotations_between_times(self, svc, add_where):
         svc.add_between_times(
             sentinel.name,

--- a/tests/unit/h/tasks/job_queue_test.py
+++ b/tests/unit/h/tasks/job_queue_test.py
@@ -55,6 +55,25 @@ class TestAddAnnotationsFromGroup:
         )
 
 
+class TestAddAnnotationsByIDs:
+    def test_it(self, queue_service):
+        job_queue.add_annotations_by_ids(
+            sentinel.name,
+            sentinel.annotation_ids,
+            sentinel.tag,
+            force=sentinel.force,
+            schedule_in=sentinel.schedule_in,
+        )
+
+        queue_service.add_by_ids.assert_called_once_with(
+            sentinel.name,
+            sentinel.annotation_ids,
+            sentinel.tag,
+            force=sentinel.force,
+            schedule_in=sentinel.schedule_in,
+        )
+
+
 @pytest.fixture(autouse=True)
 def celery(patch, pyramid_request):
     cel = patch("h.tasks.job_queue.celery")

--- a/tests/unit/h/views/admin/search_test.py
+++ b/tests/unit/h/views/admin/search_test.py
@@ -94,6 +94,28 @@ class TestSearchAdminViews:
         with pytest.raises(NotFoundError, match="Group def456 not found"):
             views.reindex_group()
 
+    def test_queue_annotaions_by_id(self, views, tasks, pyramid_request):
+        pyramid_request.params = {
+            "annotation_ids": """
+            cdff42be-2fc0-11ef-ae06-37653ab647c1
+            zf9Cvi_AEe-uBjdlOrZHwQ
+
+            """,
+            "name": "jobname",
+        }
+
+        views.queue_annotations_by_id()
+
+        tasks.job_queue.add_annotations_by_ids.delay.assert_called_once_with(
+            "jobname",
+            ["zf9Cvi_AEe-uBjdlOrZHwQ", "zf9Cvi_AEe-uBjdlOrZHwQ"],
+            tag="reindex_ids",
+            force=False,
+        )
+        assert pyramid_request.session.peek_flash("success") == [
+            "Began reindexing annotations by ID."
+        ]
+
     @pytest.fixture
     def views(self, pyramid_request, queue_service):  # pylint:disable=unused-argument
         return SearchAdminViews(pyramid_request)


### PR DESCRIPTION
For: https://github.com/hypothesis/h/issues/8727

Instead of writing a one off script or sql query to add the remaining annotations missing in annotation_slim we add a new option on the H admin pages to be able to add annotations by ID.


## Testing

- First remove all `annotation_slim` rows

In `make sql`:


```
truncate cascades to table "annotation_metadata"
```


- Go to the admin pages, http://localhost:5000/admin/search

- Pick one annotation ID form the DB

```
select id from annotation limit 1;
                  id                  
--------------------------------------
 cdff42be-2fc0-11ef-ae06-37653ab647c1
(1 row)
```


- Use that annotation ID on the textarea, select "Annotation Slim" as the job type


- Process pending jobs locally, in `make shell`

```
from h.tasks.annotations import sync_annotation_slim
sync_annotation_slim.delay(limit=10)
```

- Check the annotations has correctly being sync-ed to annotation_slim:

```
select * from annotation_slim
postgres-# ;
 id  |                pubid                 |          created          |          updated          | deleted | moderated | shared | document_id | user_id | group_id 
-----+--------------------------------------+---------------------------+---------------------------+---------+-----------+--------+-------------+---------+----------
 572 | cdff42be-2fc0-11ef-ae06-37653ab647c1 | 2024-06-21 11:24:20.72035 | 2024-06-21 11:24:20.72035 | f       | f         | t      |          16 |     228 |       29
(1 row)
```
