### PR TITLE
Send email notification on mention

### DIFF
--- a/h/emails/__init__.py
+++ b/h/emails/__init__.py
@@ -1,3 +1,3 @@
-from h.emails import reply_notification, reset_password, signup
+from h.emails import mention_notification, reply_notification, reset_password, signup
 
 __all__ = ("mention_notification", "reply_notification", "reset_password", "signup")

--- a/h/emails/mention_notification.py
+++ b/h/emails/mention_notification.py
@@ -4,6 +4,7 @@ from pyramid.request import Request
 from h import links
 from h.emails.util import get_user_url
 from h.notification.mention import MentionNotification
+from h.services.email import EmailTag
 
 
 def generate(request: Request, notification: MentionNotification):
@@ -27,4 +28,10 @@ def generate(request: Request, notification: MentionNotification):
         "h:templates/emails/mention_notification.html.jinja2", context, request=request
     )
 
-    return [notification.mentioned_user.email], subject, text, html
+    return (
+        [notification.mentioned_user.email],
+        subject,
+        text,
+        EmailTag.MENTION_NOTIFICATION,
+        html,
+    )

--- a/h/notification/mention.py
+++ b/h/notification/mention.py
@@ -14,3 +14,50 @@ class MentionNotification:
     mentioned_user: User
     annotation: Annotation
     document: Document
+
+
+def get_notifications(
+    request, annotation: Annotation, action
+) -> list[MentionNotification]:
+    # Only send notifications when new annotations are created
+    if action != "create":
+        return []
+
+    user_service = request.find_service(name="user")
+
+    # If the mentioning user doesn't exist (anymore), we can't send emails, but
+    # this would be super weird, so log a warning.
+    mentioning_user = user_service.fetch(annotation.userid)
+    if mentioning_user is None:
+        logger.warning(
+            "user who just mentioned another user no longer exists: %s",
+            annotation.userid,
+        )
+        return []
+
+    notifications = []
+    for mention in annotation.mentions:
+        # If the mentioned user doesn't exist (anymore), we can't send emails
+        mentioned_user = user_service.fetch(mention.user.userid)
+        if mentioned_user is None:
+            continue
+
+        # If mentioned user doesn't have an email address we can't email them.
+        if not mention.user.email:
+            continue
+
+        # If the mentioning user mentions self, we don't want to send an email.
+        if mentioned_user == mentioning_user:
+            continue
+
+        # If the annotation doesn't have a document, we can't send an email.
+        if annotation.document is None:
+            continue
+
+        notifications.append(
+            MentionNotification(
+                mentioning_user, mentioned_user, annotation, annotation.document
+            )
+        )
+
+    return notifications

--- a/h/services/email.py
+++ b/h/services/email.py
@@ -18,6 +18,7 @@ class EmailTag(StrEnum):
     FLAG_NOTIFICATION = "flag_notification"
     REPLY_NOTIFICATION = "reply_notification"
     RESET_PASSWORD = "reset_password"  # noqa: S105
+    MENTION_NOTIFICATION = "mention_notification"
     TEST = "test"
 
 

--- a/h/services/mention.py
+++ b/h/services/mention.py
@@ -33,7 +33,9 @@ class MentionService:
         if mentioning_user.nipsa:
             return
 
-        mentioned_userids = OrderedDict.fromkeys(self._parse_userids(annotation.text))
+        mentioned_userids = OrderedDict.fromkeys(
+            self._parse_userids(annotation.text)
+        ).keys()
         mentioned_users = self._user_service.fetch_all(mentioned_userids)
         self._session.execute(
             delete(Mention).where(Mention.annotation_id == annotation.id)

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -5,7 +5,7 @@ from pyramid.events import BeforeRender, subscriber
 from h import __version__, emails
 from h.events import AnnotationEvent
 from h.exceptions import RealtimeMessageQueueError
-from h.notification import reply
+from h.notification import mention, reply
 from h.services.annotation_read import AnnotationReadService
 from h.tasks import mailer
 
@@ -89,3 +89,27 @@ def send_reply_notifications(event):
         except OperationalError as err:  # pragma: no cover
             # We could not connect to rabbit! So carry on
             report_exception(err)
+
+
+@subscriber(AnnotationEvent)
+def send_mention_notifications(event):
+    """Send mention notifications triggered by a mention event."""
+    request = event.request
+
+    with request.tm:
+        annotation = request.find_service(AnnotationReadService).get_annotation_by_id(
+            event.annotation_id,
+        )
+        notifications = mention.get_notifications(request, annotation, event.action)
+
+        if not notifications:
+            return
+
+        for notification in notifications:
+            send_params = emails.mention_notification.generate(request, notification)
+
+            try:
+                mailer.send.delay(*send_params)
+            except OperationalError as err:  # pragma: no cover
+                # We could not connect to rabbit! So carry on
+                report_exception(err)

--- a/tests/unit/h/emails/mention_notification_test.py
+++ b/tests/unit/h/emails/mention_notification_test.py
@@ -80,7 +80,7 @@ class TestGenerate:
         html_renderer.string_response = "HTML output"
         text_renderer.string_response = "Text output"
 
-        _, _, text, html = generate(pyramid_request, notification)
+        _, _, text, _, html = generate(pyramid_request, notification)
 
         assert html == "HTML output"
         assert text == "Text output"
@@ -88,7 +88,7 @@ class TestGenerate:
     def test_returns_subject_with_reply_display_name(
         self, notification, pyramid_request, mentioning_user
     ):
-        _, subject, _, _ = generate(pyramid_request, notification)
+        _, subject, _, _, _ = generate(pyramid_request, notification)
 
         assert (
             subject
@@ -100,7 +100,7 @@ class TestGenerate:
     ):
         mentioning_user.display_name = None
 
-        _, subject, _, _ = generate(pyramid_request, notification)
+        _, subject, _, _, _ = generate(pyramid_request, notification)
 
         assert (
             subject == f"{mentioning_user.username} has mentioned you in an annotation"
@@ -109,7 +109,7 @@ class TestGenerate:
     def test_returns_parent_email_as_recipients(
         self, notification, pyramid_request, mentioned_user
     ):
-        recipients, _, _, _ = generate(pyramid_request, notification)
+        recipients, _, _, _, _ = generate(pyramid_request, notification)
 
         assert recipients == [mentioned_user.email]
 

--- a/tests/unit/h/notification/mention_test.py
+++ b/tests/unit/h/notification/mention_test.py
@@ -1,0 +1,85 @@
+from unittest.mock import call
+
+import pytest
+
+from h.notification.mention import MentionNotification, get_notifications
+
+
+class TestGetNotifications:
+    def test_it(
+        self, annotation, mentioning_user, mentioned_user, pyramid_request, user_service
+    ):
+        result = get_notifications(pyramid_request, annotation, "create")
+
+        user_service.fetch.assert_has_calls(
+            [call(mentioning_user.userid), call(mentioned_user.userid)]
+        )
+
+        assert len(result) == 1
+        assert isinstance(result[0], MentionNotification)
+        assert result[0].mentioning_user == mentioning_user
+        assert result[0].mentioned_user == mentioned_user
+        assert result[0].annotation == annotation
+        assert result[0].document == annotation.document
+
+    def test_it_returns_empty_list_when_action_is_not_create(
+        self, pyramid_request, annotation
+    ):
+        assert get_notifications(pyramid_request, annotation, "NOT_CREATE") == []
+
+    def test_it_returns_empty_list_when_mentioning_user_does_not_exist(
+        self, pyramid_request, annotation, user_service, factories
+    ):
+        user_service.fetch.side_effect = (None, factories.User())
+
+        assert get_notifications(pyramid_request, annotation, "create") == []
+
+    def test_it_returns_empty_list_when_mentioned_user_does_not_exist(
+        self, pyramid_request, annotation, user_service, factories
+    ):
+        user_service.fetch.side_effect = (factories.User(), None)
+
+        assert get_notifications(pyramid_request, annotation, "create") == []
+
+    def test_it_returns_empty_list_when_mentioned_user_has_no_email_address(
+        self, pyramid_request, annotation, mentioned_user
+    ):
+        mentioned_user.email = None
+        assert get_notifications(pyramid_request, annotation, "create") == []
+
+    def test_it_returns_empty_list_when_annotation_document_is_empty(
+        self, pyramid_request, annotation
+    ):
+        annotation.document = None
+
+        assert get_notifications(pyramid_request, annotation, "create") == []
+
+    def test_it_returns_empty_list_when_self_mention(
+        self, pyramid_request, annotation, user_service, mentioning_user
+    ):
+        user_service.fetch.side_effect = (mentioning_user, mentioning_user)
+
+        assert get_notifications(pyramid_request, annotation, "create") == []
+
+    @pytest.fixture
+    def annotation(self, factories, mentioning_user, mention):
+        return factories.Annotation(
+            userid=mentioning_user.userid, shared=True, mentions=[mention]
+        )
+
+    @pytest.fixture
+    def mentioned_user(self, factories):
+        return factories.User(nipsa=False)
+
+    @pytest.fixture
+    def mentioning_user(self, factories):
+        return factories.User(nipsa=False)
+
+    @pytest.fixture
+    def mention(self, factories, mentioned_user):
+        return factories.Mention(user=mentioned_user)
+
+    @pytest.fixture(autouse=True)
+    def user_service(self, user_service, mentioning_user, mentioned_user):
+        user_service.fetch.side_effect = (mentioning_user, mentioned_user)
+        return user_service

--- a/tests/unit/h/services/mention_test.py
+++ b/tests/unit/h/services/mention_test.py
@@ -76,10 +76,12 @@ class TestMentionService:
         return annotation
 
     @pytest.fixture
-    def annotation_slim(self, factories):
-        slim = factories.AnnotationSlim()
-        slim.user.nipsa = False
-        return slim
+    def annotation_slim(self, factories, mentioning_user):
+        return factories.AnnotationSlim(user=mentioning_user)
+
+    @pytest.fixture
+    def mentioning_user(self, factories):
+        return factories.User(nipsa=False)
 
     @pytest.fixture
     def mentioned_user(self, factories):


### PR DESCRIPTION
Refs #9338, #9279

This one just actually implements the logic for sending mention emails leveraging the generation part addressed in the previous PR.

Testing emails
===
Notifications are sent only on creation for now

- Login as devdata_admin and generate API token from http://localhost:5000/account/developer
- Create annotation
   ```
	curl -X POST --location "http://localhost:5000/api/annotations" \
    -H "Authorization: Bearer <token>" \
    -H "Content-Type: application/json" \
    -d '{
            "uri": "https://www.google.com/",
            "text": "Hello <a data-hyp-mention data-userid=\"acct:devdata_admin@localhost\">@devdata_admin</a>, take a look at this\nHello <a data-hyp-mention data-userid=\"acct:devdata_user@localhost\">@devdata_user</a>, take a look at this"
        }'
    ```
- Check `h/mail` folder for incoming mail