### PR TITLE
Use celery autoretry configuration

### DIFF
--- a/tests/unit/h/tasks/mailer_test.py
+++ b/tests/unit/h/tasks/mailer_test.py
@@ -1,4 +1,3 @@
-from smtplib import SMTPServerDisconnected
 from unittest import mock
 
 import pytest
@@ -8,15 +7,17 @@ from h.tasks import mailer
 
 
 def test_send_retries_if_mailing_fails(email_service):
-    email_service.send.side_effect = SMTPServerDisconnected()
+    email_service.send.side_effect = Exception()
 
-    mailer.send.retry = mock.Mock(spec_set=[])
-    mailer.send(
-        recipients=["foo@example.com"],
-        subject="My email subject",
-        body="Some text body",
-        tag=EmailTag.TEST,
-    )
+    mailer.send.retry = mock.Mock(wraps=mailer.send.retry)
+
+    with pytest.raises(Exception):  # noqa: B017, PT011
+        mailer.send(
+            recipients=["foo@example.com"],
+            subject="My email subject",
+            body="Some text body",
+            tag=EmailTag.TEST,
+        )
 
     assert mailer.send.retry.called
 


### PR DESCRIPTION
Refs #9290

This PR makes use of `celery.task` arguments to support retries instead of doing the same in our code.

We already have `test_send_retries_if_mailing_fails` for testing retries themselves.

Leaving the backoff as 180s, 360s, 720s as it used to work before, can be changed by [`retry_backoff`](https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.retry_backoff). 

Testing
===
- Add this code to `mailer.send`
```python
    if not recipients:
        raise socket.error("No recipients provided")
```
- Run `make dev`
- Run `make shell` with
```python
from h.tasks import mailer
mailer.send.delay(recipients=[], subject='Test', body='Test', tag='test')
```
- Observe exponential `Retry in 180s:` in the `h` celery logs