### PR TITLE
Rate-limit emails sent by the same user in a period of time

### DIFF
--- a/h/models/notification.py
+++ b/h/models/notification.py
@@ -1,4 +1,4 @@
-import enum
+from enum import StrEnum
 
 from sqlalchemy import ForeignKey, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -8,9 +8,18 @@ from h.db.mixins import Timestamps
 from h.models import helpers
 
 
-class NotificationType(enum.StrEnum):
+class NotificationType(StrEnum):
     MENTION = "mention"
     REPLY = "reply"
+
+
+class EmailTag(StrEnum):
+    ACTIVATION = "activation"
+    FLAG_NOTIFICATION = "flag_notification"
+    REPLY_NOTIFICATION = "reply_notification"
+    RESET_PASSWORD = "reset_password"  # noqa: S105
+    MENTION_NOTIFICATION = "mention_notification"
+    TEST = "test"
 
 
 class Notification(Base, Timestamps):  # pragma: no cover

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -16,9 +16,10 @@ from h.services.job_queue import JobQueueService
 from h.services.mention import MentionService
 from h.services.notification import NotificationService
 from h.services.subscription import SubscriptionService
+from h.services.task_done import TaskDoneService
 
 
-def includeme(config):  # pragma: no cover
+def includeme(config):  # pragma: no cover  # noqa: PLR0915
     # Annotation related services
     config.register_service_factory(
         "h.services.annotation_delete.annotation_delete_service_factory",
@@ -174,3 +175,6 @@ def includeme(config):  # pragma: no cover
         "h.services.analytics.analytics_service_factory", name="analytics"
     )
     config.register_service_factory("h.services.email.factory", iface=EmailService)
+    config.register_service_factory(
+        "h.services.task_done.factory", iface=TaskDoneService
+    )

--- a/h/services/task_done.py
+++ b/h/services/task_done.py
@@ -1,0 +1,43 @@
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from typing import Any
+
+from pyramid.request import Request
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.functions import count
+
+from h.models import TaskDone
+from h.models.notification import EmailTag
+
+
+@dataclass(frozen=True)
+class TaskData:
+    tag: EmailTag
+    sender_id: int
+    recipient_ids: list[int] = field(default_factory=list)
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def formatted_extra(self) -> str:
+        return ", ".join(f"{k}={v!r}" for k, v in self.extra.items() if v is not None)
+
+
+class TaskDoneService:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(self, task_data: TaskData) -> None:
+        task_done = TaskDone(data=asdict(task_data))
+        self._session.add(task_done)
+
+    def sender_mention_count(self, sender_id: str, after: datetime) -> int:
+        stmt = select(count(TaskDone.id)).where(
+            TaskDone.data["sender_id"].astext == str(sender_id),
+            TaskDone.created >= after,
+        )
+        return self._session.execute(stmt).scalar_one()
+
+
+def factory(_context, request: Request) -> TaskDoneService:
+    return TaskDoneService(session=request.db)

--- a/tests/common/factories/task_done.py
+++ b/tests/common/factories/task_done.py
@@ -15,3 +15,8 @@ class TaskDone(ModelFactory):
     def expires_at(self, _create, extracted, **_kwargs):
         if extracted:
             self.expires_at = extracted
+
+    @post_generation
+    def created(self, _create, extracted, **_kwargs):
+        if extracted:
+            self.created = extracted

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -39,6 +39,7 @@ from h.services.oauth.service import OAuthProviderService
 from h.services.organization import OrganizationService
 from h.services.search_index import SearchIndexService
 from h.services.subscription import SubscriptionService
+from h.services.task_done import TaskDoneService
 from h.services.url_migration import URLMigrationService
 from h.services.user import UserService
 from h.services.user_delete import UserDeleteService
@@ -85,6 +86,7 @@ __all__ = (
     "queue_service",
     "search_index",
     "subscription_service",
+    "task_done_service",
     "url_migration_service",
     "user_delete_service",
     "user_password_service",
@@ -340,3 +342,8 @@ def feature_service(mock_service):
 @pytest.fixture
 def email_service(mock_service):
     return mock_service(EmailService)
+
+
+@pytest.fixture
+def task_done_service(mock_service):
+    return mock_service(TaskDoneService)

--- a/tests/unit/h/services/task_done_test.py
+++ b/tests/unit/h/services/task_done_test.py
@@ -1,0 +1,54 @@
+from dataclasses import asdict
+from datetime import datetime, timedelta
+from unittest.mock import sentinel
+
+import pytest
+from sqlalchemy import select
+
+from h.models import TaskDone
+from h.models.notification import EmailTag
+from h.services.task_done import TaskData, TaskDoneService, factory
+
+
+class TestTaskDoneService:
+    def test_create(self, task_done_service, db_session):
+        task_data = TaskData(
+            tag=EmailTag.TEST,
+            sender_id=123,
+            recipient_ids=[124],
+        )
+
+        task_done_service.create(task_data)
+
+        task_dones = db_session.execute(select(TaskDone)).scalars().all()
+        assert len(task_dones) == 1
+        assert task_dones[0].data == asdict(task_data)
+
+    def test_sender_mention_count(self, task_done_service, factories):
+        task_data = TaskData(
+            tag=EmailTag.MENTION_NOTIFICATION,
+            sender_id=123,
+            recipient_ids=[124],
+        )
+        created = datetime.fromisoformat("2023-05-04 12:12:01+00:00")
+        _task_done = factories.TaskDone(created=created, data=asdict(task_data))
+
+        after = created - timedelta(seconds=1)
+        assert task_done_service.sender_mention_count(task_data.sender_id, after) == 1
+
+    @pytest.fixture
+    def task_done_service(self, pyramid_request):
+        return TaskDoneService(session=pyramid_request.db)
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, TaskDoneService):
+        service = factory(sentinel.context, pyramid_request)
+
+        TaskDoneService.assert_called_once_with(session=pyramid_request.db)
+
+        assert service == TaskDoneService.return_value
+
+    @pytest.fixture(autouse=True)
+    def TaskDoneService(self, patch):
+        return patch("h.services.task_done.TaskDoneService")


### PR DESCRIPTION
Fixes #9411

Here we rate-limit emails sent by a single user to 100 within the last 24h to prevent abuse.

Testing
===
- Set `DAILY_SENDER_MENTION_LIMIT` to a lower value like 5
- Log in as `devdata_admin`
- Create 6 annotations mentioning `devdata_user`
- Observe that only 5 emails are present in the `mail` folder
- Observe the `limit reached` line in celery logs