### PR TITLE
Ensure the header has a consistent size in group sections

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -235,9 +235,13 @@ export default function CreateEditGroupForm({
   };
 
   return (
-    <FormContainer classes="max-w-[530px] mx-auto">
+    <FormContainer>
       <GroupFormHeader group={group} title={heading} />
-      <form onSubmit={onSubmit} data-testid="form">
+      <form
+        onSubmit={onSubmit}
+        data-testid="form"
+        className="max-w-[530px] mx-auto"
+      >
         <TextField
           type="input"
           value={name}


### PR DESCRIPTION
Update group creation/edition form so that the header has a consistent size across sections, and only the form is slightly smaller in the first tab.

Before:

https://github.com/user-attachments/assets/49cd39d9-613b-4e68-b9bf-6106f82304de

AFter:

https://github.com/user-attachments/assets/d0d8c775-b9a1-42dd-9d3c-351c67c2b30d

