### PR TITLE
Moderation proof of concept implementation

### DIFF
--- a/h/db/mixins.py
+++ b/h/db/mixins.py
@@ -5,13 +5,16 @@ import datetime
 import sqlalchemy as sa
 
 
-class Timestamps:
+class CreatedMixin:
     created = sa.Column(
         sa.DateTime,
         default=datetime.datetime.utcnow,
         server_default=sa.func.now(),
         nullable=False,
     )
+
+
+class Timestamps(CreatedMixin):
     updated = sa.Column(
         sa.DateTime,
         server_default=sa.func.now(),

--- a/h/events.py
+++ b/h/events.py
@@ -1,7 +1,12 @@
+from typing import Literal
+
+AnnotationAction = Literal["create", "update", "delete"]
+
+
 class AnnotationEvent:
     """An event representing an action on an annotation."""
 
-    def __init__(self, request, annotation_id, action):
+    def __init__(self, request, annotation_id, action: AnnotationAction):
         self.request = request
         self.annotation_id = annotation_id
         self.action = action

--- a/h/migrations/versions/96cde96b2fd7_backfill_denied_based_on_moderation.py
+++ b/h/migrations/versions/96cde96b2fd7_backfill_denied_based_on_moderation.py
@@ -1,0 +1,41 @@
+"""Backfill DENIED based on moderation."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "96cde96b2fd7"
+down_revision = "c8f748cbfb8f"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    result = conn.execute(
+        sa.text(
+            """
+    UPDATE annotation
+        SET moderation_status = 'DENIED'
+    FROM annotation_moderation
+    WHERE annotation.id = annotation_moderation.annotation_id
+    AND annotation.moderation_status  is null
+    """
+        )
+    )
+    print("\tUpdated annotation rows as DENIED:", result.rowcount)  # noqa: T201
+
+    result = conn.execute(
+        sa.text(
+            """
+    UPDATE annotation_slim
+        SET moderation_status = 'DENIED'
+    FROM annotation_moderation
+    WHERE annotation_slim.pubid = annotation_moderation.annotation_id
+    AND annotation_slim.moderation_status is null
+    """
+        )
+    )
+    print("\tUpdated annotations as DENIED:", result.rowcount)  # noqa: T201
+
+
+def downgrade() -> None:
+    pass

--- a/h/migrations/versions/bd226cc1c359_create_moderation_log_table.py
+++ b/h/migrations/versions/bd226cc1c359_create_moderation_log_table.py
@@ -4,9 +4,10 @@ Revision ID: bd226cc1c359
 Revises: 96cde96b2fd7
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
+
 from h.db import types
 
 revision = "bd226cc1c359"

--- a/h/migrations/versions/bd226cc1c359_create_moderation_log_table.py
+++ b/h/migrations/versions/bd226cc1c359_create_moderation_log_table.py
@@ -1,0 +1,51 @@
+"""Create moderation log table
+
+Revision ID: bd226cc1c359
+Revises: 96cde96b2fd7
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from h.db import types
+
+revision = "bd226cc1c359"
+down_revision = "96cde96b2fd7"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "moderation_log",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("annotation_id", types.URLSafeUUID(), nullable=False),
+        sa.Column("old_moderation_status", sa.String(), nullable=False),
+        sa.Column("new_moderation_status", sa.String(), nullable=False),
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["annotation_id"],
+            ["annotation.id"],
+            name=op.f("fk__moderation_log__annotation_id__annotation"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            name=op.f("fk__moderation_log__user_id__user"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__moderation_log")),
+    )
+    op.create_index(
+        op.f("ix__moderation_log_annotation_id"),
+        "moderation_log",
+        ["annotation_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("moderation_log")
+    # ### end Alembic commands ###

--- a/h/migrations/versions/bd226cc1c359_create_moderation_log_table.py
+++ b/h/migrations/versions/bd226cc1c359_create_moderation_log_table.py
@@ -1,12 +1,7 @@
-"""Create moderation log table
-
-Revision ID: bd226cc1c359
-Revises: 96cde96b2fd7
-"""
+"""Create moderation log table."""
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import postgresql
 
 from h.db import types
 

--- a/h/migrations/versions/c8f748cbfb8f_create_the_moderation_status_column.py
+++ b/h/migrations/versions/c8f748cbfb8f_create_the_moderation_status_column.py
@@ -1,0 +1,44 @@
+"""Create the moderation_status column
+
+Revision ID: c8f748cbfb8f
+Revises: 372308320143
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "c8f748cbfb8f"
+down_revision = "372308320143"
+
+
+def upgrade() -> None:
+    moderation_status_type = postgresql.ENUM(
+        "APPROVED",
+        "DENIED",
+        "SPAM",
+        "PRIVATE",
+        name="moderationstatus",
+    )
+    moderation_status_type.create(op.get_bind(), checkfirst=True)
+    op.add_column(
+        "annotation",
+        sa.Column(
+            "moderation_status",
+            moderation_status_type,
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "annotation_slim",
+        sa.Column(
+            "moderation_status",
+            moderation_status_type,
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("annotation_slim", "moderation_status")
+    op.drop_column("annotation", "moderation_status")

--- a/h/migrations/versions/c8f748cbfb8f_create_the_moderation_status_column.py
+++ b/h/migrations/versions/c8f748cbfb8f_create_the_moderation_status_column.py
@@ -5,7 +5,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision = "c8f748cbfb8f"
-down_revision = "372308320143"
+down_revision = "cf4eedee60f7"
 
 
 def upgrade() -> None:
@@ -14,6 +14,7 @@ def upgrade() -> None:
         "DENIED",
         "SPAM",
         "PRIVATE",
+        "PENDING",
         name="moderationstatus",
     )
     moderation_status_type.create(op.get_bind(), checkfirst=True)

--- a/h/migrations/versions/c8f748cbfb8f_create_the_moderation_status_column.py
+++ b/h/migrations/versions/c8f748cbfb8f_create_the_moderation_status_column.py
@@ -1,8 +1,4 @@
-"""Create the moderation_status column
-
-Revision ID: c8f748cbfb8f
-Revises: 372308320143
-"""
+"""Create the moderation_status column."""
 
 import sqlalchemy as sa
 from alembic import op

--- a/h/migrations/versions/c8f748cbfb8f_create_the_moderation_status_column.py
+++ b/h/migrations/versions/c8f748cbfb8f_create_the_moderation_status_column.py
@@ -13,7 +13,6 @@ def upgrade() -> None:
         "APPROVED",
         "DENIED",
         "SPAM",
-        "PRIVATE",
         "PENDING",
         name="moderationstatus",
     )

--- a/h/migrations/versions/cf4eedee60f7_add_group_pre_moderated.py
+++ b/h/migrations/versions/cf4eedee60f7_add_group_pre_moderated.py
@@ -4,12 +4,12 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "cf4eedee60f7"
-down_revision = "96cde96b2fd7"
+down_revision = "9d97a3e4921e"
 
 
 def upgrade() -> None:
-    op.add_column("user_group", sa.Column("pre_moderated", sa.Boolean(), nullable=True))
+    op.add_column("group", sa.Column("pre_moderated", sa.Boolean(), nullable=True))
 
 
 def downgrade() -> None:
-    op.drop_column("user_group", "pre_moderated")
+    op.drop_column("group", "pre_moderated")

--- a/h/migrations/versions/cf4eedee60f7_add_group_pre_moderated.py
+++ b/h/migrations/versions/cf4eedee60f7_add_group_pre_moderated.py
@@ -1,0 +1,15 @@
+"""Add Group.pre_moderated."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "cf4eedee60f7"
+down_revision = "96cde96b2fd7"
+
+
+def upgrade() -> None:
+    op.add_column("user_group", sa.Column("pre_moderated", sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("user_group", "pre_moderated")

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -19,7 +19,6 @@ class ModerationStatus(Enum):
     PENDING = "PENDING"
     DENIED = "DENIED"
     SPAM = "SPAM"
-    PRIVATE = "PRIVATE"
 
     def is_hidden(self):
         return self in {self.DENIED, self.SPAM}

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -20,9 +20,6 @@ class ModerationStatus(Enum):
     DENIED = "DENIED"
     SPAM = "SPAM"
 
-    def is_hidden(self):
-        return self in {self.DENIED, self.SPAM}
-
 
 class Annotation(Base):
     """Model class representing a single annotation."""
@@ -275,6 +272,14 @@ class Annotation(Base):
         """Check if this annotation id is hidden."""
         # TODO, move to the new column after migration and backfill migration
         return self.moderation is not None
+
+    @property
+    def moderated(self):
+        # This replaces is_hidden, adding a new property to give more visibility to the change in the PoC
+        return bool(
+            self.moderation_status
+            and self.moderation_status != ModerationStatus.APPROVED
+        )
 
     def __repr__(self):
         return f"<Annotation {self.id}>"

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -14,14 +14,22 @@ from h.util import markdown_render, uri
 from h.util.user import split_user
 
 
+class ModerationStatus(Enum):
+    APPROVED = "APPROVED"
+    PENDING = "PENDING"
+    DENIED = "DENIED"
+    SPAM = "SPAM"
+    PRIVATE = "PRIVATE"
+
+    def is_hidden(self):
+        return self in {self.DENIED, self.SPAM}
+
+
 class Annotation(Base):
     """Model class representing a single annotation."""
 
-    class ModerationStatus(Enum):
-        APPROVED = "APPROVED"
-        DENIED = "DENIED"
-        SPAM = "SPAM"
-        PRIVATE = "PRIVATE"
+    # Expose the ModerationStatus directly here
+    ModerationStatus = ModerationStatus
 
     __tablename__ = "annotation"
     __table_args__ = (

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -6,7 +6,11 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableDict, MutableList
+<<<<<<< HEAD
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+=======
+from sqlalchemy.orm import Mapped, relationship
+>>>>>>> 18ca3ca3c (Model changes for Group.pre_moderated)
 
 from h.db import Base, types
 from h.models.group import Group

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -6,11 +6,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableDict, MutableList
-<<<<<<< HEAD
-from sqlalchemy.orm import Mapped, mapped_column, relationship
-=======
 from sqlalchemy.orm import Mapped, relationship
->>>>>>> 18ca3ca3c (Model changes for Group.pre_moderated)
 
 from h.db import Base, types
 from h.models.group import Group

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -1,10 +1,12 @@
 import datetime
+from enum import Enum
 from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableDict, MutableList
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from h.db import Base, types
 from h.models.group import Group
@@ -14,6 +16,12 @@ from h.util.user import split_user
 
 class Annotation(Base):
     """Model class representing a single annotation."""
+
+    class ModerationStatus(Enum):
+        APPROVED = "APPROVED"
+        DENIED = "DENIED"
+        SPAM = "SPAM"
+        PRIVATE = "PRIVATE"
 
     __tablename__ = "annotation"
     __table_args__ = (
@@ -68,7 +76,7 @@ class Annotation(Base):
         index=True,
     )
 
-    group = sa.orm.relationship(
+    group = relationship(
         Group,
         primaryjoin=(Group.pubid == groupid),
         foreign_keys=[groupid],
@@ -138,11 +146,11 @@ class Annotation(Base):
         uselist=True,
     )
 
-    mentions = sa.orm.relationship("Mention", back_populates="annotation")
+    mentions = relationship("Mention", back_populates="annotation")
 
-    notifications = sa.orm.relationship(
-        "Notification", back_populates="source_annotation"
-    )
+    notifications = relationship("Notification", back_populates="source_annotation")
+
+    moderation_status: Mapped[ModerationStatus | None]
 
     @property
     def uuid(self):

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -266,7 +266,7 @@ class Annotation(Base):
     @property
     def is_hidden(self):
         """Check if this annotation id is hidden."""
-
+        # TODO, move to the new column after migration and backfill migration
         return self.moderation is not None
 
     def __repr__(self):

--- a/h/models/annotation_moderation.py
+++ b/h/models/annotation_moderation.py
@@ -1,15 +1,16 @@
-from h.db.mixins_dataclasses import AutoincrementingIntegerID
 import sqlalchemy as sa
-
-from h.db import Base, types
+from sqlalchemy import ForeignKey
 from sqlalchemy.orm import (
     Mapped,
     MappedAsDataclass,
-    relationship,
     mapped_column,
+    relationship,
 )
+
+from h.db import Base, types
 from h.db.mixins import CreatedMixin, Timestamps
-from sqlalchemy import ForeignKey
+from h.db.mixins_dataclasses import AutoincrementingIntegerID
+from h.models.annotation import ModerationStatus
 
 
 class ModerationLog(Base, AutoincrementingIntegerID, CreatedMixin, MappedAsDataclass):
@@ -21,9 +22,10 @@ class ModerationLog(Base, AutoincrementingIntegerID, CreatedMixin, MappedAsDatac
     annotation_id: Mapped[types.URLSafeUUID] = mapped_column(
         ForeignKey("annotation.id", ondelete="CASCADE"), index=True
     )
+    annotation = relationship("Annotation")
 
-    old_moderation_status: Mapped[str] = mapped_column()
-    new_moderation_status: Mapped[str] = mapped_column()
+    old_moderation_status: Mapped[ModerationStatus | None] = mapped_column()
+    new_moderation_status: Mapped[ModerationStatus] = mapped_column()
 
 
 class AnnotationModeration(Base, Timestamps):

--- a/h/models/annotation_moderation.py
+++ b/h/models/annotation_moderation.py
@@ -1,7 +1,29 @@
+from h.db.mixins_dataclasses import AutoincrementingIntegerID
 import sqlalchemy as sa
 
 from h.db import Base, types
-from h.db.mixins import Timestamps
+from sqlalchemy.orm import (
+    Mapped,
+    MappedAsDataclass,
+    relationship,
+    mapped_column,
+)
+from h.db.mixins import CreatedMixin, Timestamps
+from sqlalchemy import ForeignKey
+
+
+class ModerationLog(Base, AutoincrementingIntegerID, CreatedMixin, MappedAsDataclass):
+    __tablename__ = "moderation_log"
+
+    user_id: Mapped[int] = mapped_column(sa.ForeignKey("user.id", ondelete="CASCADE"))
+    user = relationship("User")
+
+    annotation_id: Mapped[types.URLSafeUUID] = mapped_column(
+        ForeignKey("annotation.id", ondelete="CASCADE"), index=True
+    )
+
+    old_moderation_status: Mapped[str] = mapped_column()
+    new_moderation_status: Mapped[str] = mapped_column()
 
 
 class AnnotationModeration(Base, Timestamps):

--- a/h/models/annotation_slim.py
+++ b/h/models/annotation_slim.py
@@ -1,9 +1,11 @@
 import datetime
 
 import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, relationship
 
 from h.db import Base, types
 from h.models import helpers
+from h.models.annotation import Annotation
 
 
 class AnnotationSlim(Base):
@@ -31,7 +33,7 @@ class AnnotationSlim(Base):
     )
     """The value of annotation.id, named here pubid following the convention of group.pubid"""
 
-    annotation = sa.orm.relationship(
+    annotation = relationship(
         "Annotation", backref=sa.orm.backref("slim", uselist=False)
     )
 
@@ -64,6 +66,7 @@ class AnnotationSlim(Base):
         default=False,
         server_default=sa.sql.expression.false(),
     )
+    moderation_status: Mapped[Annotation.ModerationStatus | None]
 
     shared = sa.Column(
         sa.Boolean,
@@ -78,7 +81,7 @@ class AnnotationSlim(Base):
         nullable=False,
         index=True,
     )
-    document = sa.orm.relationship("Document")
+    document = relationship("Document")
 
     user_id = sa.Column(
         sa.Integer,
@@ -86,7 +89,7 @@ class AnnotationSlim(Base):
         nullable=False,
         index=True,
     )
-    user = sa.orm.relationship("User")
+    user = relationship("User")
 
     group_id = sa.Column(
         sa.Integer,
@@ -94,10 +97,10 @@ class AnnotationSlim(Base):
         nullable=False,
         index=True,
     )
-    group = sa.orm.relationship("Group")
+    group = relationship("Group")
 
     # Using `meta` as `metadata` is reserved by SQLAlchemy
-    meta = sa.orm.relationship("AnnotationMetadata", uselist=False)
+    meta = relationship("AnnotationMetadata", uselist=False)
 
     def __repr__(self):
         return helpers.repr_(self, ["id"])

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 import slugify
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from h import pubid
 from h.db import Base, mixins
@@ -84,6 +84,8 @@ class GroupMembership(Base):
         onupdate=datetime.datetime.utcnow,
         index=True,
     )
+
+    pre_moderated: Mapped[bool | None] = mapped_column()
 
     def __repr__(self):
         return helpers.repr_(

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -85,8 +85,6 @@ class GroupMembership(Base):
         index=True,
     )
 
-    pre_moderated: Mapped[bool | None] = mapped_column()
-
     def __repr__(self):
         return helpers.repr_(
             self,
@@ -158,6 +156,8 @@ class Group(Base, mixins.Timestamps):
     writeable_by = sa.Column(
         sa.Enum(WriteableBy, name="group_writeable_by"), nullable=True
     )
+
+    pre_moderated: Mapped[bool | None] = mapped_column()
 
     @property
     def groupid(self):

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -40,6 +40,7 @@ class AnnotationSearchIndexPresenter:
             result["references"] = self.annotation.references
 
         self._add_hidden(result)
+        self._add_moderated(result)
         self._add_nipsa(result, self.annotation.userid)
 
         return result
@@ -54,7 +55,15 @@ class AnnotationSearchIndexPresenter:
             parents_and_replies
         )
 
+        # Note that all hidden annotations are also moderated
+        # We have both concepts now to avoid a migration/reindexing on the ES side
         result["hidden"] = is_hidden
+
+    def _add_moderated(self, result):
+        moderation_service = self.request.find_service(name="annotation_moderation")
+        moderation_service.initialize_status(self.annotation)
+
+        result["moderated"] = self.annotation.is_hidden()
 
     def _add_nipsa(self, result, user_id):
         nipsa_service = self.request.find_service(name="nipsa")

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -59,12 +59,6 @@ class AnnotationSearchIndexPresenter:
         # We have both concepts now to avoid a migration/reindexing on the ES side
         result["hidden"] = is_hidden
 
-    def _add_moderated(self, result):
-        moderation_service = self.request.find_service(name="annotation_moderation")
-        moderation_service.initialize_status(self.annotation)
-
-        result["moderated"] = self.annotation.is_hidden()
-
     def _add_nipsa(self, result, user_id):
         nipsa_service = self.request.find_service(name="nipsa")
         if nipsa_service.is_flagged(user_id):

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -54,8 +54,6 @@ class AnnotationSearchIndexPresenter:
             parents_and_replies
         )
 
-        # Note that all hidden annotations are also moderated
-        # We have both concepts now to avoid a migration/reindexing on the ES side
         result["hidden"] = is_hidden
 
     def _add_nipsa(self, result, user_id):

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -40,7 +40,6 @@ class AnnotationSearchIndexPresenter:
             result["references"] = self.annotation.references
 
         self._add_hidden(result)
-        self._add_moderated(result)
         self._add_nipsa(result, self.annotation.userid)
 
         return result

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -47,7 +47,7 @@ class AnnotationSearchIndexPresenter:
     def _add_hidden(self, result):
         # Mark an annotation as hidden if it and all of it's children have been
         # moderated and hidden.
-        parents_and_replies = [self.annotation.id] + self.annotation.thread_ids  # noqa: RUF005
+        parents_and_replies = [self.annotation.id, *self.annotation.thread_ids]
 
         ann_mod_svc = self.request.find_service(name="annotation_moderation")
         is_hidden = len(ann_mod_svc.all_hidden(parents_and_replies)) == len(

--- a/h/routes.py
+++ b/h/routes.py
@@ -132,6 +132,12 @@ def includeme(config):  # noqa: PLR0915
         factory="h.traversal:AnnotationRoot",
         traverse="/{id}",
     )
+    config.add_route(
+        "api.annotation_moderation",
+        "/api/annotations/{id:[A-Za-z0-9_-]{20,22}}/moderation",
+        factory="h.traversal:AnnotationRoot",
+        traverse="/{id}",
+    )
 
     config.add_route("api.bulk.action", "/api/bulk", request_method="POST")
     config.add_route(

--- a/h/routes.py
+++ b/h/routes.py
@@ -161,6 +161,13 @@ def includeme(config):  # noqa: PLR0915
         traverse="/{pubid}",
     )
     config.add_route(
+        "api.group_annotations",
+        "/api/groups/{pubid}/annotations",
+        factory="h.traversal.GroupRequiredRoot",
+        traverse="/{pubid}",
+    )
+
+    config.add_route(
         "api.group_member",
         "/api/groups/{pubid}/members/{userid}",
         factory="h.traversal.group_membership_api_factory",
@@ -218,6 +225,12 @@ def includeme(config):  # noqa: PLR0915
     config.add_route(
         "group_edit_members",
         "/groups/{pubid}/edit/members",
+        factory="h.traversal.GroupRequiredRoot",
+        traverse="/{pubid}",
+    )
+    config.add_route(
+        "group_edit_moderation",
+        "/groups/{pubid}/edit/moderate",
         factory="h.traversal.GroupRequiredRoot",
         traverse="/{pubid}",
     )

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -359,7 +359,14 @@ class HiddenFilter:
         # If any one of these "should" clauses is true then the annotation will
         # get through the filter.
         should_clauses = [
-            Q("bool", must_not=[Q("term", nipsa=True), Q("term", hidden=True)])
+            Q(
+                "bool",
+                must_not=[
+                    Q("term", nipsa=True),
+                    Q("term", hidden=True),
+                    Q("term", moderated=True),
+                ],
+            )
         ]
 
         if self.user is not None:

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -359,14 +359,7 @@ class HiddenFilter:
         # If any one of these "should" clauses is true then the annotation will
         # get through the filter.
         should_clauses = [
-            Q(
-                "bool",
-                must_not=[
-                    Q("term", nipsa=True),
-                    Q("term", hidden=True),
-                    Q("term", moderated=True),
-                ],
-            )
+            Q("bool", must_not=[Q("term", nipsa=True), Q("term", hidden=True)])
         ]
 
         if self.user is not None:

--- a/h/security/policy/_api_cookie.py
+++ b/h/security/policy/_api_cookie.py
@@ -11,6 +11,7 @@ COOKIE_AUTHENTICATABLE_API_REQUESTS = [
     ("api.group_members", "GET"),  # List group members.
     ("api.group_member", "PATCH"),  # Edit group membership.
     ("api.group_member", "DELETE"),  # Remove group member.
+    ("api.annotation_moderation", "PATCH"),  # Change annotation moderation status.
 ]
 
 

--- a/h/security/policy/_api_cookie.py
+++ b/h/security/policy/_api_cookie.py
@@ -12,6 +12,7 @@ COOKIE_AUTHENTICATABLE_API_REQUESTS = [
     ("api.group_member", "PATCH"),  # Edit group membership.
     ("api.group_member", "DELETE"),  # Remove group member.
     ("api.annotation_moderation", "PATCH"),  # Change annotation moderation status.
+    ("api.group_annotations", "GET"),  # List group annotations.
 ]
 
 

--- a/h/services/annotation_delete.py
+++ b/h/services/annotation_delete.py
@@ -20,7 +20,7 @@ class AnnotationDeleteService:
         self.annotation_write = annotation_write
         self.job_queue = job_queue
 
-    def delete(self, annotation):
+    def delete(self, annotation, user):
         """
         Delete the given annotation.
 
@@ -36,7 +36,7 @@ class AnnotationDeleteService:
             schedule_in=60,
         )
 
-        self.annotation_write.upsert_annotation_slim(annotation)
+        self.annotation_write.upsert_annotation_slim(annotation, user)
 
         event = AnnotationEvent(self.request, annotation.id, "delete")
         self.request.notify_after_commit(event)

--- a/h/services/annotation_json.py
+++ b/h/services/annotation_json.py
@@ -135,7 +135,7 @@ class AnnotationJSONService:
 
         # The hidden value depends on whether you are the author
         user_is_author = user and user.userid == annotation.userid
-        if user_is_author or not annotation.is_hidden:
+        if user_is_author or not (annotation.is_hidden or annotation.moderated):
             model["hidden"] = False
         else:
             model["hidden"] = True

--- a/h/services/annotation_json.py
+++ b/h/services/annotation_json.py
@@ -104,6 +104,7 @@ class AnnotationJSONService:
         annotation: Annotation,
         user: User,
         with_metadata: bool = False,  # noqa: FBT002, FBT001
+        hide_moderated: bool = True,
     ):
         """
         Get the JSON presentation of an annotation for a particular user.
@@ -133,16 +134,18 @@ class AnnotationJSONService:
                 "flagCount": self._flag_service.flag_count(annotation)
             }
 
-        # The hidden value depends on whether you are the author
-        user_is_author = user and user.userid == annotation.userid
-        if user_is_author or not (annotation.is_hidden or annotation.moderated):
-            model["hidden"] = False
-        else:
-            model["hidden"] = True
+        if hide_moderated:
+            print("HIDDINGI")
+            # The hidden value depends on whether you are the author
+            user_is_author = user and user.userid == annotation.userid
+            if user_is_author or not (annotation.is_hidden or annotation.moderated):
+                model["hidden"] = False
+            else:
+                model["hidden"] = True
 
-            # Non moderators have bad content hidden from them
-            if not user_is_moderator:
-                model.update({"text": "", "tags": []})
+                # Non moderators have bad content hidden from them
+                if not user_is_moderator:
+                    model.update({"text": "", "tags": []})
 
         return model
 

--- a/h/services/annotation_json.py
+++ b/h/services/annotation_json.py
@@ -104,7 +104,7 @@ class AnnotationJSONService:
         annotation: Annotation,
         user: User,
         with_metadata: bool = False,  # noqa: FBT002, FBT001
-        hide_moderated: bool = True,
+        hide_moderated: bool = True,  # noqa: FBT002, FBT001
     ):
         """
         Get the JSON presentation of an annotation for a particular user.
@@ -135,7 +135,6 @@ class AnnotationJSONService:
             }
 
         if hide_moderated:
-            print("HIDDINGI")
             # The hidden value depends on whether you are the author
             user_is_author = user and user.userid == annotation.userid
             if user_is_author or not (annotation.is_hidden or annotation.moderated):

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -1,5 +1,6 @@
 from h.events import AnnotationAction
 from h.models import Annotation, AnnotationModeration, Group
+from h.models.annotation import ModerationStatus
 
 
 class AnnotationModerationService:

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -30,10 +30,10 @@ class AnnotationModerationService:
         if status and status != annotation.moderation_status:
             self._session.add(
                 ModerationLog(
-                    annotation=annotation,
+                    annotation_id=annotation.id,
                     old_moderation_status=annotation.moderation_status,
-                    new_moderation_status=status,
-                    user=user,
+                    new_moderation_status=status.value,
+                    user_id=user.id,
                 )
             )
             annotation.moderation_status = status

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -15,10 +15,10 @@ class AnnotationModerationService:
         if not annotation_ids:
             return set()
 
+        # TODO, move to the new column after migration and backfill migration
         query = self._session.query(AnnotationModeration.annotation_id).filter(
             AnnotationModeration.annotation_id.in_(annotation_ids)
         )
-
         return {m.annotation_id for m in query}
 
 

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -31,16 +31,12 @@ class AnnotationModerationService:
     ) -> None:
         if not annotation.moderation_status:
             # First set the right moderation status if this row as not been migrated
-            # We have already migrated all moderated (hide/unhide) annotaionts
-            # The reaminding ones are either private
+            # We have already migrated all moderated (hide/unhide) annotations
+            # The reminding ones are either private
             if annotation.private:
                 annotation.moderation_status = Annotation.ModerationStatus.PRIVATE
             else:
                 annotation.moderation_status = Annotation.ModerationStatus.APPROVED
-
-        if status is None:
-            # This is either a new annotation or an existing one created before `moderation_status`
-            pass
 
         if action == "created":
             if annotation.private:
@@ -49,9 +45,8 @@ class AnnotationModerationService:
                 annotation.moderation_status = Annotation.ModerationStatus.PENDING
             else:
                 annotation.moderation_status = Annotation.ModerationStatus.APPROVED
-        elif action == "updated":
-            if group.pre_moderated:
-                annotation.moderation_status = Annotation.ModerationStatus.PENDING
+        elif action == "updated" and group.pre_moderated:
+            annotation.moderation_status = Annotation.ModerationStatus.PENDING
 
 
 def annotation_moderation_service_factory(_context, request):

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -38,17 +38,14 @@ class AnnotationModerationService:
             )
             annotation.moderation_status = status
 
-    def initialize_status(self, annotation):
-        if not annotation.moderation_status and annotation.shared:
-            # First set the right moderation status if this row as not been migrated
-            # We have already migrated all moderated (hide/unhide) annotations
-            # The reminding ones are either private or approved
-            annotation.moderation_status = ModerationStatus.APPROVED
-
     def update_status(
-        self, action: AnnotationAction, annotation: Annotation, group: Group
+        self, action: AnnotationAction, annotation: Annotation, user: User, group: Group
     ) -> None:
-        self.initialize_status(annotation)
+        if not annotation.moderation_status and annotation.shared:
+            # If an annotation is not private but doesn't have a moderation status
+            # it means that the moderation status hasn't been migrated yet
+            # set the default `APPROVED` status
+            annotation.moderation_status = ModerationStatus.APPROVED
 
         if not annotation.shared:
             return
@@ -66,7 +63,7 @@ class AnnotationModerationService:
         ):
             new_status = ModerationStatus.PENDING
 
-        self.set_status(annotation, new_status)
+        self.set_status(annotation, user, new_status)
 
 
 def annotation_moderation_service_factory(_context, request):

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -1,6 +1,5 @@
 from h.events import AnnotationAction
-from h.models import Annotation, AnnotationModeration
-from h.models.annotation import Annotation, Group
+from h.models import Annotation, AnnotationModeration, Group
 
 
 class AnnotationModerationService:

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -28,24 +28,22 @@ class AnnotationModerationService:
         annotation.moderation_status = status
 
     def initialize_status(self, annotation):
-        if not annotation.moderation_status:
+        if not annotation.moderation_status and annotation.shared:
             # First set the right moderation status if this row as not been migrated
             # We have already migrated all moderated (hide/unhide) annotations
             # The reminding ones are either private
-            if annotation.shared:
-                annotation.moderation_status = ModerationStatus.APPROVED
-            else:
-                annotation.moderation_status = ModerationStatus.PRIVATE
+            annotation.moderation_status = ModerationStatus.APPROVED
 
     def update_status(
         self, action: AnnotationAction, annotation: Annotation, group: Group
     ) -> None:
         self.initialize_status(annotation)
 
+        if not annotation.shared:
+            return
+
         if action == "created":
-            if not annotation.shared:
-                annotation.moderation_status = ModerationStatus.PRIVATE
-            elif group.pre_moderated:
+            if group.pre_moderated:
                 annotation.moderation_status = ModerationStatus.PENDING
             else:
                 annotation.moderation_status = ModerationStatus.APPROVED

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -22,18 +22,13 @@ class AnnotationModerationService:
         )
         return {m.annotation_id for m in query}
 
-    def update_status(
-        self,
-        action: AnnotationAction,
-        annotation: Annotation,
-        group: Group,
-        status: Annotation.ModerationStatus | None,
-    ) -> None:
-        if status:
-            # If we get an explict status, we set it
-            annotation.moderation_status = status
-            return
+    def set_status(self, annotation, status):
+        # If we get an explict status, we set it
+        annotation.moderation_status = status
 
+    def update_status(
+        self, action: AnnotationAction, annotation: Annotation, group: Group
+    ) -> None:
         if not annotation.moderation_status:
             # First set the right moderation status if this row as not been migrated
             # We have already migrated all moderated (hide/unhide) annotaionts

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -1,4 +1,6 @@
-from h.models import AnnotationModeration
+from h.events import AnnotationAction
+from h.models import Annotation, AnnotationModeration
+from h.models.annotation import Annotation, Group
 
 
 class AnnotationModerationService:
@@ -20,6 +22,42 @@ class AnnotationModerationService:
             AnnotationModeration.annotation_id.in_(annotation_ids)
         )
         return {m.annotation_id for m in query}
+
+    def update_status(
+        self,
+        action: AnnotationAction,
+        annotation: Annotation,
+        group: Group,
+        status: Annotation.ModerationStatus | None,
+    ) -> None:
+        if status:
+            # If we get an explict status, we set it
+            annotation.moderation_status = status
+            return
+
+        if not annotation.moderation_status:
+            # First set the right moderation status if this row as not been migrated
+            # We have already migrated all moderated (hide/unhide) annotaionts
+            # The reaminding ones are either private
+            if annotation.private:
+                annotation.moderation_status = Annotation.ModerationStatus.PRIVATE
+            else:
+                annotation.moderation_status = Annotation.ModerationStatus.APPROVED
+
+        if status is None:
+            # This is either a new annotation or an existing one created before `moderation_status`
+            pass
+
+        if action == "created":
+            if annotation.private:
+                annotation.moderation_status = Annotation.ModerationStatus.PRIVATE
+            elif group.pre_moderated:
+                annotation.moderation_status = Annotation.ModerationStatus.PENDING
+            else:
+                annotation.moderation_status = Annotation.ModerationStatus.APPROVED
+        elif action == "updated":
+            if group.pre_moderated:
+                annotation.moderation_status = Annotation.ModerationStatus.PENDING
 
 
 def annotation_moderation_service_factory(_context, request):

--- a/h/services/annotation_read.py
+++ b/h/services/annotation_read.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 
-from sqlalchemy import select, func
+from sqlalchemy import func, select
 from sqlalchemy.orm import Query, Session, subqueryload
 
 from h.db.types import InvalidUUID

--- a/h/services/annotation_read.py
+++ b/h/services/annotation_read.py
@@ -49,6 +49,7 @@ class AnnotationReadService:
         ids: list[str] = None,  # noqa: RUF013
         eager_load: list | None = None,
         groupid: str | None = None,
+        include_private: bool = True,
     ) -> Query:
         """Create a query for searching for annotations."""
 
@@ -58,6 +59,9 @@ class AnnotationReadService:
 
         if groupid:
             query = query.where(Annotation.groupid == groupid)
+
+        if not include_private:
+            query = query.where(Annotation.shared.is_(True))
 
         if eager_load:
             query = query.options(*(subqueryload(prop) for prop in eager_load))

--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -165,11 +165,15 @@ class AnnotationWriteService:
         if not annotation.is_hidden:
             annotation.moderation = AnnotationModeration()
 
+        annotation.moderation.status = Annotation.ModerationStatus.DENIED
+
         self.upsert_annotation_slim(annotation)
 
     def unhide(self, annotation):
         """Remove the moderation status of an annotation."""
         annotation.moderation = None
+        annotation.moderation.status = Annotation.ModerationStatus.APPROVED
+        # TODO, or private ?
         self.upsert_annotation_slim(annotation)
 
     @staticmethod

--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -163,21 +163,21 @@ class AnnotationWriteService:
 
         return annotation
 
-    def hide(self, annotation):
+    def hide(self, annotation, user):
         """Hides  an annotation marking it it as "moderated"."""
         if not annotation.is_hidden:
             annotation.moderation = AnnotationModeration()
             self._moderation_service.set_status(
-                annotation, Annotation.ModerationStatus.DENIED
+                annotation, user, Annotation.ModerationStatus.DENIED
             )
 
         self.upsert_annotation_slim(annotation)
 
-    def unhide(self, annotation):
+    def unhide(self, annotation, user):
         """Remove the moderation status of an annotation."""
         annotation.moderation = None
         self._moderation_service.set_status(
-            annotation, Annotation.ModerationStatus.DENIED
+            annotation, user, Annotation.ModerationStatus.DENIED
         )
 
         self.upsert_annotation_slim(annotation)

--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -11,8 +11,8 @@ from h.models.document import update_document_metadata
 from h.schemas import ValidationError
 from h.security import Permission
 from h.services.annotation_metadata import AnnotationMetadataService
-from h.services.annotation_read import AnnotationReadService
 from h.services.annotation_moderation import AnnotationModerationService
+from h.services.annotation_read import AnnotationReadService
 from h.services.job_queue import JobQueueService
 from h.services.mention import MentionService
 from h.traversal.group import GroupContext

--- a/h/static/scripts/group-forms/components/AppRoot.tsx
+++ b/h/static/scripts/group-forms/components/AppRoot.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'preact/hooks';
 
 import CreateEditGroupForm from './CreateEditGroupForm';
 import EditGroupMembersForm from './EditGroupMembersForm';
+import ModerateGroupForm from './ModerateGroupForm';
 import Router from './Router';
 import type { ConfigObject } from '../config';
 import { Config } from '../config';
@@ -44,6 +45,10 @@ export default function AppRoot({ config }: AppRootProps) {
             <Route path={routes.groups.editMembers}>
               <EditGroupMembersForm group={group!} />
             </Route>
+            <Route path={routes.groups.moderate}>
+              <ModerateGroupForm group={group!} />
+            </Route>
+
             <Route>
               <h1 data-testid="unknown-route">Page not found</h1>
             </Route>

--- a/h/static/scripts/group-forms/components/GroupFormHeader.tsx
+++ b/h/static/scripts/group-forms/components/GroupFormHeader.tsx
@@ -53,8 +53,6 @@ export default function GroupFormHeader({
     ? routes.groups.moderate.replace(':pubid', group.pubid)
     : null;
 
-
-
   return (
     <div className="mb-4 pb-1 border-b border-b-text-grey-6">
       {group && (
@@ -89,7 +87,6 @@ export default function GroupFormHeader({
             Moderate
           </TabLink>
         )}
-
       </div>
     </div>
   );

--- a/h/static/scripts/group-forms/components/GroupFormHeader.tsx
+++ b/h/static/scripts/group-forms/components/GroupFormHeader.tsx
@@ -49,6 +49,10 @@ export default function GroupFormHeader({
     ? routes.groups.editMembers.replace(':pubid', group.pubid)
     : null;
 
+  const moderateLink = group
+    ? routes.groups.moderate.replace(':pubid', group.pubid)
+    : null;
+
   return (
     <div className="mb-4 pb-1 border-b border-b-text-grey-6">
       {group && (
@@ -76,6 +80,11 @@ export default function GroupFormHeader({
         {enableMembers && editMembersLinks && (
           <TabLink testId="members-link" href={editMembersLinks}>
             Members
+          </TabLink>
+        )}
+        {moderateLink && (
+          <TabLink testId="moderate-link" href={moderateLink}>
+            Moderate
           </TabLink>
         )}
       </div>

--- a/h/static/scripts/group-forms/components/GroupFormHeader.tsx
+++ b/h/static/scripts/group-forms/components/GroupFormHeader.tsx
@@ -49,10 +49,6 @@ export default function GroupFormHeader({
     ? routes.groups.editMembers.replace(':pubid', group.pubid)
     : null;
 
-  const moderateLink = group
-    ? routes.groups.moderate.replace(':pubid', group.pubid)
-    : null;
-
   return (
     <div className="mb-4 pb-1 border-b border-b-text-grey-6">
       {group && (
@@ -80,11 +76,6 @@ export default function GroupFormHeader({
         {enableMembers && editMembersLinks && (
           <TabLink testId="members-link" href={editMembersLinks}>
             Members
-          </TabLink>
-        )}
-        {moderateLink && (
-          <TabLink testId="moderate-link" href={moderateLink}>
-            Moderate
           </TabLink>
         )}
       </div>

--- a/h/static/scripts/group-forms/components/GroupFormHeader.tsx
+++ b/h/static/scripts/group-forms/components/GroupFormHeader.tsx
@@ -49,6 +49,12 @@ export default function GroupFormHeader({
     ? routes.groups.editMembers.replace(':pubid', group.pubid)
     : null;
 
+  const moderateLink = group
+    ? routes.groups.moderate.replace(':pubid', group.pubid)
+    : null;
+
+
+
   return (
     <div className="mb-4 pb-1 border-b border-b-text-grey-6">
       {group && (
@@ -78,6 +84,12 @@ export default function GroupFormHeader({
             Members
           </TabLink>
         )}
+        {moderateLink && (
+          <TabLink testId="moderate-link" href={moderateLink}>
+            Moderate
+          </TabLink>
+        )}
+
       </div>
     </div>
   );

--- a/h/static/scripts/group-forms/components/ModerateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/ModerateGroupForm.tsx
@@ -26,6 +26,7 @@ type TableColumn<Row> = {
 
 type AnnotationRow = {
   id: string,
+  text: string,
 };
 
 /**
@@ -43,6 +44,7 @@ const possibleRoles: Role[] = Object.keys(roleStrings) as Role[];
 function annotationToRow(annotation: Annotation): AnnotationRow {
   return {
     id: annotation.id,
+    text: annotation.text,
   };
 }
 
@@ -196,6 +198,10 @@ export default function ModerateGroupForm({
       field: 'id',
       label: 'id',
     },
+    {
+      field: 'text',
+      label: 'text',
+    },
   ];
 
   const [pendingRemoval, setPendingRemoval] = useState<string | null>(null);
@@ -261,9 +267,18 @@ export default function ModerateGroupForm({
         case 'id':
           return (
             <span data-testid="id" className="font-bold text-grey-7">
-              @{annotation.id}
+              {annotation.id}
             </span>
+
           )
+        case 'text':
+          return (
+            <span data-testid="id" className="font-bold text-grey-7">
+              {annotation.text}
+            </span>
+
+          )
+
         // istanbul ignore next
         default:
           return null;

--- a/h/static/scripts/group-forms/components/ModerateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/ModerateGroupForm.tsx
@@ -254,13 +254,12 @@ export default function ModerateGroupForm({
 
   const filteredAnnotations = useMemo(() => {
     // I'm sure there's a better way but this handles removing annos when changing their status
-    if (!annotations) return [];
+    if (!annotations) { return [] };
 
     if (statusFilter === 'ALL') {
       return annotations;
     }
 
-    console.log(annotations, statusFilter);
     return annotations.filter(
       (annotation) => annotation.moderation_status === statusFilter
     );

--- a/h/static/scripts/group-forms/components/ModerateGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/ModerateGroupForm.tsx
@@ -1,0 +1,319 @@
+import {
+  DataTable,
+  Scroll,
+  TrashIcon,
+  IconButton,
+  Pagination,
+  Select,
+} from '@hypothesis/frontend-shared';
+import { useCallback, useContext, useEffect, useState } from 'preact/hooks';
+
+import { Config } from '../config';
+import type { APIConfig, Group } from '../config';
+import type { Annotation, GroupAnnotationsResponse, Role } from '../utils/api';
+import { callAPI } from '../utils/api';
+import type { APIError } from '../utils/api';
+import FormContainer from './forms/FormContainer';
+import ErrorNotice from './ErrorNotice';
+import GroupFormHeader from './GroupFormHeader';
+import WarningDialog from './WarningDialog';
+
+type TableColumn<Row> = {
+  field: keyof Row;
+  label: string;
+  classes?: string;
+};
+
+type AnnotationRow = {
+  id: string,
+};
+
+/**
+ * Mappings between roles and labels. The keys are sorted in descending order
+ * of permissions.
+ */
+const roleStrings: Record<Role, string> = {
+  owner: 'Owner',
+  admin: 'Admin',
+  moderator: 'Moderator',
+  member: 'Member',
+};
+const possibleRoles: Role[] = Object.keys(roleStrings) as Role[];
+
+function annotationToRow(annotation: Annotation): AnnotationRow {
+  return {
+    id: annotation.id,
+  };
+}
+
+async function fetchAnnotations(
+  api: APIConfig,
+  currentUserid: string,
+  options: {
+    signal: AbortSignal;
+    pageNumber: number;
+    pageSize: number;
+  },
+): Promise<{ total: number; annotations: AnnotationRow[] }> {
+  const { pageNumber, pageSize, signal } = options;
+  const { url, method, headers } = api;
+  const { meta, data }: GroupAnnotationsResponse = await callAPI(url, {
+    headers,
+    pageSize,
+    method,
+    pageNumber,
+    signal,
+  });
+
+  return {
+    total: meta.page.total,
+    annotations: data.map(a => annotationToRow(a, currentUserid)),
+  };
+}
+
+
+async function setMemberRoles(
+  api: APIConfig,
+  userid: string,
+  roles: Role[],
+): Promise<GroupMember> {
+  const { url: urlTemplate, method, headers } = api;
+  const url = urlTemplate.replace(':userid', encodeURIComponent(userid));
+  return callAPI(url, {
+    method,
+    headers,
+    json: {
+      roles,
+    },
+  });
+}
+
+type RoleSelectProps = {
+  username: string;
+
+  disabled?: boolean;
+
+  /** The current role of the member. */
+  current: Role;
+
+  /** Ordered list of possible roles that the current user can assign to the member. */
+  available: Role[];
+
+  /** Callback for when the user requests to change the role of the member. */
+  onChange: (r: Role) => void;
+};
+
+function RoleSelect({
+  username,
+  disabled = false,
+  current,
+  available,
+  onChange,
+}: RoleSelectProps) {
+  return (
+    <Select
+      value={current}
+      onChange={onChange}
+      buttonContent={roleStrings[current]}
+      data-testid={`role-${username}`}
+      disabled={disabled}
+    >
+      {available.map(role => (
+        <Select.Option key={role} value={role}>
+          {roleStrings[role]}
+        </Select.Option>
+      ))}
+    </Select>
+  );
+}
+
+const defaultDateFormatter = new Intl.DateTimeFormat(undefined, {
+  year: 'numeric',
+  month: 'short',
+  day: '2-digit',
+});
+
+export const pageSize = 20;
+
+export type EditGroupMembersFormProps = {
+  /** The saved group details. */
+  group: Group;
+
+  /** Test seam. Formatter used to format the "Joined" date. */
+  dateFormatter?: Intl.DateTimeFormat;
+};
+
+export default function ModerateGroupForm({
+  group,
+  dateFormatter = defaultDateFormatter,
+}: EditGroupMembersFormProps) {
+  const config = useContext(Config)!;
+  const currentUserid = config.context.user.userid;
+
+  const [pageNumber, setPageNumber] = useState(1);
+  const [totalAnnotations, setTotalAnnotations] = useState<number | null>(null);
+  const totalPages =
+    totalAnnotations !== null ? Math.ceil(totalAnnotations / pageSize) : null;
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const setError = useCallback((context: string, err: Error) => {
+    const apiErr = err as APIError;
+    if (apiErr.aborted) {
+      return;
+    }
+    const message = `${context}: ${err.message}`;
+    setErrorMessage(message);
+  }, []);
+
+  // Fetch group members when the form loads.
+  const [annotations, setAnnotations] = useState<AnnotationRow[] | null>(null);
+  useEffect(() => {
+    // istanbul ignore next
+    if (!config.api.readGroupMembers) {
+      throw new Error('readGroupMembers API config missing');
+    }
+    const abort = new AbortController();
+    setErrorMessage(null);
+    fetchAnnotations(config.api.readGroupAnnotations, currentUserid, {
+      pageNumber,
+      pageSize,
+      signal: abort.signal,
+    })
+      .then(({ total, annotations }) => {
+        setAnnotations(annotations);
+        setTotalAnnotations(total);
+      })
+      .catch(err => {
+        setError('Failed to fetch group members', err);
+      });
+    return () => {
+      abort.abort();
+    };
+  }, [config.api.readGroupMembers, currentUserid, pageNumber, setError]);
+
+  const columns: TableColumn<AnnotationRow>[] = [
+    {
+      field: 'id',
+      label: 'id',
+    },
+  ];
+
+  const [pendingRemoval, setPendingRemoval] = useState<string | null>(null);
+
+  const updateMember = (userid: string, update: Partial<MemberRow>) => {
+    setMembers(
+      members =>
+        members?.map(m => {
+          return m.userid === userid ? { ...m, ...update } : m;
+        }) ?? null,
+    );
+  };
+
+  const removeUserFromGroup = async (username: string) => {
+    // istanbul ignore next
+    if (!members || !config.api.removeGroupMember) {
+      return;
+    }
+    const member = members.find(m => m.username === username);
+    // istanbul ignore next
+    if (!member) {
+      return;
+    }
+    setPendingRemoval(null);
+
+    updateMember(member.userid, { busy: true });
+
+    try {
+      await removeMember(config.api.removeGroupMember, member.userid);
+      setMembers(members =>
+        members ? members.filter(m => m.userid !== member.userid) : null,
+      );
+    } catch (err) {
+      updateMember(member.userid, { busy: false });
+      setError('Failed to remove member', err);
+    }
+  };
+
+  const changeRole = useCallback(
+    async (member: MemberRow, role: Role) => {
+      updateMember(member.userid, { role, busy: true });
+      try {
+        const updatedMember = await setMemberRoles(
+          config.api.editGroupMember!,
+          member.userid,
+          [role],
+        );
+        // Update the member row in case the role change affected other columns
+        // (eg. whether we have permission to delete the user).
+        updateMember(member.userid, memberToRow(updatedMember, currentUserid));
+      } catch (err) {
+        const prevRole = member.role;
+        updateMember(member.userid, { role: prevRole, busy: false });
+        setError('Failed to change member role', err);
+      }
+    },
+    [currentUserid, config.api.editGroupMember, setError],
+  );
+
+  const renderRow = useCallback(
+    (annotation: AnnotationRow, field: keyof AnnotationRow) => {
+      switch (field) {
+        case 'id':
+          return (
+            <span data-testid="id" className="font-bold text-grey-7">
+              @{annotation.id}
+            </span>
+          )
+        // istanbul ignore next
+        default:
+          return null;
+      }
+    },
+    [changeRole, dateFormatter],
+  );
+
+  return (
+    <>
+      <FormContainer>
+        <GroupFormHeader title="Moderate group" group={group} />
+        <ErrorNotice message={errorMessage} />
+        <div className="w-full">
+          <Scroll>
+            <DataTable
+              grid
+              striped={false}
+              title="Group annotations"
+              rows={annotations ?? []}
+              columns={columns}
+              renderItem={renderRow}
+              loading={!annotations}
+            />
+          </Scroll>
+        </div>
+        {typeof totalPages === 'number' && totalPages > 1 && (
+          <div className="mt-4 flex justify-center">
+            <Pagination
+              currentPage={pageNumber}
+              onChangePage={setPageNumber}
+              totalPages={totalPages}
+            />
+          </div>
+        )}
+      </FormContainer>
+      {pendingRemoval && (
+        <WarningDialog
+          title="Remove member?"
+          confirmAction="Remove member"
+          message={
+            <p>
+              Are you sure you want to remove <b>{pendingRemoval}</b> from the
+              group?
+            </p>
+          }
+          onConfirm={() => removeUserFromGroup(pendingRemoval)}
+          onCancel={() => setPendingRemoval(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -26,6 +26,7 @@ export type ConfigObject = {
     editGroupMember?: APIConfig;
     removeGroupMember?: APIConfig;
     readGroupAnnotations?: APIConfig;
+    changeAnnotationModerationStatus?: APIConfig;
   };
   context: {
     group: Group | null;

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -25,6 +25,7 @@ export type ConfigObject = {
     readGroupMembers?: APIConfig;
     editGroupMember?: APIConfig;
     removeGroupMember?: APIConfig;
+    readGroupAnnotations?: APIConfig;
   };
   context: {
     group: Group | null;

--- a/h/static/scripts/group-forms/routes.ts
+++ b/h/static/scripts/group-forms/routes.ts
@@ -9,5 +9,6 @@ export const routes = {
     new: '/groups/new',
     edit: '/groups/:pubid/edit',
     editMembers: '/groups/:pubid/edit/members',
+    moderate: '/groups/:pubid/edit/moderate',
   },
 };

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -6,7 +6,11 @@ export type GroupType = 'private' | 'restricted' | 'open';
 /** Member role within a group. */
 export type Role = 'owner' | 'admin' | 'moderator' | 'member';
 
-export type AnnotationModerationStatus = "pending" | "APPROVED" | "denied" | "private" | "spam";
+export type AnnotationModerationStatus =
+  | 'pending'
+  | 'APPROVED'
+  | 'denied'
+  | 'spam';
 
 /** A date and time in ISO format (eg. "2024-12-09T07:17:52+00:00") */
 export type ISODateTime = string;
@@ -49,14 +53,12 @@ export type GroupMember = {
   updated: ISODateTime | null;
 };
 
-
 export type Annotation = {
   id: string;
   text: string;
   created: string;
   moderation_status: AnnotationModerationStatus;
 };
-
 
 export type PaginatedResponse<Item> = {
   meta: {
@@ -82,8 +84,6 @@ export type GroupMembersResponse = PaginatedResponse<GroupMember>;
  * https://h.readthedocs.io/en/latest/api-reference/v2/#tag/groups/paths/~1groups~1{id}~1members/get
  */
 export type GroupAnnotationsResponse = PaginatedResponse<Annotation>;
-
-
 
 /** An error response from the h API:
  * https://h.readthedocs.io/en/latest/api-reference/v2/#section/Hypothesis-API/Errors
@@ -138,6 +138,8 @@ export type APIOptions = {
 
   /** Maximum number of items to return in response for a paginated API. */
   pageSize?: number;
+
+  query?: Record<string, string | number>;
 };
 
 /** Make an API call and return the parsed JSON body or throw APIError. */
@@ -145,6 +147,7 @@ export async function callAPI<R = unknown>(
   url: string,
   {
     headers = {},
+    query = {},
     json = null,
     pageSize,
     method = 'GET',
@@ -165,7 +168,7 @@ export async function callAPI<R = unknown>(
     options.body = JSON.stringify(json);
   }
 
-  const queryParams: Record<string, string | number> = {};
+  const queryParams: Record<string, string | number> = query;
   if (typeof pageNumber === 'number') {
     queryParams['page[number]'] = pageNumber;
   }

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -6,6 +6,8 @@ export type GroupType = 'private' | 'restricted' | 'open';
 /** Member role within a group. */
 export type Role = 'owner' | 'admin' | 'moderator' | 'member';
 
+export type AnnotationModerationStatus = "pending" | "APPROVED" | "denied" | "private" | "spam";
+
 /** A date and time in ISO format (eg. "2024-12-09T07:17:52+00:00") */
 export type ISODateTime = string;
 
@@ -51,6 +53,8 @@ export type GroupMember = {
 export type Annotation = {
   id: string;
   text: string;
+  created: string;
+  moderation_status: AnnotationModerationStatus;
 };
 
 

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -47,6 +47,12 @@ export type GroupMember = {
   updated: ISODateTime | null;
 };
 
+
+export type Annotation = {
+  id: string;
+};
+
+
 export type PaginatedResponse<Item> = {
   meta: {
     page: {
@@ -63,6 +69,16 @@ export type PaginatedResponse<Item> = {
  * https://h.readthedocs.io/en/latest/api-reference/v2/#tag/groups/paths/~1groups~1{id}~1members/get
  */
 export type GroupMembersResponse = PaginatedResponse<GroupMember>;
+
+/**
+ * Response to group members API.
+ *
+ * TOOD RIHGT LINK
+ * https://h.readthedocs.io/en/latest/api-reference/v2/#tag/groups/paths/~1groups~1{id}~1members/get
+ */
+export type GroupAnnotationsResponse = PaginatedResponse<Annotation>;
+
+
 
 /** An error response from the h API:
  * https://h.readthedocs.io/en/latest/api-reference/v2/#section/Hypothesis-API/Errors

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -7,10 +7,10 @@ export type GroupType = 'private' | 'restricted' | 'open';
 export type Role = 'owner' | 'admin' | 'moderator' | 'member';
 
 export type AnnotationModerationStatus =
-  | 'pending'
+  | 'PENDING'
   | 'APPROVED'
-  | 'denied'
-  | 'spam';
+  | 'DENIED'
+  | 'SPAM';
 
 /** A date and time in ISO format (eg. "2024-12-09T07:17:52+00:00") */
 export type ISODateTime = string;

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -50,6 +50,7 @@ export type GroupMember = {
 
 export type Annotation = {
   id: string;
+  text: string;
 };
 
 
@@ -73,7 +74,7 @@ export type GroupMembersResponse = PaginatedResponse<GroupMember>;
 /**
  * Response to group members API.
  *
- * TOOD RIHGT LINK
+ * TODO RIGHT LINK
  * https://h.readthedocs.io/en/latest/api-reference/v2/#tag/groups/paths/~1groups~1{id}~1members/get
  */
 export type GroupAnnotationsResponse = PaginatedResponse<Annotation>;

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -80,7 +80,7 @@ def create(request):
     appstruct = schema.validate(json_payload(request))
 
     annotation = request.find_service(AnnotationWriteService).create_annotation(
-        data=appstruct
+        data=appstruct, user=request.user
     )
 
     _publish_annotation_event(request, annotation, "create")
@@ -139,7 +139,7 @@ def update(context, request):
     appstruct = schema.validate(json_payload(request))
 
     annotation = request.find_service(AnnotationWriteService).update_annotation(
-        context.annotation, data=appstruct
+        context.annotation, data=appstruct, user=request.user
     )
 
     _publish_annotation_event(request, annotation, "update")
@@ -160,7 +160,7 @@ def update(context, request):
 def delete(context, request):
     """Delete the specified annotation."""
     annotation_delete_service = request.find_service(name="annotation_delete")
-    annotation_delete_service.delete(context.annotation)
+    annotation_delete_service.delete(context.annotation, request.user)
 
     # TODO: Track down why we don't return an HTTP 204 like other DELETEs  # noqa: FIX002, TD002, TD003
     return {"id": context.annotation.id, "deleted": True}

--- a/h/views/api/group_annotations.py
+++ b/h/views/api/group_annotations.py
@@ -5,6 +5,7 @@ from h.schemas.util import validate_query_params
 from h.services.annotation_read import AnnotationReadService
 from h.traversal import GroupContext
 from h.views.api.config import api_config
+from h.models import Annotation
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +31,9 @@ def list_annotations(context: GroupContext, request):
 
     annotation_json_service = request.find_service(name="annotation_json")
 
-    query = AnnotationReadService.annotation_search_query(groupid=group.pubid)
+    query = AnnotationReadService.annotation_search_query(
+        groupid=group.pubid, include_private=False
+    ).order_by(Annotation.created.desc())
 
     total = request.db.execute(AnnotationReadService.count_query(query)).scalar_one()
     annotations = request.db.scalars(query.offset(offset).limit(limit))

--- a/h/views/api/group_annotations.py
+++ b/h/views/api/group_annotations.py
@@ -1,13 +1,12 @@
 import logging
 
-
 from h.schemas.pagination import PaginationQueryParamsSchema
 from h.schemas.util import validate_query_params
 from h.security import Permission
+from h.services.annotation_read import AnnotationReadService
 from h.traversal import GroupContext
 from h.views.api.config import api_config
 from h.views.api.helpers.json_payload import json_payload
-from h.services.annotation_read import AnnotationReadService
 
 log = logging.getLogger(__name__)
 

--- a/h/views/api/group_annotations.py
+++ b/h/views/api/group_annotations.py
@@ -1,0 +1,46 @@
+import logging
+
+
+from h.schemas.pagination import PaginationQueryParamsSchema
+from h.schemas.util import validate_query_params
+from h.security import Permission
+from h.traversal import GroupContext
+from h.views.api.config import api_config
+from h.views.api.helpers.json_payload import json_payload
+from h.services.annotation_read import AnnotationReadService
+
+log = logging.getLogger(__name__)
+
+
+LIST_MEMBERS_API_CONFIG = {
+    "versions": ["v1", "v2"],
+    "route_name": "api.group_annotations",
+    "request_method": "GET",
+    "link_name": "group.annotations.read",
+    "description": "Fetch a list of all annotations of a group",
+    # "permission": Permission.Group.READ, TOOD # add permission
+}
+
+
+@api_config(request_param="page[number]", **LIST_MEMBERS_API_CONFIG)
+def list_annotations(context: GroupContext, request):
+    group = context.group
+    params = validate_query_params(PaginationQueryParamsSchema(), request.params)
+    page_number = params["page[number]"]
+    page_size = params["page[size]"]
+    offset = page_size * (page_number - 1)
+    limit = page_size
+
+    annotation_json_service = request.find_service(name="annotation_json")
+
+    query = AnnotationReadService.annotation_search_query(groupid=group.pubid)
+
+    total = request.db.execute(AnnotationReadService.count_query(query)).scalar_one()
+    annotations = request.db.scalars(query.offset(offset).limit(limit))
+
+    annotations_dicts = [
+        annotation_json_service.present_for_user(annotation, request.user)
+        for annotation in annotations
+    ]
+
+    return {"meta": {"page": {"total": total}}, "data": annotations_dicts}

--- a/h/views/api/group_annotations.py
+++ b/h/views/api/group_annotations.py
@@ -59,10 +59,14 @@ def list_annotations(context: GroupContext, request):
 def _present_for_user(_request, service, annotation, user):
     annotation_json = service.present_for_user(annotation, user, hide_moderated=False)
 
-    annotation_json["moderation_status"] = (
-        annotation.moderation_status.value
-        if annotation.moderation_status
-        else annotation.ModerationStatus.APPROVED.value
-    )
+    if not annotation.moderation_status:
+        if annotation.shared:
+            annotation_json["moderation_status"] = (
+                annotation.ModerationStatus.APPROVED.value
+            )
+        else:
+            annotation_json["moderation_status"] = None
+    else:
+        annotation_json["moderation_status"] = annotation.moderation_status.value
 
     return annotation_json

--- a/h/views/api/group_annotations.py
+++ b/h/views/api/group_annotations.py
@@ -56,7 +56,7 @@ def list_annotations(context: GroupContext, request):
 
 
 def _present_for_user(_request, service, annotation, user):
-    annotation_json = service.present_for_user(annotation, user)
+    annotation_json = service.present_for_user(annotation, user, hide_moderated=False)
 
     annotation_json["moderation_status"] = (
         annotation.moderation_status.value

--- a/h/views/api/group_annotations.py
+++ b/h/views/api/group_annotations.py
@@ -3,6 +3,7 @@ import logging
 from h.models import Annotation
 from h.schemas.pagination import PaginationQueryParamsSchema
 from h.schemas.util import validate_query_params
+from h.security import Permission
 from h.services.annotation_read import AnnotationReadService
 from h.traversal import GroupContext
 from h.views.api.config import api_config
@@ -16,7 +17,7 @@ LIST_MEMBERS_API_CONFIG = {
     "request_method": "GET",
     "link_name": "group.annotations.read",
     "description": "Fetch a list of all annotations of a group",
-    # "permission": Permission.Group.READ, TODO # add permission
+    "permission": Permission.Group.READ,
 }
 
 

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -53,6 +53,7 @@ def change_annotation_moderation_status(context, request):
     request.find_service(name="annotation_moderation").set_status(
         context.annotation, status
     )
+    request.notify_after_commit(event)
 
     annotation_json_service = request.find_service(name="annotation_json")
 

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -48,7 +48,7 @@ def delete(context, request):
     route_name="api.annotation_moderation",
     request_method="PATCH",
     link_name="annotation_moderation",
-    # permission=Permission.Annotation.MODERATE,
+    permission=Permission.Annotation.MODERATE,
 )
 def change_annotation_moderation_status(context, request):
     status = Annotation.ModerationStatus(request.json_body["moderation_status"].upper())

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -48,13 +48,14 @@ def delete(context, request):
     route_name="api.annotation_moderation",
     request_method="PATCH",
     link_name="annotation_moderation",
-    # permission=Permission.Annotation.MODERATE,  TODO: add permission
+    # permission=Permission.Annotation.MODERATE,
 )
 def change_annotation_moderation_status(context, request):
     status = Annotation.ModerationStatus(request.json_body["moderation_status"].upper())
     request.find_service(name="annotation_moderation").set_status(
         context.annotation, request.user, status
     )
+    event = events.AnnotationEvent(request, context.annotation.id, "update")
     request.notify_after_commit(event)
 
     annotation_json_service = request.find_service(name="annotation_json")

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -46,7 +46,7 @@ def delete(context, request):
     route_name="api.annotation_moderation",
     request_method="PATCH",
     link_name="annotation_moderation",
-    # permission=Permission.Annotation.MODERATE,
+    # permission=Permission.Annotation.MODERATE,  TODO: add permission
 )
 def change_annotation_moderation_status(context, request):
     status = Annotation.ModerationStatus(request.json_body["moderation_status"].upper())

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -1,6 +1,7 @@
 from pyramid.httpexceptions import HTTPNoContent
 
 from h import events
+from h.models import Annotation
 from h.security import Permission
 from h.services import AnnotationWriteService
 from h.views.api.config import api_config
@@ -38,3 +39,33 @@ def delete(context, request):
     request.notify_after_commit(event)
 
     return HTTPNoContent()
+
+
+@api_config(
+    versions=["v1", "v2"],
+    route_name="api.annotation_moderation",
+    request_method="PATCH",
+    link_name="annotation_moderation",
+    # permission=Permission.Annotation.MODERATE,
+)
+def change_annotation_moderation_status(context, request):
+    status = Annotation.ModerationStatus(request.json_body["moderation_status"].upper())
+    request.find_service(name="annotation_moderation").set_status(
+        context.annotation, status
+    )
+
+    annotation_json_service = request.find_service(name="annotation_json")
+
+    return _present_for_user(annotation_json_service, context.annotation, request.user)
+
+
+def _present_for_user(service, annotation, user):
+    annotation_json = service.present_for_user(annotation, user)
+
+    annotation_json["moderation_status"] = (
+        annotation.moderation_status.value
+        if annotation.moderation_status
+        else annotation.ModerationStatus.APPROVED.value
+    )
+
+    return annotation_json

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -64,7 +64,7 @@ def change_annotation_moderation_status(context, request):
 
 
 def _present_for_user(service, annotation, user):
-    annotation_json = service.present_for_user(annotation, user)
+    annotation_json = service.present_for_user(annotation, user, hide_moderated=False)
 
     annotation_json["moderation_status"] = (
         annotation.moderation_status.value

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -16,7 +16,7 @@ from h.views.api.config import api_config
     permission=Permission.Annotation.MODERATE,
 )
 def create(context, request):
-    request.find_service(AnnotationWriteService).hide(context.annotation)
+    request.find_service(AnnotationWriteService).hide(context.annotation, request.user)
 
     event = events.AnnotationEvent(request, context.annotation.id, "update")
     request.notify_after_commit(event)
@@ -33,7 +33,9 @@ def create(context, request):
     permission=Permission.Annotation.MODERATE,
 )
 def delete(context, request):
-    request.find_service(AnnotationWriteService).unhide(context.annotation)
+    request.find_service(AnnotationWriteService).unhide(
+        context.annotation, request.user
+    )
 
     event = events.AnnotationEvent(request, context.annotation.id, "update")
     request.notify_after_commit(event)
@@ -51,7 +53,7 @@ def delete(context, request):
 def change_annotation_moderation_status(context, request):
     status = Annotation.ModerationStatus(request.json_body["moderation_status"].upper())
     request.find_service(name="annotation_moderation").set_status(
-        context.annotation, status
+        context.annotation, request.user, status
     )
     request.notify_after_commit(event)
 

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -39,6 +39,11 @@ class GroupCreateEditController:
         request_method="GET",
         permission=Permission.Group.EDIT,
     )
+    @view_config(
+        route_name="group_edit_moderation",
+        request_method="GET",
+        permission=Permission.Group.EDIT,  # TODO  permission for moderation?
+    )
     def edit(self):
         """Render the page for editing an existing group."""
         return {
@@ -91,6 +96,9 @@ class GroupCreateEditController:
                     "updateGroup": api_config("api.group", "PATCH", id=group.pubid),
                     "readGroupMembers": api_config(
                         "api.group_members", "GET", pubid=group.pubid
+                    ),
+                    "readGroupAnnotations": api_config(
+                        "api.group_annotations", "GET", pubid=group.pubid
                     ),
                     "editGroupMember": api_config(
                         "api.group_member", "PATCH", pubid=group.pubid, userid=":userid"

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -100,6 +100,11 @@ class GroupCreateEditController:
                     "readGroupAnnotations": api_config(
                         "api.group_annotations", "GET", pubid=group.pubid
                     ),
+                    "changeAnnotationModerationStatus": api_config(
+                        "api.annotation_moderation",
+                        "PATCH",
+                        id=":annotation_id",
+                    ),
                     "editGroupMember": api_config(
                         "api.group_member", "PATCH", pubid=group.pubid, userid=":userid"
                     ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ ignore = [
     "PLR6301", # Method could be a function/classmethod/static method (doesn't use self)
     "RET501", # Do not explicitly return None if it's the only possible return value.
     "RET504", # Unnecessary assignment before return statement.
+
+    # PoC-mode 
+    "FIX002", "RUF100", "TD003", "TD004", "TD002"
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/functional/api/annotations_test.py
+++ b/tests/functional/api/annotations_test.py
@@ -1,5 +1,7 @@
 import pytest
 
+from h.models.annotation import ModerationStatus
+
 
 class TestGetAnnotation:
     def test_it_returns_annotation_if_shared(self, app, annotation):
@@ -168,6 +170,116 @@ class TestPatchAnnotation:
         assert res.json["text"] == "This is an updated annotation"
         assert res.status_code == 200
 
+    # TODO Private annotations don't always have the NULL state: if a shared annotation is edited and made private it retains its previous state from when it was shared (Pending, Approved, Denied, or Spam).
+    @pytest.mark.parametrize(
+        "pre_moderation_enabled,moderation_status,expected_moderation_status",
+        [
+            # Editing a private annotation and making it shared might change its annotation state, depending on the current state:
+            # If the group has pre-moderation disabled the annotation's moderation state becomes Approved.
+            # If the group has pre-moderation enabled the annotation's moderation state becomes Pending.
+            # (So it's the same as what happens when creating a new shared annotation, but the state change only happens when the private annotation is made shared. This is important because the state change depends on the group's pre-moderation setting at the moment when the annotation becomes shared.)
+            (False, None, ModerationStatus.APPROVED),
+            (True, None, ModerationStatus.PENDING),
+            # If a private annotation whose state is Denied is edited and made shared the state becomes Pending.
+            # (Same as what happens when editing a Denied, shared annotation, but the state change only happens when the private annotation is made shared.)
+            (True, ModerationStatus.DENIED, ModerationStatus.PENDING),
+            # TODO WHAT ABOUT MODEREATED DISABLED?
+            # If a private annotation whose state is Pending or Spam is edited and made shared the state doesn't change.
+            # (Same as when editing a Pending or Spam, shared annotation.)
+            (True, ModerationStatus.PENDING, ModerationStatus.PENDING),
+            (True, ModerationStatus.SPAM, ModerationStatus.SPAM),
+        ],
+    )
+    def test_sharing_a_private_annotation(
+        self,
+        app,
+        user_with_token,
+        user_private_annotation,
+        db_session,
+        pre_moderation_enabled,
+        moderation_status,
+        expected_moderation_status,
+    ):
+        user, token = user_with_token
+        group = user_private_annotation.group
+        group.pre_moderated = pre_moderation_enabled
+        user_private_annotation.moderation_status = moderation_status
+        db_session.commit()
+
+        headers = {"Authorization": f"Bearer {token.value}"}
+        annotation_patch = {
+            "permissions": {
+                "read": [f"group:{group.pubid}"],
+                "admin": [user.userid],
+                "updated": [user.userid],
+                "deleted": [user.userid],
+            },
+            "text": "PRIVATE",
+        }
+
+        res = app.patch_json(
+            f"/api/annotations/{user_private_annotation.id}",
+            annotation_patch,
+            headers=headers,
+        )
+
+        assert res.status_code == 200
+        db_session.refresh(user_private_annotation)
+        assert user_private_annotation.shared
+        assert user_private_annotation.moderation_status == expected_moderation_status
+
+    @pytest.mark.parametrize(
+        "pre_moderation_enabled,moderation_status,expected_moderation_status",
+        [
+            # TODO Private annotations don't always have the NULL state: if a shared annotation is edited and made private it retains its previous state from when it was shared (Pending, Approved, Denied, or Spam).
+            (True, ModerationStatus.PENDING, ModerationStatus.PENDING),
+            (True, ModerationStatus.APPROVED, ModerationStatus.APPROVED),
+            (True, ModerationStatus.SPAM, ModerationStatus.SPAM),
+            (True, ModerationStatus.DENIED, ModerationStatus.DENIED),
+            (False, ModerationStatus.APPROVED, ModerationStatus.APPROVED),
+            (False, ModerationStatus.SPAM, ModerationStatus.SPAM),
+            (False, ModerationStatus.DENIED, ModerationStatus.DENIED),
+            (False, ModerationStatus.PENDING, ModerationStatus.PENDING),
+        ],
+    )
+    def test_making_annotation_private(
+        self,
+        app,
+        user_with_token,
+        user_shared_annotation,
+        db_session,
+        pre_moderation_enabled,
+        moderation_status,
+        expected_moderation_status,
+    ):
+        user, token = user_with_token
+        group = user_shared_annotation.group
+        group.pre_moderated = pre_moderation_enabled
+        user_shared_annotation.moderation_status = moderation_status
+        db_session.commit()
+
+        headers = {"Authorization": f"Bearer {token.value}"}
+        annotation_patch = {
+            "permissions": {
+                "read": [user.userid],
+                "admin": [user.userid],
+                "updated": [user.userid],
+                "deleted": [user.userid],
+            },
+            "text": "PRIVATE",
+        }
+
+        res = app.patch_json(
+            f"/api/annotations/{user_shared_annotation.id}",
+            annotation_patch,
+            headers=headers,
+        )
+
+        assert res.status_code == 200
+        db_session.refresh(user_shared_annotation)
+        assert not user_shared_annotation.shared
+        assert user_shared_annotation.moderation_status == expected_moderation_status
+
     def test_it_returns_http_404_if_unauthenticated(self, app, user_annotation):
         annotation_patch = {"text": "whatever"}
 
@@ -266,6 +378,22 @@ def user(db_session, factories):
 @pytest.fixture
 def user_annotation(db_session, user, factories):
     ann = factories.Annotation(userid=user.userid, groupid="__world__", shared=True)
+    db_session.commit()
+    return ann
+
+
+@pytest.fixture
+def user_shared_annotation(db_session, user, factories):
+    group = factories.OpenGroup()
+    ann = factories.Annotation(userid=user.userid, groupid=group.pubid, shared=True)
+    db_session.commit()
+    return ann
+
+
+@pytest.fixture
+def user_private_annotation(db_session, user, factories):
+    group = factories.OpenGroup()
+    ann = factories.Annotation(userid=user.userid, groupid=group.pubid, shared=False)
     db_session.commit()
     return ann
 

--- a/tests/unit/h/services/annotation_moderation_test.py
+++ b/tests/unit/h/services/annotation_moderation_test.py
@@ -5,31 +5,93 @@ from h.services.annotation_moderation import (
     annotation_moderation_service_factory,
 )
 
+from h.models.annotation import ModerationStatus
 
-class TestAnnotationModerationServiceAllHidden:
-    def test_it_lists_moderated_annotation_ids(self, svc, mods):
+
+class TestModerationStatusService:
+    def test_all_hidden_lists_moderated_annotation_ids(self, svc, mods):
         ids = [m.annotation.id for m in mods[0:-1]]
         assert svc.all_hidden(ids) == set(ids)
 
-    def test_it_skips_non_moderated_annotations(self, svc, factories):
+    def test_all_hidden_skips_non_moderated_annotations(self, svc, factories):
         annotation = factories.Annotation()
 
         assert svc.all_hidden([annotation.id]) == set()
 
-    def test_it_handles_with_no_ids(self, svc):
+    def test_all_hidden_handles_with_no_ids(self, svc):
         assert svc.all_hidden([]) == set()
+
+    # When a new private annotation is created the annotation's initial moderation state should be NULL.
+    # This is the same whether pre-moderation is enabled or disabled.
+    # It should not be possible for a shared annotation to have the NULL state.
+    # Private annotations don't always have the NULL state: if a shared annotation is edited and made private it retains its previous state from when it was shared (Pending, Approved, Denied, or Spam).
+    # Editing a private annotation and making it shared might change its annotation state, depending on the current state:
+    # If a private annotation whose state is NULL is edited and made shared:
+    # If the group has pre-moderation disabled the annotation's moderation state becomes Approved.
+    # If the group has pre-moderation enabled the annotation's moderation state becomes Pending.
+    # (So it's the same as what happens when creating a new shared annotation, but the state change only happens when the private annotation is made shared. This is important because the state change depends on the group's pre-moderation setting at the moment when the annotation becomes shared.)
+    # If a private annotation whose state is Denied is edited and made shared the state becomes Pending.
+    # (Same as what happens when editing a Denied, shared annotation, but the state change only happens when the private annotation is made shared.)
+    # If a private annotation whose state is Pending or Spam is edited and made shared the state doesn't change.
+    # (Same as when editing a Pending or Spam, shared annotation.)
+
+    # fmt: off
+    @pytest.mark.parametrize("action,is_private,pre_moderation_enabled,existing_status,expected_status", [
+        #When a new annotation is created:
+        #If the group has pre-moderation disabled the annotation's initial moderation state should be Approved.
+        #If the group has pre-moderation enabled the annotation's initial moderation state should be Pending.
+        ("created", False, False, None, ModerationStatus.APPROVED),
+        ("created", False,True, None, ModerationStatus.PENDING),
+        #When an Approved annotation is edited:
+        #If the group has pre-moderation disabled the moderation state doesn’t change
+        #If the group has pre-moderation enabled the moderation state changes to Pending
+        ("updated", False,False, ModerationStatus.APPROVED, ModerationStatus.APPROVED),
+        ("updated", False,False, ModerationStatus.SPAM, ModerationStatus.SPAM),
+        ("updated", False,False, ModerationStatus.DENIED, ModerationStatus.DENIED),
+        ("updated", False,True, ModerationStatus.APPROVED, ModerationStatus.PENDING),
+        #When a Denied annotation is edited the moderation state changes to Pending
+        #(whether pre-moderation is disabled or enabled)
+        ("updated", False,True, ModerationStatus.DENIED, ModerationStatus.PENDING),
+        ("updated", False,False, ModerationStatus.DENIED, ModerationStatus.PENDING),
+        #When a Pending annotation is edited its moderation state doesn't change
+        #(whether pre-moderation is disabled or enabled)
+        ("updated", False,False, ModerationStatus.PENDING, ModerationStatus.PENDING),
+        ("updated", False,True, ModerationStatus.PENDING, ModerationStatus.PENDING),
+        #When a Spam annotation is edited its moderation state doesn't change
+        #(whether pre-moderation is disabled or enabled)
+        # DUPLICTED ("updated", False,False, ModerationStatus.SPAM, ModerationStatus.SPAM),
+        ("updated", False,True, ModerationStatus.SPAM, ModerationStatus.SPAM),
+        #Editing a private annotation does not change its moderation state as long as the annotation remains private:
+        #A private annotation whose state is NULL will remain NULL if edited.
+        ("updated", True,False, None, None),
+        #A private annotation whose state is Pending will remain Pending if edited.
+        ("updated", True,False, ModerationStatus.PENDING, ModerationStatus.PENDING),
+        #A private annotation whose state is Approved will remain Approved if edited.
+        ("updated", True,False, ModerationStatus.APPROVED, ModerationStatus.APPROVED),
+        #A private annotation whose state is Denied will remain Denied if edited.
+        ("updated", True,False, ModerationStatus.DENIED, ModerationStatus.DENIED),
+        #A private annotation whose state is Spam will remain Spam if edited.
+        ("updated", True,False, ModerationStatus.SPAM, ModerationStatus.SPAM),
+    ])
+    # fmt: on
+    def test_update_status(self, svc, action, is_private, pre_moderation_enabled, existing_status, expected_status, factories):
+        group = factories.Group(pre_moderated=pre_moderation_enabled)
+        annotation = factories.Annotation(moderation_status=existing_status, shared=not is_private)
+
+        svc.update_status(action, annotation, group)
+
+        assert annotation.moderation_status== expected_status
 
     @pytest.fixture(autouse=True)
     def mods(self, factories):
         return factories.AnnotationModeration.create_batch(3)
 
+    @pytest.fixture
+    def svc(self, db_session):
+        return AnnotationModerationService(db_session)
 
-class TestAnnotationModerationServiceFactory:
+
+class TestModerationStatusServiceFactory:
     def test_it_returns_service(self, pyramid_request):
         svc = annotation_moderation_service_factory(None, pyramid_request)
         assert isinstance(svc, AnnotationModerationService)
-
-
-@pytest.fixture
-def svc(db_session):
-    return AnnotationModerationService(db_session)

--- a/tests/unit/h/services/annotation_moderation_test.py
+++ b/tests/unit/h/services/annotation_moderation_test.py
@@ -1,11 +1,10 @@
 import pytest
 
+from h.models.annotation import ModerationStatus
 from h.services.annotation_moderation import (
     AnnotationModerationService,
     annotation_moderation_service_factory,
 )
-
-from h.models.annotation import ModerationStatus
 
 
 class TestModerationStatusService:
@@ -43,10 +42,9 @@ class TestModerationStatusService:
         ("created", False, False, None, ModerationStatus.APPROVED),
         ("created", False,True, None, ModerationStatus.PENDING),
         #When an Approved annotation is edited:
-        #If the group has pre-moderation disabled the moderation state doesn’t change
+        #If the group has pre-moderation disabled the moderation state doesn't change
         #If the group has pre-moderation enabled the moderation state changes to Pending
         ("updated", False,False, ModerationStatus.APPROVED, ModerationStatus.APPROVED),
-        ("updated", False,False, ModerationStatus.SPAM, ModerationStatus.SPAM),
         ("updated", False,False, ModerationStatus.DENIED, ModerationStatus.DENIED),
         ("updated", False,True, ModerationStatus.APPROVED, ModerationStatus.PENDING),
         #When a Denied annotation is edited the moderation state changes to Pending
@@ -59,7 +57,7 @@ class TestModerationStatusService:
         ("updated", False,True, ModerationStatus.PENDING, ModerationStatus.PENDING),
         #When a Spam annotation is edited its moderation state doesn't change
         #(whether pre-moderation is disabled or enabled)
-        # DUPLICTED ("updated", False,False, ModerationStatus.SPAM, ModerationStatus.SPAM),
+        ("updated", False,False, ModerationStatus.SPAM, ModerationStatus.SPAM),
         ("updated", False,True, ModerationStatus.SPAM, ModerationStatus.SPAM),
         #Editing a private annotation does not change its moderation state as long as the annotation remains private:
         #A private annotation whose state is NULL will remain NULL if edited.

--- a/tests/unit/h/services/annotation_moderation_test.py
+++ b/tests/unit/h/services/annotation_moderation_test.py
@@ -20,56 +20,50 @@ class TestModerationStatusService:
     def test_all_hidden_handles_with_no_ids(self, svc):
         assert svc.all_hidden([]) == set()
 
-    # When a new private annotation is created the annotation's initial moderation state should be NULL.
-    # This is the same whether pre-moderation is enabled or disabled.
-    # It should not be possible for a shared annotation to have the NULL state.
-    # Private annotations don't always have the NULL state: if a shared annotation is edited and made private it retains its previous state from when it was shared (Pending, Approved, Denied, or Spam).
-    # Editing a private annotation and making it shared might change its annotation state, depending on the current state:
-    # If a private annotation whose state is NULL is edited and made shared:
-    # If the group has pre-moderation disabled the annotation's moderation state becomes Approved.
-    # If the group has pre-moderation enabled the annotation's moderation state becomes Pending.
-    # (So it's the same as what happens when creating a new shared annotation, but the state change only happens when the private annotation is made shared. This is important because the state change depends on the group's pre-moderation setting at the moment when the annotation becomes shared.)
-    # If a private annotation whose state is Denied is edited and made shared the state becomes Pending.
-    # (Same as what happens when editing a Denied, shared annotation, but the state change only happens when the private annotation is made shared.)
-    # If a private annotation whose state is Pending or Spam is edited and made shared the state doesn't change.
-    # (Same as when editing a Pending or Spam, shared annotation.)
-
     # fmt: off
     @pytest.mark.parametrize("action,is_private,pre_moderation_enabled,existing_status,expected_status", [
         #When a new annotation is created:
         #If the group has pre-moderation disabled the annotation's initial moderation state should be Approved.
         #If the group has pre-moderation enabled the annotation's initial moderation state should be Pending.
         ("created", False, False, None, ModerationStatus.APPROVED),
-        ("created", False,True, None, ModerationStatus.PENDING),
+        ("created", False, True, None, ModerationStatus.PENDING),
         #When an Approved annotation is edited:
         #If the group has pre-moderation disabled the moderation state doesn't change
         #If the group has pre-moderation enabled the moderation state changes to Pending
-        ("updated", False,False, ModerationStatus.APPROVED, ModerationStatus.APPROVED),
-        ("updated", False,False, ModerationStatus.DENIED, ModerationStatus.DENIED),
-        ("updated", False,True, ModerationStatus.APPROVED, ModerationStatus.PENDING),
+        ("updated", False, False, ModerationStatus.APPROVED, ModerationStatus.APPROVED),
+        ("updated", False, False, ModerationStatus.DENIED, ModerationStatus.DENIED),
+        ("updated", False, True, ModerationStatus.APPROVED, ModerationStatus.PENDING),
         #When a Denied annotation is edited the moderation state changes to Pending
         #(whether pre-moderation is disabled or enabled)
-        ("updated", False,True, ModerationStatus.DENIED, ModerationStatus.PENDING),
-        ("updated", False,False, ModerationStatus.DENIED, ModerationStatus.PENDING),
+        ("updated", False, True, ModerationStatus.DENIED, ModerationStatus.PENDING),
+        ("updated", False, False, ModerationStatus.DENIED, ModerationStatus.PENDING),
         #When a Pending annotation is edited its moderation state doesn't change
         #(whether pre-moderation is disabled or enabled)
-        ("updated", False,False, ModerationStatus.PENDING, ModerationStatus.PENDING),
-        ("updated", False,True, ModerationStatus.PENDING, ModerationStatus.PENDING),
+        ("updated", False, False, ModerationStatus.PENDING, ModerationStatus.PENDING),
+        ("updated", False, True, ModerationStatus.PENDING, ModerationStatus.PENDING),
         #When a Spam annotation is edited its moderation state doesn't change
         #(whether pre-moderation is disabled or enabled)
-        ("updated", False,False, ModerationStatus.SPAM, ModerationStatus.SPAM),
-        ("updated", False,True, ModerationStatus.SPAM, ModerationStatus.SPAM),
+        ("updated", False, False, ModerationStatus.SPAM, ModerationStatus.SPAM),
+        ("updated", False, True, ModerationStatus.SPAM, ModerationStatus.SPAM),
         #Editing a private annotation does not change its moderation state as long as the annotation remains private:
         #A private annotation whose state is NULL will remain NULL if edited.
-        ("updated", True,False, None, None),
+        ("updated", True, False, None, None),
         #A private annotation whose state is Pending will remain Pending if edited.
-        ("updated", True,False, ModerationStatus.PENDING, ModerationStatus.PENDING),
+        ("updated", True, False, ModerationStatus.PENDING, ModerationStatus.PENDING),
         #A private annotation whose state is Approved will remain Approved if edited.
-        ("updated", True,False, ModerationStatus.APPROVED, ModerationStatus.APPROVED),
+        ("updated", True, False, ModerationStatus.APPROVED, ModerationStatus.APPROVED),
         #A private annotation whose state is Denied will remain Denied if edited.
         ("updated", True,False, ModerationStatus.DENIED, ModerationStatus.DENIED),
         #A private annotation whose state is Spam will remain Spam if edited.
-        ("updated", True,False, ModerationStatus.SPAM, ModerationStatus.SPAM),
+        ("updated", True, False, ModerationStatus.SPAM, ModerationStatus.SPAM),
+        # When a new private annotation is created the annotation's initial moderation state should be NULL.
+        # This is the same whether pre-moderation is enabled or disabled.
+        # It should not be possible for a shared annotation to have the NULL state.
+        ("created", True, False, None, None),
+        ("created", True, True, None, None),
+        # It should not be possible for a shared annotation to have the NULL state.
+        # We are not migrating all null and shared annotations to approved so this can happen.
+        # We could write an XFAIL test here
     ])
     # fmt: on
     def test_update_status(self, svc, action, is_private, pre_moderation_enabled, existing_status, expected_status, factories):


### PR DESCRIPTION
- [Hypothesis's ~2017 Moderation Feature](https://docs.google.com/document/d/1NzArJi9K8tHmxmwCYe30_qs0LIboPh4dZMIZdA8ZJJQ/edit?tab=t.0#heading=h.87ulgtiy7cch)


- [ERD: Moderation](https://docs.google.com/document/d/1NzArJi9K8tHmxmwCYe30_qs0LIboPh4dZMIZdA8ZJJQ/edit?tab=t.0#heading=h.87ulgtiy7cch)
 

This PR:

### Migrate AnnotationModeration

- [x] Creates a new moderation_status column on Annotation (and Annotation Slim)

Every existing annotation will start with a null value there.


- [x] Creates a new moderation_log table.

- [x] Updates the current hide/unhide feature to also take into account the new column. 

We'll set it to DENIED when hiding and to APPROVED when "`unhidden".

We'll also create an audit record on moderation_log for it.

- [x] Migration to backfill "DENIED" based on the existing AnnotationModeration rows.

- [ ] TODO Migration to backfill moderation_log based on AnnotationModeration.

- [ ] TODO switch reads off AnnotationModeration to the new moderation_status.



### Pre moderated group creation

- [ ] TODO feature flag for pre-moderation
- [x] Migration for Group.pre_moderated
- [ ] TODO expose "pre_moderated" on the groups API used in the  grup edit form.
- [ ] TODO consume "pre_moderated" on the group edit API.
- [ ] TODO UI for `pre_moderated` toggle.



### Moderation queue

- [x] New endpoint to list the annotations of a group
- [x] New endpoint to change the moderation status of an annotation.
- [x] Expose new endpoints to the edit UI config.
- [x] FE for moderation 
- [ ] TODO Link to annotation in context
- [ ] TODO allow moderated (or pending) annotations to be visible in context
- [ ] TODO link to user
