### PR TITLE
Keep an audit track of user renames

### DIFF
--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -6,7 +6,7 @@ from h import models
 from h.accounts.events import ActivationEvent
 from h.i18n import TranslationString as _
 from h.security import Permission
-from h.services.user_rename import UserRenameError
+from h.services.user_rename import UserRenameError, UserRenameService
 
 
 class UserNotFoundError(Exception):
@@ -112,9 +112,9 @@ def users_rename(request):  # pragma: no cover
     old_username = user.username
     new_username = request.params.get("new_username").strip()
 
-    svc = request.find_service(name="user_rename")
+    svc: UserRenameService = request.find_service(name="user_rename")
     try:
-        svc.rename(user, new_username)
+        svc.rename(user, new_username, request.user, tag=request.matched_route.name)
 
     except (UserRenameError, ValueError) as exc:
         request.session.flash(str(exc), "error")


### PR DESCRIPTION
Follow the same pattern we use for user deletions, stora an audit record of renames.

## Testing
- Apply the migration with

`tox -e dev --run-command 'alembic upgrade head'`

- Login as `devdata_admin` 

- Head to http://localhost:5000/admin/users
- Find `devdata_user`
- Rename to something else, eg. `devdata_renamed`
- Rename again, `devdata_re_renamed`
- Check the data in the DB

```
select * from user_rename where user_id;
 id | user_id |           old_userid           |            new_userid             |        requested_at        |         requested_by         |        tag         
----+---------+--------------------------------+-----------------------------------+----------------------------+------------------------------+--------------------
  5 |    5654 | acct:devdata_user@localhost    | acct:devdata_renamed@localhost    | 2025-02-03 14:00:48.727052 | acct:devdata_admin@localhost | admin.users_rename
  6 |    5654 | acct:devdata_renamed@localhost | acct:devdata_re_renamed@localhost | 2025-02-03 14:01:10.687173 | acct:devdata_admin@localhost | admin.users_rename
(2 rows)
```

- Now delete the user on the admin interface
- In `make shell` run the user deletion task

```
from h.tasks.cleanup import purge_deleted_users
purge_deleted_users.delay()
```

- We have kept the audit record but not it's not linked to a row in "User"

```
 5 |         | acct:devdata_user@localhost    | acct:devdata_renamed@localhost    | 2025-02-03 14:00:48.727052 | acct:devdata_admin@localhost | admin.users_rename
  6 |         | acct:devdata_renamed@localhost | acct:devdata_re_renamed@localhost | 2025-02-03 14:01:10.687173 | acct:devdata_admin@localhost | admin.users_rename
```
