### PR TITLE
Populate task done table

### DIFF
--- a/h/services/user_signup.py
+++ b/h/services/user_signup.py
@@ -7,7 +7,7 @@ from sqlalchemy.exc import IntegrityError
 from h.emails import signup
 from h.models import Activation, User, UserIdentity
 from h.services import SubscriptionService
-from h.services.email import EmailTag, LogData
+from h.services.email import EmailTag, TaskData
 from h.services.exceptions import ConflictError
 from h.services.user_password import UserPasswordService
 from h.tasks import email
@@ -131,12 +131,10 @@ class UserSignupService:
             email=user.email,
             activation_code=user.activation.code,
         )
-        log_data = LogData(
-            tag=EmailTag.ACTIVATION,
-            sender_id=user.id,
-            recipient_ids=[user.id],
+        task_data = TaskData(
+            tag=EmailTag.ACTIVATION, sender_id=user.id, recipient_ids=[user.id]
         )
-        email.send.delay(asdict(email_data), asdict(log_data))
+        email.send.delay(asdict(email_data), asdict(task_data))
 
 
 def user_signup_service_factory(_context, request):

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -12,7 +12,7 @@ from h.models.notification import NotificationType
 from h.notification import mention, reply
 from h.services import NotificationService
 from h.services.annotation_read import AnnotationReadService
-from h.services.email import LogData
+from h.services.email import TaskData
 from h.tasks import annotations, email
 
 logger = logging.getLogger(__name__)
@@ -110,14 +110,14 @@ def send_reply_notifications(event):
             return
 
         email_data = emails.reply_notification.generate(request, notification)
-        log_data = LogData(
+        task_data = TaskData(
             tag=email_data.tag,
             sender_id=notification.reply_user.id,
             recipient_ids=[notification.parent_user.id],
             extra={"annotation_id": annotation.id},
         )
         try:
-            email.send.delay(asdict(email_data), asdict(log_data))
+            email.send.delay(asdict(email_data), asdict(task_data))
         except OperationalError as err:  # pragma: no cover
             # We could not connect to rabbit! So carry on
             report_exception(err)
@@ -154,14 +154,14 @@ def send_mention_notifications(event):
                 continue
 
             email_data = emails.mention_notification.generate(request, notification)
-            log_data = LogData(
+            task_data = TaskData(
                 tag=email_data.tag,
                 sender_id=notification.mentioning_user.id,
                 recipient_ids=[notification.mentioned_user.id],
                 extra={"annotation_id": annotation.id},
             )
             try:
-                email.send.delay(asdict(email_data), asdict(log_data))
+                email.send.delay(asdict(email_data), asdict(task_data))
             except OperationalError as err:  # pragma: no cover
                 # We could not connect to rabbit! So carry on
                 report_exception(err)

--- a/h/tasks/email.py
+++ b/h/tasks/email.py
@@ -6,7 +6,7 @@ This module defines a Celery task for sending emails in a worker process.
 
 from typing import Any
 
-from h.services.email import EmailData, EmailService, LogData
+from h.services.email import EmailData, EmailService, TaskData
 from h.tasks.celery import celery, get_task_logger
 
 __all__ = ("send",)
@@ -24,12 +24,12 @@ logger = get_task_logger(__name__)
 def send(
     self,  # noqa: ARG001
     email_data: dict[str, Any],
-    log_data: dict[str, Any],
+    task_data: dict[str, Any],
 ) -> None:
     """Send an email.
 
     :param email_data: A dictionary containing email data compatible with EmailData class.
-    :param log_data: A dictionary containing log data compatible with LogData class.
+    :param task_data: A dictionary containing log data compatible with LogData class.
     """
     service: EmailService = celery.request.find_service(EmailService)
-    service.send(EmailData(**email_data), LogData(**log_data))
+    service.send(EmailData(**email_data), TaskData(**task_data))

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -30,7 +30,7 @@ from h.schemas.forms.accounts import (
     ResetPasswordSchema,
 )
 from h.services import SubscriptionService
-from h.services.email import LogData
+from h.services.email import TaskData
 from h.tasks import email
 from h.util.view import json_view
 
@@ -213,10 +213,10 @@ class ForgotPasswordController:
 
     def _send_forgot_password_email(self, user):
         email_data = reset_password.generate(self.request, user)
-        log_data = LogData(
+        task_data = TaskData(
             tag=email_data.tag, sender_id=user.id, recipient_ids=[user.id]
         )
-        email.send.delay(asdict(email_data), asdict(log_data))
+        email.send.delay(asdict(email_data), asdict(task_data))
 
 
 @view_defaults(

--- a/h/views/admin/email.py
+++ b/h/views/admin/email.py
@@ -5,7 +5,7 @@ from pyramid.view import view_config
 
 from h.emails import test
 from h.security import Permission
-from h.services.email import LogData
+from h.services.email import TaskData
 from h.tasks import email
 
 
@@ -33,11 +33,8 @@ def email_test(request):
         return HTTPSeeOther(location=index)
 
     email_data = test.generate(request, request.params["recipient"])
-    log_data = LogData(
-        tag=email_data.tag,
-        sender_id=request.user.id,
-    )
-    result = email.send.delay(asdict(email_data), asdict(log_data))
+    task_data = TaskData(tag=email_data.tag, sender_id=request.user.id)
+    result = email.send.delay(asdict(email_data), asdict(task_data))
     index = request.route_path("admin.email", _query={"taskid": result.task_id})
     return HTTPSeeOther(location=index)
 

--- a/h/views/api/flags.py
+++ b/h/views/api/flags.py
@@ -6,7 +6,7 @@ from h import links
 from h.emails import flag_notification
 from h.security import Permission
 from h.security.permission_map import GROUP_MODERATE_PREDICATES
-from h.services.email import LogData
+from h.services.email import TaskData
 from h.tasks import email
 from h.views.api.config import api_config
 
@@ -41,10 +41,10 @@ def _email_group_moderators(request, annotation):
     for membership in memberships:
         if user_email := membership.user.email:
             email_data = flag_notification.generate(request, user_email, incontext_link)
-            log_data = LogData(
+            task_data = TaskData(
                 tag=email_data.tag,
                 sender_id=request.user.id,
                 recipient_ids=[membership.user.id],
                 extra={"annotation_id": annotation.id},
             )
-            email.send.delay(asdict(email_data), asdict(log_data))
+            email.send.delay(asdict(email_data), asdict(task_data))

--- a/tests/unit/h/services/email_test.py
+++ b/tests/unit/h/services/email_test.py
@@ -117,14 +117,9 @@ class TestEmailService:
         )
 
     @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.debug = False
-        return pyramid_request
-
-    @pytest.fixture
     def email_service(self, pyramid_request, pyramid_mailer):
         request_mailer = pyramid_mailer.get_mailer.return_value
-        return EmailService(pyramid_request, request_mailer)
+        return EmailService(pyramid_request.debug, pyramid_request.db, request_mailer)
 
     @pytest.fixture
     def info_caplog(self, caplog):
@@ -137,7 +132,9 @@ class TestFactory:
         service = factory(sentinel.context, pyramid_request)
 
         EmailService.assert_called_once_with(
-            request=pyramid_request, mailer=pyramid_mailer.get_mailer.return_value
+            debug=pyramid_request.debug,
+            session=pyramid_request.db,
+            mailer=pyramid_mailer.get_mailer.return_value,
         )
 
         assert service == EmailService.return_value
@@ -150,3 +147,9 @@ class TestFactory:
 @pytest.fixture(autouse=True)
 def pyramid_mailer(patch):
     return patch("h.services.email.pyramid_mailer", autospec=True)
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.debug = False
+    return pyramid_request

--- a/tests/unit/h/services/user_signup_test.py
+++ b/tests/unit/h/services/user_signup_test.py
@@ -94,7 +94,7 @@ class TestUserSignupService:
         user_password_service.update_password.assert_called_once_with(user, "wibble")
 
     def test_signup_sends_email(
-        self, svc, signup, tasks_email, pyramid_request, asdict, LogData
+        self, svc, signup, tasks_email, pyramid_request, asdict, TaskData
     ):
         signup.generate.return_value = sentinel.email_data
 
@@ -108,10 +108,10 @@ class TestUserSignupService:
         )
 
         asdict.assert_has_calls(
-            [call(signup.generate.return_value), call(LogData.return_value)]
+            [call(signup.generate.return_value), call(TaskData.return_value)]
         )
         tasks_email.send.delay.assert_called_once_with(
-            sentinel.email_data, sentinel.log_data
+            sentinel.email_data, sentinel.task_data
         )
 
     def test_signup_does_not_send_email_when_activation_not_required(
@@ -194,7 +194,7 @@ class TestUserSignupService:
     def asdict(self, patch):
         return patch(
             "h.services.user_signup.asdict",
-            side_effect=[sentinel.email_data, sentinel.log_data],
+            side_effect=[sentinel.email_data, sentinel.task_data],
         )
 
 
@@ -223,5 +223,5 @@ class TestUserSignupServiceFactory:
 
 
 @pytest.fixture(autouse=True)
-def LogData(patch):
-    return patch("h.services.user_signup.LogData")
+def TaskData(patch):
+    return patch("h.services.user_signup.TaskData")

--- a/tests/unit/h/subscribers_test.py
+++ b/tests/unit/h/subscribers_test.py
@@ -123,7 +123,7 @@ class TestSendReplyNotifications:
         emails,
         tasks_email,
         asdict,
-        LogData,
+        TaskData,
     ):
         subscribers.send_reply_notifications(event)
 
@@ -153,9 +153,9 @@ class TestSendReplyNotifications:
         )
 
         email_data = emails.reply_notification.generate.return_value
-        asdict.assert_has_calls([call(email_data), call(LogData.return_value)])
+        asdict.assert_has_calls([call(email_data), call(TaskData.return_value)])
         tasks_email.send.delay.assert_called_once_with(
-            sentinel.email_data, sentinel.log_data
+            sentinel.email_data, sentinel.task_data
         )
 
         notification_service.save_notification.assert_called_once_with(
@@ -224,7 +224,7 @@ class TestSendMentionNotifications:
         emails,
         tasks_email,
         asdict,
-        LogData,
+        TaskData,
     ):
         notifications = mention.get_notifications.return_value
 
@@ -251,9 +251,9 @@ class TestSendMentionNotifications:
         )
 
         email_data = emails.mention_notification.generate.return_value
-        asdict.assert_has_calls([call(email_data), call(LogData.return_value)])
+        asdict.assert_has_calls([call(email_data), call(TaskData.return_value)])
         tasks_email.send.delay.assert_called_once_with(
-            sentinel.email_data, sentinel.log_data
+            sentinel.email_data, sentinel.task_data
         )
 
         notification_service.save_notification.assert_called_once_with(
@@ -364,10 +364,10 @@ def report_exception(patch):
 @pytest.fixture(autouse=True)
 def asdict(patch):
     return patch(
-        "h.subscribers.asdict", side_effect=[sentinel.email_data, sentinel.log_data]
+        "h.subscribers.asdict", side_effect=[sentinel.email_data, sentinel.task_data]
     )
 
 
 @pytest.fixture(autouse=True)
-def LogData(patch):
-    return patch("h.subscribers.LogData", autospec=True)
+def TaskData(patch):
+    return patch("h.subscribers.TaskData", autospec=True)

--- a/tests/unit/h/tasks/email_test.py
+++ b/tests/unit/h/tasks/email_test.py
@@ -2,24 +2,24 @@ from unittest import mock
 
 import pytest
 
-from h.services.email import EmailData, EmailTag, LogData
+from h.services.email import EmailData, EmailTag, TaskData
 from h.tasks import email
 
 
-def test_send(email_data, log_data, email_service):
-    email.send(email_data, log_data)
+def test_send(email_data, task_data, email_service):
+    email.send(email_data, task_data)
 
     email_service.send.assert_called_once_with(
-        EmailData(**email_data), LogData(**log_data)
+        EmailData(**email_data), TaskData(**task_data)
     )
 
 
-def test_send_retries_if_mailing_fails(email_data, log_data, email_service):
+def test_send_retries_if_mailing_fails(email_data, task_data, email_service):
     email_service.send.side_effect = Exception()
     email.send.retry = mock.Mock(wraps=email.send.retry)
 
     with pytest.raises(Exception) as exc_info:  # noqa: PT011
-        email.send(email_data, log_data)
+        email.send(email_data, task_data)
     assert exc_info.type is Exception
 
     assert email.send.retry.called
@@ -36,7 +36,7 @@ def email_data():
 
 
 @pytest.fixture
-def log_data():
+def task_data():
     return {"tag": EmailTag.TEST, "sender_id": 123, "recipient_ids": [123]}
 
 

--- a/tests/unit/h/views/accounts_test.py
+++ b/tests/unit/h/views/accounts_test.py
@@ -10,7 +10,7 @@ from h_matchers import Any
 from pyramid import httpexceptions
 
 from h.models import Subscriptions
-from h.services.email import EmailData, EmailTag, LogData
+from h.services.email import EmailData, EmailTag, TaskData
 from h.tasks import email
 from h.views import accounts as views
 
@@ -289,13 +289,11 @@ class TestForgotPasswordController:
             tag=EmailTag.TEST,
             html="HTML output",
         )
-        log_data = LogData(
-            tag=email_data.tag,
-            sender_id=user.id,
-            recipient_ids=[user.id],
+        task_data = TaskData(
+            tag=email_data.tag, sender_id=user.id, recipient_ids=[user.id]
         )
         tasks_email.send.delay.assert_called_once_with(
-            asdict(email_data), asdict(log_data)
+            asdict(email_data), asdict(task_data)
         )
 
     def test_post_redirects_on_success(

--- a/tests/unit/h/views/admin/email_test.py
+++ b/tests/unit/h/views/admin/email_test.py
@@ -4,7 +4,7 @@ from unittest.mock import create_autospec
 import pytest
 from pyramid.httpexceptions import HTTPSeeOther
 
-from h.services.email import EmailData, EmailTag, LogData
+from h.services.email import EmailData, EmailTag, TaskData
 from h.tasks import email
 from h.views.admin.email import email_index, email_test, preview_mention_notification
 
@@ -48,9 +48,9 @@ class TestEmailTest:
             tag=EmailTag.TEST,
             html="html",
         )
-        log_data = LogData(tag=email_data.tag, sender_id=user.id)
+        task_data = TaskData(tag=email_data.tag, sender_id=user.id)
         tasks_email.send.delay.assert_called_once_with(
-            asdict(email_data), asdict(log_data)
+            asdict(email_data), asdict(task_data)
         )
 
     def test_redirects(self, pyramid_request):


### PR DESCRIPTION
Refs #9291 

Here we actually populate `task_done` table with the info about the emails we send. It's done in `email` service itself just after we the sending.

Testing
===
- Run migration from target #9436
- Log in as `devdata_admin`
- Create a reply / mention notification of `devdata_user`
- Observe new rows in the `task_done` table where `data ->> 'tag'` has appropriate value
```sql
select * from task_done;
```