### PR TITLE
Concurrent writes to AnnotationModeration and moderation_status

### DIFF
--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -32,10 +32,17 @@ class AnnotationModerationService:
                     annotation_id=annotation.id,
                     old_moderation_status=annotation.moderation_status,
                     new_moderation_status=status.value,
-                    user_id=user.id,
+                    moderator_id=user.id,
                 )
             )
             annotation.moderation_status = status
+
+    def update_status(self, annotation: Annotation) -> None:
+        if not annotation.moderation_status and annotation.shared:
+            # If an annotation is not private but doesn't have a moderation status
+            # it means that the moderation status hasn't been migrated yet.
+            # Set the default `APPROVED` status
+            annotation.moderation_status = ModerationStatus.APPROVED
 
 
 def annotation_moderation_service_factory(_context, request):

--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -80,6 +80,7 @@ class AnnotationWriteService:
             created=annotation.created,
             updated=annotation.updated,
         )
+        self._moderation_service.update_status(annotation)
 
         self._db.add(annotation)
         self.upsert_annotation_slim(annotation)
@@ -143,6 +144,7 @@ class AnnotationWriteService:
                 document.get("document_uri_dicts", {}),
                 updated=annotation.updated,
             )
+        self._moderation_service.update_status(annotation)
         self.upsert_annotation_slim(annotation)
 
         if annotation_metadata:

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -14,8 +14,8 @@ from h.views.api.config import api_config
     description="Hide an annotation as a group moderator",
     permission=Permission.Annotation.MODERATE,
 )
-def create(context, request):
-    request.find_service(AnnotationWriteService).hide(context.annotation)
+def hide(context, request):
+    request.find_service(AnnotationWriteService).hide(context.annotation, request.user)
 
     event = events.AnnotationEvent(request, context.annotation.id, "update")
     request.notify_after_commit(event)
@@ -31,8 +31,10 @@ def create(context, request):
     description="Unhide an annotation as a group moderator",
     permission=Permission.Annotation.MODERATE,
 )
-def delete(context, request):
-    request.find_service(AnnotationWriteService).unhide(context.annotation)
+def unhide(context, request):
+    request.find_service(AnnotationWriteService).unhide(
+        context.annotation, request.user
+    )
 
     event = events.AnnotationEvent(request, context.annotation.id, "update")
     request.notify_after_commit(event)

--- a/tests/unit/h/services/annotation_moderation_test.py
+++ b/tests/unit/h/services/annotation_moderation_test.py
@@ -1,35 +1,78 @@
 import pytest
 
+from h.models.annotation import ModerationStatus
 from h.services.annotation_moderation import (
     AnnotationModerationService,
     annotation_moderation_service_factory,
 )
 
 
-class TestAnnotationModerationServiceAllHidden:
-    def test_it_lists_moderated_annotation_ids(self, svc, mods):
+class TestAnnotationModerationService:
+    def test_all_hidden_lists_moderated_annotation_ids(self, svc, mods):
         ids = [m.annotation.id for m in mods[0:-1]]
         assert svc.all_hidden(ids) == set(ids)
 
-    def test_it_skips_non_moderated_annotations(self, svc, factories):
+    def test_all_hidden_skips_non_moderated_annotations(self, svc, factories):
         annotation = factories.Annotation()
 
         assert svc.all_hidden([annotation.id]) == set()
 
-    def test_it_handles_with_no_ids(self, svc):
+    def test_all_hidden_handles_with_no_ids(self, svc):
         assert svc.all_hidden([]) == set()
+
+    def test_set_status_with_None_status_doesnt_change_it(self, svc, annotation, user):
+        annotation.moderation_status = ModerationStatus.APPROVED
+
+        svc.set_status(annotation, user, None)
+
+        assert annotation.moderation_status is ModerationStatus.APPROVED
+
+    def test_set_status_with_same_status_doesnt_change_it(self, svc, annotation, user):
+        annotation.moderation_status = ModerationStatus.APPROVED
+
+        svc.set_status(annotation, user, ModerationStatus.APPROVED)
+
+        assert annotation.moderation_status is ModerationStatus.APPROVED
+        assert annotation.moderation_log == []
+
+    def test_set_status(self, svc, annotation, user):
+        annotation.moderation_status = ModerationStatus.APPROVED
+
+        svc.set_status(annotation, user, ModerationStatus.DENIED)
+
+        assert annotation.moderation_status is ModerationStatus.DENIED
+        assert annotation.moderation_log[0].annotation_id == annotation.id
+        assert annotation.moderation_log[0].user_id == user.id
+        assert (
+            annotation.moderation_log[0].old_moderation_status
+            == ModerationStatus.APPROVED
+        )
+        assert (
+            annotation.moderation_log[0].new_moderation_status
+            == ModerationStatus.DENIED
+        )
 
     @pytest.fixture(autouse=True)
     def mods(self, factories):
         return factories.AnnotationModeration.create_batch(3)
+
+    @pytest.fixture
+    def annotation(self, factories):
+        return factories.Annotation()
+
+    @pytest.fixture
+    def user(self, factories, db_session):
+        user = factories.User()
+        db_session.flush()
+        return user
+
+
+@pytest.fixture
+def svc(db_session):
+    return AnnotationModerationService(db_session)
 
 
 class TestAnnotationModerationServiceFactory:
     def test_it_returns_service(self, pyramid_request):
         svc = annotation_moderation_service_factory(None, pyramid_request)
         assert isinstance(svc, AnnotationModerationService)
-
-
-@pytest.fixture
-def svc(db_session):
-    return AnnotationModerationService(db_session)

--- a/tests/unit/h/services/annotation_moderation_test.py
+++ b/tests/unit/h/services/annotation_moderation_test.py
@@ -42,7 +42,7 @@ class TestAnnotationModerationService:
 
         assert annotation.moderation_status is ModerationStatus.DENIED
         assert annotation.moderation_log[0].annotation_id == annotation.id
-        assert annotation.moderation_log[0].user_id == user.id
+        assert annotation.moderation_log[0].moderator_id == user.id
         assert (
             annotation.moderation_log[0].old_moderation_status
             == ModerationStatus.APPROVED
@@ -51,6 +51,21 @@ class TestAnnotationModerationService:
             annotation.moderation_log[0].new_moderation_status
             == ModerationStatus.DENIED
         )
+
+    @pytest.mark.parametrize("moderation_status", [None, ModerationStatus.APPROVED])
+    @pytest.mark.parametrize("shared", [False, True])
+    def test_update_status_initializes_moderation_status(
+        self, svc, annotation, moderation_status, shared
+    ):
+        annotation.moderation_status = moderation_status
+        annotation.shared = shared
+
+        svc.update_status(annotation)
+
+        if not moderation_status and shared:
+            assert annotation.moderation_status == ModerationStatus.APPROVED
+        else:
+            assert annotation.moderation_status == moderation_status
 
     @pytest.fixture(autouse=True)
     def mods(self, factories):

--- a/tests/unit/h/services/annotation_write_test.py
+++ b/tests/unit/h/services/annotation_write_test.py
@@ -23,6 +23,7 @@ class TestAnnotationWriteService:
         mention_service,
         _validate_group,  # noqa: PT019
         db_session,
+        moderation_service,
     ):
         root_annotation = factories.Annotation()
         annotation_read_service.get_annotation_by_id.return_value = root_annotation
@@ -43,6 +44,7 @@ class TestAnnotationWriteService:
             schedule_in=60,
         )
         mention_service.update_mentions.assert_called_once_with(anno)
+        moderation_service.update_status.assert_called_once_with(anno)
 
         assert anno == Any.instance_of(Annotation).with_attrs(
             {

--- a/tests/unit/h/views/api/moderation_test.py
+++ b/tests/unit/h/views/api/moderation_test.py
@@ -7,7 +7,7 @@ from h.traversal import AnnotationContext
 from h.views.api import moderation as views
 
 
-class TestCreate:
+class TestHide:
     def test_it(
         self,
         pyramid_request,
@@ -16,10 +16,10 @@ class TestCreate:
         events,
         annotation,
     ):
-        response = views.create(annotation_context, pyramid_request)
+        response = views.hide(annotation_context, pyramid_request)
 
         annotation_write_service.hide.assert_called_once_with(
-            annotation_context.annotation
+            annotation_context.annotation, pyramid_request.user
         )
         events.AnnotationEvent.assert_called_once_with(
             pyramid_request, annotation.id, "update"
@@ -31,7 +31,7 @@ class TestCreate:
         assert isinstance(response, HTTPNoContent)
 
 
-class TestDelete:
+class TestUnhide:
     def test_it(
         self,
         pyramid_request,
@@ -40,10 +40,10 @@ class TestDelete:
         events,
         annotation,
     ):
-        response = views.delete(annotation_context, pyramid_request)
+        response = views.unhide(annotation_context, pyramid_request)
 
         annotation_write_service.unhide.assert_called_once_with(
-            annotation_context.annotation
+            annotation_context.annotation, pyramid_request.user
         )
         events.AnnotationEvent.assert_called_once_with(
             pyramid_request, annotation.id, "update"


### PR DESCRIPTION
### Testing

- Flag and hide an annotation.
- Query the DB, in `make sql`:

```
 select annotation.id, moderation_status, annotation_moderation.created from annotation left outer join annotation_moderation on annotation_id = annotation.id order by annotation.created desc limit 1;
                  id                  | moderation_status |          created           
--------------------------------------+-------------------+----------------------------
 429735c4-19f8-11f0-af72-7bd8ee18feac | DENIED            | 2025-04-15 12:51:14.756085
(1 row)
```

We have both a row on annotation_moderation and the right status on moderation_status.


- Now, unhide the annotation, repeat the query:

```
select annotation.id, moderation_status, annotation_moderation.created from annotation left outer join annotation_moderation on annotation_id = annotation.id order by annotation.created desc limit 1;
                  id                  | moderation_status | created 
--------------------------------------+-------------------+---------
 429735c4-19f8-11f0-af72-7bd8ee18feac | APPROVED          | 
(1 row)
```
The row on annotation_moderation has disappeared and the status has changed to APPROVED.

- We also have now a record of these changes over moderation_log:

```
select * from moderation_log;
 id | user_id |            annotation_id             | old_moderation_status | new_moderation_status |          created          
----+---------+--------------------------------------+-----------------------+-----------------------+---------------------------
  1 |       3 | 429735c4-19f8-11f0-af72-7bd8ee18feac | APPROVED              | DENIED                | 2025-04-15 12:51:14.75972
  2 |       3 | 429735c4-19f8-11f0-af72-7bd8ee18feac | DENIED                | APPROVED              | 2025-04-15 12:55:08.99321
(2 rows)
```