### PR TITLE
Adjust parent migration to keep a linear alembic history

### DIFF
--- a/h/migrations/versions/7f9cbef8bb18_create_the_user_rename_table.py
+++ b/h/migrations/versions/7f9cbef8bb18_create_the_user_rename_table.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "7f9cbef8bb18"
-down_revision = "550865ed6622"
+down_revision = "f59898e861be"
 
 
 def upgrade() -> None:


### PR DESCRIPTION
I didn't rebase main before merging a new migration and the history is now not linear. 