### PR TITLE
Register activity.user_search route for streamer app

### DIFF
--- a/h/streamer/app.py
+++ b/h/streamer/app.py
@@ -27,6 +27,7 @@ def create_app(_global_config, **settings):
     config.add_route("ws", "/ws")
     config.add_route("annotation", "/a/{id}", static=True)
     config.add_route("api.annotation", "/api/annotations/{id}", static=True)
+    config.add_route("activity.user_search", "/users/{username}", static=True)
 
     # Health check
     config.scan("h.views.status")


### PR DESCRIPTION
Fixes #9429

Register `activity.user_search` route as static in streamer app, so that we can dynamically generate user profile URLs when serializing an annotation with mentions.

### Test steps

1. Open the client in two browsers.
2. Create an annotation in one of them. Verify the real-time updates widget is displayed in the other one.
3. Create another annotation, with a mention this time. Verify that the value displayed in the real-time updates widget has increased, and there's no crash in `h` logs.