### PR TITLE
Put back the h/_version.py export-subst

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+h/_version.py export-subst


### PR DESCRIPTION
This is used to set a `__version__` variable that's used in a few
places, see:
https://hypothes-is.slack.com/archives/C4K6M7P5E/p1738232992837669
