### PR TITLE
Fix annotation authority queue service publish

### DIFF
--- a/h/services/annotation_authority_queue.py
+++ b/h/services/annotation_authority_queue.py
@@ -36,6 +36,10 @@ class AnnotationAuthorityQueueService:
 
     def publish(self, event_action: str, annotation_id: str) -> None:
         annotation = self._annotation_read_service.get_annotation_by_id(annotation_id)
+        if not annotation:
+            LOG.error("Annotation %r not found", annotation_id)
+            return
+
         authority_queue_config = self._authority_queue_config.get(annotation.authority)
         if not authority_queue_config:
             return

--- a/tests/unit/h/services/annotation_authority_queue_test.py
+++ b/tests/unit/h/services/annotation_authority_queue_test.py
@@ -77,6 +77,18 @@ class TestAnnotationAuthorityQueueService:
             },
         )
 
+    def test_publish_with_invalid_annotation(
+        self, svc, Celery, annotation_read_service
+    ):
+        annotation_read_service.get_annotation_by_id.return_value = None
+
+        svc.publish("create", sentinel.annotation_id)
+
+        annotation_read_service.get_annotation_by_id.assert_called_once_with(
+            sentinel.annotation_id
+        )
+        Celery.assert_not_called()
+
     def test_parse_config_when_not_present(self, svc):
         assert not svc._parse_authority_queue_config(None)  # noqa: SLF001
 


### PR DESCRIPTION
We need to handle deletion of the annotation when it gets to the celery task.

Testing
===
- Run `celery` without the fix
- Run tests over `tests/functional/api/annotations_test.py`
- Inspect the celery logs for error
`AttributeError: 'NoneType' object has no attribute 'authority'`
- Do the same with the fix and observe no error