### PR TITLE
Allow handling subscription to mention notifications

### DIFF
--- a/h/models/subscriptions.py
+++ b/h/models/subscriptions.py
@@ -16,6 +16,7 @@ class Subscriptions(Base):
         """
 
         REPLY = "reply"
+        MENTION = "mention"
 
     __tablename__ = "subscriptions"
 

--- a/h/static/styles/components/_form-checkbox.scss
+++ b/h/static/styles/components/_form-checkbox.scss
@@ -10,6 +10,7 @@
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
+  margin-bottom: 2px;
 }
 
 .form-checkbox--inline {

--- a/tests/unit/h/accounts/schemas_test.py
+++ b/tests/unit/h/accounts/schemas_test.py
@@ -376,6 +376,27 @@ class TestDeleteAccountSchema:
         return schemas.DeleteAccountSchema().bind(request=pyramid_csrf_request)
 
 
+@pytest.mark.usefixtures("feature_service")
+class TestNotificationSchema:
+    def test_it(self, schema, user, feature_service):
+        schema.deserialize({"notifications": ["reply", "mention"]})
+
+        feature_service.enabled.assert_called_once_with("at_mentions", user)
+
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User()
+
+    @pytest.fixture
+    def pyramid_csrf_request(self, pyramid_csrf_request, user):
+        pyramid_csrf_request.user = user
+        return pyramid_csrf_request
+
+    @pytest.fixture
+    def schema(self, pyramid_csrf_request):
+        return schemas.NotificationsSchema().bind(request=pyramid_csrf_request)
+
+
 @pytest.fixture
 def dummy_node(pyramid_request):
     class DummyNode:


### PR DESCRIPTION
Refs #9398

This adds a new notification setting in [Notifications](http://localhost:5000/account/settings/notifications) allowing to manage whether or not you want to receive mention notifications. The default is true like for replies. The underlying idea is that we [create a subscription](https://github.com/hypothesis/h/blob/b4cd7751f2abf3f8809e21bd1c01414fd1ba2f40/h/services/subscription.py#L43) for a user on the first subscription access if it's missing.

Testing
===
- Log in as `devdata_admin`
- Create annotation mentioning `devdata_user`
- Observe that there's new mention email in `/mail` folder
- Log in as `devdata_user`
- Disable mention notification setting
- Log in as `devdata_admin`
- Create annotation mentioning `devdata_user`
- Observe that there's no new mention email in `/mail` folder