### PR TITLE
Backfill moderation status based on AnnotationModeration

### DIFF
--- a/h/migrations/versions/077e087027b1_backfill_moderation_status_based_on_.py
+++ b/h/migrations/versions/077e087027b1_backfill_moderation_status_based_on_.py
@@ -1,0 +1,28 @@
+"""Backfill moderation_status based on AnnotationModeration."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "077e087027b1"
+down_revision = "2aacaede8542"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    result = conn.execute(
+        sa.text(
+            """
+    UPDATE annotation
+        SET moderation_status = 'DENIED'
+    FROM annotation_moderation
+    WHERE annotation.id = annotation_moderation.annotation_id
+    AND annotation.moderation_status is null
+    """
+        )
+    )
+    print("\tUpdated annotation rows as DENIED:", result.rowcount)  # noqa: T201
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
### Testing 

- Flag and hide an annotation in `main`
- Switch to this branch and run the migration:

```
PYTHONPATH=. tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='1927699192'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
2025-04-15 15:15:52 1837985 alembic.runtime.migration [INFO] Context impl PostgresqlImpl.
2025-04-15 15:15:52 1837985 alembic.runtime.migration [INFO] Will assume transactional DDL.
2025-04-15 15:15:52 1837985 alembic.runtime.migration [INFO] Running upgrade 2aacaede8542 -> 077e087027b1, Backfill moderation_status based on AnnotationModeration.
        Updated annotation rows as DENIED: 1
```