### PR TITLE
Enable CSRF protection globally by default

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -16,7 +16,6 @@ from h.models.user import (
     USERNAME_PATTERN,
 )
 from h.schemas import validators
-from h.schemas.base import CSRFSchema
 from h.schemas.forms.accounts.util import PASSWORD_MIN_LENGTH
 from h.util.user import format_userid
 
@@ -153,7 +152,7 @@ def _privacy_accepted_message():
     return privacy_msg
 
 
-class RegisterSchema(CSRFSchema):
+class RegisterSchema(colander.Schema):
     username = colander.SchemaNode(
         colander.String(),
         validator=colander.All(
@@ -197,7 +196,7 @@ class RegisterSchema(CSRFSchema):
     )
 
 
-class EmailChangeSchema(CSRFSchema):
+class EmailChangeSchema(colander.Schema):
     email = email_node(title=_("Email address"))
     # No validators: all validation is done on the email field
     password = password_node(title=_("Confirm password"), hide_until_form_active=True)
@@ -215,7 +214,7 @@ class EmailChangeSchema(CSRFSchema):
             raise exc
 
 
-class PasswordChangeSchema(CSRFSchema):
+class PasswordChangeSchema(colander.Schema):
     password = password_node(title=_("Current password"), inactive_label=_("Password"))
     new_password = new_password_node(
         title=_("New password"), hide_until_form_active=True
@@ -245,7 +244,7 @@ class PasswordChangeSchema(CSRFSchema):
             raise exc
 
 
-class DeleteAccountSchema(CSRFSchema):
+class DeleteAccountSchema(colander.Schema):
     password = password_node(title=_("Confirm password"))
 
     def validator(self, node, value):
@@ -272,7 +271,7 @@ def deferred_notification_widget(node, kw):  # noqa: ARG001
     return deform.widget.CheckboxChoiceWidget(omit_label=True, values=types)
 
 
-class NotificationsSchema(CSRFSchema):
+class NotificationsSchema(colander.Schema):
     notifications = colander.SchemaNode(
         colander.Set(),
         widget=deferred_notification_widget,

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -203,7 +203,6 @@ class EmailChangeSchema(CSRFSchema):
     password = password_node(title=_("Confirm password"), hide_until_form_active=True)
 
     def validator(self, node, value):
-        super().validator(node, value)
         exc = colander.Invalid(node)
         request = node.bindings["request"]
         svc = request.find_service(name="user_password")
@@ -231,7 +230,6 @@ class PasswordChangeSchema(CSRFSchema):
     )
 
     def validator(self, node, value):  # pragma: no cover
-        super().validator(node, value)
         exc = colander.Invalid(node)
         request = node.bindings["request"]
         svc = request.find_service(name="user_password")
@@ -251,8 +249,6 @@ class DeleteAccountSchema(CSRFSchema):
     password = password_node(title=_("Confirm password"))
 
     def validator(self, node, value):
-        super().validator(node, value)
-
         request = node.bindings["request"]
         svc = request.find_service(name="user_password")
 

--- a/h/app.py
+++ b/h/app.py
@@ -30,6 +30,8 @@ def create_app(_global_config, **settings):  # pragma: no cover
 
 
 def includeme(config):  # pragma: no cover
+    config.set_default_csrf_options(require_csrf=True)
+
     config.scan("h.subscribers")
 
     config.add_tween("h.tweens.conditional_http_tween_factory", under=EXCVIEW)

--- a/h/schemas/auth_client.py
+++ b/h/schemas/auth_client.py
@@ -3,13 +3,13 @@ import deform
 
 from h import i18n
 from h.models.auth_client import GrantType
-from h.schemas.base import CSRFSchema, enum_type
+from h.schemas.base import enum_type
 
 _ = i18n.TranslationString
 GrantTypeSchemaType = enum_type(GrantType)
 
 
-class CreateAuthClientSchema(CSRFSchema):
+class CreateAuthClientSchema(colander.Schema):
     name = colander.SchemaNode(
         colander.String(),
         title=_("Name"),

--- a/h/schemas/auth_client.py
+++ b/h/schemas/auth_client.py
@@ -57,8 +57,6 @@ class CreateAuthClientSchema(CSRFSchema):
     )
 
     def validator(self, node, value):
-        super().validator(node, value)
-
         grant_type = value.get("grant_type")
         redirect_url = value.get("redirect_url")
 

--- a/h/schemas/base.py
+++ b/h/schemas/base.py
@@ -6,7 +6,7 @@ import colander
 import deform
 import jsonschema
 from pyramid import httpexceptions
-from pyramid.csrf import check_csrf_token, get_csrf_token
+from pyramid.csrf import get_csrf_token
 
 
 @colander.deferred
@@ -21,22 +21,48 @@ class ValidationError(httpexceptions.HTTPBadRequest):
 
 class CSRFSchema(colander.Schema):
     """
-    A CSRFSchema backward-compatible with the one from the hem module.
+    Add a hidden CSRF token to forms when seralized using Deform.
 
-    Unlike hem, this doesn't require that the csrf_token appear in the
-    serialized appstruct.
+    This is intended as a base class for other schemas to inherit from if the
+    schema's form needs a CSRF token (by default all form submissions do need a
+    CSRF token).
+
+    This schema *does not* implement CSRF verification when receiving requests.
+    That's enabled globally for non-GET requests by
+    config.set_default_csrf_options(require_csrf=True).
     """
 
     csrf_token = colander.SchemaNode(
         colander.String(),
         widget=deform.widget.HiddenWidget(),
+        # When serializing (i.e. when rendering a form) if there's no
+        # csrf_token then call deferred_csrf_token() to get one.
         default=deferred_csrf_token,
-        missing=None,
+        # Allow data with no "csrf_token" field to be *deserialized* successfully
+        # (the deserialized data will contain no "csrf_token" field.)
+        #
+        # CSRF protection isn't provided by this schema, it's provided by
+        # Pyramid's config.set_default_csrf_options(require_csrf=True).
+        #
+        # Nonetheless, without a `missing` value, when deserializing any
+        # subclass of this schema Colander would require a csrf_token field to
+        # be present in the data (even if this schema doesn't actually check
+        # that the token is valid).
+        #
+        # In production any request missing a CSRF token would be rejected by
+        # Pyramid's CSRF protection before even reaching schema
+        # deserialization. So by the time we get to schema deserialization
+        # there must be a CSRF token and this `missing` value is seemingly
+        # unnecessary.
+        #
+        # However:
+        #
+        # 1. The CSRF token may be in an X-CSRF-Token header rather than in a
+        #    POST param.
+        # 2. Unittests for schemas often don't set a CSRF token and would fail
+        #    if this `missing` value wasn't here.
+        missing=colander.drop,
     )
-
-    def validator(self, node, _value):
-        request = node.bindings["request"]
-        check_csrf_token(request)
 
 
 class JSONSchema:

--- a/h/schemas/forms/accounts/edit_profile.py
+++ b/h/schemas/forms/accounts/edit_profile.py
@@ -5,7 +5,6 @@ from h import i18n
 from h.accounts import util
 from h.models.user import DISPLAY_NAME_MAX_LENGTH
 from h.schemas import validators
-from h.schemas.base import CSRFSchema
 
 _ = i18n.TranslationString
 
@@ -24,7 +23,7 @@ def validate_orcid(node, cstruct):
         raise colander.Invalid(node, str(exc))  # noqa: B904
 
 
-class EditProfileSchema(CSRFSchema):
+class EditProfileSchema(colander.Schema):
     display_name = colander.SchemaNode(
         colander.String(),
         missing=None,

--- a/h/schemas/forms/accounts/forgot_password.py
+++ b/h/schemas/forms/accounts/forgot_password.py
@@ -3,12 +3,11 @@ import deform
 
 from h import i18n, models
 from h.schemas import validators
-from h.schemas.base import CSRFSchema
 
 _ = i18n.TranslationString
 
 
-class ForgotPasswordSchema(CSRFSchema):
+class ForgotPasswordSchema(colander.Schema):
     email = colander.SchemaNode(
         colander.String(),
         validator=colander.All(validators.Email()),

--- a/h/schemas/forms/accounts/forgot_password.py
+++ b/h/schemas/forms/accounts/forgot_password.py
@@ -17,8 +17,6 @@ class ForgotPasswordSchema(CSRFSchema):
     )
 
     def validator(self, node, value):
-        super().validator(node, value)
-
         request = node.bindings["request"]
         email = value.get("email")
         user = models.User.get_by_email(request.db, email, request.default_authority)

--- a/h/schemas/forms/accounts/login.py
+++ b/h/schemas/forms/accounts/login.py
@@ -2,7 +2,6 @@ import colander
 import deform
 
 from h import i18n
-from h.schemas.base import CSRFSchema
 from h.services.user import UserNotActivated
 
 _ = i18n.TranslationString
@@ -25,7 +24,7 @@ def _deferred_password_widget(_node, kwargs):
     )
 
 
-class LoginSchema(CSRFSchema):
+class LoginSchema(colander.Schema):
     username = colander.SchemaNode(
         colander.String(),
         title=_("Username / email"),

--- a/h/schemas/forms/accounts/login.py
+++ b/h/schemas/forms/accounts/login.py
@@ -36,8 +36,6 @@ class LoginSchema(CSRFSchema):
     )
 
     def validator(self, node, value):
-        super().validator(node, value)
-
         request = node.bindings["request"]
         username = value.get("username")
         password = value.get("password")

--- a/h/schemas/forms/accounts/reset_password.py
+++ b/h/schemas/forms/accounts/reset_password.py
@@ -4,7 +4,6 @@ import pytz
 from itsdangerous import BadData, SignatureExpired
 
 from h import i18n, models
-from h.schemas.base import CSRFSchema
 from h.schemas.forms.accounts import util
 
 _ = i18n.TranslationString
@@ -60,7 +59,7 @@ class ResetCode(colander.SchemaType):
         return user
 
 
-class ResetPasswordSchema(CSRFSchema):
+class ResetPasswordSchema(colander.Schema):
     # N.B. this is the field into which the user puts their reset code, but we
     # call it `user` because when validated, it will return a `User` object.
     user = colander.SchemaNode(

--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -14,7 +14,6 @@ from h.models.group import (
     GROUP_NAME_MIN_LENGTH,
 )
 from h.schemas import validators
-from h.schemas.base import CSRFSchema
 from h.util import group_scope
 
 _ = i18n.TranslationString
@@ -137,7 +136,7 @@ def group_organization_select_widget(_node, kwargs):
     return SelectWidget(values=list(zip(org_pubids, org_labels, strict=False)))
 
 
-class AdminGroupSchema(CSRFSchema):
+class AdminGroupSchema(colander.Schema):
     def __init__(self, *args):
         super().__init__(*args)
 

--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -219,5 +219,4 @@ class AdminGroupSchema(CSRFSchema):
     )
 
     def validator(self, node, value):
-        super().validator(node, value)
         username_validator(node, value)

--- a/h/schemas/forms/admin/organization.py
+++ b/h/schemas/forms/admin/organization.py
@@ -6,7 +6,6 @@ from deform.widget import TextAreaWidget, TextInputWidget
 import h.i18n
 from h.models.organization import Organization
 from h.schemas import validators
-from h.schemas.base import CSRFSchema
 
 _ = h.i18n.TranslationString
 
@@ -36,7 +35,7 @@ def validate_logo(node, value):
         raise colander.Invalid(node, _("Logo does not start with <svg> tag"))
 
 
-class OrganizationSchema(CSRFSchema):
+class OrganizationSchema(colander.Schema):
     authority = colander.SchemaNode(colander.String(), title=_("Authority"))
 
     name = colander.SchemaNode(

--- a/h/templates/accounts/developer.html.jinja2
+++ b/h/templates/accounts/developer.html.jinja2
@@ -20,6 +20,7 @@
     {% endif %}
 
       <form method="post" class="js-disable-on-submit">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         {% if token %}
           <button type="submit" class="btn"
                   title="{% trans %}Delete your API token and generate a new one{% endtrans%}">

--- a/h/templates/admin/groups_edit.html.jinja2
+++ b/h/templates/admin/groups_edit.html.jinja2
@@ -7,7 +7,9 @@
   {{ form }}
   {% if pubid != '__world__' %}
     <form method="POST"
-          action="{{request.route_path('admin.groups_delete', id=pubid)}}">
+          action="{{request.route_path('admin.groups_delete', id=pubid)}}"
+          id="delete_group">
+      <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
       <button class="btn btn--danger js-confirm-submit"
               data-confirm-message="Group &quot;{{ group_name }}&quot; has {{ annotation_count }} annotation(s) and {{ member_count }} member(s). Are you sure you want to delete it?">Delete</button>
     </form>

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -8,6 +8,7 @@
       class="form {{ field.css_class or '' }}
              {%- if field.use_inline_editing %} js-form {% endif %}">
   <input type="hidden" name="__formid__" value="{{ field.formid }}" />
+  <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
 
   <div class="form__backdrop" data-ref="formBackdrop"></div>
 

--- a/h/templates/oauth/authorize.html.jinja2
+++ b/h/templates/oauth/authorize.html.jinja2
@@ -14,6 +14,7 @@
     </p>
 
     <form class="form js-authorize-form" method="POST">
+      <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
       <div class="form-actions">
         <button type="button" class="btn btn--cancel" data-ref="cancelBtn">Cancel</button>
         <div class="u-stretch"></div>

--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -65,6 +65,7 @@ def add_api_view(  # noqa: PLR0913
                                   `route_name` must be specified.
     :param dict **settings: Arguments to pass on to ``config.add_view``
     """
+    settings.setdefault("require_csrf", False)
     settings.setdefault("renderer", "json")
     settings.setdefault("decorator", (cors_policy, version_media_type_header(subtype)))
 

--- a/tests/unit/h/accounts/schemas_test.py
+++ b/tests/unit/h/accounts/schemas_test.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock
 
 import colander
 import pytest
-from pyramid.exceptions import BadCSRFToken
 
 from h.accounts import schemas
 from h.services.user_password import UserPasswordService
@@ -156,9 +155,7 @@ class TestRegisterSchema:
 
         result = schema.deserialize(valid_params)
 
-        assert result == dict(
-            valid_params, privacy_accepted=True, comms_opt_in=None, csrf_token=None
-        )
+        assert result == dict(valid_params, privacy_accepted=True, comms_opt_in=None)
 
     @pytest.fixture
     def valid_params(self):
@@ -193,18 +190,6 @@ class TestEmailChangeSchema:
         pyramid_config.testing_securitypolicy(user.userid)
 
         schema.deserialize({"email": user.email, "password": "flibble"})
-
-    def test_it_is_invalid_if_csrf_token_missing(self, pyramid_request, schema):
-        del pyramid_request.headers["X-CSRF-Token"]
-
-        with pytest.raises(BadCSRFToken):
-            schema.deserialize({"email": "foo@bar.com", "password": "flibble"})
-
-    def test_it_is_invalid_if_csrf_token_wrong(self, pyramid_request, schema):
-        pyramid_request.headers["X-CSRF-Token"] = "WRONG"
-
-        with pytest.raises(BadCSRFToken):
-            schema.deserialize({"email": "foo@bar.com", "password": "flibble"})
 
     def test_it_is_invalid_if_password_wrong(self, schema, user_password_service):
         user_password_service.check_password.return_value = False

--- a/tests/unit/h/schemas/base_test.py
+++ b/tests/unit/h/schemas/base_test.py
@@ -3,8 +3,6 @@ from unittest.mock import Mock
 
 import colander
 import pytest
-from pyramid import csrf
-from pyramid.exceptions import BadCSRFToken
 
 from h.schemas import ValidationError
 from h.schemas.base import CSRFSchema, JSONSchema, enum_type
@@ -23,28 +21,6 @@ class ExampleJSONSchema(JSONSchema):
         "properties": {"foo": {"type": "string"}, "bar": {"type": "integer"}},
         "required": ["foo", "bar"],
     }
-
-
-class TestCSRFSchema:
-    def test_raises_badcsrf_with_bad_csrf(self, pyramid_request):
-        schema = ExampleCSRFSchema().bind(request=pyramid_request)
-
-        with pytest.raises(BadCSRFToken):
-            schema.deserialize({})
-
-    def test_ok_with_good_csrf(self, pyramid_request):
-        csrf_token = csrf.get_csrf_token(pyramid_request)
-        pyramid_request.POST["csrf_token"] = csrf_token
-        schema = ExampleCSRFSchema().bind(request=pyramid_request)
-
-        # Does not raise
-        schema.deserialize({})
-
-    def test_ok_with_good_csrf_from_header(self, pyramid_csrf_request):
-        schema = ExampleCSRFSchema().bind(request=pyramid_csrf_request)
-
-        # Does not raise
-        schema.deserialize({})
 
 
 class TestJSONSchema:

--- a/tests/unit/h/schemas/base_test.py
+++ b/tests/unit/h/schemas/base_test.py
@@ -5,13 +5,9 @@ import colander
 import pytest
 
 from h.schemas import ValidationError
-from h.schemas.base import CSRFSchema, JSONSchema, enum_type
+from h.schemas.base import JSONSchema, enum_type
 
 pytestmark = pytest.mark.usefixtures("pyramid_config")
-
-
-class ExampleCSRFSchema(CSRFSchema):
-    pass
 
 
 class ExampleJSONSchema(JSONSchema):

--- a/tests/unit/h/schemas/forms/accounts/login_test.py
+++ b/tests/unit/h/schemas/forms/accounts/login_test.py
@@ -2,7 +2,6 @@ from unittest.mock import Mock
 
 import colander
 import pytest
-from pyramid.exceptions import BadCSRFToken
 
 from h.schemas.forms.accounts import LoginSchema
 from h.services.user import UserNotActivated
@@ -45,12 +44,6 @@ class TestLoginSchema:
         result = schema.deserialize({"username": "jeannie", "password": "cake"})
 
         assert result["user"] is user
-
-    def test_invalid_with_bad_csrf(self, pyramid_request):
-        schema = LoginSchema().bind(request=pyramid_request)
-
-        with pytest.raises(BadCSRFToken):
-            schema.deserialize({"username": "jeannie", "password": "cake"})
 
     def test_invalid_with_inactive_user(self, pyramid_csrf_request, user_service):
         schema = LoginSchema().bind(request=pyramid_csrf_request)

--- a/tests/unit/h/schemas/forms/admin/group_test.py
+++ b/tests/unit/h/schemas/forms/admin/group_test.py
@@ -3,7 +3,6 @@ from unittest.mock import call
 
 import colander
 import pytest
-from pyramid.exceptions import BadCSRFToken
 
 from h.models.group import (
     GROUP_DESCRIPTION_MAX_LENGTH,
@@ -17,18 +16,6 @@ from h.schemas.forms.admin.group import AdminGroupSchema
 class TestAdminGroupSchema:
     def test_it_allows_with_valid_data(self, group_data, bound_schema):
         bound_schema.deserialize(group_data)
-
-    def test_it_raises_if_csrf_token_missing(self, group_data, bound_schema):
-        del bound_schema.bindings["request"].headers["X-CSRF-Token"]
-
-        with pytest.raises(BadCSRFToken):
-            bound_schema.deserialize(group_data)
-
-    def test_it_raises_if_csrf_token_wrong(self, group_data, bound_schema):
-        bound_schema.bindings["request"].headers["X-CSRF-Token"] = "foobar"
-
-        with pytest.raises(BadCSRFToken):
-            bound_schema.deserialize(group_data)
 
     def test_it_raises_if_name_too_short(self, group_data, bound_schema):
         too_short_name = "a" * (GROUP_NAME_MIN_LENGTH - 1)


### PR DESCRIPTION
Enable Pyramid's `config.set_default_csrf_options(require_csrf=True)` which causes it to require a valid CSRF token for all requests with a request method that is *not* one of `GET`, `HEAD`, `OPTIONS` or `TRACE`.

The CSRF token must be in a `csrf_token` POST parameter or an `X-CSRF-Token` header, and must match the CSRF token stored in the signed session cookie.

It also checks that the request's `Referer` (if any) is the current host.

See:

* https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/security.html#checking-csrf-tokens-automatically
* https://docs.pylonsproject.org/projects/pyramid/en/latest/api/config.html#pyramid.config.Configurator.set_default_csrf_options

This is a safer default. The current implementation requires all views receiving form submissions to use a Colander schema that's a subclass of `CSRFSchema`. It's too easy to forget to add CSRF protection to a form if it doesn't use Colander (for example: perhaps there are no parameters to be validated) or if it has a schema that doesn't subclass `CSRFSchema`. Even if the view's schema *does* sublass `CSRFSchema`, if it wants to have a `validate()` method it must remember to call `super().validate()` or it'll disable `CSRFSchema`'s CSRF protection.

This commit removes the CSRF protection code from `CSRFSchema` (that schema is now only used to *serialize* the CSRF tokens into the forms, but doesn't do any CSRF validation at *deserialization* time) and instead enables Pyramid's global CSRF protection option.

CSRF protection can be disabled for individual views by passing `require_csrf=False` to `@view_config`. This has been added to h's custom `@api_config` decorator so that CSRF protection is disabled for all API endpoints.
