### PR TITLE
Migration for Group.pre_moderated

### DIFF
--- a/h/migrations/versions/1d26b96db4af_add_group_pre_moderated.py
+++ b/h/migrations/versions/1d26b96db4af_add_group_pre_moderated.py
@@ -1,0 +1,15 @@
+"""Add Group.pre_moderated."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "1d26b96db4af"
+down_revision = "9d97a3e4921e"
+
+
+def upgrade() -> None:
+    op.add_column("group", sa.Column("pre_moderated", sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("group", "pre_moderated")

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -14,6 +14,7 @@ FEATURES = {
         "using a cached version?"
     ),
     "group_members": "Allow users to manage group members in new group forms",
+    "group_moderation": "Allow users to moderate annotations in groups",
     "group_type": "Allow users to choose group type in new group forms",
     "html_image_annotation": "Support image annotations in HTML",
     "pdf_custom_text_layer": "Use custom text layer in PDFs for improved text selection",


### PR DESCRIPTION
Add a nullable column to "Group" to represent whether or not a group has pre moderation enabled.

Model changes over: https://github.com/hypothesis/h/pull/9471


#### Testing 

- Apply the migration:

```
PYTHONPATH=. tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='610518512'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
2025-04-15 10:15:22 366208 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2025-04-15 10:15:22 366208 alembic.runtime.migration [INFO] Will assume transactional DDL.
2025-04-15 10:15:22 366208 alembic.runtime.migration [INFO] Running upgrade 9d97a3e4921e -> 1d26b96db4af, Add Group.pre_moderated.
```