### PR TITLE
Send relevant email headers to thread mentions emails by document

### DIFF
--- a/h/emails/mention_notification.py
+++ b/h/emails/mention_notification.py
@@ -12,6 +12,7 @@ def generate(request: Request, notification: MentionNotification) -> EmailData:
     selectors = notification.annotation.target[0].get("selector", [])
     quote = next((s for s in selectors if s.get("type") == "TextQuoteSelector"), None)
     username = notification.mentioning_user.username
+    document_url = notification.annotation.target_uri
 
     unsubscribe_token = request.find_service(SubscriptionService).get_unsubscribe_token(
         user_id=notification.mentioned_user.userid, type_=Subscriptions.Type.MENTION
@@ -24,8 +25,8 @@ def generate(request: Request, notification: MentionNotification) -> EmailData:
         "annotation_url": links.incontext_link(request, notification.annotation)
         or request.route_url("annotation", id=notification.annotation.id),
         "document_title": notification.document.title
-        or notification.annotation.target_uri,
-        "document_url": notification.annotation.target_uri,
+        or document_url,
+        "document_url": document_url,
         "annotation": notification.annotation,
         "annotation_quote": quote.get("exact") if quote else None,
         "app_url": request.registry.settings.get("h.app_url"),
@@ -50,4 +51,5 @@ def generate(request: Request, notification: MentionNotification) -> EmailData:
         body=text,
         tag=EmailTag.MENTION_NOTIFICATION,
         html=html,
+        id=f"<hypothesis/h/mention/{document_url}>"
     )

--- a/h/services/email.py
+++ b/h/services/email.py
@@ -30,15 +30,32 @@ class EmailData:
     body: str
     tag: EmailTag
     html: str | None = None
+    id: str | None = None
+    """Message ID to set in Message-ID header"""
+    parent_id: str | None = None
+    """
+    Parent message ID to be set in In-Reply-To and References headers.
+    Defaults to `id`
+    """
 
     @property
     def message(self) -> pyramid_mailer.message.Message:
+        extra_headers = {"X-MC-Tags": self.tag}
+        parent_id = self.parent_id if self.parent_id is not None else self.id
+
+        if self.id:
+            extra_headers["Message-ID"] = self.id
+
+        if parent_id:
+            extra_headers["In-Reply-To"] = parent_id
+            extra_headers["References"] = parent_id
+
         return pyramid_mailer.message.Message(
             subject=self.subject,
             recipients=self.recipients,
             body=self.body,
             html=self.html,
-            extra_headers={"X-MC-Tags": self.tag},
+            extra_headers=extra_headers,
         )
 
 


### PR DESCRIPTION
Closes #9381 

Make sure mention email notifications send the `Message-ID`, `In-Reply-To` and `References` headers so that email clients like GMail can group emails in the same thread when you have been mentioned more than once in the same document.