### PR TITLE
Expose annotation.quote on the authority queue

### DIFF
--- a/h/emails/mention_notification.py
+++ b/h/emails/mention_notification.py
@@ -9,8 +9,6 @@ from h.services.email import EmailData, EmailTag
 
 
 def generate(request: Request, notification: MentionNotification) -> EmailData:
-    selectors = notification.annotation.target[0].get("selector", [])
-    quote = next((s for s in selectors if s.get("type") == "TextQuoteSelector"), None)
     username = notification.mentioning_user.username
 
     unsubscribe_token = request.find_service(SubscriptionService).get_unsubscribe_token(
@@ -27,7 +25,7 @@ def generate(request: Request, notification: MentionNotification) -> EmailData:
         or notification.annotation.target_uri,
         "document_url": notification.annotation.target_uri,
         "annotation": notification.annotation,
-        "annotation_quote": quote.get("exact") if quote else None,
+        "annotation_quote": notification.annotation.quote,
         "app_url": request.registry.settings.get("h.app_url"),
         "unsubscribe_url": request.route_url(
             "unsubscribe",

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -175,6 +175,15 @@ class Annotation(Base):
 
         return [target]
 
+    @property
+    def quote(self) -> str | None:
+        """Quote text the annotation is referring to."""
+        selectors = self.target[0].get("selector", [])
+        quote = next(
+            (s for s in selectors if s.get("type") == "TextQuoteSelector"), None
+        )
+        return quote.get("exact") if quote else None
+
     @hybrid_property
     def text(self):
         return self._text

--- a/h/services/annotation_authority_queue.py
+++ b/h/services/annotation_authority_queue.py
@@ -50,6 +50,8 @@ class AnnotationAuthorityQueueService:
         )
         # We already done the work to sanitize the text, send that value to the queue
         annotation_dict["text_rendered"] = annotation.text_rendered
+        # Also expose the quoted text if it exists
+        annotation_dict["quote"] = annotation.quote
 
         payload = {
             "action": event_action,

--- a/tests/unit/h/services/annotation_authority_queue_test.py
+++ b/tests/unit/h/services/annotation_authority_queue_test.py
@@ -59,6 +59,7 @@ class TestAnnotationAuthorityQueueService:
             with_metadata=True,
         )
         assert annotation_presented["text_rendered"] == annotation.text_rendered
+        assert annotation_presented["quote"] == annotation.quote
         Celery.assert_called_once_with(
             annotation_read_service.get_annotation_by_id.return_value.authority,
         )


### PR DESCRIPTION
Needed for the email template on the LMS side.


# Testing

- Apply a diff like this on the LMS side

```diff
diff --git a/lms/tasks/annotations.py b/lms/tasks/annotations.py
index 2508416f0..feff7d855 100644
--- a/lms/tasks/annotations.py
+++ b/lms/tasks/annotations.py
@@ -61,6 +61,7 @@ def annotation_event(*, event) -> None:
 
     These are published directly on LMS's queue by H
     """
+    print(event)
     annotation_event = AnnotationEvent(**event)
     annotation = annotation_event.annotation
```

- Restart make dev in both H and LMS
- Create a new annotation with mention on https://hypothesis.instructure.com/courses/125/assignments/873
- The resulting message in LMS has quote in the data passed.
