### PR TITLE
Allow unsubscribing from mention email

### DIFF
--- a/h/templates/emails/mention_notification.html.jinja2
+++ b/h/templates/emails/mention_notification.html.jinja2
@@ -703,8 +703,10 @@ h4{
                                   <tbody>
                                   <tr>
                                     <td valign="top" class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-                                      Hypothesis, 2261 Market Street, #632, San Francisco, California 94114, United States of America<br>
-{#                                      <a href="{{ preferences_url}}">Change your email preferences</a> or <a href="{{ unsubscribe_url }}">unsubscribe from these emails</a>.#}
+                                      Hypothesis, 2261 Market Street, #632, San Francisco, California 94114, United States of America<br />
+                                      <br />
+                                      <br />
+                                      <a href="{{ preferences_url }}">Change your email preferences</a> or <a href="{{ unsubscribe_url }}">unsubscribe from these emails</a>.
                                     </td>
                                   </tr>
                                   </tbody>

--- a/h/templates/emails/mention_notification.txt.jinja2
+++ b/h/templates/emails/mention_notification.txt.jinja2
@@ -7,3 +7,5 @@
 {{ (annotation.text or "")|striptags }}
 
 View the thread and respond: {{ annotation_url }}
+
+If you'd rather not receive these notifications you can unsubscribe: {{ unsubscribe_url }}

--- a/tests/unit/h/emails/mention_notification_test.py
+++ b/tests/unit/h/emails/mention_notification_test.py
@@ -190,6 +190,15 @@ class TestGenerate:
         )
 
     @pytest.fixture(autouse=True)
+    def subscription_service(self, subscription_service):
+        subscription_service.get_unsubscribe_token.return_value = "FAKETOKEN"
+        return subscription_service
+
+    @pytest.fixture(autouse=True)
     def routes(self, pyramid_config):
         pyramid_config.add_route("annotation", "/ann/{id}")
         pyramid_config.add_route("stream.user_query", "/stream/user/{user}")
+        pyramid_config.add_route("unsubscribe", "/unsub/{token}")
+        pyramid_config.add_route(
+            "account_notifications", "/account/settings/notifications"
+        )


### PR DESCRIPTION
Refs #9399 

This one adds unsubscribe link via token to the mention notification email.

Testing
===
- Log in as `devdata_admin`
- Create annotation mentioning `devdata_user`
- Observe that there's new mention email in /mail folder
- Log in as `devdata_user`
- Click unsubscribe from mentions link
- Log in as `devdata_admin`
- Create another annotation mentioning `devdata_user`
- Observe that there's no new mention email in /mail folder

One caveat of existing behavior is that even when you can unsubscribe `devdata_user` from notifications even if you're logged as `devdata_admin`. But since you need access to the email in the first case, that isn't necessarily a problem.