### PR TITLE
Set elasticsearch loglevel to warning in production

### DIFF
--- a/conf/production.ini
+++ b/conf/production.ini
@@ -10,7 +10,7 @@ use = call:h.app:create_app
 use: egg:PasteDeploy#prefix
 
 [loggers]
-keys = root, h, alembic
+keys = root, h, alembic, elasticsearch
 
 [handlers]
 keys = console
@@ -31,6 +31,11 @@ qualname = h
 level = INFO
 handlers =
 qualname = alembic
+
+[logger_elasticsearch]
+level = WARNING
+handlers =
+qualname = elasticsearch
 
 [handler_console]
 class = StreamHandler


### PR DESCRIPTION
Refs https://hypothes-is.slack.com/archives/CR3E3S7K8/p1739805494884969

After changing root level log level to `info` we ended up having too many `elasticsearch` logs in production.
This fixes that specifically for `elasticsearch` logger.

Tested the conf via `development.ini` locally