### PR TITLE
Expose annotation metadata on the authority queue

### DIFF
--- a/h/models/annotation_metadata.py
+++ b/h/models/annotation_metadata.py
@@ -17,7 +17,7 @@ class AnnotationMetadata(Base):
     )
     """FK to annotation_slim.id"""
 
-    annotation_slim = sa.orm.relationship("AnnotationSlim")
+    annotation_slim = sa.orm.relationship("AnnotationSlim", back_populates="meta")
 
     data = sa.Column(
         MutableDict.as_mutable(pg.JSONB),

--- a/h/models/annotation_slim.py
+++ b/h/models/annotation_slim.py
@@ -96,5 +96,8 @@ class AnnotationSlim(Base):
     )
     group = sa.orm.relationship("Group")
 
+    # Using `meta` as `metadata` is reserved by SQLAlchemy
+    meta = sa.orm.relationship("AnnotationMetadata", uselist=False)
+
     def __repr__(self):
         return helpers.repr_(self, ["id"])

--- a/h/services/annotation_authority_queue.py
+++ b/h/services/annotation_authority_queue.py
@@ -44,7 +44,7 @@ class AnnotationAuthorityQueueService:
             return
 
         annotation_dict = self._annotation_json_service.present_for_user(
-            annotation=annotation, user=annotation.slim.user
+            annotation=annotation, user=annotation.slim.user, with_metadata=True
         )
 
         payload = {

--- a/h/services/annotation_json.py
+++ b/h/services/annotation_json.py
@@ -50,7 +50,7 @@ class AnnotationJSONService:
         self._feature_service = feature_service
         self._request = request
 
-    def present(self, annotation: Annotation):
+    def present(self, annotation: Annotation, with_metadata: bool = False):  # noqa: FBT002, FBT001
         """
         Get the JSON presentation of an annotation.
 
@@ -99,9 +99,17 @@ class AnnotationJSONService:
         if annotation.references:
             model["references"] = annotation.references
 
+        if with_metadata and annotation.slim.meta:
+            model["metadata"] = annotation.slim.meta.data
+
         return model
 
-    def present_for_user(self, annotation: Annotation, user: User):
+    def present_for_user(
+        self,
+        annotation: Annotation,
+        user: User,
+        with_metadata: bool = False,  # noqa: FBT002, FBT001
+    ):
         """
         Get the JSON presentation of an annotation for a particular user.
 
@@ -114,7 +122,7 @@ class AnnotationJSONService:
         """
 
         # Get the basic version which isn't user specific
-        model = self.present(annotation)
+        model = self.present(annotation, with_metadata=with_metadata)
 
         # The flagged value depends on whether this particular user has flagged
         model["flagged"] = self._flag_service.flagged(user=user, annotation=annotation)

--- a/tests/unit/h/services/annotation_authority_queue_test.py
+++ b/tests/unit/h/services/annotation_authority_queue_test.py
@@ -48,6 +48,7 @@ class TestAnnotationAuthorityQueueService:
         annotation_json_service.present_for_user.assert_called_once_with(
             annotation=annotation_read_service.get_annotation_by_id.return_value,
             user=annotation_read_service.get_annotation_by_id.return_value.slim.user,
+            with_metadata=True,
         )
         Celery.assert_called_once_with(
             annotation_read_service.get_annotation_by_id.return_value.authority

--- a/tests/unit/h/services/annotation_json_test.py
+++ b/tests/unit/h/services/annotation_json_test.py
@@ -5,7 +5,7 @@ import pytest
 from h_matchers import Any
 from pyramid.authorization import Everyone
 
-from h.models import Annotation
+from h.models import Annotation, AnnotationMetadata
 from h.security.permissions import Permission
 from h.services.annotation_json import AnnotationJSONService, factory
 from h.traversal import AnnotationContext
@@ -52,6 +52,19 @@ class TestAnnotationJSONService:
 
         DocumentJSONPresenter.assert_called_once_with(annotation.document)
         DocumentJSONPresenter.return_value.asdict.assert_called_once_with()
+
+    def test_present_with_metadata(self, service, annotation):
+        data = {
+            "lms": {
+                "guid": "guid",
+                "assignment": {"resource_link_id": "resource_link_id"},
+            }
+        }
+        annotation.slim.meta = AnnotationMetadata(data=data)
+
+        result = service.present(annotation, with_metadata=True)
+
+        assert result["metadata"] == data
 
     def test_present_without_references(self, service, annotation):
         annotation.references = None
@@ -233,7 +246,10 @@ class TestAnnotationJSONService:
     @pytest.fixture
     def annotation(self, factories):
         return factories.Annotation(
-            moderation=None, groupid="NOT WORLD", tags=["some-tags"]
+            moderation=None,
+            groupid="NOT WORLD",
+            tags=["some-tags"],
+            slim=factories.AnnotationSlim(),
         )
 
     @pytest.fixture


### PR DESCRIPTION
This was part of the PoC, see https://github.com/hypothesis/h/pull/9402

The comments on the PR are also copied from that PR.


Split it on its own PR to make it easier to review.


##  Testing

(Copied and adapted from https://github.com/hypothesis/h/pull/9402)

- Run `make devdata` on H.


- Checkout `main` on LMS.


- Apply a diff like this on LMS

```diff
diff --git a/lms/tasks/annotations.py b/lms/tasks/annotations.py
index 9ebc1a3b6..56dc29caf 100644
--- a/lms/tasks/annotations.py
+++ b/lms/tasks/annotations.py
@@ -14,4 +14,5 @@ def annotation_event(*, event) -> None:  # noqa: ARG001
     """
     # For now we are just consuming the messages to keep the queue clean while
     # we deploy the publishing side on H.
+    print(event)
     return
```

- Restart H's and LMS's `make dev` so celery changes are picked up


- Make an annotation on a assignment

https://hypothesis.instructure.com/courses/125/assignments/873


- Check the logs over LMS

the print statement shows the annotation data contains metadata:


```
 'metadata': {'lms': {'guid': 'XXX:canvas-lms', 'assignment': {'resource_link_id': 'XXX'}}}, 'flagged': False, 'hidden': False}}
```


