### PR TITLE
Expire authority queue tasks after 24 hours

### DIFF
--- a/h/services/annotation_authority_queue.py
+++ b/h/services/annotation_authority_queue.py
@@ -61,6 +61,8 @@ class AnnotationAuthorityQueueService:
                 queue=authority_queue_config.queue_name,
                 # We need to pass the connection explicitly to avoid using the default connection / broker
                 connection=connection,
+                # Expire these tasks just in case something prevents them from being processed
+                expires=60 * 60 * 24,
                 kwargs={"event": payload},
             )
             LOG.info(

--- a/tests/unit/h/services/annotation_authority_queue_test.py
+++ b/tests/unit/h/services/annotation_authority_queue_test.py
@@ -64,6 +64,7 @@ class TestAnnotationAuthorityQueueService:
             "task",
             queue="queue",
             connection=Connection.return_value.__enter__.return_value,
+            expires=60 * 60 * 24,
             kwargs={
                 "event": {
                     "action": "create",


### PR DESCRIPTION
Just in case messages are not being processed for some reason, we want to avoid for example sending mention emails in LMS for old annotations.

In those cases the tradeoff is not sending the email at all vs sending it very late.