### PR TITLE
Revert "Make log_data required in mailer.send"

### DIFF
--- a/h/services/email.py
+++ b/h/services/email.py
@@ -62,7 +62,7 @@ class EmailService:
         self._request = request
         self._mailer = mailer
 
-    def send(self, email_data: EmailData, log_data: LogData) -> None:
+    def send(self, email_data: EmailData, log_data: LogData | None = None) -> None:
         if self._request.debug:  # pragma: no cover
             logger.info("emailing in debug mode: check the `mail/` directory")
         try:
@@ -75,15 +75,16 @@ class EmailService:
         except smtplib.SMTPException:
             raise
 
-        separator = ", " if log_data.extra_msg else ""
-        logger.info(
-            "Sent email: tag=%r, sender_id=%s, recipient_ids=%s%s%s",
-            log_data.tag,
-            log_data.sender_id,
-            log_data.recipient_ids,
-            separator,
-            log_data.extra_msg,
-        )
+        if log_data:
+            separator = ", " if log_data.extra_msg else ""
+            logger.info(
+                "Sent email: tag=%r, sender_id=%s, recipient_ids=%s%s%s",
+                log_data.tag,
+                log_data.sender_id,
+                log_data.recipient_ids,
+                separator,
+                log_data.extra_msg,
+            )
 
 
 def factory(_context, request: Request) -> EmailService:

--- a/h/tasks/mailer.py
+++ b/h/tasks/mailer.py
@@ -24,11 +24,11 @@ logger = get_task_logger(__name__)
 def send(
     self,  # noqa: ARG001
     email_data: dict[str, Any],
-    log_data: dict[str, Any],
+    log_data: dict[str, Any] | None = None,
 ) -> None:
     """Send an email.
 
     :param email_data: A dictionary containing email data compatible with EmailData class.
     """
     service: EmailService = celery.request.find_service(EmailService)
-    service.send(EmailData(**email_data), LogData(**log_data))
+    service.send(EmailData(**email_data), LogData(**log_data) if log_data else None)

--- a/tests/unit/h/services/email_test.py
+++ b/tests/unit/h/services/email_test.py
@@ -7,10 +7,14 @@ from h.services.email import EmailData, EmailService, EmailTag, LogData, factory
 
 
 class TestEmailService:
-    def test_send_creates_email_message(
-        self, email_data, log_data, email_service, pyramid_mailer
-    ):
-        email_service.send(email_data, log_data)
+    def test_send_creates_email_message(self, email_service, pyramid_mailer):
+        email = EmailData(
+            recipients=["foo@example.com"],
+            subject="My email subject",
+            body="Some text body",
+            tag=EmailTag.TEST,
+        )
+        email_service.send(email)
 
         pyramid_mailer.message.Message.assert_called_once_with(
             recipients=["foo@example.com"],
@@ -21,7 +25,7 @@ class TestEmailService:
         )
 
     def test_send_creates_email_message_with_html_body(
-        self, log_data, email_service, pyramid_mailer
+        self, email_service, pyramid_mailer
     ):
         email = EmailData(
             recipients=["foo@example.com"],
@@ -30,7 +34,7 @@ class TestEmailService:
             tag=EmailTag.TEST,
             html="<p>An HTML body</p>",
         )
-        email_service.send(email, log_data)
+        email_service.send(email)
 
         pyramid_mailer.message.Message.assert_called_once_with(
             recipients=["foo@example.com"],
@@ -41,32 +45,60 @@ class TestEmailService:
         )
 
     def test_send_dispatches_email_using_request_mailer(
-        self, email_data, log_data, email_service, pyramid_mailer
+        self, email_service, pyramid_mailer
     ):
         request_mailer = pyramid_mailer.get_mailer.return_value
         message = pyramid_mailer.message.Message.return_value
 
-        email_service.send(email_data, log_data)
+        email = EmailData(
+            recipients=["foo@example.com"],
+            subject="My email subject",
+            body="Some text body",
+            tag=EmailTag.TEST,
+        )
+        email_service.send(email)
 
         request_mailer.send_immediately.assert_called_once_with(message)
 
-    def test_raises_smtplib_exception(
-        self, email_data, log_data, email_service, pyramid_mailer
-    ):
+    def test_raises_smtplib_exception(self, email_service, pyramid_mailer):
         request_mailer = pyramid_mailer.get_mailer.return_value
         request_mailer.send_immediately.side_effect = smtplib.SMTPException()
 
+        email = EmailData(
+            recipients=["foo@example.com"],
+            subject="My email subject",
+            body="Some text body",
+            tag=EmailTag.TEST,
+        )
         with pytest.raises(smtplib.SMTPException):
-            email_service.send(email_data, log_data)
+            email_service.send(email)
 
-    def test_send_logging(self, email_data, log_data, email_service, info_caplog):
+    def test_send_logging(self, email_service, info_caplog):
+        email_data = EmailData(
+            recipients=["foo@example.com"],
+            subject="My email subject",
+            body="Some text body",
+            tag=EmailTag.TEST,
+        )
+        user_id = 123
+        log_data = LogData(
+            tag=email_data.tag,
+            sender_id=user_id,
+            recipient_ids=[user_id],
+        )
         email_service.send(email_data, log_data)
 
         assert info_caplog.messages == [
-            f"Sent email: tag={log_data.tag!r}, sender_id={log_data.sender_id}, recipient_ids={log_data.recipient_ids}"
+            f"Sent email: tag={log_data.tag!r}, sender_id={user_id}, recipient_ids={[user_id]}"
         ]
 
-    def test_send_logging_with_extra(self, email_data, email_service, info_caplog):
+    def test_send_logging_with_extra(self, email_service, info_caplog):
+        email_data = EmailData(
+            recipients=["foo@example.com"],
+            subject="My email subject",
+            body="Some text body",
+            tag=EmailTag.TEST,
+        )
         user_id = 123
         annotation_id = "annotation_id"
         log_data = LogData(
@@ -80,23 +112,6 @@ class TestEmailService:
         assert info_caplog.messages == [
             f"Sent email: tag={log_data.tag!r}, sender_id={user_id}, recipient_ids={[user_id]}, annotation_id={annotation_id!r}"
         ]
-
-    @pytest.fixture
-    def email_data(self):
-        return EmailData(
-            recipients=["foo@example.com"],
-            subject="My email subject",
-            body="Some text body",
-            tag=EmailTag.TEST,
-        )
-
-    @pytest.fixture
-    def log_data(self):
-        return LogData(
-            tag=EmailTag.TEST,
-            sender_id=123,
-            recipient_ids=[123],
-        )
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
Reverts hypothesis/h#9410

Signup stopped working, see [sentry here](https://hypothesis.sentry.io/issues/6438168358/?alert_rule_id=7345746&alert_type=issue&notification_uuid=ab6062e3-83b0-4458-a6cf-5c15b1366d1a&project=37293&referrer=slack)