### PR TITLE
Handle repeated annotation notifications on edit

### DIFF
--- a/h/notification/mention.py
+++ b/h/notification/mention.py
@@ -19,8 +19,8 @@ class MentionNotification:
 def get_notifications(
     request, annotation: Annotation, action
 ) -> list[MentionNotification]:
-    # Only send notifications when new annotations are created
-    if action != "create":
+    # Only send notifications when annotations are created or updated
+    if action not in {"create", "update"}:
         return []
 
     # Only send notifications for shared annotations

--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -164,6 +164,10 @@ class AnnotationWriteService:
             force=not update_timestamp,
         )
 
+        user = self._user_service.fetch(annotation.userid)
+        if self._feature_service.enabled("at_mentions", user):  # pragma: no cover
+            self._mention_service.update_mentions(annotation)
+
         return annotation
 
     def hide(self, annotation):

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -2,7 +2,7 @@ from unittest.mock import create_autospec
 
 import pytest
 
-from h.services import MentionService
+from h.services import MentionService, NotificationService
 from h.services.analytics import AnalyticsService
 from h.services.annotation_delete import AnnotationDeleteService
 from h.services.annotation_json import AnnotationJSONService
@@ -77,6 +77,7 @@ __all__ = (
     "mock_service",
     "moderation_service",
     "nipsa_service",
+    "notification_service",
     "oauth_provider_service",
     "organization_service",
     "queue_service",
@@ -317,6 +318,11 @@ def user_update_service(mock_service):
 @pytest.fixture
 def mention_service(mock_service):
     return mock_service(MentionService)
+
+
+@pytest.fixture
+def notification_service(mock_service):
+    return mock_service(NotificationService)
 
 
 @pytest.fixture


### PR DESCRIPTION
Refs #9386 

Here we start processing mentions on notification edit and handle repeated notifications if they happen.
This is how it works building upon existing logic.
- On both create and edit we update mentions now
- Which [deletes old mentions](https://github.com/hypothesis/h/blob/3dd9b9f1238c890a45a3d41ef2429c5d8fe9a612/h/services/mention.py#L42) from mention table and creates new ones
- Edit of a reply [doesn't create](https://github.com/hypothesis/h/blob/bf4eb55d92d870e56ed96abc8acfd88f2c792718/h/notification/reply.py#L53) new notifications
- If a user already mentioned they [don't get reply notification](https://github.com/hypothesis/h/blob/63b2c4f94ecbf534f995298144f43cc010f3dc65/h/subscribers.py#L101)
- Right before sending mention notification we check if [they are allowed](https://github.com/hypothesis/h/blob/63b2c4f94ecbf534f995298144f43cc010f3dc65/h/subscribers.py#L140)
- Which means that the notification [doesn't exist](https://github.com/hypothesis/h/blob/1ea7fbe612bfea9d44a69d00a96e307e4d6c9e22/h/services/notification.py#L22) for an annotation + user pair
- And we [haven't reached](https://github.com/hypothesis/h/blob/1ea7fbe612bfea9d44a69d00a96e307e4d6c9e22/h/services/notification.py#L23) the annotation limit yet

Testing replies with mentions
===
- Log in as `devdata_user`
- Create public annotation
- Log in as `devdata_admin`
- Enable at_mentions feature for everyone in http://localhost:5000/admin/features
- Reply to the first annotation
- Observe that there's a new reply email in `mail/` folder
- Edit reply annotation with mentions
- Observe that there's no new mention email in the `mail/` folder
- Run `make sql` and inspect notification table for replies
```sql
select * from notification order by created;
```
- Clear notification table if needed
```sql
truncate notification;
```

Testing just mentions
===
- Create non-reply annotation without mentions
- Edit it adding mentions
- Observe that there's a new mention notification in `mail/` folder
- Edit it again with the same mentions
- Observe that there's no new mention email in the `mail/` folder


This is how [to test API directly](https://github.com/hypothesis/h/pull/9356).