### PR TITLE
Include description and joining date in mention model

### DIFF
--- a/docs/_extra/api-reference/schemas/annotation.yaml
+++ b/docs/_extra/api-reference/schemas/annotation.yaml
@@ -222,4 +222,11 @@ Annotation:
             type: string
             format: uri
             description: The link to the user profile
+          description:
+            type: string
+            description: The user description
+          created:
+            type: string
+            format: date-time
+            description: When the user was created
       description: An array of user mentions the annotation text

--- a/h/presenters/mention_json.py
+++ b/h/presenters/mention_json.py
@@ -3,6 +3,7 @@ from typing import Any
 from pyramid.request import Request
 
 from h.models import Mention
+from h.util.datetime import utc_iso8601
 from h.util.user import format_userid, get_user_url
 
 
@@ -22,4 +23,6 @@ class MentionJSONPresenter:
             "username": self._mention.user.username,
             "display_name": self._mention.user.display_name,
             "link": get_user_url(self._mention.user, self._request),
+            "description": self._mention.user.description,
+            "created": utc_iso8601(self._mention.user.activation_date),
         }

--- a/tests/unit/h/presenters/mention_json_test.py
+++ b/tests/unit/h/presenters/mention_json_test.py
@@ -1,7 +1,9 @@
+import factory
 import pytest
 
 from h.models import Mention
 from h.presenters.mention_json import MentionJSONPresenter
+from h.util.datetime import utc_iso8601
 from h.util.user import format_userid
 
 
@@ -17,6 +19,8 @@ class TestMentionJSONPresenter:
             "username": user.username,
             "display_name": user.display_name,
             "link": f"http://example.com/users/{user.username}",
+            "description": user.description,
+            "created": utc_iso8601(user.activation_date),
         }
 
     def test_as_dict_with_different_username(self, user, annotation, pyramid_request):
@@ -29,7 +33,10 @@ class TestMentionJSONPresenter:
 
     @pytest.fixture
     def user(self, factories):
-        return factories.User.build()
+        return factories.User.build(
+            description="user description",
+            activation_date=factory.Faker("date_time_this_decade"),
+        )
 
     @pytest.fixture
     def annotation(self, factories):


### PR DESCRIPTION
Refs #9348

Exposing `description` and `activation_date` from the `user` model in the `mentions` on a returned annotation

Testing
===
- Run `make devdata` to make sure `devdata_user` is in the db
- Run `make sql`
- Execute sql so that the user has both fields filled.
```sql
UPDATE public."user" SET description = 'hello world', activation_date = '2025-02-13 09:37:44.000000' WHERE username = 'devdata_user';
```
- Log in as `devdata_user` and generate API token from http://localhost:5000/account/developer
- Create annotation with mentions
   ```
	curl -X POST --location "http://localhost:5000/api/annotations" \
    -H "Authorization: Bearer <token>" \
    -H "Content-Type: application/json" \
    -d '{
            "uri": "https://www.google.com/",
            "text": "Hello <a data-hyp-mention data-userid=\"acct:devdata_admin@localhost\">@devdata_admin</a>, take a look at this\nHello <a data-hyp-mention data-userid=\"acct:devdata_user@localhost\">@devdata_user</a>, take a look at this"
        }'
    ```
- Confirm that the fields are present in the output
```
            "description": "hello world",
            "created": "2025-02-13T09:37:44.000000+00:00"
```