### PR TITLE
Remove indentation in CSS in mentions email template

### DIFF
--- a/h/templates/emails/mention_notification.html.jinja2
+++ b/h/templates/emails/mention_notification.html.jinja2
@@ -15,475 +15,475 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>There has been some activity in Hypothesis</title>
   <style type="text/css">
-      p{
-          margin:0;
-          margin-bottom: 20px;
-          padding:0;
-      }
-      table{
-          border-collapse:collapse;
-      }
-      h1,h2,h3,h4,h5,h6{
-          display:block;
-          margin:0;
-          padding:0;
-      }
-      img,a img{
-          border:0;
-          height:auto;
-          outline:none;
-          text-decoration:none;
-      }
-      body,#bodyTable,#bodyCell{
-          height:100%;
-          margin:0;
-          padding:0;
-          width:100%;
-      }
-      .mcnPreviewText{
-          display:none !important;
-      }
-      #outlook a{
-          padding:0;
-      }
-      img{
-          -ms-interpolation-mode:bicubic;
-      }
-      table{
-          mso-table-lspace:0pt;
-          mso-table-rspace:0pt;
-      }
-      .ReadMsgBody{
-          width:100%;
-      }
-      .ExternalClass{
-          width:100%;
-      }
-      p,a,li,td,blockquote{
-          mso-line-height-rule:exactly;
-      }
-      a[href^=tel],a[href^=sms]{
-          color:inherit;
-          cursor:default;
-          text-decoration:none;
-      }
-      p,a,li,td,body,table,blockquote{
-          -ms-text-size-adjust:100%;
-          -webkit-text-size-adjust:100%;
-      }
-      .ExternalClass,.ExternalClass p,.ExternalClass td,.ExternalClass div,.ExternalClass span,.ExternalClass font{
-          line-height:100%;
-      }
-      a[x-apple-data-detectors]{
-          color:inherit !important;
-          text-decoration:none !important;
-          font-size:inherit !important;
-          font-family:inherit !important;
-          font-weight:inherit !important;
-          line-height:inherit !important;
-      }
-      a.mcnButton{
-          display:block;
-      }
-      .mcnImage,.mcnRetinaImage{
-          vertical-align:bottom;
-      }
-      .mcnTextContent{
-          word-break:break-word;
-      }
-      .mcnTextContent img{
-          height:auto !important;
-      }
-      .mcnDividerBlock{
-          table-layout:fixed !important;
-      }
-      /* @tab Page @section background style @tip Set the background color and top border for your email. You may want to choose colors that match your company's branding. */
-      body,#bodyTable{
-          /*@editable*/
-          background-color:#363636;
-      }
-      /* @tab Page @section background style @tip Set the background color and top border for your email. You may want to choose colors that match your company's branding. */
-      #bodyCell{
-          /*@editable*/
-          border-top:0;
-      }
-      /* @tab Page @section heading 1 @tip Set the styling for all first-level headings in your emails. These should be the largest of your headings. @style heading 1 */
-      h1{
-          /*@editable*/
-          color:#bd1c2b !important;
-          /*@editable*/
-          font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-          /*@editable*/
-          font-size:40px;
-          /*@editable*/
-          font-style:normal;
-          /*@editable*/
-          font-weight:bold;
-          /*@editable*/
-          line-height:100%;
-          /*@editable*/
-          letter-spacing:-1px;
-          /*@editable*/
-          text-align:center;
-      }
-      /* @tab Page @section heading 2 @tip Set the styling for all second-level headings in your emails. @style heading 2 */
-      h2{
-          /*@editable*/
-          color:#404040 !important;
-          /*@editable*/
-          font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-          /*@editable*/
-          font-size:26px;
-          /*@editable*/
-          font-style:normal;
-          /*@editable*/
-          font-weight:bold;
-          /*@editable*/
-          line-height:125%;
-          /*@editable*/
-          letter-spacing:-.75px;
-          /*@editable*/
-          text-align:left;
-      }
-      /* @tab Page @section heading 3 @tip Set the styling for all third-level headings in your emails. @style heading 3 */
-      h3{
-          /*@editable*/
-          color:#606060 !important;
-          /*@editable*/
-          font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-          /*@editable*/
-          font-size:18px;
-          /*@editable*/
-          font-style:normal;
-          /*@editable*/
-          font-weight:bold;
-          /*@editable*/
-          line-height:125%;
-          /*@editable*/
-          letter-spacing:-.5px;
-          /*@editable*/
-          text-align:left;
-      }
-      /* @tab Page @section heading 4 @tip Set the styling for all fourth-level headings in your emails. These should be the smallest of your headings. @style heading 4 */
-      h4{
-          /*@editable*/
-          color:#808080 !important;
-          /*@editable*/
-          font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-          /*@editable*/
-          font-size:16px;
-          /*@editable*/
-          font-style:normal;
-          /*@editable*/
-          font-weight:bold;
-          /*@editable*/
-          line-height:125%;
-          /*@editable*/
-          letter-spacing:normal;
-          /*@editable*/
-          text-align:left;
-      }
-      /* @tab Preheader @section preheader text @tip Set the styling for your email's preheader text. Choose a size and color that is easy to read. */
-      .preheaderContainer .mcnTextContent,.preheaderContainer .mcnTextContent p{
-          /*@editable*/
-          color:#bd1c2b;
-          /*@editable*/
-          font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-          /*@editable*/
-          font-size:11px;
-          /*@editable*/
-          line-height:125%;
-          /*@editable*/
-          text-align:left;
-      }
-      /* @tab Preheader @section preheader link @tip Set the styling for your email's header links. Choose a color that helps them stand out from your text. */
-      .preheaderContainer .mcnTextContent a{
-          /*@editable*/
-          color:#bd1c2b;
-          /*@editable*/
-          font-weight:normal;
-          /*@editable*/
-          text-decoration:underline;
-      }
-      /* @tab Header @section header style @tip Set the background color and borders for your email's header area. */
-      #templateHeader{
-          /*@editable*/
-          background-color:#EEEEEE;
-          /*@editable*/
-          border-top:0;
-          /*@editable*/
-          border-bottom:0;
-      }
-      /* @tab Header @section header text @tip Set the styling for your email's header text. Choose a size and color that is easy to read. */
-      .headerContainer .mcnTextContent,.headerContainer .mcnTextContent p{
-          /*@editable*/
-          color:#606060;
-          /*@editable*/
-          font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-          /*@editable*/
-          font-size:15px;
-          /*@editable*/
-          line-height:150%;
-          /*@editable*/
-          text-align:left;
-      }
-      /* @tab Header @section header link @tip Set the styling for your email's header links. Choose a color that helps them stand out from your text. */
-      .headerContainer .mcnTextContent a{
-          /*@editable*/
-          color:#bd1c2b;
-          /*@editable*/
-          font-weight:normal;
-          /*@editable*/
-          text-decoration:underline;
-      }
-      /* @tab Body @section body style @tip Set the background color and borders for your email's body area. */
-      #templateBody{
-          /*@editable*/
-          background-color:#eeeeee;
-          /*@editable*/
-          border-top:0;
-          /*@editable*/
-          border-bottom:0;
-      }
-      /* @tab Body @section body container @tip Set the background color and border for your email's body text container. */
-      #bodyBackground{
-          /*@editable*/
-          background-color:#FFFFFF;
-          /*@editable*/
-          border:1px solid #D5D5D5;
-      }
-      /* @tab Body @section body text @tip Set the styling for your email's body text. Choose a size and color that is easy to read. */
-      .bodyContainer .mcnTextContent,.bodyContainer .mcnTextContent p{
-          /*@editable*/
-          color:#606060;
-          /*@editable*/
-          font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-          /*@editable*/
-          font-size:15px;
-          /*@editable*/
-          line-height:150%;
-          /*@editable*/
-          text-align:left;
-      }
-      /* @tab Body @section body link @tip Set the styling for your email's body links. Choose a color that helps them stand out from your text. */
-      .bodyContainer .mcnTextContent a {
-          /*@editable*/
-          color:#bd1c2b;
-          /*@editable*/
-          font-weight:normal;
-          /*@editable*/
-          text-decoration:underline;
-      }
+p{
+    margin:0;
+    margin-bottom: 20px;
+    padding:0;
+}
+table{
+    border-collapse:collapse;
+}
+h1,h2,h3,h4,h5,h6{
+    display:block;
+    margin:0;
+    padding:0;
+}
+img,a img{
+    border:0;
+    height:auto;
+    outline:none;
+    text-decoration:none;
+}
+body,#bodyTable,#bodyCell{
+    height:100%;
+    margin:0;
+    padding:0;
+    width:100%;
+}
+.mcnPreviewText{
+    display:none !important;
+}
+#outlook a{
+    padding:0;
+}
+img{
+    -ms-interpolation-mode:bicubic;
+}
+table{
+    mso-table-lspace:0pt;
+    mso-table-rspace:0pt;
+}
+.ReadMsgBody{
+    width:100%;
+}
+.ExternalClass{
+    width:100%;
+}
+p,a,li,td,blockquote{
+    mso-line-height-rule:exactly;
+}
+a[href^=tel],a[href^=sms]{
+    color:inherit;
+    cursor:default;
+    text-decoration:none;
+}
+p,a,li,td,body,table,blockquote{
+    -ms-text-size-adjust:100%;
+    -webkit-text-size-adjust:100%;
+}
+.ExternalClass,.ExternalClass p,.ExternalClass td,.ExternalClass div,.ExternalClass span,.ExternalClass font{
+    line-height:100%;
+}
+a[x-apple-data-detectors]{
+    color:inherit !important;
+    text-decoration:none !important;
+    font-size:inherit !important;
+    font-family:inherit !important;
+    font-weight:inherit !important;
+    line-height:inherit !important;
+}
+a.mcnButton{
+    display:block;
+}
+.mcnImage,.mcnRetinaImage{
+    vertical-align:bottom;
+}
+.mcnTextContent{
+    word-break:break-word;
+}
+.mcnTextContent img{
+    height:auto !important;
+}
+.mcnDividerBlock{
+    table-layout:fixed !important;
+}
+/* @tab Page @section background style @tip Set the background color and top border for your email. You may want to choose colors that match your company's branding. */
+body,#bodyTable{
+    /*@editable*/
+    background-color:#363636;
+}
+/* @tab Page @section background style @tip Set the background color and top border for your email. You may want to choose colors that match your company's branding. */
+#bodyCell{
+    /*@editable*/
+    border-top:0;
+}
+/* @tab Page @section heading 1 @tip Set the styling for all first-level headings in your emails. These should be the largest of your headings. @style heading 1 */
+h1{
+    /*@editable*/
+    color:#bd1c2b !important;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:40px;
+    /*@editable*/
+    font-style:normal;
+    /*@editable*/
+    font-weight:bold;
+    /*@editable*/
+    line-height:100%;
+    /*@editable*/
+    letter-spacing:-1px;
+    /*@editable*/
+    text-align:center;
+}
+/* @tab Page @section heading 2 @tip Set the styling for all second-level headings in your emails. @style heading 2 */
+h2{
+    /*@editable*/
+    color:#404040 !important;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:26px;
+    /*@editable*/
+    font-style:normal;
+    /*@editable*/
+    font-weight:bold;
+    /*@editable*/
+    line-height:125%;
+    /*@editable*/
+    letter-spacing:-.75px;
+    /*@editable*/
+    text-align:left;
+}
+/* @tab Page @section heading 3 @tip Set the styling for all third-level headings in your emails. @style heading 3 */
+h3{
+    /*@editable*/
+    color:#606060 !important;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:18px;
+    /*@editable*/
+    font-style:normal;
+    /*@editable*/
+    font-weight:bold;
+    /*@editable*/
+    line-height:125%;
+    /*@editable*/
+    letter-spacing:-.5px;
+    /*@editable*/
+    text-align:left;
+}
+/* @tab Page @section heading 4 @tip Set the styling for all fourth-level headings in your emails. These should be the smallest of your headings. @style heading 4 */
+h4{
+    /*@editable*/
+    color:#808080 !important;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:16px;
+    /*@editable*/
+    font-style:normal;
+    /*@editable*/
+    font-weight:bold;
+    /*@editable*/
+    line-height:125%;
+    /*@editable*/
+    letter-spacing:normal;
+    /*@editable*/
+    text-align:left;
+}
+/* @tab Preheader @section preheader text @tip Set the styling for your email's preheader text. Choose a size and color that is easy to read. */
+.preheaderContainer .mcnTextContent,.preheaderContainer .mcnTextContent p{
+    /*@editable*/
+    color:#bd1c2b;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:11px;
+    /*@editable*/
+    line-height:125%;
+    /*@editable*/
+    text-align:left;
+}
+/* @tab Preheader @section preheader link @tip Set the styling for your email's header links. Choose a color that helps them stand out from your text. */
+.preheaderContainer .mcnTextContent a{
+    /*@editable*/
+    color:#bd1c2b;
+    /*@editable*/
+    font-weight:normal;
+    /*@editable*/
+    text-decoration:underline;
+}
+/* @tab Header @section header style @tip Set the background color and borders for your email's header area. */
+#templateHeader{
+    /*@editable*/
+    background-color:#EEEEEE;
+    /*@editable*/
+    border-top:0;
+    /*@editable*/
+    border-bottom:0;
+}
+/* @tab Header @section header text @tip Set the styling for your email's header text. Choose a size and color that is easy to read. */
+.headerContainer .mcnTextContent,.headerContainer .mcnTextContent p{
+    /*@editable*/
+    color:#606060;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:15px;
+    /*@editable*/
+    line-height:150%;
+    /*@editable*/
+    text-align:left;
+}
+/* @tab Header @section header link @tip Set the styling for your email's header links. Choose a color that helps them stand out from your text. */
+.headerContainer .mcnTextContent a{
+    /*@editable*/
+    color:#bd1c2b;
+    /*@editable*/
+    font-weight:normal;
+    /*@editable*/
+    text-decoration:underline;
+}
+/* @tab Body @section body style @tip Set the background color and borders for your email's body area. */
+#templateBody{
+    /*@editable*/
+    background-color:#eeeeee;
+    /*@editable*/
+    border-top:0;
+    /*@editable*/
+    border-bottom:0;
+}
+/* @tab Body @section body container @tip Set the background color and border for your email's body text container. */
+#bodyBackground{
+    /*@editable*/
+    background-color:#FFFFFF;
+    /*@editable*/
+    border:1px solid #D5D5D5;
+}
+/* @tab Body @section body text @tip Set the styling for your email's body text. Choose a size and color that is easy to read. */
+.bodyContainer .mcnTextContent,.bodyContainer .mcnTextContent p{
+    /*@editable*/
+    color:#606060;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:15px;
+    /*@editable*/
+    line-height:150%;
+    /*@editable*/
+    text-align:left;
+}
+/* @tab Body @section body link @tip Set the styling for your email's body links. Choose a color that helps them stand out from your text. */
+.bodyContainer .mcnTextContent a {
+    /*@editable*/
+    color:#bd1c2b;
+    /*@editable*/
+    font-weight:normal;
+    /*@editable*/
+    text-decoration:underline;
+}
 
-      .bodyContainer .mcnTextContent a[data-hyp-mention] {
-          /*@editable*/
-          font-weight:bold;
-          /*@editable*/
-          text-decoration:none;
-      }
+.bodyContainer .mcnTextContent a[data-hyp-mention] {
+    /*@editable*/
+    font-weight:bold;
+    /*@editable*/
+    text-decoration:none;
+}
 
-      /* @tab Footer @section footer style @tip Set the background color and borders for your email's footer area. */
-      #templateFooter{
-          /*@editable*/
-          background-color:#363636;
-          /*@editable*/
-          border-top:0;
-          /*@editable*/
-          border-bottom:0;
-      }
-      /* @tab Footer @section footer text @tip Set the styling for your email's footer text. Choose a size and color that is easy to read. */
-      .footerContainer .mcnTextContent,.footerContainer .mcnTextContent p{
-          /*@editable*/
-          color:#CCCCCC;
-          /*@editable*/
-          font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-          /*@editable*/
-          font-size:11px;
-          /*@editable*/
-          line-height:125%;
-          /*@editable*/
-          text-align:center;
-      }
-      /* @tab Footer @section footer link @tip Set the styling for your email's footer links. Choose a color that helps them stand out from your text. */
-      .footerContainer .mcnTextContent a{
-          /*@editable*/
-          color:#CCCCCC;
-          /*@editable*/
-          font-weight:normal;
-          /*@editable*/
-          text-decoration:underline;
-      }
-      @media only screen and (max-width: 480px){
-          body,table,td,p,a,li,blockquote{
-              -webkit-text-size-adjust:none !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          body{
-              width:100% !important;
-              min-width:100% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .templateContainer{
-              max-width:600px !important;
-              width:100% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcnRetinaImage{
-              max-width:100% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcnImage{
-              height:auto !important;
-              width:100% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcnCartContainer,.mcnCaptionTopContent,.mcnRecContentContainer,.mcnCaptionBottomContent,.mcnTextContentContainer,.mcnBoxedTextContentContainer,.mcnImageGroupContentContainer,.mcnCaptionLeftTextContentContainer,.mcnCaptionRightTextContentContainer,.mcnCaptionLeftImageContentContainer,.mcnCaptionRightImageContentContainer,.mcnImageCardLeftTextContentContainer,.mcnImageCardRightTextContentContainer,.mcnImageCardLeftImageContentContainer,.mcnImageCardRightImageContentContainer{
-              max-width:100% !important;
-              width:100% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcnBoxedTextContentContainer{
-              min-width:100% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcnImageGroupContent{
-              padding:9px !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcnCaptionLeftContentOuter .mcnTextContent,.mcnCaptionRightContentOuter .mcnTextContent{
-              padding-top:9px !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcnImageCardTopImageContent,.mcnCaptionBottomContent:last-child .mcnCaptionBottomImageContent,.mcnCaptionBlockInner .mcnCaptionTopContent:last-child .mcnTextContent{
-              padding-top:18px !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcnImageCardBottomImageContent{
-              padding-bottom:9px !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcnImageGroupBlockInner{
-              padding-top:0 !important;
-              padding-bottom:0 !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcnImageGroupBlockOuter{
-              padding-top:9px !important;
-              padding-bottom:9px !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcnTextContent,.mcnBoxedTextContentColumn{
-              padding-right:18px !important;
-              padding-left:18px !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcnImageCardLeftImageContent,.mcnImageCardRightImageContent{
-              padding-right:18px !important;
-              padding-bottom:0 !important;
-              padding-left:18px !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          .mcpreview-image-uploader{
-              display:none !important;
-              width:100% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          /* @tab Mobile Styles @section heading 1 @tip Make the first-level headings larger in size for better readability on small screens. */
-          h1{
-              /*@editable*/
-              font-size:24px !important;
-              /*@editable*/
-              line-height:125% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          /* @tab Mobile Styles @section heading 2 @tip Make the second-level headings larger in size for better readability on small screens. */
-          h2{
-              /*@editable*/
-              font-size:20px !important;
-              /*@editable*/
-              line-height:125% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          /* @tab Mobile Styles @section heading 3 @tip Make the third-level headings larger in size for better readability on small screens. */
-          h3{
-              /*@editable*/
-              font-size:18px !important;
-              /*@editable*/
-              line-height:125% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          /* @tab Mobile Styles @section heading 4 @tip Make the fourth-level headings larger in size for better readability on small screens. */
-          h4{
-              /*@editable*/
-              font-size:16px !important;
-              /*@editable*/
-              line-height:125% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          /* @tab Mobile Styles @section Boxed Text @tip Make the boxed text larger in size for better readability on small screens. We recommend a font size of at least 16px. */
-          .mcnBoxedTextContentContainer .mcnTextContent,.mcnBoxedTextContentContainer .mcnTextContent p{
-              /*@editable*/
-              font-size:18px !important;
-              /*@editable*/
-              line-height:125% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          /* @tab Mobile Styles @section Preheader Text @tip Make the preheader text larger in size for better readability on small screens. */
-          .preheaderContainer .mcnTextContent,.preheaderContainer .mcnTextContent p{
-              /*@editable*/
-              font-size:14px !important;
-              /*@editable*/
-              line-height:115% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          /* @tab Mobile Styles @section Header Text @tip Make the header text larger in size for better readability on small screens. */
-          .headerContainer .mcnTextContent,.headerContainer .mcnTextContent p{
-              /*@editable*/
-              font-size:18px !important;
-              /*@editable*/
-              line-height:125% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          /* @tab Mobile Styles @section Body Text @tip Make the body text larger in size for better readability on small screens. We recommend a font size of at least 16px. */
-          .bodyContainer .mcnTextContent,.bodyContainer .mcnTextContent p{
-              /*@editable*/
-              font-size:18px !important;
-              /*@editable*/
-              line-height:125% !important;
-          }
-      }
-      @media only screen and (max-width: 480px){
-          /* @tab Mobile Styles @section footer text @tip Make the body content text larger in size for better readability on small screens. */
-          .footerContainer .mcnTextContent,.footerContainer .mcnTextContent p{
-              /*@editable*/
-              font-size:14px !important;
-              /*@editable*/
-              line-height:115% !important;
-          }
-      }
+/* @tab Footer @section footer style @tip Set the background color and borders for your email's footer area. */
+#templateFooter{
+    /*@editable*/
+    background-color:#363636;
+    /*@editable*/
+    border-top:0;
+    /*@editable*/
+    border-bottom:0;
+}
+/* @tab Footer @section footer text @tip Set the styling for your email's footer text. Choose a size and color that is easy to read. */
+.footerContainer .mcnTextContent,.footerContainer .mcnTextContent p{
+    /*@editable*/
+    color:#CCCCCC;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:11px;
+    /*@editable*/
+    line-height:125%;
+    /*@editable*/
+    text-align:center;
+}
+/* @tab Footer @section footer link @tip Set the styling for your email's footer links. Choose a color that helps them stand out from your text. */
+.footerContainer .mcnTextContent a{
+    /*@editable*/
+    color:#CCCCCC;
+    /*@editable*/
+    font-weight:normal;
+    /*@editable*/
+    text-decoration:underline;
+}
+@media only screen and (max-width: 480px){
+    body,table,td,p,a,li,blockquote{
+        -webkit-text-size-adjust:none !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    body{
+        width:100% !important;
+        min-width:100% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .templateContainer{
+        max-width:600px !important;
+        width:100% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcnRetinaImage{
+        max-width:100% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcnImage{
+        height:auto !important;
+        width:100% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcnCartContainer,.mcnCaptionTopContent,.mcnRecContentContainer,.mcnCaptionBottomContent,.mcnTextContentContainer,.mcnBoxedTextContentContainer,.mcnImageGroupContentContainer,.mcnCaptionLeftTextContentContainer,.mcnCaptionRightTextContentContainer,.mcnCaptionLeftImageContentContainer,.mcnCaptionRightImageContentContainer,.mcnImageCardLeftTextContentContainer,.mcnImageCardRightTextContentContainer,.mcnImageCardLeftImageContentContainer,.mcnImageCardRightImageContentContainer{
+        max-width:100% !important;
+        width:100% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcnBoxedTextContentContainer{
+        min-width:100% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcnImageGroupContent{
+        padding:9px !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcnCaptionLeftContentOuter .mcnTextContent,.mcnCaptionRightContentOuter .mcnTextContent{
+        padding-top:9px !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcnImageCardTopImageContent,.mcnCaptionBottomContent:last-child .mcnCaptionBottomImageContent,.mcnCaptionBlockInner .mcnCaptionTopContent:last-child .mcnTextContent{
+        padding-top:18px !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcnImageCardBottomImageContent{
+        padding-bottom:9px !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcnImageGroupBlockInner{
+        padding-top:0 !important;
+        padding-bottom:0 !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcnImageGroupBlockOuter{
+        padding-top:9px !important;
+        padding-bottom:9px !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcnTextContent,.mcnBoxedTextContentColumn{
+        padding-right:18px !important;
+        padding-left:18px !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcnImageCardLeftImageContent,.mcnImageCardRightImageContent{
+        padding-right:18px !important;
+        padding-bottom:0 !important;
+        padding-left:18px !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    .mcpreview-image-uploader{
+        display:none !important;
+        width:100% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section heading 1 @tip Make the first-level headings larger in size for better readability on small screens. */
+    h1{
+        /*@editable*/
+        font-size:24px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section heading 2 @tip Make the second-level headings larger in size for better readability on small screens. */
+    h2{
+        /*@editable*/
+        font-size:20px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section heading 3 @tip Make the third-level headings larger in size for better readability on small screens. */
+    h3{
+        /*@editable*/
+        font-size:18px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section heading 4 @tip Make the fourth-level headings larger in size for better readability on small screens. */
+    h4{
+        /*@editable*/
+        font-size:16px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section Boxed Text @tip Make the boxed text larger in size for better readability on small screens. We recommend a font size of at least 16px. */
+    .mcnBoxedTextContentContainer .mcnTextContent,.mcnBoxedTextContentContainer .mcnTextContent p{
+        /*@editable*/
+        font-size:18px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section Preheader Text @tip Make the preheader text larger in size for better readability on small screens. */
+    .preheaderContainer .mcnTextContent,.preheaderContainer .mcnTextContent p{
+        /*@editable*/
+        font-size:14px !important;
+        /*@editable*/
+        line-height:115% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section Header Text @tip Make the header text larger in size for better readability on small screens. */
+    .headerContainer .mcnTextContent,.headerContainer .mcnTextContent p{
+        /*@editable*/
+        font-size:18px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section Body Text @tip Make the body text larger in size for better readability on small screens. We recommend a font size of at least 16px. */
+    .bodyContainer .mcnTextContent,.bodyContainer .mcnTextContent p{
+        /*@editable*/
+        font-size:18px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+@media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section footer text @tip Make the body content text larger in size for better readability on small screens. */
+    .footerContainer .mcnTextContent,.footerContainer .mcnTextContent p{
+        /*@editable*/
+        font-size:14px !important;
+        /*@editable*/
+        line-height:115% !important;
+    }
+}
   </style>
 </head>
 <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">


### PR DESCRIPTION
Closes #9389 

On one of my first `@mentions` tests with an actual email being sent, I found out styles were pretty much broken in GMail web, while they worked in other email clients.

After some debugging I have found out it is because the styles defined inside the `<style />` tag cannot be indented. This was the case in the LMS digest email, but I thought that would not be relevant and changed it here to make it more readable.

This PR removes the indentation to fix the email styles in GMail web, without affecting other email clients.

Before:

![image](https://github.com/user-attachments/assets/0038c7e9-c5dc-4499-bde9-fdad968c507a)

After:

![image](https://github.com/user-attachments/assets/159806cc-6ce1-411a-aa9e-dbddbe8dfcdc)

> [!NOTE]  
> There's still another issue, in which mention tags are not being rendered as intended. I assume it is because the style is set via `a[data-hyp-mention]` CSS selector, and that's too "advanced".
> I'll investigate that separately.