### PR TITLE
Remove mailer send args support

### DIFF
--- a/h/emails/flag_notification.py
+++ b/h/emails/flag_notification.py
@@ -1,21 +1,16 @@
 from pyramid.renderers import render
+from pyramid.request import Request
 
 from h.i18n import TranslationString as _
-from h.services.email import EmailTag
+from h.services.email import EmailData, EmailTag
 
 
-def generate(request, email, incontext_link):
-    """
-    Generate an email to notify the group admin when a group member flags an annotation.
+def generate(request: Request, email: str, incontext_link: str) -> EmailData:
+    """Generate an email to notify the group admin when a group member flags an annotation.
 
     :param request: the current request
-    :type request: pyramid.request.Request
     :param email: the group admin's email address
-    :type email: text
     :param incontext_link: the direct link to the flagged annotation
-    :type incontext_link: text
-
-    :returns: a 4-element tuple containing: recipients, subject, text, html
     """
     context = {"incontext_link": incontext_link}
 
@@ -28,4 +23,10 @@ def generate(request, email, incontext_link):
         "h:templates/emails/flag_notification.html.jinja2", context, request=request
     )
 
-    return [email], subject, text, EmailTag.FLAG_NOTIFICATION, html
+    return EmailData(
+        recipients=[email],
+        subject=subject,
+        body=text,
+        tag=EmailTag.FLAG_NOTIFICATION,
+        html=html,
+    )

--- a/h/emails/mention_notification.py
+++ b/h/emails/mention_notification.py
@@ -3,10 +3,10 @@ from pyramid.request import Request
 
 from h import links
 from h.notification.mention import MentionNotification
-from h.services.email import EmailTag
+from h.services.email import EmailData, EmailTag
 
 
-def generate(request: Request, notification: MentionNotification):
+def generate(request: Request, notification: MentionNotification) -> EmailData:
     selectors = notification.annotation.target[0].get("selector", [])
     quote = next((s for s in selectors if s.get("type") == "TextQuoteSelector"), None)
     username = notification.mentioning_user.username
@@ -31,10 +31,10 @@ def generate(request: Request, notification: MentionNotification):
         "h:templates/emails/mention_notification.html.jinja2", context, request=request
     )
 
-    return (
-        [notification.mentioned_user.email],
-        subject,
-        text,
-        EmailTag.MENTION_NOTIFICATION,
-        html,
+    return EmailData(
+        recipients=[notification.mentioned_user.email],
+        subject=subject,
+        body=text,
+        tag=EmailTag.MENTION_NOTIFICATION,
+        html=html,
     )

--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -6,16 +6,14 @@ from h.emails.util import get_user_url
 from h.models import Subscriptions
 from h.notification.reply import Notification
 from h.services import SubscriptionService
-from h.services.email import EmailTag
+from h.services.email import EmailData, EmailTag
 
 
-def generate(request: Request, notification: Notification):
-    """
-    Generate an email for a reply notification.
+def generate(request: Request, notification: Notification) -> EmailData:
+    """Generate an email for a reply notification.
 
     :param request: the current request
     :param notification: the reply notification data structure
-    :returns: a 4-element tuple containing: recipients, subject, text, html
     """
 
     unsubscribe_token = request.find_service(SubscriptionService).get_unsubscribe_token(
@@ -51,10 +49,10 @@ def generate(request: Request, notification: Notification):
         "h:templates/emails/reply_notification.html.jinja2", context, request=request
     )
 
-    return (
-        [notification.parent_user.email],
-        subject,
-        text,
-        EmailTag.REPLY_NOTIFICATION,
-        html,
+    return EmailData(
+        recipients=[notification.parent_user.email],
+        subject=subject,
+        body=text,
+        tag=EmailTag.REPLY_NOTIFICATION,
+        html=html,
     )

--- a/h/emails/reset_password.py
+++ b/h/emails/reset_password.py
@@ -1,19 +1,16 @@
 from pyramid.renderers import render
+from pyramid.request import Request
 
 from h.i18n import TranslationString as _
-from h.services.email import EmailTag
+from h.models import User
+from h.services.email import EmailData, EmailTag
 
 
-def generate(request, user):
-    """
-    Generate an email for a user password reset request.
+def generate(request: Request, user: User) -> EmailData:
+    """Generate an email for a user password reset request.
 
     :param request: the current request
-    :type request: pyramid.request.Request
     :param user: the user to whom to send the reset code
-    :type user: h.models.User
-
-    :returns: a 4-element tuple containing: recipients, subject, text, html
     """
     serializer = request.registry.password_reset_serializer
     code = serializer.dumps(user.username)
@@ -32,4 +29,10 @@ def generate(request, user):
         "h:templates/emails/reset_password.html.jinja2", context, request=request
     )
 
-    return [user.email], subject, text, EmailTag.RESET_PASSWORD, html
+    return EmailData(
+        recipients=[user.email],
+        subject=subject,
+        body=text,
+        tag=EmailTag.RESET_PASSWORD,
+        html=html,
+    )

--- a/h/emails/signup.py
+++ b/h/emails/signup.py
@@ -1,23 +1,19 @@
 from pyramid.renderers import render
+from pyramid.request import Request
 
 from h.i18n import TranslationString as _
-from h.services.email import EmailTag
+from h.services.email import EmailData, EmailTag
 
 
-def generate(request, user_id, email, activation_code):
-    """
-    Generate an email for a user signup.
+def generate(
+    request: Request, user_id: int, email: str, activation_code: str
+) -> EmailData:
+    """Generate an email for a user signup.
 
     :param request: the current request
-    :type request: pyramid.request.Request
     :param user_id: the new user's primary key ID
-    :type user_id: int
     :param email: the new user's email address
-    :type email: text
     :param activation_code: the activation code
-    :type activation_code: text
-
-    :returns: a 4-element tuple containing: recipients, subject, text, html
     """
     context = {
         "activate_link": request.route_url("activate", id=user_id, code=activation_code)
@@ -28,4 +24,10 @@ def generate(request, user_id, email, activation_code):
     text = render("h:templates/emails/signup.txt.jinja2", context, request=request)
     html = render("h:templates/emails/signup.html.jinja2", context, request=request)
 
-    return [email], subject, text, EmailTag.ACTIVATION, html
+    return EmailData(
+        recipients=[email],
+        subject=subject,
+        body=text,
+        tag=EmailTag.ACTIVATION,
+        html=html,
+    )

--- a/h/emails/test.py
+++ b/h/emails/test.py
@@ -2,21 +2,17 @@ import datetime
 import platform
 
 from pyramid.renderers import render
+from pyramid.request import Request
 
 from h import __version__
-from h.services.email import EmailTag
+from h.services.email import EmailData, EmailTag
 
 
-def generate(request, recipient):
-    """
-    Generate a test email.
+def generate(request: Request, recipient: str) -> EmailData:
+    """Generate a test email.
 
     :param request: the current request
-    :type request: pyramid.request.Request
     :param recipient: the recipient of the test email
-    :type recipient: str
-
-    :returns: a 4-element tuple containing: recipients, subject, text, html
     """
 
     context = {
@@ -29,4 +25,10 @@ def generate(request, recipient):
     text = render("h:templates/emails/test.txt.jinja2", context, request=request)
     html = render("h:templates/emails/test.html.jinja2", context, request=request)
 
-    return [recipient], "Test mail", text, EmailTag.TEST, html
+    return EmailData(
+        recipients=[recipient],
+        subject="Test mail",
+        body=text,
+        tag=EmailTag.TEST,
+        html=html,
+    )

--- a/h/services/user_signup.py
+++ b/h/services/user_signup.py
@@ -123,13 +123,13 @@ class UserSignupService:
         self.session.flush()
 
         # Send the activation email
-        mail_params = signup.generate(
+        email = signup.generate(
             request=self.request,
             user_id=user.id,
             email=user.email,
             activation_code=user.activation.code,
         )
-        tasks_mailer.send.delay(*mail_params)
+        tasks_mailer.send.delay(email)
 
 
 def user_signup_service_factory(_context, request):

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -88,9 +88,9 @@ def send_reply_notifications(event):
         if reply_notification.parent_user in mentioned_users:
             return
 
-        send_params = emails.reply_notification.generate(request, reply_notification)
+        email = emails.reply_notification.generate(request, reply_notification)
         try:
-            mailer.send.delay(*send_params)
+            mailer.send.delay(email)
         except OperationalError as err:  # pragma: no cover
             # We could not connect to rabbit! So carry on
             report_exception(err)
@@ -108,9 +108,9 @@ def send_mention_notifications(event):
         notifications = mention.get_notifications(request, annotation, event.action)
 
         for notification in notifications:
-            send_params = emails.mention_notification.generate(request, notification)
+            email = emails.mention_notification.generate(request, notification)
             try:
-                mailer.send.delay(*send_params)
+                mailer.send.delay(email)
             except OperationalError as err:  # pragma: no cover
                 # We could not connect to rabbit! So carry on
                 report_exception(err)

--- a/h/tasks/celery.py
+++ b/h/tasks/celery.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 
 celery = Celery("h")
 celery.conf.update(
+    accept_content=["json", "pickle"],
     broker_url=os.environ.get(
         "CELERY_BROKER_URL",
         os.environ.get("BROKER_URL", "amqp://guest:guest@localhost:5672//"),

--- a/h/tasks/mailer.py
+++ b/h/tasks/mailer.py
@@ -4,7 +4,7 @@ A module for sending email.
 This module defines a Celery task for sending emails in a worker process.
 """
 
-from h.services.email import EmailData, EmailService, EmailTag
+from h.services.email import EmailData, EmailService
 from h.tasks.celery import celery, get_task_logger
 
 __all__ = ("send",)
@@ -19,32 +19,10 @@ logger = get_task_logger(__name__)
     max_retries=3,
     retry_jitter=False,
 )
-def send(  # noqa: PLR0913
-    self,  # noqa: ARG001
-    recipients: list[str] | EmailData,
-    subject: str | None = None,
-    body: str | None = None,
-    tag: EmailTag | None = None,
-    html: str | None = None,
-) -> None:
+def send(self, email: EmailData) -> None:  # noqa: ARG001
     """Send an email.
 
-    :param recipients: the list of email addresses to send to or an EmailData object
-    :param subject: the email subject
-    :param body: the email body
-    :param tag: the email tag
-    :param html: HTML version of the email
+    :param email: The email data to send.
     """
     service = celery.request.find_service(EmailService)
-
-    if isinstance(recipients, EmailData):
-        email = recipients
-    else:
-        email = EmailData(
-            recipients=recipients,
-            subject=subject,
-            body=body,
-            tag=tag,
-            html=html,
-        )
     service.send(email)

--- a/h/tasks/mailer.py
+++ b/h/tasks/mailer.py
@@ -4,10 +4,12 @@ A module for sending email.
 This module defines a Celery task for sending emails in a worker process.
 """
 
-from h.services.email import EmailService, EmailTag
-from h.tasks.celery import celery
+from h.services.email import EmailData, EmailService, EmailTag
+from h.tasks.celery import celery, get_task_logger
 
 __all__ = ("send",)
+
+logger = get_task_logger(__name__)
 
 
 @celery.task(
@@ -19,23 +21,30 @@ __all__ = ("send",)
 )
 def send(  # noqa: PLR0913
     self,  # noqa: ARG001
-    recipients: list[str],
-    subject: str,
-    body: str,
-    tag: EmailTag,
+    recipients: list[str] | EmailData,
+    subject: str | None = None,
+    body: str | None = None,
+    tag: EmailTag | None = None,
     html: str | None = None,
 ) -> None:
-    """
-    Send an email.
+    """Send an email.
 
-    :param recipients: the list of email addresses to send the email to
-    :type recipients: list of unicode strings
-
-    :param subject: the subject of the email
-    :type subject: unicode
-
-    :param body: the body of the email
-    :type body: unicode
+    :param recipients: the list of email addresses to send to or an EmailData object
+    :param subject: the email subject
+    :param body: the email body
+    :param tag: the email tag
+    :param html: HTML version of the email
     """
     service = celery.request.find_service(EmailService)
-    service.send(recipients=recipients, subject=subject, body=body, html=html, tag=tag)
+
+    if isinstance(recipients, EmailData):
+        email = recipients
+    else:
+        email = EmailData(
+            recipients=recipients,
+            subject=subject,
+            body=body,
+            tag=tag,
+            html=html,
+        )
+    service.send(email)

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -210,8 +210,8 @@ class ForgotPasswordController:
             raise httpexceptions.HTTPFound(self.request.route_path("index"))
 
     def _send_forgot_password_email(self, user):
-        send_params = reset_password.generate(self.request, user)
-        mailer.send.delay(*send_params)
+        email = reset_password.generate(self.request, user)
+        mailer.send.delay(email)
 
 
 @view_defaults(

--- a/h/views/admin/mailer.py
+++ b/h/views/admin/mailer.py
@@ -29,8 +29,8 @@ def mailer_test(request):
         index = request.route_path("admin.mailer")
         return HTTPSeeOther(location=index)
 
-    mail = test.generate(request, request.params["recipient"])
-    result = mailer.send.delay(*mail)
+    email = test.generate(request, request.params["recipient"])
+    result = mailer.send.delay(email)
     index = request.route_path("admin.mailer", _query={"taskid": result.task_id})
     return HTTPSeeOther(location=index)
 

--- a/h/views/api/flags.py
+++ b/h/views/api/flags.py
@@ -37,5 +37,5 @@ def _email_group_moderators(request, annotation):
 
     for membership in memberships:
         if email := membership.user.email:
-            send_params = flag_notification.generate(request, email, incontext_link)
-            mailer.send.delay(*send_params)
+            email = flag_notification.generate(request, email, incontext_link)
+            mailer.send.delay(email)

--- a/tests/unit/h/emails/flag_notification_test.py
+++ b/tests/unit/h/emails/flag_notification_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from h.emails.flag_notification import generate
-from h.services.email import EmailTag
+from h.services.email import EmailData, EmailTag
 
 
 class TestGenerate:
@@ -24,17 +24,19 @@ class TestGenerate:
         html_renderer.string_response = "HTML output"
         text_renderer.string_response = "Text output"
 
-        recipients, subject, text, tag, html = generate(
+        email = generate(
             pyramid_request,
             email="foo@example.com",
             incontext_link="http://hyp.is/a/ann1",
         )
 
-        assert recipients == ["foo@example.com"]
-        assert subject == "An annotation has been flagged"
-        assert html == "HTML output"
-        assert tag == EmailTag.FLAG_NOTIFICATION
-        assert text == "Text output"
+        assert email == EmailData(
+            recipients=["foo@example.com"],
+            subject="An annotation has been flagged",
+            body="Text output",
+            html="HTML output",
+            tag=EmailTag.FLAG_NOTIFICATION,
+        )
 
     @pytest.fixture
     def html_renderer(self, pyramid_config):

--- a/tests/unit/h/emails/mention_notification_test.py
+++ b/tests/unit/h/emails/mention_notification_test.py
@@ -80,18 +80,18 @@ class TestGenerate:
         html_renderer.string_response = "HTML output"
         text_renderer.string_response = "Text output"
 
-        _, _, text, _, html = generate(pyramid_request, notification)
+        email = generate(pyramid_request, notification)
 
-        assert html == "HTML output"
-        assert text == "Text output"
+        assert email.body == "Text output"
+        assert email.html == "HTML output"
 
     def test_returns_subject_with_reply_display_name(
         self, notification, pyramid_request, mentioning_user
     ):
-        _, subject, _, _, _ = generate(pyramid_request, notification)
+        email = generate(pyramid_request, notification)
 
         assert (
-            subject
+            email.subject
             == f"{mentioning_user.display_name} has mentioned you in an annotation"
         )
 
@@ -100,18 +100,19 @@ class TestGenerate:
     ):
         mentioning_user.display_name = None
 
-        _, subject, _, _, _ = generate(pyramid_request, notification)
+        email = generate(pyramid_request, notification)
 
         assert (
-            subject == f"@{mentioning_user.username} has mentioned you in an annotation"
+            email.subject
+            == f"@{mentioning_user.username} has mentioned you in an annotation"
         )
 
     def test_returns_parent_email_as_recipients(
         self, notification, pyramid_request, mentioned_user
     ):
-        recipients, _, _, _, _ = generate(pyramid_request, notification)
+        email = generate(pyramid_request, notification)
 
-        assert recipients == [mentioned_user.email]
+        assert email.recipients == [mentioned_user.email]
 
     def test_jinja_templates_render(
         self, notification, pyramid_config, pyramid_request

--- a/tests/unit/h/emails/reply_notification_test.py
+++ b/tests/unit/h/emails/reply_notification_test.py
@@ -99,9 +99,9 @@ class TestGenerate:
         parent_user.display_name = "Parent 👩"
         reply_user.display_name = "Child 👧"
 
-        (_, subject, _, _, _) = generate(pyramid_request, notification)
+        email = generate(pyramid_request, notification)
 
-        assert subject == "Child 👧 has replied to your annotation"
+        assert email.subject == "Child 👧 has replied to your annotation"
 
     def test_returns_usernames_if_no_display_names(
         self,
@@ -130,30 +130,30 @@ class TestGenerate:
         html_renderer.string_response = "HTML output"
         text_renderer.string_response = "Text output"
 
-        _, _, text, _, html = generate(pyramid_request, notification)
+        email = generate(pyramid_request, notification)
 
-        assert html == "HTML output"
-        assert text == "Text output"
+        assert email.body == "Text output"
+        assert email.html == "HTML output"
 
     def test_returns_subject_with_reply_display_name(
         self, notification, pyramid_request
     ):
-        _, subject, _, _, _ = generate(pyramid_request, notification)
+        email = generate(pyramid_request, notification)
 
-        assert subject == "Ron Burgundy has replied to your annotation"
+        assert email.subject == "Ron Burgundy has replied to your annotation"
 
     def test_returns_subject_with_reply_username(
         self, notification, pyramid_request, reply_user
     ):
         reply_user.display_name = None
-        _, subject, _, _, _ = generate(pyramid_request, notification)
+        email = generate(pyramid_request, notification)
 
-        assert subject == "ron has replied to your annotation"
+        assert email.subject == "ron has replied to your annotation"
 
     def test_returns_parent_email_as_recipients(self, notification, pyramid_request):
-        recipients, _, _, _, _ = generate(pyramid_request, notification)
+        email = generate(pyramid_request, notification)
 
-        assert recipients == ["pat@ric.ia"]
+        assert email.recipients == ["pat@ric.ia"]
 
     def test_jinja_templates_render(
         self, notification, pyramid_config, pyramid_request

--- a/tests/unit/h/emails/reset_password_test.py
+++ b/tests/unit/h/emails/reset_password_test.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from h.emails.reset_password import generate
-from h.services.email import EmailTag
+from h.services.email import EmailData, EmailTag
 
 
 @pytest.mark.usefixtures("routes")
@@ -39,13 +39,15 @@ class TestGenerate:
         html_renderer.string_response = "HTML output"
         text_renderer.string_response = "Text output"
 
-        recipients, subject, text, tag, html = generate(pyramid_request, user)
+        email = generate(pyramid_request, user)
 
-        assert recipients == [user.email]
-        assert subject == "Reset your password"
-        assert html == "HTML output"
-        assert tag == EmailTag.RESET_PASSWORD
-        assert text == "Text output"
+        assert email == EmailData(
+            recipients=[user.email],
+            subject="Reset your password",
+            body="Text output",
+            html="HTML output",
+            tag=EmailTag.RESET_PASSWORD,
+        )
 
     def test_jinja_templates_render(
         self, pyramid_config, pyramid_request, serializer, user

--- a/tests/unit/h/emails/signup_test.py
+++ b/tests/unit/h/emails/signup_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from h.emails.signup import generate
-from h.services.email import EmailTag
+from h.services.email import EmailData, EmailTag
 
 
 @pytest.mark.usefixtures("routes")
@@ -28,18 +28,20 @@ class TestGenerate:
         html_renderer.string_response = "HTML output"
         text_renderer.string_response = "Text output"
 
-        recipients, subject, text, tag, html = generate(
+        email = generate(
             pyramid_request,
             user_id=1234,
             email="foo@example.com",
             activation_code="abcd4567",
         )
 
-        assert recipients == ["foo@example.com"]
-        assert subject == "Please activate your account"
-        assert html == "HTML output"
-        assert tag == EmailTag.ACTIVATION
-        assert text == "Text output"
+        assert email == EmailData(
+            recipients=["foo@example.com"],
+            subject="Please activate your account",
+            body="Text output",
+            html="HTML output",
+            tag=EmailTag.ACTIVATION,
+        )
 
     def test_jinja_templates_render(self, pyramid_config, pyramid_request):
         """Ensure that the jinja templates don't contain syntax errors."""

--- a/tests/unit/h/emails/test_test.py
+++ b/tests/unit/h/emails/test_test.py
@@ -3,7 +3,7 @@ from h_matchers import Any
 
 from h import __version__
 from h.emails.test import generate
-from h.services.email import EmailTag
+from h.services.email import EmailData, EmailTag
 
 
 class TestGenerate:
@@ -27,15 +27,15 @@ class TestGenerate:
         html_renderer.string_response = "HTML output"
         text_renderer.string_response = "Text output"
 
-        recipients, subject, text, tag, html = generate(
-            pyramid_request, "meerkat@example.com"
-        )
+        email = generate(pyramid_request, "meerkat@example.com")
 
-        assert recipients == ["meerkat@example.com"]
-        assert subject == "Test mail"
-        assert html == "HTML output"
-        assert tag == EmailTag.TEST
-        assert text == "Text output"
+        assert email == EmailData(
+            recipients=["meerkat@example.com"],
+            subject="Test mail",
+            body="Text output",
+            html="HTML output",
+            tag=EmailTag.TEST,
+        )
 
     def test_jinja_templates_render(self, pyramid_config, pyramid_request):
         """Ensure that the jinja templates don't contain syntax errors"""  # noqa: D400, D415

--- a/tests/unit/h/services/email_test.py
+++ b/tests/unit/h/services/email_test.py
@@ -3,17 +3,18 @@ from unittest.mock import sentinel
 
 import pytest
 
-from h.services.email import EmailService, EmailTag, factory
+from h.services.email import EmailData, EmailService, EmailTag, factory
 
 
 class TestEmailService:
     def test_send_creates_email_message(self, email_service, pyramid_mailer):
-        email_service.send(
+        email = EmailData(
             recipients=["foo@example.com"],
             subject="My email subject",
             body="Some text body",
             tag=EmailTag.TEST,
         )
+        email_service.send(email)
 
         pyramid_mailer.message.Message.assert_called_once_with(
             recipients=["foo@example.com"],
@@ -26,13 +27,14 @@ class TestEmailService:
     def test_send_creates_email_message_with_html_body(
         self, email_service, pyramid_mailer
     ):
-        email_service.send(
+        email = EmailData(
             recipients=["foo@example.com"],
             subject="My email subject",
             body="Some text body",
             tag=EmailTag.TEST,
             html="<p>An HTML body</p>",
         )
+        email_service.send(email)
 
         pyramid_mailer.message.Message.assert_called_once_with(
             recipients=["foo@example.com"],
@@ -48,12 +50,13 @@ class TestEmailService:
         request_mailer = pyramid_mailer.get_mailer.return_value
         message = pyramid_mailer.message.Message.return_value
 
-        email_service.send(
+        email = EmailData(
             recipients=["foo@example.com"],
             subject="My email subject",
             body="Some text body",
             tag=EmailTag.TEST,
         )
+        email_service.send(email)
 
         request_mailer.send_immediately.assert_called_once_with(message)
 
@@ -61,13 +64,14 @@ class TestEmailService:
         request_mailer = pyramid_mailer.get_mailer.return_value
         request_mailer.send_immediately.side_effect = smtplib.SMTPException()
 
+        email = EmailData(
+            recipients=["foo@example.com"],
+            subject="My email subject",
+            body="Some text body",
+            tag=EmailTag.TEST,
+        )
         with pytest.raises(smtplib.SMTPException):
-            email_service.send(
-                recipients=["foo@example.com"],
-                subject="My email subject",
-                body="Some text body",
-                tag=EmailTag.TEST,
-            )
+            email_service.send(email)
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):

--- a/tests/unit/h/services/user_signup_test.py
+++ b/tests/unit/h/services/user_signup_test.py
@@ -94,7 +94,7 @@ class TestUserSignupService:
         user_password_service.update_password.assert_called_once_with(user, "wibble")
 
     def test_signup_sends_email(self, svc, signup, tasks_mailer, pyramid_request):
-        signup.generate.return_value = ["signup", "args"]
+        signup.generate.return_value = sentinel.email
 
         user = svc.signup(username="foo", email="foo@bar.com")
 
@@ -105,7 +105,7 @@ class TestUserSignupService:
             activation_code=user.activation.code,
         )
 
-        tasks_mailer.send.delay.assert_called_once_with(*signup.generate.return_value)
+        tasks_mailer.send.delay.assert_called_once_with(signup.generate.return_value)
 
     def test_signup_does_not_send_email_when_activation_not_required(
         self, svc, signup, tasks_mailer

--- a/tests/unit/h/subscribers_test.py
+++ b/tests/unit/h/subscribers_test.py
@@ -133,8 +133,8 @@ class TestSendReplyNotifications:
         emails.reply_notification.generate.assert_called_once_with(
             pyramid_request, notification
         )
-        send_params = emails.reply_notification.generate.return_value
-        mailer.send.delay.assert_called_once_with(*send_params)
+        email = emails.reply_notification.generate.return_value
+        mailer.send.delay.assert_called_once_with(email)
 
     def test_it_does_nothing_if_no_notification_is_required(self, event, reply, mailer):
         reply.get_notification.return_value = None
@@ -201,8 +201,8 @@ class TestSendMentionNotifications:
         emails.mention_notification.generate.assert_called_once_with(
             pyramid_request, notifications[0]
         )
-        send_params = emails.mention_notification.generate.return_value
-        mailer.send.delay.assert_called_once_with(*send_params)
+        email = emails.mention_notification.generate.return_value
+        mailer.send.delay.assert_called_once_with(email)
 
     def test_it_does_nothing_if_no_notification_is_required(
         self, event, mention, mailer

--- a/tests/unit/h/tasks/mailer_test.py
+++ b/tests/unit/h/tasks/mailer_test.py
@@ -2,13 +2,12 @@ from unittest import mock
 
 import pytest
 
-from h.services.email import EmailTag
+from h.services.email import EmailData, EmailTag
 from h.tasks import mailer
 
 
 def test_send_retries_if_mailing_fails(email_service):
     email_service.send.side_effect = Exception()
-
     mailer.send.retry = mock.Mock(wraps=mailer.send.retry)
 
     with pytest.raises(Exception):  # noqa: B017, PT011
@@ -18,6 +17,22 @@ def test_send_retries_if_mailing_fails(email_service):
             body="Some text body",
             tag=EmailTag.TEST,
         )
+
+    assert mailer.send.retry.called
+
+
+def test_send_retries_if_mailing_fails_with_email_data(email_service):
+    email_service.send.side_effect = Exception()
+    mailer.send.retry = mock.Mock(wraps=mailer.send.retry)
+
+    email = EmailData(
+        recipients=["foo@example.com"],
+        subject="My email subject",
+        body="Some text body",
+        tag=EmailTag.TEST,
+    )
+    with pytest.raises(Exception):  # noqa: B017, PT011
+        mailer.send(email)
 
     assert mailer.send.retry.called
 

--- a/tests/unit/h/tasks/mailer_test.py
+++ b/tests/unit/h/tasks/mailer_test.py
@@ -10,21 +10,6 @@ def test_send_retries_if_mailing_fails(email_service):
     email_service.send.side_effect = Exception()
     mailer.send.retry = mock.Mock(wraps=mailer.send.retry)
 
-    with pytest.raises(Exception):  # noqa: B017, PT011
-        mailer.send(
-            recipients=["foo@example.com"],
-            subject="My email subject",
-            body="Some text body",
-            tag=EmailTag.TEST,
-        )
-
-    assert mailer.send.retry.called
-
-
-def test_send_retries_if_mailing_fails_with_email_data(email_service):
-    email_service.send.side_effect = Exception()
-    mailer.send.retry = mock.Mock(wraps=mailer.send.retry)
-
     email = EmailData(
         recipients=["foo@example.com"],
         subject="My email subject",

--- a/tests/unit/h/views/accounts_test.py
+++ b/tests/unit/h/views/accounts_test.py
@@ -8,6 +8,7 @@ from h_matchers import Any
 from pyramid import httpexceptions
 
 from h.models import Subscriptions
+from h.services.email import EmailData, EmailTag
 from h.views import accounts as views
 
 
@@ -277,9 +278,14 @@ class TestForgotPasswordController:
 
         controller.post()
 
-        mailer.send.delay.assert_called_once_with(
-            ["giraffe@thezoo.org"], "Reset yer passwor!", "HTML output", "Text output"
+        email = EmailData(
+            recipients=["giraffe@thezoo.org"],
+            subject="Reset yer passwor!",
+            body="Text output",
+            tag=EmailTag.TEST,
+            html="HTML output",
         )
+        mailer.send.delay.assert_called_once_with(email)
 
     def test_post_redirects_on_success(
         self, factories, form_validating_to, pyramid_request
@@ -302,11 +308,12 @@ class TestForgotPasswordController:
     @pytest.fixture
     def reset_password_email(self, patch):
         reset_password_email = patch("h.views.accounts.reset_password")
-        reset_password_email.generate.return_value = (
-            ["giraffe@thezoo.org"],
-            "Reset yer passwor!",
-            "HTML output",
-            "Text output",
+        reset_password_email.generate.return_value = EmailData(
+            recipients=["giraffe@thezoo.org"],
+            subject="Reset yer passwor!",
+            body="Text output",
+            tag=EmailTag.TEST,
+            html="HTML output",
         )
         return reset_password_email
 

--- a/tests/unit/h/views/api/flags_test.py
+++ b/tests/unit/h/views/api/flags_test.py
@@ -4,6 +4,7 @@ import pytest
 from pyramid.httpexceptions import HTTPNoContent
 
 from h.models import GroupMembership, GroupMembershipRoles
+from h.services.email import EmailData
 from h.traversal import AnnotationContext
 from h.views.api import flags
 
@@ -39,8 +40,24 @@ class TestCreate:
             for user in moderators
         ]
         assert mailer.send.delay.call_args_list == [
-            call(sentinel.email1, sentinel.subject1, sentinel.text1, sentinel.html1),
-            call(sentinel.email2, sentinel.subject2, sentinel.text2, sentinel.html2),
+            call(
+                EmailData(
+                    recipients=sentinel.email1,
+                    subject=sentinel.subject1,
+                    body=sentinel.text1,
+                    tag=sentinel.tag1,
+                    html=sentinel.html1,
+                )
+            ),
+            call(
+                EmailData(
+                    recipients=sentinel.email2,
+                    subject=sentinel.subject2,
+                    body=sentinel.text2,
+                    tag=sentinel.tag2,
+                    html=sentinel.html2,
+                )
+            ),
         ]
         assert isinstance(response, HTTPNoContent)
 
@@ -102,8 +119,20 @@ def flag_notification(mocker):
         "h.views.api.flags.flag_notification", autospec=True
     )
     flag_notification.generate.side_effect = [
-        (sentinel.email1, sentinel.subject1, sentinel.text1, sentinel.html1),
-        (sentinel.email2, sentinel.subject2, sentinel.text2, sentinel.html2),
+        EmailData(
+            recipients=sentinel.email1,
+            subject=sentinel.subject1,
+            body=sentinel.text1,
+            tag=sentinel.tag1,
+            html=sentinel.html1,
+        ),
+        EmailData(
+            recipients=sentinel.email2,
+            subject=sentinel.subject2,
+            body=sentinel.text2,
+            tag=sentinel.tag2,
+            html=sentinel.html2,
+        ),
     ]
     return flag_notification
 


### PR DESCRIPTION
Refs #9365 

Removing args backwards compatibility introduced to drain the queue from in-flight messages with different function signature.