### PR TITLE
Remove mailer send args support

### DIFF
--- a/h/tasks/celery.py
+++ b/h/tasks/celery.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 
 celery = Celery("h")
 celery.conf.update(
+    accept_content=["json"],
     broker_url=os.environ.get(
         "CELERY_BROKER_URL",
         os.environ.get("BROKER_URL", "amqp://guest:guest@localhost:5672//"),

--- a/h/tasks/mailer.py
+++ b/h/tasks/mailer.py
@@ -6,7 +6,7 @@ This module defines a Celery task for sending emails in a worker process.
 
 from typing import Any
 
-from h.services.email import EmailData, EmailService, EmailTag
+from h.services.email import EmailData, EmailService
 from h.tasks.celery import celery, get_task_logger
 
 __all__ = ("send",)
@@ -21,32 +21,11 @@ logger = get_task_logger(__name__)
     max_retries=3,
     retry_jitter=False,
 )
-def send(  # noqa: PLR0913
-    self,  # noqa: ARG001
-    recipients: list[str] | dict[str, Any],
-    subject: str | None = None,
-    body: str | None = None,
-    html: str | None = None,
-    tag: EmailTag | None = None,
-) -> None:
+def send(self, email_data: dict[str, Any]) -> None:  # noqa: ARG001
     """Send an email.
 
-    :param recipients: A list of email addresses or a dictionary with email data.
-    :param subject: The subject of the email.
-    :param body: The body of the email.
-    :param html: The HTML body of the email.
-    :param tag: An tag for the email.
+    :param email_data: A dictionary containing email data compatible with EmailData class.
     """
-    if isinstance(recipients, dict):
-        email = EmailData(**recipients)
-    else:
-        email = EmailData(
-            recipients=recipients,
-            subject=subject,
-            body=body,
-            html=html,
-            tag=tag,
-        )
-
     service: EmailService = celery.request.find_service(EmailService)
+    email = EmailData(**email_data)
     service.send(email)

--- a/tests/unit/h/subscribers_test.py
+++ b/tests/unit/h/subscribers_test.py
@@ -138,10 +138,10 @@ class TestSendReplyNotifications:
         reply.get_notification.assert_called_once_with(
             pyramid_request, annotation, event.action
         )
-        reply_notification = reply.get_notification.return_value
+        notification = reply.get_notification.return_value
 
         emails.reply_notification.generate.assert_called_once_with(
-            pyramid_request, reply_notification
+            pyramid_request, notification
         )
 
         mention.get_notifications.assert_called_once_with(
@@ -149,7 +149,7 @@ class TestSendReplyNotifications:
         )
 
         notification_service.allow_notifications.assert_called_once_with(
-            annotation, reply_notification.parent_user
+            annotation, notification.parent_user
         )
         email = emails.reply_notification.generate.return_value
         asdict.assert_called_once_with(email)
@@ -158,7 +158,7 @@ class TestSendReplyNotifications:
 
         notification_service.save_notification.assert_called_once_with(
             annotation=annotation,
-            recipient=reply_notification.parent_user,
+            recipient=notification.parent_user,
             notification_type=NotificationType.REPLY,
         )
 

--- a/tests/unit/h/tasks/mailer_test.py
+++ b/tests/unit/h/tasks/mailer_test.py
@@ -10,21 +10,6 @@ def test_send_retries_if_mailing_fails(email_service):
     email_service.send.side_effect = Exception()
     mailer.send.retry = mock.Mock(wraps=mailer.send.retry)
 
-    with pytest.raises(Exception):  # noqa: B017, PT011
-        mailer.send(
-            recipients=["foo@example.com"],
-            subject="My email subject",
-            body="Some text body",
-            tag=EmailTag.TEST,
-        )
-
-    assert mailer.send.retry.called
-
-
-def test_send_retries_if_mailing_fails_with_dict(email_service):
-    email_service.send.side_effect = Exception()
-    mailer.send.retry = mock.Mock(wraps=mailer.send.retry)
-
     email_data = {
         "recipients": ["foo@example.com"],
         "subject": "My email subject",


### PR DESCRIPTION
Refs #9365 

Here we remove backwards compatibility argument support for `mailer.send`.