### PR TITLE
Expose moderation_status in annotation JSON

### DIFF
--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -18,7 +18,7 @@ key to. So for convenience the test module can instead just do
 """
 
 from h.models.activation import Activation
-from h.models.annotation import Annotation
+from h.models.annotation import Annotation, ModerationStatus
 from h.models.annotation_metadata import AnnotationMetadata
 from h.models.annotation_slim import AnnotationSlim
 from h.models.auth_client import AuthClient

--- a/h/services/annotation_json.py
+++ b/h/services/annotation_json.py
@@ -69,6 +69,7 @@ class AnnotationJSONService:
                 "text": annotation.text or "",
                 "tags": annotation.tags or [],
                 "group": annotation.groupid,
+                "moderation_status": self._get_moderation_status(annotation),
                 #  Convert our simple internal annotation storage format into the
                 #  legacy complex permissions dict format that is still used in
                 #  some places.
@@ -199,6 +200,18 @@ class AnnotationJSONService:
 
         # Only people in the group can read it
         return f"group:{annotation.groupid}"
+
+    @staticmethod
+    def _get_moderation_status(annotation) -> str | None:
+        if not annotation.moderation_status:
+            if not annotation.shared:
+                # If an annotation is private and doesn't have a moderation status, return None.
+                return None
+
+            # Otherwise it means that the moderation status hasn't been migrated yet to "APPROVED"
+            return Annotation.ModerationStatus.APPROVED.value
+
+        return annotation.moderation_status.value
 
 
 def factory(_context, request):


### PR DESCRIPTION
For existing annotations that don't have a moderation status yet, ie they have null in the DB, we'll return "APPROVED" if they are shared or None otherwise.

For the rest we'll return the moderation status from the DB.



### Testing 


- Check the output of any endpoint that returns annotations, for example the search API. The result now includes moderation status:

![Screenshot from 2025-04-24 09-09-52](https://github.com/user-attachments/assets/0edbc83f-f681-4c33-9e54-c58c1f5fb070)


