### PR TITLE
Add control to enable pre-moderation in groups

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -6,6 +6,7 @@ import {
   LockFilledIcon,
   GlobeIcon,
   GlobeLockIcon,
+  Checkbox,
 } from '@hypothesis/frontend-shared';
 import { Config } from '../config';
 import type { Group } from '../config';
@@ -108,6 +109,9 @@ export default function CreateEditGroupForm({
   const [groupType, setGroupType] = useState<GroupType>(
     group?.type ?? 'private',
   );
+  const [preModerated, setPreModerated] = useState(
+    group?.pre_moderated ?? false,
+  );
 
   // Set when the user selects a new group type if confirmation is required.
   // Cleared after confirmation.
@@ -158,6 +162,7 @@ export default function CreateEditGroupForm({
         name,
         description,
         type: groupType,
+        pre_moderated: preModerated,
       };
 
       response = (await callAPI(config.api.createGroup.url, {
@@ -185,6 +190,7 @@ export default function CreateEditGroupForm({
         name,
         description,
         type: groupType,
+        pre_moderated: preModerated,
       };
 
       (await callAPI(config.api.updateGroup!.url, {
@@ -240,7 +246,7 @@ export default function CreateEditGroupForm({
       <form
         onSubmit={onSubmit}
         data-testid="form"
-        className="max-w-[530px] mx-auto"
+        className="max-w-[530px] mx-auto flex flex-col gap-y-4"
       >
         <TextField
           type="input"
@@ -262,7 +268,7 @@ export default function CreateEditGroupForm({
         />
 
         {config.features.group_type && (
-          <>
+          <div>
             <Label id={groupTypeLabel} text="Group type" />
             <RadioGroup
               aria-labelledby={groupTypeLabel}
@@ -290,10 +296,25 @@ export default function CreateEditGroupForm({
                 <GlobeIcon /> Open
               </RadioGroup.Radio>
             </RadioGroup>
-          </>
+          </div>
         )}
 
-        <div className="mt-2 pt-2 border-t border-t-text-grey-6 flex items-center gap-x-4">
+        {config.features.group_moderation && (
+          <fieldset>
+            <legend className="font-bold">Moderation</legend>
+            <Checkbox
+              data-testid="pre-moderation"
+              checked={preModerated}
+              onChange={e =>
+                setPreModerated((e.target as HTMLInputElement).checked)
+              }
+            >
+              Enable pre-moderation for this group.
+            </Checkbox>
+          </fieldset>
+        )}
+
+        <div className="pt-2 border-t border-t-text-grey-6 flex items-center gap-x-4">
           <span>
             {/* These are in a child span to avoid a gap between them. */}
             <Star />

--- a/h/static/scripts/group-forms/components/forms/TextField.tsx
+++ b/h/static/scripts/group-forms/components/forms/TextField.tsx
@@ -98,7 +98,7 @@ export default function TextField({
   const InputComponent = type === 'input' ? Input : Textarea;
 
   return (
-    <div className="mb-4">
+    <div>
       <Label htmlFor={id} text={label} required={required} />
       <InputComponent
         id={id}

--- a/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
@@ -201,6 +201,7 @@ describe('CreateEditGroupForm', () => {
           name,
           description,
           type,
+          pre_moderated: false,
         },
       });
       assert.calledOnceWithExactly(fakeSetLocation, groupURL);
@@ -222,6 +223,40 @@ describe('CreateEditGroupForm', () => {
     // It exits its loading state after receiving an error response.
     await assertInLoadingState(wrapper, false);
     assert.isFalse(savedConfirmationShowing(wrapper));
+  });
+
+  describe('pre-moderation', () => {
+    const preModerationCheckbox = wrapper =>
+      wrapper.find('Checkbox[data-testid="pre-moderation"]');
+
+    const isModerationEnabled = wrapper =>
+      preModerationCheckbox(wrapper).prop('checked');
+
+    [true, false].forEach(moderationEnabled => {
+      it('shows pre-moderation checkbox when group moderation is enabled', () => {
+        config.features.group_moderation = moderationEnabled;
+        const { wrapper } = createWrapper();
+
+        assert.equal(
+          preModerationCheckbox(wrapper).exists(),
+          moderationEnabled,
+        );
+      });
+    });
+
+    it('toggles pre-moderation by clicking on it', () => {
+      config.features.group_moderation = true;
+      const { wrapper } = createWrapper();
+
+      assert.isFalse(isModerationEnabled(wrapper));
+      preModerationCheckbox(wrapper)
+        .props()
+        .onChange({
+          target: { checked: true },
+        });
+      wrapper.update();
+      assert.isTrue(isModerationEnabled(wrapper));
+    });
   });
 
   context('when editing an existing group', () => {
@@ -334,6 +369,7 @@ describe('CreateEditGroupForm', () => {
             name,
             description,
             type: newGroupType,
+            pre_moderated: false,
           },
         }),
       );

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -37,6 +37,7 @@ export type ConfigObject = {
   features: {
     group_members: boolean;
     group_type: boolean;
+    group_moderation: boolean;
   };
 };
 

--- a/h/static/scripts/group-forms/utils/api.ts
+++ b/h/static/scripts/group-forms/utils/api.ts
@@ -19,6 +19,7 @@ export type CreateUpdateGroupAPIRequest = {
   name: string;
   description?: string;
   type?: GroupType;
+  pre_moderated?: boolean;
 };
 
 /**

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -70,6 +70,7 @@ class GroupCreateEditController:
             "features": {
                 "group_members": self.request.feature("group_members"),
                 "group_type": self.request.feature("group_type"),
+                "group_moderation": self.request.feature("group_moderation"),
             },
         }
 

--- a/tests/unit/h/views/groups_test.py
+++ b/tests/unit/h/views/groups_test.py
@@ -10,9 +10,10 @@ from h.views import groups as views
 
 @pytest.mark.usefixtures("annotation_stats_service")
 class TestGroupCreateEditController:
-    @pytest.mark.parametrize("group_type_flag", [True, False])
-    def test_create(self, pyramid_request, assets_env, mocker, group_type_flag):
-        pyramid_request.feature.flags["group_type"] = group_type_flag
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_create(self, pyramid_request, assets_env, mocker, flag):
+        pyramid_request.feature.flags["group_type"] = flag
+        pyramid_request.feature.flags["group_moderation"] = flag
 
         mocker.spy(views, "get_csrf_token")
 
@@ -24,9 +25,7 @@ class TestGroupCreateEditController:
         views.get_csrf_token.assert_called_once_with(pyramid_request)
         assert result == {
             "page_title": (
-                "Create a new group"
-                if group_type_flag
-                else "Create a new private group"
+                "Create a new group" if flag else "Create a new private group"
             ),
             "js_config": {
                 "styles": assets_env.urls.return_value,
@@ -42,8 +41,9 @@ class TestGroupCreateEditController:
                     "user": {"userid": sentinel.authenticated_userid},
                 },
                 "features": {
-                    "group_type": group_type_flag,
+                    "group_type": flag,
                     "group_members": pyramid_request.feature.flags["group_members"],
+                    "group_moderation": flag,
                 },
             },
         }
@@ -125,6 +125,9 @@ class TestGroupCreateEditController:
                 "features": {
                     "group_type": pyramid_request.feature.flags["group_type"],
                     "group_members": pyramid_request.feature.flags["group_members"],
+                    "group_moderation": pyramid_request.feature.flags[
+                        "group_moderation"
+                    ],
                 },
             },
         }
@@ -143,6 +146,7 @@ class TestGroupCreateEditController:
     def pyramid_request(self, pyramid_request):
         pyramid_request.feature.flags["group_type"] = True
         pyramid_request.feature.flags["group_members"] = True
+        pyramid_request.feature.flags["group_moderation"] = True
         return pyramid_request
 
 


### PR DESCRIPTION
Closes #9474 

Add a new control to group creation/edition form, that allows you to enable/disable pre-moderation in said group.

This control is displayed only if the feature is enabled.

![image](https://github.com/user-attachments/assets/fbe9ae96-f83f-4866-9b4a-5e849ad27132)

### Test steps

1. Go to http://localhost:5000/groups/new, and verify there's no "pre-moderation" control at the bottom
2. Go to http://localhost:5000/admin/features, and enable `group_moderation`.
3. Repeat step 1, and check that a new pre-moderation control is displayed now.
4. Click the new control, and verify the checked state can be toggled.
5. When saving changes during creation or edition, the pre-moderation checked status should be taken into consideration.

### TODO

- [x] Prepopulate the right value when editing an existing group
- [x] Save the value when submitting the form
- [x] Add FE tests
