### PR TITLE
Remove unique from annotation metadata primary key

### DIFF
--- a/h/models/annotation_metadata.py
+++ b/h/models/annotation_metadata.py
@@ -12,7 +12,6 @@ class AnnotationMetadata(Base):
         sa.Integer,
         sa.ForeignKey("annotation_slim.id", ondelete="cascade"),
         nullable=False,
-        unique=True,
         primary_key=True,
     )
     """FK to annotation_slim.id"""


### PR DESCRIPTION
The problem is that when created without migrations annotation metadata table is missing the constraint `uq__annotation_metadata__annotation_id` but it always tries to add it when I try to `autogenerate` revision.

We have two migrations related to that, the one [when we created the table](https://github.com/hypothesis/h/blob/e87b601f56f36513ef47c2e0cec3eeb85bca2709/h/migrations/versions/34c8067db0ee_annotation_metatada.py#L29) and the one when we tried to address the problem [concurrently creating the index](https://github.com/hypothesis/h/blob/eb5bc0aff2557c8b6da6267a70860d16dc00fc26/h/migrations/versions/78d3d6fe1d42_metadata_unique_constraint.py#L20).

It doesn't really make sense to have `unique=True` on a primary key in [single-column case](https://github.com/sqlalchemy/sqlalchemy/discussions/5887#discussioncomment-320969) so let's remove that.
Then `autogenerate` produces an empty migration as expected.
Ultimately it seems to be an asymmetry issue between sqlalchemy `create_all` and alembic `autogenerate`.