### PR TITLE
Migration to create Annotation.moderation_status

### DIFF
--- a/h/migrations/versions/bd0cc0e6ed54_create_the_moderation_status_column.py
+++ b/h/migrations/versions/bd0cc0e6ed54_create_the_moderation_status_column.py
@@ -1,0 +1,28 @@
+"""Create the moderation_status column."""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "bd0cc0e6ed54"
+down_revision = "1d26b96db4af"
+
+
+def upgrade() -> None:
+    moderation_status_type = postgresql.ENUM(
+        "APPROVED",
+        "DENIED",
+        "SPAM",
+        "PENDING",
+        name="moderationstatus",
+    )
+    moderation_status_type.create(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        "annotation",
+        sa.Column("moderation_status", moderation_status_type, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("annotation", "moderation_status")


### PR DESCRIPTION
Model changes over: https://github.com/hypothesis/h/pull/9476

### Testing

- Run the migration with:

```
PYTHONPATH=. tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='620172004'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
2025-04-15 14:07:00 1506497 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2025-04-15 14:07:00 1506497 alembic.runtime.migration [INFO] Will assume transactional DDL.
2025-04-15 14:07:00 1506497 alembic.runtime.migration [INFO] Running upgrade 1d26b96db4af -> bd0cc0e6ed54, Create the moderation_status column.
```
