### PR TITLE
Add admin route to preview mentions email

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -54,6 +54,10 @@ def includeme(config):  # noqa: PLR0915
     )
     config.add_route("admin.mailer", "/admin/mailer")
     config.add_route("admin.mailer_test", "/admin/mailer/test")
+    config.add_route(
+        "admin.mailer.preview.mention_notification",
+        "/admin/mailer/preview/mention-notification",
+    )
     config.add_route("admin.nipsa", "/admin/nipsa")
     config.add_route("admin.oauthclients", "/admin/oauthclients")
     config.add_route("admin.oauthclients_create", "/admin/oauthclients/new")

--- a/h/templates/admin/mailer.html.jinja2
+++ b/h/templates/admin/mailer.html.jinja2
@@ -12,11 +12,11 @@
   </div>
 {% endif %}
 
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title">Send a test email</h3>
+  <div class="card">
+    <div class="card-header">
+      <h3 class="card-title mb-0">Send a test email</h3>
     </div>
-    <div class="panel-body">
+    <div class="card-body">
       <form method="POST" action="{{ request.route_path('admin.mailer_test') }}" class="form-inline">
         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <div class="form-group">
@@ -26,6 +26,18 @@
         </div>
       </form>
     </div>
+  </div>
+
+  <div class="card mt-3">
+    <div class="card-header">
+      <h3 class="card-title mb-0">Preview the Mentions Email Template</h3>
+    </div>
+    <iframe
+      class="card-body p-0"
+      style="height: 20em; border: none;"
+      src="{{ request.route_url("admin.mailer.preview.mention_notification") }}"
+    >
+    </iframe>
   </div>
 
 {% endblock %}

--- a/h/views/admin/mailer.py
+++ b/h/views/admin/mailer.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pyramid.httpexceptions import HTTPSeeOther
 from pyramid.view import view_config
 
@@ -33,3 +35,24 @@ def mailer_test(request):
     result = mailer.send.delay(*mail)
     index = request.route_path("admin.mailer", _query={"taskid": result.task_id})
     return HTTPSeeOther(location=index)
+
+
+@view_config(
+    route_name="admin.mailer.preview.mention_notification",
+    request_method="GET",
+    permission=Permission.AdminPage.LOW_RISK,
+    renderer="h:templates/emails/mention_notification.html.jinja2",
+)
+def preview_mention_notification(_request):
+    return {
+        "user_url": "https://example.com/user",
+        "user_display_name": "Jane Doe",
+        "annotation_url": "https://example.com/bouncer",  # Bouncer link (AKA: annotation deeplink)
+        "document_title": "The title",
+        "document_url": "https://example.com/document",  # Document public URL
+        "annotation": {
+            "updated": datetime(year=2025, month=1, day=11, hour=18, minute=36),  # noqa: DTZ001
+            "text": 'Hello <a data-hyp-mention data-userid="acct:user@example.com">@user</a>, how are you?',
+            "text_rendered": 'Hello <a data-hyp-mention data-userid="acct:user@example.com">@user</a>, how are you?',
+        },
+    }

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -61,6 +61,10 @@ def test_includeme():
         ),
         call("admin.mailer", "/admin/mailer"),
         call("admin.mailer_test", "/admin/mailer/test"),
+        call(
+            "admin.mailer.preview.mention_notification",
+            "/admin/mailer/preview/mention-notification",
+        ),
         call("admin.nipsa", "/admin/nipsa"),
         call("admin.oauthclients", "/admin/oauthclients"),
         call("admin.oauthclients_create", "/admin/oauthclients/new"),

--- a/tests/unit/h/views/admin/mailer_test.py
+++ b/tests/unit/h/views/admin/mailer_test.py
@@ -1,7 +1,9 @@
+from datetime import datetime
+
 import pytest
 from pyramid.httpexceptions import HTTPSeeOther
 
-from h.views.admin.mailer import mailer_index, mailer_test
+from h.views.admin.mailer import mailer_index, mailer_test, preview_mention_notification
 
 
 class TestMailerIndex:
@@ -47,6 +49,27 @@ class TestMailerTest:
 
         assert isinstance(result, HTTPSeeOther)
         assert result.location == "/adm/mailer?taskid=a1b2c3"
+
+
+class TestPreviewMentionNotification:
+    def test_returns_dummy_data(self, pyramid_request):
+        result = preview_mention_notification(pyramid_request)
+
+        assert (
+            result
+            == {
+                "user_url": "https://example.com/user",
+                "user_display_name": "Jane Doe",
+                "annotation_url": "https://example.com/bouncer",  # Bouncer link (AKA: annotation deeplink)
+                "document_title": "The title",
+                "document_url": "https://example.com/document",  # Document public URL
+                "annotation": {
+                    "updated": datetime(year=2025, month=1, day=11, hour=18, minute=36),  # noqa: DTZ001
+                    "text": 'Hello <a data-hyp-mention data-userid="acct:user@example.com">@user</a>, how are you?',
+                    "text_rendered": 'Hello <a data-hyp-mention data-userid="acct:user@example.com">@user</a>, how are you?',
+                },
+            }
+        )
 
 
 class FakeResult:


### PR DESCRIPTION
Part of #9355 

Similar to what we have in LMS for the email digest, and to help debug and template the mention notification email, this PR adds a new admin route where we render a dummy preview of said email.

Additionally, this also adds an iframe pointing to that route in the admin mailer section, for convenience: http://localhost:5000/admin/mailer

![image](https://github.com/user-attachments/assets/8dfd263d-9793-47bb-ac5e-cb0254298bc8)

I also took the opportunity to fix some bootstrap styles in the mailer section. Specifically, this section is using `panel` components, which were removed in bootstrap 4, and [replaced](https://getbootstrap.com/docs/4.6/migration/#panels) by `cards`.
