### PR TITLE
Disallow periods at the start and end of new usernames

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -194,7 +194,7 @@ components:
         The userID should be of the format `acct:<username>@<authority>`
       schema:
         type: string
-        pattern: 'acct:^[A-Za-z0-9._]{3,30}@.*$'
+        pattern: 'acct:^[A-Za-z0.9_][A-Za-z0-9._]{1,28}[A-Za-z0-9_]@.*$'
 
   # -------------------------
   # Reusable responses

--- a/docs/_extra/api-reference/hypothesis-v2.yaml
+++ b/docs/_extra/api-reference/hypothesis-v2.yaml
@@ -192,7 +192,7 @@ components:
         The userID should be of the format `acct:<username>@<authority>`
       schema:
         type: string
-        pattern: 'acct:^[A-Za-z0-9._]{3,30}@.*$'
+        pattern: 'acct:^[A-Za-z0.9_][A-Za-z0-9._]{1,28}[A-Za-z0-9_]@.*$'
 
   # -------------------------
   # Reusable responses

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -160,7 +160,9 @@ class RegisterSchema(CSRFSchema):
             validators.Length(min=USERNAME_MIN_LENGTH, max=USERNAME_MAX_LENGTH),
             colander.Regex(
                 USERNAME_PATTERN,
-                msg=_("Must have only letters, numbers, periods, and underscores."),
+                msg=_(
+                    "Must have only letters, numbers, periods and underscores. May not start or end with period."
+                ),
             ),
             unique_username,
             unblacklisted_username,

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -19,7 +19,11 @@ if TYPE_CHECKING:
 
 USERNAME_MIN_LENGTH = 3
 USERNAME_MAX_LENGTH = 30
-USERNAME_PATTERN = "(?i)^[A-Z0-9._]+$"
+
+# nb. This pattern is used in Python code, JSON schemas and HTML forms, so it
+# needs to use portable syntax.
+USERNAME_PATTERN = "^[A-Za-z0-9_][A-Za-z0-9._]+[A-Za-z0-9_]$"
+
 EMAIL_MAX_LENGTH = 100
 DISPLAY_NAME_MAX_LENGTH = 30
 USER_PUBID_LENGTH = 12

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -22,6 +22,12 @@ USERNAME_MAX_LENGTH = 30
 
 # nb. This pattern is used in Python code, JSON schemas and HTML forms, so it
 # needs to use portable syntax.
+#
+# This pattern was changed in Feb 2025 to restrict the characters that can occur
+# at the start and end of usernames. There are a small number of existing user
+# accounts which do not conform to the latest pattern. Hence APIs and forms
+# which accept existing usernames need to support a more liberal pattern
+# (`[A-Za-z0-9._]+`).
 USERNAME_PATTERN = "^[A-Za-z0-9_][A-Za-z0-9._]+[A-Za-z0-9_]$"
 
 EMAIL_MAX_LENGTH = 100

--- a/h/schemas/api/user.py
+++ b/h/schemas/api/user.py
@@ -3,6 +3,7 @@ from h.models.user import (
     EMAIL_MAX_LENGTH,
     USERNAME_MAX_LENGTH,
     USERNAME_MIN_LENGTH,
+    USERNAME_PATTERN,
 )
 from h.schemas.base import JSONSchema
 
@@ -18,7 +19,7 @@ class CreateUserAPISchema(JSONSchema):
                 "type": "string",
                 "minLength": USERNAME_MIN_LENGTH,
                 "maxLength": USERNAME_MAX_LENGTH,
-                "pattern": "^[A-Za-z0-9._]+$",
+                "pattern": USERNAME_PATTERN,
             },
             "email": {
                 "type": "string",

--- a/h/templates/admin/users.html.jinja2
+++ b/h/templates/admin/users.html.jinja2
@@ -73,7 +73,7 @@
       <form method="POST" action="{{request.route_path('admin.users_rename')}}" class="form-inline">
         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <input type="hidden" name="userid" value="{{user.userid}}">
-        <input type="text" name="new_username" placeholder="New Username" pattern="^[A-Za-z0-9._]+$">
+        <input type="text" name="new_username" placeholder="New Username" pattern="{{ username_pattern }}">
         <button class="btn" type="submit">Change username</button>
       </form>
 

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -5,6 +5,7 @@ from pyramid.view import view_config
 from h import models
 from h.accounts.events import ActivationEvent
 from h.i18n import TranslationString as _
+from h.models.user import USERNAME_PATTERN
 from h.security import Permission
 from h.services.user_rename import UserRenameError, UserRenameService
 
@@ -69,6 +70,7 @@ def users_index(request):
         "authority": authority,
         "user": user,
         "user_meta": user_meta,
+        "username_pattern": USERNAME_PATTERN,
         "format_date": format_date,
     }
 

--- a/tests/unit/h/accounts/schemas_test.py
+++ b/tests/unit/h/accounts/schemas_test.py
@@ -86,8 +86,8 @@ class TestRegisterSchema:
         schema = schemas.RegisterSchema().bind(request=pyramid_request)
 
         with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({"username": "a"})
-        assert exc.value.asdict()["username"] == ("Must be 3 characters or more.")
+            schema.deserialize({"username": "ab"})
+        assert "Must be 3 characters or more." in exc.value.asdict()["username"]
 
     def test_it_is_invalid_when_username_too_long(self, pyramid_request):
         schema = schemas.RegisterSchema().bind(request=pyramid_request)
@@ -102,7 +102,7 @@ class TestRegisterSchema:
         with pytest.raises(colander.Invalid) as exc:
             schema.deserialize({"username": "Fred Flintstone"})
         assert exc.value.asdict()["username"] == (
-            "Must have only letters, numbers, periods, and underscores."
+            "Must have only letters, numbers, periods and underscores. May not start or end with period."
         )
 
     def test_it_is_invalid_with_false_privacy_accepted(self, pyramid_request):

--- a/tests/unit/h/schemas/api/user_test.py
+++ b/tests/unit/h/schemas/api/user_test.py
@@ -47,8 +47,16 @@ class TestCreateUserAPISchema:
         with pytest.raises(ValidationError):
             schema.validate(payload)
 
-    def test_it_raises_when_username_format_invalid(self, schema, payload):
-        payload["username"] = "dagr!un"
+    @pytest.mark.parametrize(
+        "username",
+        [
+            "invalid!chars",
+            ".starts_with_period",
+            "ends_with_period.",
+        ],
+    )
+    def test_it_raises_when_username_format_invalid(self, schema, payload, username):
+        payload["username"] = username
 
         with pytest.raises(ValidationError):
             schema.validate(payload)

--- a/tests/unit/h/views/admin/users_test.py
+++ b/tests/unit/h/views/admin/users_test.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
+from h_matchers import Any
 from pyramid import httpexceptions
 
 from h.models import Annotation
@@ -35,6 +36,7 @@ def test_users_index(pyramid_request):
         "username": None,
         "authority": None,
         "user": None,
+        "username_pattern": Any.string(),
         "user_meta": {},
         "format_date": format_date,
     }
@@ -89,6 +91,7 @@ def test_users_index_no_user_found(models, pyramid_request):
         "authority": "foo.org",
         "user": None,
         "user_meta": {},
+        "username_pattern": Any.string(),
         "format_date": format_date,
     }
 
@@ -107,6 +110,7 @@ def test_users_index_user_marked_as_deleted(models, pyramid_request, factories):
         "authority": "foo.org",
         "user": None,
         "user_meta": {},
+        "username_pattern": Any.string(),
         "format_date": format_date,
     }
 
@@ -128,6 +132,7 @@ def test_users_index_user_found(
         "authority": "foo.org",
         "user": user,
         "user_meta": {"annotations_count": 8},
+        "username_pattern": Any.string(),
         "format_date": format_date,
     }
 

--- a/tests/unit/h/views/admin/users_test.py
+++ b/tests/unit/h/views/admin/users_test.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
-from h_matchers import Any
 from pyramid import httpexceptions
 
 from h.models import Annotation
@@ -36,7 +35,7 @@ def test_users_index(pyramid_request):
         "username": None,
         "authority": None,
         "user": None,
-        "username_pattern": Any.string(),
+        "username_pattern": mock.ANY,
         "user_meta": {},
         "format_date": format_date,
     }
@@ -91,7 +90,7 @@ def test_users_index_no_user_found(models, pyramid_request):
         "authority": "foo.org",
         "user": None,
         "user_meta": {},
-        "username_pattern": Any.string(),
+        "username_pattern": mock.ANY,
         "format_date": format_date,
     }
 
@@ -110,7 +109,7 @@ def test_users_index_user_marked_as_deleted(models, pyramid_request, factories):
         "authority": "foo.org",
         "user": None,
         "user_meta": {},
-        "username_pattern": Any.string(),
+        "username_pattern": mock.ANY,
         "format_date": format_date,
     }
 
@@ -132,7 +131,7 @@ def test_users_index_user_found(
         "authority": "foo.org",
         "user": user,
         "user_meta": {"annotations_count": 8},
-        "username_pattern": Any.string(),
+        "username_pattern": mock.ANY,
         "format_date": format_date,
     }
 


### PR DESCRIPTION
Work towards resolving an ambiguity when parsing mentions out of text like `"I like this @bob."` by disallowing periods at the start and end of usernames.

There are a small number (~2000 or <0.1%) of existing accounts which do contain periods at the start or end of usernames. We need to continue to allow those accounts to be used, but we can get away with not supporting extracting mentions for those users from text.

Fixes https://github.com/hypothesis/h/issues/9335.

**Testing:**

1. Try to create a new user account that starts or ends with a period. This should be rejected, with a helpful validation error.
2. Try to log in to an existing user account that starts or ends with a period. This should work as before.
3. Try to rename a user account to start or end with a period. This should be rejected.