### PR TITLE
Keep mention attributes when filtering annotation markdown

### DIFF
--- a/h/services/mention.py
+++ b/h/services/mention.py
@@ -7,9 +7,8 @@ from sqlalchemy.orm import Session
 from h.models import Annotation, Mention
 from h.services.html import parse_html_links
 from h.services.user import UserService
+from h.util.markdown_render import MENTION_ATTRIBUTE, MENTION_USERID
 
-MENTION_ATTRIBUTE = "data-hyp-mention"
-MENTION_USERID = "data-userid"
 MENTION_LIMIT = 5
 
 logger = logging.getLogger(__name__)

--- a/h/util/markdown_render.py
+++ b/h/util/markdown_render.py
@@ -5,6 +5,8 @@ from bleach.linkifier import LinkifyFilter
 from markdown import Markdown
 
 LINK_REL = "nofollow noopener"
+MENTION_ATTRIBUTE = "data-hyp-mention"
+MENTION_USERID = "data-userid"
 
 MARKDOWN_TAGS = [
     "a",
@@ -53,6 +55,10 @@ def render(text):
 
 def _filter_link_attributes(_tag, name, value):
     if name in ["href", "title"]:
+        return True
+
+    # Keep attributes used in mention tags
+    if name in [MENTION_ATTRIBUTE, MENTION_USERID]:
         return True
 
     if name == "target" and value == "_blank":

--- a/tests/unit/h/emails/mention_notification_test.py
+++ b/tests/unit/h/emails/mention_notification_test.py
@@ -41,7 +41,6 @@ class TestGenerate:
         self,
         annotation,
         notification,
-        mentioning_user,
         pyramid_request,
         html_renderer,
         text_renderer,
@@ -52,7 +51,6 @@ class TestGenerate:
         generate(pyramid_request, notification)
 
         expected_context = {
-            "username": f"@{mentioning_user.username}",
             "annotation_url": f"http://example.com/ann/{annotation.id}",
         }
         html_renderer.assert_(**expected_context)  # noqa: PT009

--- a/tests/unit/h/emails/mention_notification_test.py
+++ b/tests/unit/h/emails/mention_notification_test.py
@@ -41,6 +41,7 @@ class TestGenerate:
         self,
         annotation,
         notification,
+        mentioning_user,
         pyramid_request,
         html_renderer,
         text_renderer,
@@ -51,6 +52,7 @@ class TestGenerate:
         generate(pyramid_request, notification)
 
         expected_context = {
+            "username": f"@{mentioning_user.username}",
             "annotation_url": f"http://example.com/ann/{annotation.id}",
         }
         html_renderer.assert_(**expected_context)  # noqa: PT009

--- a/tests/unit/h/util/markdown_render_test.py
+++ b/tests/unit/h/util/markdown_render_test.py
@@ -16,10 +16,20 @@ class TestRender:
         actual = markdown_render.render(r"Foobar \(1 + 1 = 2\)")
         assert actual == "<p>Foobar \\(1 + 1 = 2\\)</p>"
 
+    def test_it_preserves_mention_attributes(self):
+        actual = markdown_render.render(
+            '<a data-hyp-mention="" data-userid="acct:username@example.com">@username</a>'
+        )
+        assert (
+            actual
+            == '<p><a data-hyp-mention="" data-userid="acct:username@example.com">@username</a></p>'
+        )
+
     @pytest.mark.parametrize(
         "text",
         [
             '<p><a href="mailto:foo@example.net">example</a></p>',  # Don't add rel and target attrs to mailto: links
+            '<p><a data-hyp-mention="" data-userid="acct:username@example.com">@username</a></p>',
             '<p><a title="foobar">example</a></p>',
             '<p><a href="https://example.org" rel="nofollow noopener" target="_blank" title="foobar">example</a></p>',
             "<blockquote>Foobar</blockquote>",


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h/pull/9358

Part of https://github.com/hypothesis/h/issues/9341

Ensure we keep the `data-hyp-mention` and `data-userid` attributes in links when rendering and filtering the annotation markdown.

This will allow us to identify mention tags and apply custom styling and extra logic.