### PR TITLE
Use same document-based subject in mention emails

### DIFF
--- a/h/emails/mention_notification.py
+++ b/h/emails/mention_notification.py
@@ -34,7 +34,7 @@ def generate(request: Request, notification: MentionNotification) -> EmailData:
         "preferences_url": request.route_url("account_notifications"),
     }
 
-    subject = f"{context['user_display_name']} has mentioned you in an annotation"
+    subject = f"You have been mentioned in {context['document_title']}"
     text = render(
         "h:templates/emails/mention_notification.txt.jinja2", context, request=request
     )

--- a/tests/unit/h/emails/mention_notification_test.py
+++ b/tests/unit/h/emails/mention_notification_test.py
@@ -93,27 +93,12 @@ class TestGenerate:
         assert email.body == "Text output"
         assert email.html == "HTML output"
 
-    def test_returns_subject_with_reply_display_name(
-        self, notification, pyramid_request, mentioning_user
+    def test_returns_subject_with_document_title(
+        self, document, notification, pyramid_request
     ):
         email = generate(pyramid_request, notification)
 
-        assert (
-            email.subject
-            == f"{mentioning_user.display_name} has mentioned you in an annotation"
-        )
-
-    def test_returns_subject_with_reply_username(
-        self, notification, pyramid_request, mentioning_user
-    ):
-        mentioning_user.display_name = None
-
-        email = generate(pyramid_request, notification)
-
-        assert (
-            email.subject
-            == f"@{mentioning_user.username} has mentioned you in an annotation"
-        )
+        assert email.subject == f"You have been mentioned in {document.title}"
 
     def test_returns_parent_email_as_recipients(
         self, notification, pyramid_request, mentioned_user


### PR DESCRIPTION
Closes #9381 

This PR is an alternative to https://github.com/hypothesis/h/pull/9418, in which we try to generate consistent subjects in mention emails, so that they get threaded by document in GMail.

The main challenge is having something that uniquely represents a document and is human-friendly enough. I used the document title, falling back to the document URL when not available, as that's what we use in the activity pages to group annotations by document.

In the LMS we could use the assignment title instead.

### TODO

- [x] Test if this approach works for email clients other than GMail
    - [It doesn't for Thunderbird](https://github.com/hypothesis/h/pull/9422#issuecomment-2754442274). Thunderbird requires the email ID headers.
- [x] Test with a few different document types and see how we resolve the document title.