### PR TITLE
Expose annotation.text_rendered on the authority queue

### DIFF
--- a/h/services/annotation_authority_queue.py
+++ b/h/services/annotation_authority_queue.py
@@ -48,6 +48,8 @@ class AnnotationAuthorityQueueService:
         annotation_dict = self._annotation_json_service.present_for_user(
             annotation=annotation, user=annotation.slim.user, with_metadata=True
         )
+        # We already done the work to sanitize the text, send that value to the queue
+        annotation_dict["text_rendered"] = annotation.text_rendered
 
         payload = {
             "action": event_action,

--- a/tests/unit/h/services/annotation_authority_queue_test.py
+++ b/tests/unit/h/services/annotation_authority_queue_test.py
@@ -44,6 +44,8 @@ class TestAnnotationAuthorityQueueService:
         annotation,
         Connection,
     ):
+        annotation_presented = {"id": annotation.id}
+        annotation_json_service.present_for_user.return_value = annotation_presented
         annotation_read_service.get_annotation_by_id.return_value = annotation
 
         svc.publish("create", sentinel.annotation_id)
@@ -56,6 +58,7 @@ class TestAnnotationAuthorityQueueService:
             user=annotation_read_service.get_annotation_by_id.return_value.slim.user,
             with_metadata=True,
         )
+        assert annotation_presented["text_rendered"] == annotation.text_rendered
         Celery.assert_called_once_with(
             annotation_read_service.get_annotation_by_id.return_value.authority,
         )
@@ -67,7 +70,7 @@ class TestAnnotationAuthorityQueueService:
             kwargs={
                 "event": {
                     "action": "create",
-                    "annotation": annotation_json_service.present_for_user.return_value,
+                    "annotation": annotation_presented,
                 }
             },
         )


### PR DESCRIPTION
This will save work for the clients (LMS) and guarantee that the text rendered is always the same.