### PR TITLE
Truncate mentioned userids instead of users

### DIFF
--- a/tests/unit/h/services/mention_test.py
+++ b/tests/unit/h/services/mention_test.py
@@ -50,6 +50,7 @@ class TestMentionService:
         service.update_mentions(annotation)
 
         assert len(annotation.mentions) == limit
+        assert annotation.mentions[0].user == mentioned_user
 
     def test_update_mentions_with_groupid_not_world(
         self, service, annotation, factories


### PR DESCRIPTION
Fixes https://hypothes-is.slack.com/archives/C2BLQDKHA/p1742888061925929?thread_ts=1742842141.736719&cid=C2BLQDKHA

We want to truncate ordered parsed userids first and then create annotation mentions for the truncated part exactly.