### PR TITLE
Migration to create ModerationLog

### DIFF
--- a/h/db/mixins.py
+++ b/h/db/mixins.py
@@ -5,13 +5,16 @@ import datetime
 import sqlalchemy as sa
 
 
-class Timestamps:
+class CreatedMixin:
     created = sa.Column(
         sa.DateTime,
         default=datetime.datetime.utcnow,
         server_default=sa.func.now(),
         nullable=False,
     )
+
+
+class Timestamps(CreatedMixin):
     updated = sa.Column(
         sa.DateTime,
         server_default=sa.func.now(),

--- a/h/db/mixins_dataclasses.py
+++ b/h/db/mixins_dataclasses.py
@@ -16,7 +16,7 @@ class AutoincrementingIntegerID(MappedAsDataclass):
     )
 
 
-class Timestamps(MappedAsDataclass):
+class CreatedMixin(MappedAsDataclass):
     created: Mapped[datetime] = mapped_column(
         init=False,
         repr=False,
@@ -24,6 +24,9 @@ class Timestamps(MappedAsDataclass):
         sort_order=-10,
         nullable=False,
     )
+
+
+class Timestamps(CreatedMixin, MappedAsDataclass):
     updated: Mapped[datetime] = mapped_column(
         init=False,
         repr=False,

--- a/h/migrations/versions/2aacaede8542_create_the_moderation_log_table.py
+++ b/h/migrations/versions/2aacaede8542_create_the_moderation_log_table.py
@@ -1,0 +1,53 @@
+"""Create the moderation log table."""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from h.db.types import URLSafeUUID
+
+revision = "2aacaede8542"
+down_revision = "bd0cc0e6ed54"
+
+
+def upgrade() -> None:
+    moderation_status_type = postgresql.ENUM(
+        name="moderationstatus",
+        create_type=False,
+    )
+
+    op.create_table(
+        "moderation_log",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("moderator_id", sa.Integer(), nullable=False),
+        sa.Column("annotation_id", URLSafeUUID(), nullable=False),
+        sa.Column("old_moderation_status", moderation_status_type, nullable=True),
+        sa.Column("new_moderation_status", moderation_status_type, nullable=False),
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["annotation_id"],
+            ["annotation.id"],
+            name=op.f("fk__moderation_log__annotation_id__annotation"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["moderator_id"],
+            ["user.id"],
+            name=op.f("fk__moderation_log__moderator_id_user"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__moderation_log")),
+    )
+    op.create_index(
+        op.f("ix__moderation_log_annotation_id"),
+        "moderation_log",
+        ["annotation_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix__moderation_log_annotation_id"), table_name="moderation_log")
+    op.drop_table("moderation_log")


### PR DESCRIPTION
Model changes over: https://github.com/hypothesis/h/pull/9478


### Testing 

- Apply the migration with:

```
PYTHONPATH=. tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='620172004'                                                             af, Create the moderation_status column.
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-che____________________________________________________________________ck
dev run-test: commands[0] | alembic upgrade head
2025-04-15 14:07:00 1506497 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2025-04-15 14:07:00 1506497 alembic.runtime.migration [INFO] Will assume transactional DDL.
2025-04-15 14:07:00 1506497 alembic.runtime.migration [INFO] Running upgrade bd0cc0e6ed54 -> 2aacaede8542, Create the moderation log table.
```