### PR TITLE
Generate mention notification emails

### DIFF
--- a/h/emails/__init__.py
+++ b/h/emails/__init__.py
@@ -1,3 +1,3 @@
 from h.emails import reply_notification, reset_password, signup
 
-__all__ = ("reply_notification", "reset_password", "signup")
+__all__ = ("mention_notification", "reply_notification", "reset_password", "signup")

--- a/h/emails/mention_notification.py
+++ b/h/emails/mention_notification.py
@@ -1,0 +1,30 @@
+from pyramid.renderers import render
+from pyramid.request import Request
+
+from h import links
+from h.emails.util import get_user_url
+from h.notification.mention import MentionNotification
+
+
+def generate(request: Request, notification: MentionNotification):
+    context = {
+        "user_url": get_user_url(notification.mentioning_user, request),
+        "user_display_name": notification.mentioning_user.display_name
+        or notification.mentioning_user.username,
+        "annotation_url": links.incontext_link(request, notification.annotation)
+        or request.route_url("annotation", id=notification.annotation.id),
+        "document_title": notification.document.title
+        or notification.annotation.target_uri,
+        "document_url": notification.annotation.target_uri,
+        "annotation": notification.annotation,
+    }
+
+    subject = f"{context['user_display_name']} has mentioned you in an annotation"
+    text = render(
+        "h:templates/emails/mention_notification.txt.jinja2", context, request=request
+    )
+    html = render(
+        "h:templates/emails/mention_notification.html.jinja2", context, request=request
+    )
+
+    return [notification.mentioned_user.email], subject, text, html

--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -2,6 +2,7 @@ from pyramid.renderers import render
 from pyramid.request import Request
 
 from h import links
+from h.emails.util import get_user_url
 from h.models import Subscriptions
 from h.notification.reply import Notification
 from h.services import SubscriptionService
@@ -28,7 +29,7 @@ def generate(request: Request, notification: Notification):
         "parent": notification.parent,
         "parent_user_display_name": notification.parent_user.display_name
         or notification.parent_user.username,
-        "parent_user_url": _get_user_url(notification.parent_user, request),
+        "parent_user_url": get_user_url(notification.parent_user, request),
         "unsubscribe_url": request.route_url(
             "unsubscribe",
             token=unsubscribe_token,
@@ -39,7 +40,7 @@ def generate(request: Request, notification: Notification):
         or request.route_url("annotation", id=notification.reply.id),
         "reply_user_display_name": notification.reply_user.display_name
         or notification.reply_user.username,
-        "reply_user_url": _get_user_url(notification.reply_user, request),
+        "reply_user_url": get_user_url(notification.reply_user, request),
     }
 
     subject = f"{context['reply_user_display_name']} has replied to your annotation"
@@ -57,10 +58,3 @@ def generate(request: Request, notification: Notification):
         EmailTag.REPLY_NOTIFICATION,
         html,
     )
-
-
-def _get_user_url(user, request):
-    if user.authority == request.default_authority:
-        return request.route_url("stream.user_query", user=user.username)
-
-    return None

--- a/h/emails/util.py
+++ b/h/emails/util.py
@@ -1,0 +1,10 @@
+from pyramid.request import Request
+
+from h.models import User
+
+
+def get_user_url(user: User, request: Request) -> str | None:
+    if user.authority == request.default_authority:
+        return request.route_url("stream.user_query", user=user.username)
+
+    return None

--- a/h/notification/mention.py
+++ b/h/notification/mention.py
@@ -1,0 +1,16 @@
+import logging
+from dataclasses import dataclass
+
+from h.models import Annotation, Document, User
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MentionNotification:
+    """A data structure representing a mention notification in an annotation."""
+
+    mentioning_user: User
+    mentioned_user: User
+    annotation: Annotation
+    document: Document

--- a/h/templates/emails/mention_notification.html.jinja2
+++ b/h/templates/emails/mention_notification.html.jinja2
@@ -1,0 +1,26 @@
+<p>
+  {% if user_url %}
+    <a href="{{ user_url }}">{{ user_display_name }}</a>
+  {% else %}
+    {{ user_display_name }}
+  {% endif %}
+  has
+  <a href="{{ annotation_url }}">mentioned you</a>
+  on
+  <a href="{{ document_url }}">&ldquo;{{ document_title }}&rdquo;</a>:
+</p>
+
+<p>
+  On
+  {{ annotation.updated | human_timestamp }}
+  {% if user_url %}
+    <a href="{{ user_url }}">{{ user_display_name }}</a>
+  {% else %}
+    {{ user_display_name }}
+  {% endif %}
+  commented:
+</p>
+
+<blockquote>{{ (annotation.text or "")|striptags }}</blockquote>
+
+<p><a href="{{ annotation_url }}">View the thread and respond</a>.</p>

--- a/h/templates/emails/mention_notification.txt.jinja2
+++ b/h/templates/emails/mention_notification.txt.jinja2
@@ -1,0 +1,7 @@
+{{ user_display_name }} has mentioned you on "{{ document_title }}":
+
+On {{ annotation.updated | human_timestamp }} {{ user_display_name }} commented:
+
+> {{ (annotation.text or "")|striptags }}
+
+View the thread and respond: {{ annotation_url }}

--- a/h/templates/emails/reply_notification.html.jinja2
+++ b/h/templates/emails/reply_notification.html.jinja2
@@ -21,7 +21,7 @@
   commented:
 </p>
 
-<blockquote>{{ parent.text or "" }}</blockquote>
+<blockquote>{{ (parent.text or "")|striptags }}</blockquote>
 
 <p>
   On
@@ -34,7 +34,7 @@
   replied:
 </p>
 
-<blockquote>{{ reply.text or "" }}</blockquote>
+<blockquote>{{ (reply.text or "")|striptags }}</blockquote>
 
 <p><a href="{{ reply_url }}">View the thread and respond</a>.</p>
 

--- a/h/templates/emails/reply_notification.txt.jinja2
+++ b/h/templates/emails/reply_notification.txt.jinja2
@@ -2,11 +2,11 @@
 
 On {{ parent.created | human_timestamp }} {{ parent_user_display_name }} commented:
 
-> {{ parent.text or "" }}
+> {{ (parent.text or "")|striptags }}
 
 On {{ reply.created | human_timestamp }} {{ reply_user_display_name }} replied:
 
-> {{ reply.text or "" }}
+> {{ (reply.text or "")|striptags }}
 
 View the thread and respond: {{ reply_url }}
 

--- a/tests/unit/h/emails/mention_notification_test.py
+++ b/tests/unit/h/emails/mention_notification_test.py
@@ -1,0 +1,206 @@
+import datetime
+
+import pytest
+
+from h.emails.mention_notification import generate
+from h.emails.util import get_user_url
+from h.models import Annotation, Document
+from h.notification.mention import MentionNotification
+
+
+class TestGenerate:
+    def test_it(
+        self,
+        annotation,
+        notification,
+        document,
+        mentioning_user,
+        pyramid_request,
+        html_renderer,
+        text_renderer,
+        links,
+    ):
+        generate(pyramid_request, notification)
+
+        links.incontext_link.assert_called_once_with(
+            pyramid_request, notification.annotation
+        )
+
+        expected_context = {
+            "user_url": get_user_url(notification.mentioning_user, pyramid_request),
+            "user_display_name": mentioning_user.display_name,
+            "annotation_url": links.incontext_link.return_value,
+            "document_title": document.title,
+            "document_url": annotation.target_uri,
+            "annotation": notification.annotation,
+        }
+        html_renderer.assert_(**expected_context)  # noqa: PT009
+        text_renderer.assert_(**expected_context)  # noqa: PT009
+
+    def test_falls_back_to_individual_page_if_no_bouncer(
+        self,
+        annotation,
+        notification,
+        pyramid_request,
+        html_renderer,
+        text_renderer,
+        links,
+    ):
+        links.incontext_link.return_value = None
+
+        generate(pyramid_request, notification)
+
+        expected_context = {
+            "annotation_url": f"http://example.com/ann/{annotation.id}",
+        }
+        html_renderer.assert_(**expected_context)  # noqa: PT009
+        text_renderer.assert_(**expected_context)  # noqa: PT009
+
+    def test_returns_usernames_if_no_display_names(
+        self,
+        notification,
+        mentioning_user,
+        pyramid_request,
+        html_renderer,
+        text_renderer,
+    ):
+        mentioning_user.display_name = None
+
+        generate(pyramid_request, notification)
+
+        expected_context = {
+            "user_display_name": mentioning_user.username,
+        }
+        html_renderer.assert_(**expected_context)  # noqa: PT009
+        text_renderer.assert_(**expected_context)  # noqa: PT009
+
+    def test_returns_text_and_body_results_from_renderers(
+        self, notification, pyramid_request, html_renderer, text_renderer
+    ):
+        html_renderer.string_response = "HTML output"
+        text_renderer.string_response = "Text output"
+
+        _, _, text, html = generate(pyramid_request, notification)
+
+        assert html == "HTML output"
+        assert text == "Text output"
+
+    def test_returns_subject_with_reply_display_name(
+        self, notification, pyramid_request, mentioning_user
+    ):
+        _, subject, _, _ = generate(pyramid_request, notification)
+
+        assert (
+            subject
+            == f"{mentioning_user.display_name} has mentioned you in an annotation"
+        )
+
+    def test_returns_subject_with_reply_username(
+        self, notification, pyramid_request, mentioning_user
+    ):
+        mentioning_user.display_name = None
+
+        _, subject, _, _ = generate(pyramid_request, notification)
+
+        assert (
+            subject == f"{mentioning_user.username} has mentioned you in an annotation"
+        )
+
+    def test_returns_parent_email_as_recipients(
+        self, notification, pyramid_request, mentioned_user
+    ):
+        recipients, _, _, _ = generate(pyramid_request, notification)
+
+        assert recipients == [mentioned_user.email]
+
+    def test_jinja_templates_render(
+        self, notification, pyramid_config, pyramid_request
+    ):
+        """Ensure that the jinja templates don't contain syntax errors."""
+        pyramid_config.include("pyramid_jinja2")
+        pyramid_config.include("h.jinja_extensions")
+
+        generate(pyramid_request, notification)
+
+    def test_urls_not_set_for_third_party_users(
+        self, notification, pyramid_request, html_renderer, text_renderer
+    ):
+        pyramid_request.default_authority = "foo.org"
+        expected_context = {"user_url": None}
+
+        generate(pyramid_request, notification)
+
+        html_renderer.assert_(**expected_context)  # noqa: PT009
+        text_renderer.assert_(**expected_context)  # noqa: PT009
+
+    def test_urls_set_for_first_party_users(
+        self,
+        notification,
+        pyramid_request,
+        html_renderer,
+        text_renderer,
+        mentioning_user,
+    ):
+        expected_context = {
+            "user_url": f"http://example.com/stream/user/{mentioning_user.username}",
+        }
+
+        generate(pyramid_request, notification)
+
+        html_renderer.assert_(**expected_context)  # noqa: PT009
+        text_renderer.assert_(**expected_context)  # noqa: PT009
+
+    @pytest.fixture
+    def notification(self, mentioning_user, mentioned_user, annotation, document):
+        return MentionNotification(
+            mentioning_user=mentioning_user,
+            mentioned_user=mentioned_user,
+            annotation=annotation,
+            document=document,
+        )
+
+    @pytest.fixture
+    def document(self, db_session):
+        doc = Document(title="My fascinating page")
+        db_session.add(doc)
+        db_session.flush()
+        return doc
+
+    @pytest.fixture
+    def mentioning_user(self, factories):
+        return factories.User()
+
+    @pytest.fixture
+    def mentioned_user(self, factories):
+        return factories.User()
+
+    @pytest.fixture
+    def annotation(self):
+        common = {
+            "id": "foo123",
+            "created": datetime.datetime.now(tz=datetime.UTC),
+            "updated": datetime.datetime.now(tz=datetime.UTC),
+            "text": "Foo is true",
+        }
+        return Annotation(target_uri="http://example.org/", **common)
+
+    @pytest.fixture(autouse=True)
+    def links(self, patch):
+        return patch("h.emails.mention_notification.links")
+
+    @pytest.fixture(autouse=True)
+    def html_renderer(self, pyramid_config):
+        return pyramid_config.testing_add_renderer(
+            "h:templates/emails/mention_notification.html.jinja2"
+        )
+
+    @pytest.fixture(autouse=True)
+    def text_renderer(self, pyramid_config):
+        return pyramid_config.testing_add_renderer(
+            "h:templates/emails/mention_notification.txt.jinja2"
+        )
+
+    @pytest.fixture(autouse=True)
+    def routes(self, pyramid_config):
+        pyramid_config.add_route("annotation", "/ann/{id}")
+        pyramid_config.add_route("stream.user_query", "/stream/user/{user}")


### PR DESCRIPTION
Refs #9338, #9279

This one just adds the ability to generate mention notification emails which we will be actually sending in a follow up PR.

See testing instructions in #9345