### PR TITLE
Add feature flag for group pre-moderation

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -14,6 +14,7 @@ FEATURES = {
         "using a cached version?"
     ),
     "group_members": "Allow users to manage group members in new group forms",
+    "group_moderation": "Allow users to moderate annotations in groups",
     "group_type": "Allow users to choose group type in new group forms",
     "html_image_annotation": "Support image annotations in HTML",
     "pdf_custom_text_layer": "Use custom text layer in PDFs for improved text selection",


### PR DESCRIPTION
This will eventually control if we show the option to create pre-moderated groups and whether or not we show the entry point to the moderation UI.