### PR TITLE
Do not evaluate at_mentions ff while creating/updating/reading annotations

### DIFF
--- a/h/services/annotation_json.py
+++ b/h/services/annotation_json.py
@@ -9,7 +9,6 @@ from h.security import Identity, identity_permits
 from h.security.permissions import Permission
 from h.services import MentionService
 from h.services.annotation_read import AnnotationReadService
-from h.services.feature import FeatureService
 from h.services.flag import FlagService
 from h.services.links import LinksService
 from h.services.user import UserService
@@ -28,7 +27,6 @@ class AnnotationJSONService:
         flag_service: FlagService,
         user_service: UserService,
         mention_service: MentionService,
-        feature_service: FeatureService,
         request: Request,
     ):
         """
@@ -39,7 +37,6 @@ class AnnotationJSONService:
         :param flag_service: FlagService instance
         :param user_service: UserService instance
         :param mention_service: MentionService instance
-        :param feature_service: FeatureService instance
         :param request: The current request
         """
         self._annotation_read_service = annotation_read_service
@@ -47,7 +44,6 @@ class AnnotationJSONService:
         self._flag_service = flag_service
         self._user_service = user_service
         self._mention_service = mention_service
-        self._feature_service = feature_service
         self._request = request
 
     def present(self, annotation: Annotation, with_metadata: bool = False):  # noqa: FBT002, FBT001
@@ -89,11 +85,10 @@ class AnnotationJSONService:
         )
 
         user = self._user_service.fetch(annotation.userid)
-        if self._feature_service.enabled("at_mentions", user):  # pragma: no cover
-            model["mentions"] = [
-                MentionJSONPresenter(mention, self._request).asdict()
-                for mention in annotation.mentions
-            ]
+        model["mentions"] = [
+            MentionJSONPresenter(mention, self._request).asdict()
+            for mention in annotation.mentions
+        ]
         model.update(user_info(user))
 
         if annotation.references:
@@ -215,6 +210,5 @@ def factory(_context, request):
         flag_service=request.find_service(name="flag"),
         user_service=request.find_service(name="user"),
         mention_service=request.find_service(MentionService),
-        feature_service=request.find_service(name="feature"),
         request=request,
     )

--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -12,10 +12,8 @@ from h.schemas import ValidationError
 from h.security import Permission
 from h.services.annotation_metadata import AnnotationMetadataService
 from h.services.annotation_read import AnnotationReadService
-from h.services.feature import FeatureService
 from h.services.job_queue import JobQueueService
 from h.services.mention import MentionService
-from h.services.user import UserService
 from h.traversal.group import GroupContext
 from h.util.group_scope import url_in_scope
 
@@ -33,8 +31,6 @@ class AnnotationWriteService:
         annotation_read_service: AnnotationReadService,
         annotation_metadata_service: AnnotationMetadataService,
         mention_service: MentionService,
-        user_service: UserService,
-        feature_service: FeatureService,
     ):
         self._db = db_session
         self._has_permission = has_permission
@@ -42,8 +38,6 @@ class AnnotationWriteService:
         self._annotation_read_service = annotation_read_service
         self._annotation_metadata_service = annotation_metadata_service
         self._mention_service = mention_service
-        self._user_service = user_service
-        self._feature_service = feature_service
 
     def create_annotation(self, data: dict) -> Annotation:
         """
@@ -97,9 +91,7 @@ class AnnotationWriteService:
             schedule_in=60,
         )
 
-        user = self._user_service.fetch(annotation.userid)
-        if self._feature_service.enabled("at_mentions", user):  # pragma: no cover
-            self._mention_service.update_mentions(annotation)
+        self._mention_service.update_mentions(annotation)
 
         return annotation
 
@@ -164,9 +156,7 @@ class AnnotationWriteService:
             force=not update_timestamp,
         )
 
-        user = self._user_service.fetch(annotation.userid)
-        if self._feature_service.enabled("at_mentions", user):  # pragma: no cover
-            self._mention_service.update_mentions(annotation)
+        self._mention_service.update_mentions(annotation)
 
         return annotation
 
@@ -299,6 +289,4 @@ def service_factory(_context, request) -> AnnotationWriteService:
         annotation_read_service=request.find_service(AnnotationReadService),
         annotation_metadata_service=request.find_service(AnnotationMetadataService),
         mention_service=request.find_service(MentionService),
-        user_service=request.find_service(name="user"),
-        feature_service=request.find_service(name="feature"),
     )

--- a/tests/unit/h/services/annotation_json_test.py
+++ b/tests/unit/h/services/annotation_json_test.py
@@ -226,7 +226,6 @@ class TestAnnotationJSONService:
         flag_service,
         user_service,
         mention_service,
-        feature_service,
         pyramid_request,
     ):
         return AnnotationJSONService(
@@ -235,7 +234,6 @@ class TestAnnotationJSONService:
             flag_service=flag_service,
             user_service=user_service,
             mention_service=mention_service,
-            feature_service=feature_service,
             request=pyramid_request,
         )
 
@@ -279,7 +277,6 @@ class TestFactory:
         links_service,
         user_service,
         mention_service,
-        feature_service,
     ):
         service = factory(sentinel.context, pyramid_request)
 
@@ -289,7 +286,6 @@ class TestFactory:
             flag_service=flag_service,
             user_service=user_service,
             mention_service=mention_service,
-            feature_service=feature_service,
             request=pyramid_request,
         )
         assert service == AnnotationJSONService.return_value

--- a/tests/unit/h/services/annotation_write_test.py
+++ b/tests/unit/h/services/annotation_write_test.py
@@ -21,7 +21,6 @@ class TestAnnotationWriteService:
         queue_service,
         annotation_read_service,
         mention_service,
-        user_service,
         _validate_group,  # noqa: PT019
         db_session,
     ):
@@ -43,7 +42,6 @@ class TestAnnotationWriteService:
             tag="storage.create_annotation",
             schedule_in=60,
         )
-        user_service.fetch.assert_called_once_with(create_data["userid"])
         mention_service.update_mentions.assert_called_once_with(anno)
 
         assert anno == Any.instance_of(Annotation).with_attrs(
@@ -284,8 +282,6 @@ class TestAnnotationWriteService:
         annotation_read_service,
         annotation_metadata_service,
         mention_service,
-        user_service,
-        feature_service,
     ):
         return AnnotationWriteService(
             db_session=db_session,
@@ -294,8 +290,6 @@ class TestAnnotationWriteService:
             annotation_read_service=annotation_read_service,
             annotation_metadata_service=annotation_metadata_service,
             mention_service=mention_service,
-            user_service=user_service,
-            feature_service=feature_service,
         )
 
     @pytest.fixture
@@ -332,8 +326,6 @@ class TestServiceFactory:
         annotation_read_service,
         annotation_metadata_service,
         mention_service,
-        user_service,
-        feature_service,
     ):
         svc = service_factory(sentinel.context, pyramid_request)
 
@@ -344,8 +336,6 @@ class TestServiceFactory:
             annotation_read_service=annotation_read_service,
             annotation_metadata_service=annotation_metadata_service,
             mention_service=mention_service,
-            user_service=user_service,
-            feature_service=feature_service,
         )
         assert svc == AnnotationWriteService.return_value
 


### PR DESCRIPTION
We originally decided to check that `at_mentions` is enabled for the active user, when creating or editing an annotation, and if not, we would not try to process mention tags from the annotation text.

Similarly we decided not to return `mentions` when serializing an annotation, if the feature was not enabled for the active user.

However, we have found this can be problematic when overwriting features from the LMS. In that case, the client may think the feature is enabled, but from h backend point of view, it is still disabled.

This mismatch causes a confusing user experience in which all mention-related UI controls are enabled (like the suggestions popover when typing `@`), but once you save the annotation, all mentions seem to be invalid, because the backend did not try to parse them.

Since we are about to enable this feature for first party-users, we have decided it's safe to remove the feature check in the backend.

The only exception is the checkbox to enable/disable mentions email notifications, which is entirely handled by `h` and therefore not affected by this mismatch.