### PR TITLE
Normalize email data subject before sending

### DIFF
--- a/h/services/email.py
+++ b/h/services/email.py
@@ -34,8 +34,9 @@ class EmailData:
         extra_headers = {"X-MC-Tags": self.tag}
         if self.subaccount:
             extra_headers["X-MC-Subaccount"] = self.subaccount
+        subject = " ".join(self.subject.splitlines())
         return pyramid_mailer.message.Message(
-            subject=self.subject,
+            subject=subject,
             recipients=self.recipients,
             body=self.body,
             html=self.html,

--- a/tests/unit/h/services/email_test.py
+++ b/tests/unit/h/services/email_test.py
@@ -59,6 +59,7 @@ class TestEmailService:
             tag=EmailTag.TEST,
             subaccount="subaccount",
         )
+
         email_service.send(email, task_data)
 
         pyramid_mailer.message.Message.assert_called_once_with(
@@ -67,6 +68,26 @@ class TestEmailService:
             body="Some text body",
             html=None,
             extra_headers={"X-MC-Tags": EmailTag.TEST, "X-MC-Subaccount": "subaccount"},
+        )
+
+    def test_send_creates_email_message_normalizing_subject(
+        self, task_data, email_service, pyramid_mailer
+    ):
+        email = EmailData(
+            recipients=["foo@example.com"],
+            subject="My email\nsubject",
+            body="Some text body",
+            tag=EmailTag.TEST,
+        )
+
+        email_service.send(email, task_data)
+
+        pyramid_mailer.message.Message.assert_called_once_with(
+            recipients=["foo@example.com"],
+            subject="My email subject",
+            body="Some text body",
+            html=None,
+            extra_headers={"X-MC-Tags": EmailTag.TEST},
         )
 
     def test_send_creates_mention_email_when_sender_limit_not_reached(


### PR DESCRIPTION
Fixes https://hypothes-is.slack.com/archives/C0LUWQQJJ/p1744376351941759

This takes care of [`BadHeaders` exception](https://github.com/Pylons/pyramid_mailer/blob/0.15.1/pyramid_mailer/message.py#L308) triggered when email subject contains newlines by normalizing it.
We don't need to normalize sender or recipients as these are expected to be valid email addresses.
Extra headers containing tag or subaccount are fine as well since these are our own enum string values.