### PR TITLE
Fix @mentions feature usage

### DIFF
--- a/h/services/annotation_json.py
+++ b/h/services/annotation_json.py
@@ -87,13 +87,14 @@ class AnnotationJSONService:
                 "links": self._links_service.get_all(annotation),
             }
         )
-        if self._feature_service.enabled("at_mentions"):  # pragma: no cover
+
+        user = self._user_service.fetch(annotation.userid)
+        if self._feature_service.enabled("at_mentions", user):  # pragma: no cover
             model["mentions"] = [
                 MentionJSONPresenter(mention, self._request).asdict()
                 for mention in annotation.mentions
             ]
-
-        model.update(user_info(self._user_service.fetch(annotation.userid)))
+        model.update(user_info(user))
 
         if annotation.references:
             model["references"] = annotation.references

--- a/tests/unit/h/services/annotation_write_test.py
+++ b/tests/unit/h/services/annotation_write_test.py
@@ -21,6 +21,7 @@ class TestAnnotationWriteService:
         queue_service,
         annotation_read_service,
         mention_service,
+        user_service,
         _validate_group,  # noqa: PT019
         db_session,
     ):
@@ -42,6 +43,7 @@ class TestAnnotationWriteService:
             tag="storage.create_annotation",
             schedule_in=60,
         )
+        user_service.fetch.assert_called_once_with(create_data["userid"])
         mention_service.update_mentions.assert_called_once_with(anno)
 
         assert anno == Any.instance_of(Annotation).with_attrs(
@@ -282,6 +284,7 @@ class TestAnnotationWriteService:
         annotation_read_service,
         annotation_metadata_service,
         mention_service,
+        user_service,
         feature_service,
     ):
         return AnnotationWriteService(
@@ -291,6 +294,7 @@ class TestAnnotationWriteService:
             annotation_read_service=annotation_read_service,
             annotation_metadata_service=annotation_metadata_service,
             mention_service=mention_service,
+            user_service=user_service,
             feature_service=feature_service,
         )
 
@@ -328,6 +332,7 @@ class TestServiceFactory:
         annotation_read_service,
         annotation_metadata_service,
         mention_service,
+        user_service,
         feature_service,
     ):
         svc = service_factory(sentinel.context, pyramid_request)
@@ -339,6 +344,7 @@ class TestServiceFactory:
             annotation_read_service=annotation_read_service,
             annotation_metadata_service=annotation_metadata_service,
             mention_service=mention_service,
+            user_service=user_service,
             feature_service=feature_service,
         )
         assert svc == AnnotationWriteService.return_value


### PR DESCRIPTION
Refs https://hypothes-is.slack.com/archives/C4K6M7P5E/p1739546697743619

When deciding if we enable @mentions feature we should take into logged-in user.

Testing
===
- Login as `devdata_admin` and generate API token from http://localhost:5000/account/developer
- Login as `devdata_user` and generate API token from http://localhost:5000/account/developer
- Enable `at_mentions` feature for admins in http://localhost:5000/admin/features
- Try creating an annotation with mentions as admin and user using corresponding token
   ```
	curl -X POST --location "http://localhost:5000/api/annotations" \
    -H "Authorization: Bearer <token>" \
    -H "Content-Type: application/json" \
    -d '{
            "uri": "https://www.google.com/",
            "text": "Hello <a data-hyp-mention data-userid=\"acct:devdata_admin@localhost\">@devdata_admin</a>, take a look at this\nHello <a data-hyp-mention data-userid=\"acct:devdata_user@localhost\">@devdata_user</a>, take a look at this"
        }'
    ```
- Observe that the mentions are created and returned only for admin so we take the logged-in user into account