### PR TITLE
Add feature flag for PDF image annotation

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -16,6 +16,7 @@ FEATURES = {
     "group_members": "Allow users to manage group members in new group forms",
     "group_type": "Allow users to choose group type in new group forms",
     "pdf_custom_text_layer": "Use custom text layer in PDFs for improved text selection",
+    "pdf_image_annotation": "Support image annotations in PDFs",
     "styled_highlight_clusters": "Style different clusters of highlights in the client",
     "at_mentions": "Allow mentioning other users in annotations",
 }


### PR DESCRIPTION
This will be used in the client to determine whether to show controls for creating image annotations in PDFs. On the backend we probably won't need to pay attention to this flag at all.