### PR TITLE
Fix `AdminGroupSchema` CSRF protection

### DIFF
--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -139,7 +139,7 @@ def group_organization_select_widget(_node, kwargs):
 
 class AdminGroupSchema(CSRFSchema):
     def __init__(self, *args):
-        super().__init__(validator=username_validator, *args)  # noqa: B026
+        super().__init__(*args)
 
     group_type = colander.SchemaNode(
         colander.String(),
@@ -217,3 +217,7 @@ class AdminGroupSchema(CSRFSchema):
         widget=SequenceWidget(add_subitem_text_template=_("Add member")),
         missing=None,
     )
+
+    def validator(self, node, value):
+        super().validator(node, value)
+        username_validator(node, value)

--- a/tests/unit/h/schemas/forms/admin/group_test.py
+++ b/tests/unit/h/schemas/forms/admin/group_test.py
@@ -3,6 +3,7 @@ from unittest.mock import call
 
 import colander
 import pytest
+from pyramid.exceptions import BadCSRFToken
 
 from h.models.group import (
     GROUP_DESCRIPTION_MAX_LENGTH,
@@ -16,6 +17,18 @@ from h.schemas.forms.admin.group import AdminGroupSchema
 class TestAdminGroupSchema:
     def test_it_allows_with_valid_data(self, group_data, bound_schema):
         bound_schema.deserialize(group_data)
+
+    def test_it_raises_if_csrf_token_missing(self, group_data, bound_schema):
+        del bound_schema.bindings["request"].headers["X-CSRF-Token"]
+
+        with pytest.raises(BadCSRFToken):
+            bound_schema.deserialize(group_data)
+
+    def test_it_raises_if_csrf_token_wrong(self, group_data, bound_schema):
+        bound_schema.bindings["request"].headers["X-CSRF-Token"] = "foobar"
+
+        with pytest.raises(BadCSRFToken):
+            bound_schema.deserialize(group_data)
 
     def test_it_raises_if_name_too_short(self, group_data, bound_schema):
         too_short_name = "a" * (GROUP_NAME_MIN_LENGTH - 1)


### PR DESCRIPTION
Doing `super().__init__(validator=username_validator)` overrides the Colander schema's global validator function, with the result that the [base `CSRFSchema` class's `validator()` method](https://github.com/hypothesis/h/blob/a3a53e92e1290c3f867ae922fa3f257d1a602757/h/schemas/base.py#L37-L39) never gets called and there is no CSRF protection.

Replace this with a subclass `validator()` method that calls the superclass's method first.

This is the same way as it's done in several other `CSRFSchema` subclasses throughout the code.

## Testing

1. Log in as devdata_admin
2. Go to http://localhost:5000/admin/groups/new
3. Use devtools to delete the hidden `"csrf_token"` form field
4. Fill in the form and submit it

On `main` the form submission will succeed with no CSRF token. On this branch it'll fail.