### PR TITLE
Add task done table

### DIFF
--- a/h/db/mixins_dataclasses.py
+++ b/h/db/mixins_dataclasses.py
@@ -1,0 +1,34 @@
+"""
+Mixins for use with model classes that use SQLAlchemy's dataclasses integration.
+
+See: https://docs.sqlalchemy.org/en/20/orm/dataclasses.html
+"""
+
+from datetime import datetime
+
+from sqlalchemy import func
+from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
+
+
+class AutoincrementingIntegerID(MappedAsDataclass):
+    id: Mapped[int] = mapped_column(
+        init=False, primary_key=True, autoincrement=True, sort_order=-100
+    )
+
+
+class Timestamps(MappedAsDataclass):
+    created: Mapped[datetime] = mapped_column(
+        init=False,
+        repr=False,
+        server_default=func.now(),
+        sort_order=-10,
+        nullable=False,
+    )
+    updated: Mapped[datetime] = mapped_column(
+        init=False,
+        repr=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+        sort_order=-10,
+        nullable=False,
+    )

--- a/h/migrations/versions/9d97a3e4921e_add_task_done.py
+++ b/h/migrations/versions/9d97a3e4921e_add_task_done.py
@@ -1,0 +1,42 @@
+"""Add task done table.
+
+Revision ID: 9d97a3e4921e
+Revises: 372308320143
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "9d97a3e4921e"
+down_revision = "372308320143"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "task_done",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column(
+            "expires_at",
+            sa.DateTime(),
+            server_default=sa.text("now() + interval '30 days'"),
+            nullable=False,
+        ),
+        sa.Column(
+            "data",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__task_done")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("task_done")

--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -38,6 +38,7 @@ from h.models.notification import Notification
 from h.models.organization import Organization
 from h.models.setting import Setting
 from h.models.subscriptions import Subscriptions
+from h.models.task_done import TaskDone
 from h.models.token import Token
 from h.models.user import User
 from h.models.user_deletion import UserDeletion
@@ -68,6 +69,7 @@ __all__ = (
     "Organization",
     "Setting",
     "Subscriptions",
+    "TaskDone",
     "Token",
     "User",
     "UserDeletion",

--- a/h/models/task_done.py
+++ b/h/models/task_done.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, MappedAsDataclass
+from sqlalchemy.testing.schema import mapped_column
+
+from h.db import Base
+from h.db.mixins import Timestamps
+from h.db.mixins_dataclasses import AutoincrementingIntegerID
+
+
+class TaskDone(Base, AutoincrementingIntegerID, Timestamps, MappedAsDataclass):
+    __tablename__ = "task_done"
+
+    expires_at: Mapped[datetime] = mapped_column(
+        init=False, nullable=False, server_default=text("now() + interval '30 days'")
+    )
+    data: Mapped[dict] = mapped_column(
+        JSONB, server_default=text("'{}'::jsonb"), nullable=True
+    )


### PR DESCRIPTION
Refs #9291

Here we add task done table to support email monitoring. One PR for both the model and migration is fine since it's not being used yet.

I've decided to add the table without key field since in the context of user-initiated emails it doesn't make as much sense as in the context of scheduled digests in `lms`. We can't really guarantee its uniqueness but still can query the table via json data field. Lifting up user IDs out of data might be worth it to make rate-limiting easier but not strictly necessary and can be done at a later date.