### PR TITLE
Increase annotation mention limit to 25

### DIFF
--- a/h/services/mention.py
+++ b/h/services/mention.py
@@ -9,7 +9,7 @@ from h.services.html import parse_html_links
 from h.services.user import UserService
 from h.util.markdown_render import MENTION_ATTRIBUTE, MENTION_USERID
 
-MENTION_LIMIT = 5
+MENTION_LIMIT = 25
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes https://hypothes-is.slack.com/archives/C2C2U40LW/p1742896371947239

Annotation mention limit of 5 per annotation turned out to be too low, increasing to 25 instead.