### PR TITLE
Log a message whenever an email is sent

### DIFF
--- a/h/services/email.py
+++ b/h/services/email.py
@@ -1,8 +1,9 @@
 # noqa: A005
 
 import smtplib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import Any
 
 import pyramid_mailer
 import pyramid_mailer.message
@@ -42,6 +43,18 @@ class EmailData:
         )
 
 
+@dataclass(frozen=True)
+class LogData:
+    tag: EmailTag
+    sender_id: int
+    recipient_ids: list[int] = field(default_factory=list)
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def extra_msg(self) -> str:
+        return ", ".join(f"{k}={v!r}" for k, v in self.extra.items() if v is not None)
+
+
 class EmailService:
     """A service for sending emails."""
 
@@ -49,11 +62,11 @@ class EmailService:
         self._request = request
         self._mailer = mailer
 
-    def send(self, email: EmailData) -> None:
+    def send(self, email_data: EmailData, log_data: LogData | None = None) -> None:
         if self._request.debug:  # pragma: no cover
             logger.info("emailing in debug mode: check the `mail/` directory")
         try:
-            self._mailer.send_immediately(email.message)
+            self._mailer.send_immediately(email_data.message)
         except smtplib.SMTPRecipientsRefused as exc:  # pragma: no cover
             logger.warning(
                 "Recipient was refused when trying to send an email. Does the user have an invalid email address?",
@@ -61,6 +74,17 @@ class EmailService:
             )
         except smtplib.SMTPException:
             raise
+
+        if log_data:
+            separator = ", " if log_data.extra_msg else ""
+            logger.info(
+                "Sent email: tag=%r, sender_id=%s, recipient_ids=%s%s%s",
+                log_data.tag,
+                log_data.sender_id,
+                log_data.recipient_ids,
+                separator,
+                log_data.extra_msg,
+            )
 
 
 def factory(_context, request: Request) -> EmailService:

--- a/h/tasks/mailer.py
+++ b/h/tasks/mailer.py
@@ -6,7 +6,7 @@ This module defines a Celery task for sending emails in a worker process.
 
 from typing import Any
 
-from h.services.email import EmailData, EmailService
+from h.services.email import EmailData, EmailService, LogData
 from h.tasks.celery import celery, get_task_logger
 
 __all__ = ("send",)
@@ -21,11 +21,14 @@ logger = get_task_logger(__name__)
     max_retries=3,
     retry_jitter=False,
 )
-def send(self, email_data: dict[str, Any]) -> None:  # noqa: ARG001
+def send(
+    self,  # noqa: ARG001
+    email_data: dict[str, Any],
+    log_data: dict[str, Any] | None = None,
+) -> None:
     """Send an email.
 
     :param email_data: A dictionary containing email data compatible with EmailData class.
     """
     service: EmailService = celery.request.find_service(EmailService)
-    email = EmailData(**email_data)
-    service.send(email)
+    service.send(EmailData(**email_data), LogData(**log_data) if log_data else None)

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -30,6 +30,7 @@ from h.schemas.forms.accounts import (
     ResetPasswordSchema,
 )
 from h.services import SubscriptionService
+from h.services.email import LogData
 from h.tasks import mailer
 from h.util.view import json_view
 
@@ -211,8 +212,11 @@ class ForgotPasswordController:
             raise httpexceptions.HTTPFound(self.request.route_path("index"))
 
     def _send_forgot_password_email(self, user):
-        email = reset_password.generate(self.request, user)
-        mailer.send.delay(asdict(email))
+        email_data = reset_password.generate(self.request, user)
+        log_data = LogData(
+            tag=email_data.tag, sender_id=user.id, recipient_ids=[user.id]
+        )
+        mailer.send.delay(asdict(email_data), asdict(log_data))
 
 
 @view_defaults(

--- a/h/views/admin/mailer.py
+++ b/h/views/admin/mailer.py
@@ -5,6 +5,7 @@ from pyramid.view import view_config
 
 from h.emails import test
 from h.security import Permission
+from h.services.email import LogData
 from h.tasks import mailer
 
 
@@ -31,8 +32,12 @@ def mailer_test(request):
         index = request.route_path("admin.mailer")
         return HTTPSeeOther(location=index)
 
-    email = test.generate(request, request.params["recipient"])
-    result = mailer.send.delay(asdict(email))
+    email_data = test.generate(request, request.params["recipient"])
+    log_data = LogData(
+        tag=email_data.tag,
+        sender_id=request.user.id,
+    )
+    result = mailer.send.delay(asdict(email_data), asdict(log_data))
     index = request.route_path("admin.mailer", _query={"taskid": result.task_id})
     return HTTPSeeOther(location=index)
 

--- a/tests/unit/h/tasks/mailer_test.py
+++ b/tests/unit/h/tasks/mailer_test.py
@@ -2,8 +2,40 @@ from unittest import mock
 
 import pytest
 
-from h.services.email import EmailTag
+from h.services.email import EmailData, EmailTag, LogData
 from h.tasks import mailer
+
+
+def test_send_without_log_data(email_service):
+    email_data = {
+        "recipients": ["foo@example.com"],
+        "subject": "My email subject",
+        "body": "Some text body",
+        "tag": EmailTag.TEST,
+    }
+    mailer.send(email_data)
+
+    email_service.send.assert_called_once_with(EmailData(**email_data), None)
+
+
+def test_send_with_log_data(email_service):
+    email_data = {
+        "recipients": ["foo@example.com"],
+        "subject": "My email subject",
+        "body": "Some text body",
+        "tag": EmailTag.TEST,
+    }
+    log_data = {
+        "sender_id": 123,
+        "recipient_ids": [456],
+        "tag": EmailTag.TEST,
+        "extra": {"annotation_id": "annotation_id"},
+    }
+    mailer.send(email_data, log_data)
+
+    email_service.send.assert_called_once_with(
+        EmailData(**email_data), LogData(**log_data)
+    )
 
 
 def test_send_retries_if_mailing_fails(email_service):


### PR DESCRIPTION
Refs #9288

This PR adds logging of the fact that a notification has been sent after having done so. The logging happens in the email service right after successful sending.

Testing
===
- Log in as `devdata_admin`
- Create a reply / mention notification of `devdata_user`
- Observe `Send email ...` in the logs

Testing backwards compatibility
===
- Run `make shell`
- Execute this code
```python
from dataclasses import asdict

from h.services.email import EmailData, EmailTag
from h.tasks import mailer

if __name__ == "__main__":
    email_data = EmailData(
        recipients=["example.com"],
        subject="My email subject",
        body="Some text body",
        tag=EmailTag.TEST,
        html="<p>An HTML body</p>",
    )
    mailer.send.delay(asdict(email_data))
```
- Inspect `/mail` folder the new new mail