### PR TITLE
Use an absolute URL for the logo in mention notifications

### DIFF
--- a/h/emails/mention_notification.py
+++ b/h/emails/mention_notification.py
@@ -10,6 +10,7 @@ def generate(request: Request, notification: MentionNotification):
     selectors = notification.annotation.target[0].get("selector", [])
     quote = next((s for s in selectors if s.get("type") == "TextQuoteSelector"), None)
     username = notification.mentioning_user.username
+
     context = {
         "username": username,
         "user_display_name": notification.mentioning_user.display_name
@@ -21,6 +22,7 @@ def generate(request: Request, notification: MentionNotification):
         "document_url": notification.annotation.target_uri,
         "annotation": notification.annotation,
         "annotation_quote": quote.get("exact") if quote else None,
+        "app_url": request.registry.settings.get("h.app_url"),
     }
 
     subject = f"{context['user_display_name']} has mentioned you in an annotation"

--- a/h/templates/emails/mention_notification.html.jinja2
+++ b/h/templates/emails/mention_notification.html.jinja2
@@ -525,7 +525,7 @@ h4{
                                   <tbody>
                                   <tr>
                                     <td class="mcnImageContent" valign="top" style="padding-right: 9px; padding-left: 9px; padding-top: 0; padding-bottom: 0; text-align:center;">
-                                      <img align="center" alt="" src="{{ asset_url('images/hypothesis-wordmark-logo.png') }}" width="225.60000000000002" style="max-width:1358px; padding-bottom: 0; display: inline !important; vertical-align: bottom;" class="mcnImage">
+                                      <img align="center" alt="" src="{{ app_url }}{{ asset_url('images/hypothesis-wordmark-logo.png') }}" width="225.60000000000002" style="max-width:1358px; padding-bottom: 0; display: inline !important; vertical-align: bottom;" class="mcnImage">
                                     </td>
                                   </tr>
                                   </tbody>

--- a/tests/unit/h/emails/mention_notification_test.py
+++ b/tests/unit/h/emails/mention_notification_test.py
@@ -19,6 +19,13 @@ class TestGenerate:
         text_renderer,
         links,
     ):
+        app_url = "https://example.com"
+        pyramid_request.registry.settings.update(
+            {
+                "h.app_url": app_url,
+            }
+        )
+
         generate(pyramid_request, notification)
 
         links.incontext_link.assert_called_once_with(
@@ -33,6 +40,7 @@ class TestGenerate:
             "document_url": annotation.target_uri,
             "annotation": notification.annotation,
             "annotation_quote": "quoted text",
+            "app_url": app_url,
         }
         html_renderer.assert_(**expected_context)  # noqa: PT009
         text_renderer.assert_(**expected_context)  # noqa: PT009


### PR DESCRIPTION
Forward the `app_url` setting to the template when rendering mention emails, so that the logo URL is absolute and works when loaded in an email client.