### PR TITLE
Use a consistent subject for mention and reply emails

### DIFF
--- a/h/emails/mention_notification.py
+++ b/h/emails/mention_notification.py
@@ -2,6 +2,7 @@ from pyramid.renderers import render
 from pyramid.request import Request
 
 from h import links
+from h.emails.util import email_subject
 from h.models import Subscriptions
 from h.notification.mention import MentionNotification
 from h.services import SubscriptionService
@@ -34,7 +35,7 @@ def generate(request: Request, notification: MentionNotification) -> EmailData:
         "preferences_url": request.route_url("account_notifications"),
     }
 
-    subject = f"{context['user_display_name']} has mentioned you in an annotation"
+    subject = email_subject(context["document_title"])
     text = render(
         "h:templates/emails/mention_notification.txt.jinja2", context, request=request
     )

--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -2,7 +2,7 @@ from pyramid.renderers import render
 from pyramid.request import Request
 
 from h import links
-from h.emails.util import get_user_url
+from h.emails.util import email_subject, get_user_url
 from h.models import Subscriptions
 from h.notification.reply import Notification
 from h.services import SubscriptionService
@@ -41,7 +41,7 @@ def generate(request: Request, notification: Notification) -> EmailData:
         "reply_user_url": get_user_url(notification.reply_user, request),
     }
 
-    subject = f"{context['reply_user_display_name']} has replied to your annotation"
+    subject = email_subject(context["document_title"])
     text = render(
         "h:templates/emails/reply_notification.txt.jinja2", context, request=request
     )

--- a/h/emails/util.py
+++ b/h/emails/util.py
@@ -8,3 +8,7 @@ def get_user_url(user: User, request: Request) -> str | None:
         return request.route_url("stream.user_query", user=user.username)
 
     return None
+
+
+def email_subject(document: str) -> str:
+    return f"New activity on {document}"

--- a/tests/unit/h/emails/mention_notification_test.py
+++ b/tests/unit/h/emails/mention_notification_test.py
@@ -93,27 +93,12 @@ class TestGenerate:
         assert email.body == "Text output"
         assert email.html == "HTML output"
 
-    def test_returns_subject_with_reply_display_name(
-        self, notification, pyramid_request, mentioning_user
+    def test_returns_subject_with_document_title(
+        self, document, notification, pyramid_request
     ):
         email = generate(pyramid_request, notification)
 
-        assert (
-            email.subject
-            == f"{mentioning_user.display_name} has mentioned you in an annotation"
-        )
-
-    def test_returns_subject_with_reply_username(
-        self, notification, pyramid_request, mentioning_user
-    ):
-        mentioning_user.display_name = None
-
-        email = generate(pyramid_request, notification)
-
-        assert (
-            email.subject
-            == f"@{mentioning_user.username} has mentioned you in an annotation"
-        )
+        assert email.subject == f"New activity on {document.title}"
 
     def test_returns_parent_email_as_recipients(
         self, notification, pyramid_request, mentioned_user

--- a/tests/unit/h/emails/reply_notification_test.py
+++ b/tests/unit/h/emails/reply_notification_test.py
@@ -89,20 +89,6 @@ class TestGenerate:
         html_renderer.assert_(**expected_context)  # noqa: PT009
         text_renderer.assert_(**expected_context)  # noqa: PT009
 
-    def test_supports_non_ascii_display_names(
-        self,
-        notification,
-        pyramid_request,
-        parent_user,
-        reply_user,
-    ):
-        parent_user.display_name = "Parent 👩"
-        reply_user.display_name = "Child 👧"
-
-        email = generate(pyramid_request, notification)
-
-        assert email.subject == "Child 👧 has replied to your annotation"
-
     def test_returns_usernames_if_no_display_names(
         self,
         notification,
@@ -135,20 +121,12 @@ class TestGenerate:
         assert email.body == "Text output"
         assert email.html == "HTML output"
 
-    def test_returns_subject_with_reply_display_name(
-        self, notification, pyramid_request
+    def test_returns_subject_with_document_title(
+        self, document, notification, pyramid_request
     ):
         email = generate(pyramid_request, notification)
 
-        assert email.subject == "Ron Burgundy has replied to your annotation"
-
-    def test_returns_subject_with_reply_username(
-        self, notification, pyramid_request, reply_user
-    ):
-        reply_user.display_name = None
-        email = generate(pyramid_request, notification)
-
-        assert email.subject == "ron has replied to your annotation"
+        assert email.subject == f"New activity on {document.title}"
 
     def test_returns_parent_email_as_recipients(self, notification, pyramid_request):
         email = generate(pyramid_request, notification)


### PR DESCRIPTION
Closes https://github.com/hypothesis/h/issues/9381

Use a subject like `New activity in {document_title_or_url}` in all mentions and reply emails.

Using a consistent subject allows clients like GMail group all emails in a single thread.