### PR TITLE
Fix crash when using admin pages to edit groups

### DIFF
--- a/h/services/group_members.py
+++ b/h/services/group_members.py
@@ -104,15 +104,14 @@ class GroupMembersService:
                         be the members of this group
         """
         current_mem_ids = [member.userid for member in group.members]
-        userids_for_removal = [
-            mem_id for mem_id in current_mem_ids if mem_id not in userids
-        ]
 
         for userid in userids:
-            self.member_join(group, userid)
+            if userid not in current_mem_ids:
+                self.member_join(group, userid)
 
-        for userid in userids_for_removal:
-            self.member_leave(group, userid)
+        for userid in current_mem_ids:
+            if userid not in userids:
+                self.member_leave(group, userid)
 
     def member_join(self, group, userid, roles=None) -> GroupMembership:
         """


### PR DESCRIPTION
Fixes https://github.com/hypothesis/h/issues/9387.

The `GroupMembersService.update_members()` method (which is called by
the admin pages when editing an open or restricted group) has a problem:
it's unaware of group membership roles (the method was written before
roles had been implemented). It accepts a `group` and a list of
`userids` and updates the group's members to match the given `userids`
(removing existing members and adding new members as necessary), but all
members that it adds get the default `"member"` role.

This causes a `ConflictError` when `update_members()` tries to add a
member and the member already exists but with a different role.

This commit doesn't fix the wider issue that `update_members()` is
unaware of roles. Instead, it just refactors `update_members()` to avoid
unnecessarily re-adding members that already exist (leaving those
existing memberships and their roles untouched). This avoids the crash
when editing groups on the admin pages.

`update_members()` is still limited in that it can only be used to add
members with the `"member"` role and to remove members. It cannot add
members with any other role nor can it update the roles of existing
members. That's a problem for another day.
