### PR TITLE
Don't send multiple emails on reply with mentions

### DIFF
--- a/tests/unit/h/subscribers_test.py
+++ b/tests/unit/h/subscribers_test.py
@@ -149,6 +149,20 @@ class TestSendReplyNotifications:
         # No explosions please
         subscribers.send_reply_notifications(event)
 
+    def test_it_does_nothing_if_the_reply_user_is_mentioned(
+        self, event, reply, mailer, mention
+    ):
+        reply_notification = mock.MagicMock()
+        reply.get_notification.return_value = reply_notification
+
+        mention_notifications = [mock.MagicMock()]
+        mention.get_notifications.return_value = mention_notifications
+        mention_notifications[0].mentioned_user = reply_notification.parent_user
+
+        subscribers.send_reply_notifications(event)
+
+        mailer.send.delay.assert_not_called()
+
     @pytest.fixture
     def event(self, pyramid_request):
         return AnnotationEvent(pyramid_request, {"id": "any"}, "action")


### PR DESCRIPTION
Refs #9344 

Changes `send_reply_notifications` so that it doesn't send reply notification if mention notification to the same user would've been sent for the same annotation.

Testing
===
- Login as `devdata_admin` and generate API token from http://localhost:5000/account/developer
- Login as `devdata_user` and generate API token from http://localhost:5000/account/developer
- Enable `at_mentions` feature for everyone in http://localhost:5000/admin/features
- Create parent annotation we will be replying to as admin
```
curl -X POST --location "http://localhost:5000/api/annotations" \
    -H "Authorization: Bearer <admin token>" \
    -H "Content-Type: application/json" \
    -d '{
            "uri": "https://www.google.com/",
            "text": "Hello world",
            "group": "__world__",
            "permissions":{"read":["group:__world__"]}
        }'
```
- Create reply annotation with mentions as user referencing parent one
```
curl -X POST --location "http://localhost:5000/api/annotations" \
    -H "Authorization: Bearer <user token>" \
    -H "Content-Type: application/json" \
    -d '{
            "references": ["<response parent annotation id>"],
            "text": "Hello <a data-hyp-mention data-userid=\"acct:devdata_admin@localhost\">@devdata_admin</a>, take a look at this\nHello <a data-hyp-mention data-userid=\"acct:devdata_user@localhost\">@devdata_user</a>, take a look at this",
            "uri": "https://www.google.com/",
            "group": "__world__",
            "permissions":{"read":["group:__world__"]}
        }'
```
- Confirm that only the mention notification email appears in `/mail` folder