### PR TITLE
Allow mentioning on only me annotations

### DIFF
--- a/h/notification/mention.py
+++ b/h/notification/mention.py
@@ -23,6 +23,10 @@ def get_notifications(
     if action != "create":
         return []
 
+    # Only send notifications for shared annotations
+    if not annotation.shared:
+        return []
+
     user_service = request.find_service(name="user")
 
     # If the mentioning user doesn't exist (anymore), we can't send emails, but

--- a/h/services/mention.py
+++ b/h/services/mention.py
@@ -25,9 +25,6 @@ class MentionService:
     def update_mentions(self, annotation: Annotation) -> None:
         self._session.flush()
 
-        # Only shared annotations can have mentions
-        if not annotation.shared:
-            return
         mentioning_user = self._user_service.fetch(annotation.userid)
         # NIPSA users do not send mentions
         if mentioning_user.nipsa:

--- a/tests/unit/h/notification/mention_test.py
+++ b/tests/unit/h/notification/mention_test.py
@@ -61,6 +61,13 @@ class TestGetNotifications:
 
         assert get_notifications(pyramid_request, annotation, "create") == []
 
+    def test_it_returns_empty_list_when_annotation_not_shared(
+        self, pyramid_request, annotation
+    ):
+        annotation.shared = False
+
+        assert get_notifications(pyramid_request, annotation, "create") == []
+
     @pytest.fixture
     def annotation(self, factories, mentioning_user, mention):
         return factories.Annotation(

--- a/tests/unit/h/services/mention_test.py
+++ b/tests/unit/h/services/mention_test.py
@@ -61,13 +61,6 @@ class TestMentionService:
 
         assert len(annotation.mentions) == 0
 
-    def test_update_mentions_with_private_annotation(self, service, annotation):
-        annotation.shared = False
-
-        service.update_mentions(annotation)
-
-        assert len(annotation.mentions) == 0
-
     @pytest.fixture
     def annotation(self, annotation_slim, mentioned_user):
         annotation = annotation_slim.annotation


### PR DESCRIPTION
Refs #9350

Instead of disabling mention creation in annotations which are not shared we create them but do not send their notifications.

Testing
===
- Login as devdata_admin and generate API token from http://localhost:5000/account/developer
- Create annotation with user-only read permission
   ```
    curl -X POST --location "http://localhost:5000/api/annotations" \
    -H "Authorization: Bearer <token>" \
    -H "Content-Type: application/json" \
    -d '{
            "uri": "https://www.google.com/",
            "text": "Hello <a data-hyp-mention data-userid=\"acct:devdata_admin@localhost\">@devdata_admin</a>, take a look at this\nHello <a data-hyp-mention data-userid=\"acct:devdata_user@localhost\">@devdata_user</a>, take a look at this. https://google.com",
            "group": "__world__",
            "permissions":{"read":["acct:devdata_admin@localhost"]}
        }'
    ```
- Check that `h/mail` does not have a new email but the mentions have been returned in the response