### PR TITLE
Add notification service

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -13,6 +13,7 @@ from h.services.bulk_api import (
 from h.services.email import EmailService
 from h.services.job_queue import JobQueueService
 from h.services.mention import MentionService
+from h.services.notification import NotificationService
 from h.services.subscription import SubscriptionService
 
 
@@ -45,6 +46,9 @@ def includeme(config):  # pragma: no cover
         "h.services.annotation_write.service_factory", iface=AnnotationWriteService
     )
     config.register_service_factory("h.services.mention.factory", iface=MentionService)
+    config.register_service_factory(
+        "h.services.notification.factory", iface=NotificationService
+    )
 
     # Other services
     config.register_service_factory(

--- a/h/services/notification.py
+++ b/h/services/notification.py
@@ -1,0 +1,63 @@
+from sqlalchemy import exists, select
+from sqlalchemy.sql.functions import count
+
+from h.db import Session
+from h.models import Annotation, Notification, User
+from h.models.notification import NotificationType
+from h.services.user import UserService
+
+# Limit for the number of notifications per annotation
+NOTIFICATION_LIMIT = 100
+
+
+class NotificationService:
+    """A service for managing user notifications."""
+
+    def __init__(self, session: Session, user_service: UserService) -> None:
+        self._session = session
+        self._user_service = user_service
+
+    def allow_notifications(self, annotation: Annotation, user: User) -> bool:
+        return (
+            not self._notification_exists(annotation, user)
+            and self._notification_count(annotation) < NOTIFICATION_LIMIT
+        )
+
+    def _notification_exists(self, annotation: Annotation, recipient: User) -> bool:
+        """Check if a notification already exists for the given annotation and recipient."""
+        self._session.flush()
+        stmt = select(
+            exists().where(
+                Notification.source_annotation == annotation,
+                Notification.recipient == recipient,
+            )
+        )
+        return self._session.execute(stmt).scalar()
+
+    def _notification_count(self, annotation: Annotation) -> int:
+        """Count the number of notifications for the given annotation."""
+        stmt = select(count(Notification.id)).where(
+            Notification.source_annotation == annotation
+        )
+        return self._session.execute(stmt).scalar()
+
+    def save_notification(
+        self,
+        annotation: Annotation,
+        recipient: User,
+        notification_type: NotificationType,
+    ) -> None:
+        notification = Notification(
+            source_annotation=annotation,
+            recipient=recipient,
+            notification_type=notification_type,
+        )
+        self._session.add(notification)
+
+
+def factory(_context, request) -> NotificationService:
+    """Return a NotificationService instance for the passed context and request."""
+    return NotificationService(
+        session=request.db,
+        user_service=request.find_service(name="user"),
+    )

--- a/tests/unit/h/services/notification_test.py
+++ b/tests/unit/h/services/notification_test.py
@@ -1,0 +1,73 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from h.models.notification import NotificationType
+from h.services.notification import NotificationService, factory
+
+
+class TestNotificationService:
+    def test_allow_notifications(self, service, annotation, user):
+        assert service.allow_notifications(annotation, user)
+
+    def test_dont_allow_notifications_when_notification_exists(
+        self, service, annotation, user
+    ):
+        service.save_notification(annotation, user, NotificationType.MENTION)
+
+        assert not service.allow_notifications(annotation, user)
+
+    def test_dont_allow_notifications_when_limit_reached(
+        self, service, annotation, user, patch
+    ):
+        patch("h.services.notification.NOTIFICATION_LIMIT", new=1, autospec=False)
+        service.save_notification(annotation, user, NotificationType.MENTION)
+
+        assert not service.allow_notifications(annotation, user)
+
+    def test_notification_exists(self, service, annotation, user):
+        service.save_notification(annotation, user, NotificationType.MENTION)
+
+        assert service._notification_exists(annotation, user)  # noqa: SLF001
+
+    def test_notification_doesnt_exist(self, service, annotation, user):
+        assert not service._notification_exists(annotation, user)  # noqa: SLF001
+
+    def test_notification_count(self, service, annotation, user):
+        service.save_notification(annotation, user, NotificationType.MENTION)
+
+        assert service._notification_count(annotation) == 1  # noqa: SLF001
+
+    def test_save_notification(self, service, annotation, user):
+        service.save_notification(annotation, user, NotificationType.REPLY)
+
+        assert service._notification_exists(annotation, user)  # noqa: SLF001
+        assert service._notification_count(annotation) == 1  # noqa: SLF001
+
+    @pytest.fixture
+    def annotation(self, factories, user):
+        return factories.Annotation(userid=user.userid)
+
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User()
+
+    @pytest.fixture
+    def service(self, db_session, user_service):
+        return NotificationService(db_session, user_service)
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, user_service, NotificationService):
+        service = factory(sentinel.context, pyramid_request)
+
+        NotificationService.assert_called_once_with(
+            session=pyramid_request.db,
+            user_service=user_service,
+        )
+
+        assert service == NotificationService.return_value
+
+    @pytest.fixture
+    def NotificationService(self, patch):
+        return patch("h.services.notification.NotificationService")


### PR DESCRIPTION
Refs #9351

This just adds `NotificationService` which is to be used in a follow-up PR to control notifications sent.
No user-facing changes yet