### PR TITLE
Update mention json payload

### DIFF
--- a/docs/_extra/api-reference/schemas/annotation.yaml
+++ b/docs/_extra/api-reference/schemas/annotation.yaml
@@ -209,9 +209,12 @@ Annotation:
             pattern: "acct:^[A-Za-z0-9._]{3,30}@.*$"
             description: user account ID in the format `"acct:<username>@<authority>"`
             example: "acct:felicity_nunsun@hypothes.is"
+          original_userid:
+            type: string
+            description: The original account ID mentioned in the annotation text
           username:
             type: string
-            description: The username of the user at the time of the mention
+            description: The username of the user
           display_name:
             type: string
             description: The display name of the user

--- a/h/presenters/mention_json.py
+++ b/h/presenters/mention_json.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from h.models import Mention
+from h.util.user import format_userid
 
 
 class MentionJSONPresenter:
@@ -12,7 +13,10 @@ class MentionJSONPresenter:
     def asdict(self) -> dict[str, Any]:
         return {
             "userid": self._mention.user.userid,
-            "username": self._mention.username,
+            "original_userid": format_userid(
+                self._mention.username, self._mention.user.authority
+            ),
+            "username": self._mention.user.username,
             "display_name": self._mention.user.display_name,
             "link": self._mention.user.uri,
         }

--- a/tests/unit/h/presenters/mention_json_test.py
+++ b/tests/unit/h/presenters/mention_json_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from h.models import Mention
 from h.presenters.mention_json import MentionJSONPresenter
+from h.util.user import format_userid
 
 
 class TestMentionJSONPresenter:
@@ -12,10 +13,19 @@ class TestMentionJSONPresenter:
 
         assert data == {
             "userid": user.userid,
+            "original_userid": user.userid,
             "username": user.username,
             "display_name": user.display_name,
             "link": user.uri,
         }
+
+    def test_as_dict_with_different_username(self, user, annotation):
+        new_username = "new_username"
+        mention = Mention(annotation=annotation, user=user, username=new_username)
+
+        data = MentionJSONPresenter(mention).asdict()
+
+        assert data["original_userid"] == format_userid(new_username, user.authority)
 
     @pytest.fixture
     def user(self, factories):

--- a/tests/unit/h/services/mention_test.py
+++ b/tests/unit/h/services/mention_test.py
@@ -104,6 +104,7 @@ class TestFactory:
             session=pyramid_request.db,
             user_service=user_service,
         )
+
         assert service == MentionService.return_value
 
     @pytest.fixture


### PR DESCRIPTION
Refs #9322, #9322

Basically just returning `original_userid` to make it easier for API consumers