### PR TITLE
Add styles for mentions in activity pages

### DIFF
--- a/h/static/styles/components/_annotation-card.scss
+++ b/h/static/styles/components/_annotation-card.scss
@@ -151,4 +151,10 @@
   & {
     overflow-wrap: break-word;
   }
+
+  & a[data-hyp-mention] {
+    text-decoration: none;
+    font-weight: bold;
+    color: color.$brand;
+  }
 }


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/h/pull/9358

Add a couple CSS lines to ensure mention tags in annotation bodies are styled in bold and brand color.

![image](https://github.com/user-attachments/assets/114a4a8b-594b-42d3-b43a-9d76461cf54b)

This PR does not cover checking if the mentions are valid or not, nor linking to user profile pages. Those improvements will be eventually implemented separately.