### PR TITLE
Add section to moderate groups

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -233,6 +233,12 @@ def includeme(config):  # noqa: PLR0915
         factory="h.traversal.GroupRequiredRoot",
         traverse="/{pubid}",
     )
+    config.add_route(
+        "group_moderation",
+        "/groups/{pubid}/moderate",
+        factory="h.traversal.GroupRequiredRoot",
+        traverse="/{pubid}",
+    )
     # Match "/<pubid>/": we redirect to the version with the slug.
     config.add_route(
         "group_read",

--- a/h/static/scripts/group-forms/components/AppRoot.tsx
+++ b/h/static/scripts/group-forms/components/AppRoot.tsx
@@ -7,6 +7,7 @@ import Router from './Router';
 import type { ConfigObject } from '../config';
 import { Config } from '../config';
 import { routes } from '../routes';
+import GroupModeration from './GroupModeration';
 
 export type AppRootProps = {
   config: ConfigObject;
@@ -43,6 +44,9 @@ export default function AppRoot({ config }: AppRootProps) {
             </Route>
             <Route path={routes.groups.editMembers}>
               <EditGroupMembersForm group={group!} />
+            </Route>
+            <Route path={routes.groups.moderation}>
+              <GroupModeration group={group!} />
             </Route>
             <Route>
               <h1 data-testid="unknown-route">Page not found</h1>

--- a/h/static/scripts/group-forms/components/GroupFormHeader.tsx
+++ b/h/static/scripts/group-forms/components/GroupFormHeader.tsx
@@ -42,6 +42,7 @@ export default function GroupFormHeader({
 }: GroupFormHeaderProps) {
   const config = useContext(Config);
   const enableMembers = config?.features.group_members;
+  const enableModeration = config?.features.group_moderation;
 
   // This should be replaced with a proper URL generation function that handles
   // escaping etc.
@@ -50,6 +51,9 @@ export default function GroupFormHeader({
     : null;
   const editMembersLinks = group
     ? routes.groups.editMembers.replace(':pubid', group.pubid)
+    : null;
+  const moderationLinks = group
+    ? routes.groups.moderation.replace(':pubid', group.pubid)
     : null;
 
   return (
@@ -79,6 +83,11 @@ export default function GroupFormHeader({
         {enableMembers && editMembersLinks && (
           <TabLink testId="members-link" href={editMembersLinks}>
             Members
+          </TabLink>
+        )}
+        {enableModeration && moderationLinks && (
+          <TabLink testId="moderation-link" href={moderationLinks}>
+            Moderation
           </TabLink>
         )}
       </div>

--- a/h/static/scripts/group-forms/components/GroupModeration.tsx
+++ b/h/static/scripts/group-forms/components/GroupModeration.tsx
@@ -1,0 +1,20 @@
+import GroupFormHeader from './GroupFormHeader';
+import type { Group } from '../config';
+import FormContainer from './forms/FormContainer';
+
+export type GroupModerationProps = {
+  /** The group to be moderated */
+  group: Group;
+};
+
+export default function GroupModeration({ group }: GroupModerationProps) {
+  return (
+    <FormContainer>
+      <GroupFormHeader title="Moderate group" group={group} />
+      <p>Moderate group {group.name}</p>
+      <p>
+        <i>TODO Annotations list</i>
+      </p>
+    </FormContainer>
+  );
+}

--- a/h/static/scripts/group-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/group-forms/components/test/AppRoot-test.js
@@ -24,6 +24,7 @@ describe('AppRoot', () => {
     $imports.$mock({
       './CreateEditGroupForm': mockComponent('CreateEditGroupForm'),
       './EditGroupMembersForm': mockComponent('EditGroupMembersForm'),
+      './GroupModeration': mockComponent('GroupModeration'),
     });
   });
 
@@ -95,6 +96,10 @@ describe('AppRoot', () => {
     {
       path: '/groups/1234/edit/members',
       selector: 'EditGroupMembersForm',
+    },
+    {
+      path: '/groups/1234/moderate',
+      selector: 'GroupModeration',
     },
     {
       path: '/unknown',

--- a/h/static/scripts/group-forms/components/test/GroupFormHeader-test.js
+++ b/h/static/scripts/group-forms/components/test/GroupFormHeader-test.js
@@ -8,7 +8,10 @@ describe('GroupFormHeader', () => {
 
   beforeEach(() => {
     config = {
-      features: { group_members: true },
+      features: {
+        group_members: true,
+        group_moderation: true,
+      },
     };
   });
 
@@ -36,6 +39,7 @@ describe('GroupFormHeader', () => {
     assert.isFalse(getLink(header, 'activity-link').exists());
     assert.isFalse(getLink(header, 'settings-link').exists());
     assert.isFalse(getLink(header, 'members-link').exists());
+    assert.isFalse(getLink(header, 'moderation-link').exists());
   });
 
   it('renders group activity link and tabs if there is a group', () => {
@@ -49,6 +53,9 @@ describe('GroupFormHeader', () => {
 
     const membersLink = getLink(header, 'members-link');
     assert.equal(membersLink.prop('href'), '/groups/abc123/edit/members');
+
+    const moderationLink = getLink(header, 'moderation-link');
+    assert.equal(moderationLink.prop('href'), '/groups/abc123/moderate');
   });
 
   it('does not show tabs if the members flag is disabled', () => {
@@ -57,6 +64,12 @@ describe('GroupFormHeader', () => {
     assert.isTrue(getLink(header, 'activity-link').exists());
     assert.isFalse(getLink(header, 'settings-link').exists());
     assert.isFalse(getLink(header, 'members-link').exists());
+  });
+
+  it('does not show moderation link if the moderation flag is disabled', () => {
+    config.features.group_moderation = false;
+    const header = createHeader({ group });
+    assert.isFalse(getLink(header, 'moderation-link').exists());
   });
 
   it('should pass a11y checks', checkAccessibility({ content: createHeader }));

--- a/h/static/scripts/group-forms/components/test/GroupModeration-test.js
+++ b/h/static/scripts/group-forms/components/test/GroupModeration-test.js
@@ -1,0 +1,16 @@
+import { mount } from '@hypothesis/frontend-testing';
+import GroupModeration from '../GroupModeration';
+
+describe('GroupModeration', () => {
+  function createComponent(groupName = 'The group') {
+    return mount(<GroupModeration group={{ name: groupName }} />);
+  }
+
+  it('renders form header', () => {
+    const wrapper = createComponent();
+    assert.equal(
+      wrapper.find('GroupFormHeader').prop('title'),
+      'Moderate group',
+    );
+  });
+});

--- a/h/static/scripts/group-forms/routes.ts
+++ b/h/static/scripts/group-forms/routes.ts
@@ -9,5 +9,6 @@ export const routes = {
     new: '/groups/new',
     edit: '/groups/:pubid/edit',
     editMembers: '/groups/:pubid/edit/members',
+    moderation: '/groups/:pubid/moderate',
   },
 };

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -39,6 +39,11 @@ class GroupCreateEditController:
         request_method="GET",
         permission=Permission.Group.EDIT,
     )
+    @view_config(
+        route_name="group_moderation",
+        request_method="GET",
+        permission=Permission.Group.EDIT,
+    )
     def edit(self):
         """Render the page for editing an existing group."""
         return {

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -216,6 +216,12 @@ def test_includeme():
             traverse="/{pubid}",
         ),
         call(
+            "group_moderation",
+            "/groups/{pubid}/moderate",
+            factory="h.traversal.GroupRequiredRoot",
+            traverse="/{pubid}",
+        ),
+        call(
             "group_read",
             "/groups/{pubid}/{slug:[^/]*}",
             factory="h.traversal.GroupRequiredRoot",


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h/pull/9473

Add a new "Moderation" tab to groups, that is only displayed if the group moderation FF is enabled.

The tab is unconditionally displayed for groups with "pre-moderation" not enabled, because we still want certain users with more privileges to moderate any kind of group. The only difference is that annotations in groups without pre-moderation will get annotations automatically approved by default, but they can still be denied or marked as spam later on.

This PR does not cover listing annotations yet, just adding the new route with an "empty" template.

![image](https://github.com/user-attachments/assets/f2b6fffd-d25e-4594-8048-155776494c94)

### TODO

- [x] Add FE tests