### PR TITLE
Take pre_moderated on group PATCH

### DIFF
--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -18,6 +18,7 @@ GROUP_SCHEMA_PROPERTIES = {
     "description": {"type": "string", "maxLength": GROUP_DESCRIPTION_MAX_LENGTH},
     "groupid": {"type": "string", "pattern": GROUPID_PATTERN},
     "type": {"enum": ["private", "restricted", "open"]},
+    "pre_moderated": {"type": "boolean"},
 }
 
 

--- a/tests/unit/h/views/api/groups_test.py
+++ b/tests/unit/h/views/api/groups_test.py
@@ -337,6 +337,7 @@ class TestUpdate:
                     type="private",
                 ),
             ),
+            ({"pre_moderated": True}, call.update(sentinel.group, pre_moderated=True)),
         ],
     )
     def test_update(


### PR DESCRIPTION
This is necessary to toggle the value on the group setting feature.


### Testing

- Use the edit group feature, change the name of the group. That works as before
- Copy the cURL and adapt it to change `pre_moderated`


```
curl 'http://localhost:5000/api/groups/odyKZKd1' \
  -X 'PATCH' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json; charset=UTF-8' \
  -b 'auth=AUTH' \
  -H 'Origin: http://localhost:5000' \
  -H 'Referer: http://localhost:5000/groups/odyKZKd1/edit' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36' \
  -H 'X-CSRF-Token: 068d53313ff848f8826fd9e929250281' \
  -H 'sec-ch-ua: "Google Chrome";v="135", "Not-A.Brand";v="8", "Chromium";v="135"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "Linux"' \
  --data-raw '{"id":"odyKZKd1","name":"New group","description":"","type":"open", "pre_moderated": true}'
```

- Check the change in `make sql`: 

```select * from "group" where pre_moderated = true;```
