### PR TITLE
Add `mixins_dataclasses.py`

### DIFF
--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -18,29 +18,30 @@ import sqlalchemy
 import zope.sqlalchemy
 import zope.sqlalchemy.datamanager
 from sqlalchemy import text
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 __all__ = ("Base", "Session", "create_engine", "post_create", "pre_create")
 
 log = logging.getLogger(__name__)
 
-# Create a default metadata object with naming conventions for indexes and
-# constraints. This makes changing such constraints and indexes with alembic
-# after creation much easier. See:
-#
-#   http://docs.sqlalchemy.org/en/latest/core/constraints.html#configuring-constraint-naming-conventions
-#
-metadata = sqlalchemy.MetaData(
-    naming_convention={
-        "ix": "ix__%(column_0_label)s",
-        "uq": "uq__%(table_name)s__%(column_0_name)s",
-        "ck": "ck__%(table_name)s__%(constraint_name)s",
-        "fk": "fk__%(table_name)s__%(column_0_name)s__%(referred_table_name)s",
-        "pk": "pk__%(table_name)s",
-    }
-)
 
-Base = declarative_base(metadata=metadata)
+class Base(DeclarativeBase):
+    # Create a default metadata object with naming conventions for indexes and
+    # constraints. This makes changing such constraints and indexes with
+    # alembic after creation much easier. See:
+    #
+    #   http://docs.sqlalchemy.org/en/latest/core/constraints.html#configuring-constraint-naming-conventions
+    #
+    metadata = sqlalchemy.MetaData(
+        naming_convention={
+            "ix": "ix__%(column_0_label)s",
+            "uq": "uq__%(table_name)s__%(column_0_name)s",
+            "ck": "ck__%(table_name)s__%(constraint_name)s",
+            "fk": "fk__%(table_name)s__%(column_0_name)s__%(referred_table_name)s",
+            "pk": "pk__%(table_name)s",
+        }
+    )
+
 
 Session = sessionmaker()
 

--- a/h/db/mixins_dataclasses.py
+++ b/h/db/mixins_dataclasses.py
@@ -1,0 +1,34 @@
+"""
+Mixins for use with model classes that use SQLAlchemy's dataclasses integration.
+
+See: https://docs.sqlalchemy.org/en/20/orm/dataclasses.html
+"""
+
+from datetime import datetime
+
+from sqlalchemy import func
+from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
+
+
+class AutoincrementingIntegerID(MappedAsDataclass):
+    id: Mapped[int] = mapped_column(
+        init=False, primary_key=True, autoincrement=True, sort_order=-100
+    )
+
+
+class Timestamps(MappedAsDataclass):
+    created: Mapped[datetime] = mapped_column(
+        init=False,
+        repr=False,
+        server_default=func.now(),
+        sort_order=-10,
+        nullable=False,
+    )
+    updated: Mapped[datetime] = mapped_column(
+        init=False,
+        repr=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+        sort_order=-10,
+        nullable=False,
+    )


### PR DESCRIPTION
Add autoincrementing-integer-primary-key and created-updated mixins that can be used with model classes that use SQLAlchemy's dataclasses support, like this:

```python
class GroupInvite(Base, AutoincrementingIntegerID, Timestamps, MappedAsDataclass):
    ...
```

We can't merge this yet because nothing uses the new mixins yet (hence why coverage is failing), but I thought it'd be useful to push this PR now then in future when someone needs these mixins they can cherry-pick the commit into their own PR.

Full working example of a model class that uses these: https://github.com/hypothesis/h/pull/9426