### PR TITLE
Rename mention created API field to join

### DIFF
--- a/docs/_extra/api-reference/schemas/annotation.yaml
+++ b/docs/_extra/api-reference/schemas/annotation.yaml
@@ -225,8 +225,8 @@ Annotation:
           description:
             type: string
             description: The user description
-          created:
+          joined:
             type: string
             format: date-time
-            description: When the user was created
+            description: When the user joined
       description: An array of user mentions the annotation text

--- a/h/presenters/mention_json.py
+++ b/h/presenters/mention_json.py
@@ -24,5 +24,5 @@ class MentionJSONPresenter:
             "display_name": self._mention.user.display_name,
             "link": get_user_url(self._mention.user, self._request),
             "description": self._mention.user.description,
-            "created": utc_iso8601(self._mention.user.activation_date),
+            "joined": utc_iso8601(self._mention.user.activation_date),
         }

--- a/tests/unit/h/presenters/mention_json_test.py
+++ b/tests/unit/h/presenters/mention_json_test.py
@@ -20,7 +20,7 @@ class TestMentionJSONPresenter:
             "display_name": user.display_name,
             "link": f"http://example.com/users/{user.username}",
             "description": user.description,
-            "created": utc_iso8601(user.activation_date),
+            "joined": utc_iso8601(user.activation_date),
         }
 
     def test_as_dict_with_different_username(self, user, annotation, pyramid_request):


### PR DESCRIPTION
As discussed [in slack](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1739534261793979?thread_ts=1739531545.214939&cid=C4K6M7P5E), this PR renames the `created` field in mentions to `joined`, so that it's more obvious it is the date in which the mentioned user joined, not the date in which the mention itself was created.