### PR TITLE
Group's annotations endpoint

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -151,6 +151,12 @@ def includeme(config):  # noqa: PLR0915
         factory="h.traversal.GroupRequiredRoot",
         traverse="/{id}",
     )
+    config.add_route(
+        "api.group_annotations",
+        "/api/groups/{pubid}/annotations",
+        factory="h.traversal.GroupRequiredRoot",
+        traverse="/{pubid}",
+    )
     config.add_route("api.profile", "/api/profile")
     config.add_route("api.profile_groups", "/api/profile/groups")
     config.add_route("api.debug_token", "/api/debug-token")
@@ -212,12 +218,6 @@ def includeme(config):  # noqa: PLR0915
     config.add_route(
         "group_edit",
         "/groups/{pubid}/edit",
-        factory="h.traversal.GroupRequiredRoot",
-        traverse="/{pubid}",
-    )
-    config.add_route(
-        "api.group_annotations",
-        "/api/groups/{pubid}/annotations",
         factory="h.traversal.GroupRequiredRoot",
         traverse="/{pubid}",
     )

--- a/h/routes.py
+++ b/h/routes.py
@@ -216,6 +216,12 @@ def includeme(config):  # noqa: PLR0915
         traverse="/{pubid}",
     )
     config.add_route(
+        "api.group_annotations",
+        "/api/groups/{pubid}/annotations",
+        factory="h.traversal.GroupRequiredRoot",
+        traverse="/{pubid}",
+    )
+    config.add_route(
         "group_edit_members",
         "/groups/{pubid}/edit/members",
         factory="h.traversal.GroupRequiredRoot",

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -1,6 +1,9 @@
 """Schema for validating API group resources."""
 
+import colander
+
 from h.i18n import TranslationString as _
+from h.models.annotation import ModerationStatus
 from h.models.group import (
     GROUP_DESCRIPTION_MAX_LENGTH,
     GROUP_NAME_MAX_LENGTH,
@@ -20,6 +23,20 @@ GROUP_SCHEMA_PROPERTIES = {
     "type": {"enum": ["private", "restricted", "open"]},
     "pre_moderated": {"type": "boolean"},
 }
+
+
+class FilterGroupAnnotationsSchema(colander.Schema):
+    moderation_status = colander.SchemaNode(
+        colander.String(),
+        validator=colander.OneOf(["approved", "pending", "denied", "spam"]),
+        missing=None,
+    )
+
+    def validator(self, _node, cstruct):
+        moderation_status = cstruct.get("moderation_status")
+
+        if moderation_status:
+            cstruct["moderation_status"] = ModerationStatus(moderation_status.upper())
 
 
 class GroupAPISchema(JSONSchema):

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -28,7 +28,7 @@ GROUP_SCHEMA_PROPERTIES = {
 class FilterGroupAnnotationsSchema(colander.Schema):
     moderation_status = colander.SchemaNode(
         colander.String(),
-        validator=colander.OneOf(["approved", "pending", "denied", "spam"]),
+        validator=colander.OneOf(["APPROVED", "PENDING", "DENIED", "SPAM"]),
         missing=None,
     )
 
@@ -36,7 +36,7 @@ class FilterGroupAnnotationsSchema(colander.Schema):
         moderation_status = cstruct.get("moderation_status")
 
         if moderation_status:
-            cstruct["moderation_status"] = ModerationStatus(moderation_status.upper())
+            cstruct["moderation_status"] = ModerationStatus(moderation_status)
 
 
 class GroupAPISchema(JSONSchema):

--- a/h/schemas/pagination.py
+++ b/h/schemas/pagination.py
@@ -1,16 +1,29 @@
+from dataclasses import dataclass
+
 from colander import Integer, Range, Schema, SchemaNode
+
+from h.schemas.util import validate_query_params
 
 
 class PaginationQueryParamsSchema(Schema):
-    page = SchemaNode(
-        Integer(),
-        name="page[number]",
-        validator=Range(min=1),
-        missing=1,
-    )
+    page = SchemaNode(Integer(), name="page[number]", validator=Range(min=1), missing=1)
     size = SchemaNode(
-        Integer(),
-        name="page[size]",
-        validator=Range(min=1, max=100),
-        missing=20,
+        Integer(), name="page[size]", validator=Range(min=1, max=100), missing=20
     )
+
+
+@dataclass
+class Pagination:
+    offset: int
+    limit: int
+
+    @classmethod
+    def from_params(cls, params: dict) -> "Pagination":
+        pagination_params = validate_query_params(PaginationQueryParamsSchema(), params)
+        page_number = pagination_params["page[number]"]
+        page_size = pagination_params["page[size]"]
+
+        return cls(
+            offset=page_size * (page_number - 1),
+            limit=page_size,
+        )

--- a/h/security/policy/_api_cookie.py
+++ b/h/security/policy/_api_cookie.py
@@ -11,6 +11,7 @@ COOKIE_AUTHENTICATABLE_API_REQUESTS = [
     ("api.group_members", "GET"),  # List group members.
     ("api.group_member", "PATCH"),  # Edit group membership.
     ("api.group_member", "DELETE"),  # Remove group member.
+    ("api.group_annotations", "GET"),  # List of a group's annotations.
 ]
 
 

--- a/h/services/annotation_read.py
+++ b/h/services/annotation_read.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 
-from sqlalchemy import select
+from sqlalchemy import Select, func, or_, select
 from sqlalchemy.orm import Query, Session, subqueryload
 
 from h.db.types import InvalidUUID
@@ -39,25 +39,56 @@ class AnnotationReadService:
             return []
 
         annotations = self._db.execute(
-            self._annotation_search_query(ids=ids, eager_load=eager_load)
+            self.annotation_search_query(ids=ids, eager_load=eager_load)
         ).scalars()
 
         return sorted(annotations, key=lambda annotation: ids.index(annotation.id))
 
     @staticmethod
-    def _annotation_search_query(
-        ids: list[str] = None,  # noqa: RUF013
+    def annotation_search_query(
+        ids: list[str] | None = None,
+        *,
         eager_load: list | None = None,
+        groupid: str | None = None,
+        include_private: bool = True,
+        moderation_status: Annotation.ModerationStatus | None = None,
     ) -> Query:
         """Create a query for searching for annotations."""
 
         query = select(Annotation)
-        query = query.where(Annotation.id.in_(ids))
+        if ids:
+            query = query.where(Annotation.id.in_(ids))
+
+        if groupid:
+            query = query.where(Annotation.groupid == groupid)
+
+        if moderation_status:
+            if moderation_status == Annotation.ModerationStatus.APPROVED:
+                # We have not migrated all annotations to have a moderation status
+                # APPROVED is implicit when no moderation status is set
+                query = query.where(
+                    or_(
+                        Annotation.moderation_status.is_(None),
+                        Annotation.moderation_status
+                        == Annotation.ModerationStatus.APPROVED,
+                    )
+                )
+            else:
+                query = query.where(Annotation.moderation_status == moderation_status)
+
+        if not include_private:
+            query = query.where(Annotation.shared.is_(True))
 
         if eager_load:
             query = query.options(*(subqueryload(prop) for prop in eager_load))
 
         return query
+
+    @staticmethod
+    def count_query(query: Select[Annotation]) -> Select[int]:
+        """Convert an annotations query into a count of annotations."""
+
+        return query.with_only_columns(func.count(Annotation.id))
 
 
 def service_factory(_context, request) -> AnnotationReadService:

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -26,6 +26,7 @@ export type ConfigObject = {
     readGroupMembers?: APIConfig;
     editGroupMember?: APIConfig;
     removeGroupMember?: APIConfig;
+    groupAnnotations?: APIConfig;
   };
   context: {
     group: Group | null;

--- a/h/views/api/group_annotations.py
+++ b/h/views/api/group_annotations.py
@@ -1,5 +1,7 @@
 from h.models import Annotation
+from h.schemas.api.group import FilterGroupAnnotationsSchema
 from h.schemas.pagination import Pagination
+from h.schemas.util import validate_query_params
 from h.security import Permission
 from h.services.annotation_read import AnnotationReadService
 from h.traversal import GroupContext
@@ -16,17 +18,13 @@ from h.views.api.config import api_config
     request_param="page[number]",
 )
 def list_annotations(context: GroupContext, request):
-    group = context.group
-
     pagination = Pagination.from_params(request.params)
+    params = validate_query_params(FilterGroupAnnotationsSchema(), request.params)
 
+    group = context.group
     annotation_json_service = request.find_service(name="annotation_json")
 
-    moderation_status_filter = (
-        Annotation.ModerationStatus(request.params.get("moderation_status").upper())
-        if request.params.get("moderation_status")
-        else None
-    )
+    moderation_status_filter = params["moderation_status"]
     query = AnnotationReadService.annotation_search_query(
         groupid=group.pubid,
         include_private=False,

--- a/h/views/api/group_annotations.py
+++ b/h/views/api/group_annotations.py
@@ -1,0 +1,50 @@
+from h.models import Annotation
+from h.schemas.pagination import PaginationQueryParamsSchema
+from h.schemas.util import validate_query_params
+from h.security import Permission
+from h.services.annotation_read import AnnotationReadService
+from h.traversal import GroupContext
+from h.views.api.config import api_config
+
+
+@api_config(
+    versions=["v1", "v2"],
+    route_name="api.group_annotations",
+    request_method="GET",
+    link_name="group.annotations.read",
+    description="Fetch a list of all annotations of a group",
+    permission=Permission.Group.MODERATE,
+    request_param="page[number]",
+)
+def list_annotations(context: GroupContext, request):
+    group = context.group
+    params = validate_query_params(PaginationQueryParamsSchema(), request.params)
+    page_number = params["page[number]"]
+    page_size = params["page[size]"]
+    offset = page_size * (page_number - 1)
+    limit = page_size
+
+    annotation_json_service = request.find_service(name="annotation_json")
+
+    moderation_status_filter = (
+        Annotation.ModerationStatus(request.params.get("moderation_status").upper())
+        if request.params.get("moderation_status")
+        else None
+    )
+    query = AnnotationReadService.annotation_search_query(
+        groupid=group.pubid,
+        include_private=False,
+        moderation_status=moderation_status_filter,
+    )
+
+    total = request.db.execute(AnnotationReadService.count_query(query)).scalar_one()
+    annotations = request.db.scalars(
+        query.order_by(Annotation.created.desc()).offset(offset).limit(limit)
+    )
+
+    annotations_dicts = [
+        annotation_json_service.present_for_user(annotation, request.user)
+        for annotation in annotations
+    ]
+
+    return {"meta": {"page": {"total": total}}, "data": annotations_dicts}

--- a/h/views/api/group_annotations.py
+++ b/h/views/api/group_annotations.py
@@ -26,9 +26,7 @@ def list_annotations(context: GroupContext, request):
 
     moderation_status_filter = params["moderation_status"]
     query = AnnotationReadService.annotation_search_query(
-        groupid=group.pubid,
-        include_private=False,
-        moderation_status=moderation_status_filter,
+        groupid=group.pubid, moderation_status=moderation_status_filter
     )
 
     total = request.db.execute(AnnotationReadService.count_query(query)).scalar_one()

--- a/h/views/api/group_members.py
+++ b/h/views/api/group_members.py
@@ -5,8 +5,7 @@ from pyramid.httpexceptions import HTTPConflict, HTTPNoContent, HTTPNotFound
 
 from h.presenters import GroupMembershipJSONPresenter
 from h.schemas.api.group_membership import EditGroupMembershipAPISchema
-from h.schemas.pagination import PaginationQueryParamsSchema
-from h.schemas.util import validate_query_params
+from h.schemas.pagination import Pagination
 from h.security import Permission
 from h.services.group_members import ConflictError
 from h.traversal import (
@@ -60,15 +59,11 @@ def list_members(context: GroupContext, request):
     group = context.group
     group_members_service = request.find_service(name="group_members")
 
-    params = validate_query_params(PaginationQueryParamsSchema(), request.params)
-    page_number = params["page[number]"]
-    page_size = params["page[size]"]
-    offset = page_size * (page_number - 1)
-    limit = page_size
+    pagination = Pagination.from_params(request.params)
 
     total = group_members_service.count_memberships(group)
     memberships = group_members_service.get_memberships(
-        group, offset=offset, limit=limit
+        group, offset=pagination.offset, limit=pagination.limit
     )
 
     membership_dicts = [

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -102,6 +102,9 @@ class GroupCreateEditController:
                         pubid=group.pubid,
                         userid=":userid",
                     ),
+                    "groupAnnotations": api_config(
+                        "api.group_annotations", "GET", pubid=group.pubid
+                    ),
                 }
             )
 

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -144,6 +144,12 @@ def test_includeme():
             factory="h.traversal.GroupRequiredRoot",
             traverse="/{id}",
         ),
+        call(
+            "api.group_annotations",
+            "/api/groups/{pubid}/annotations",
+            factory="h.traversal.GroupRequiredRoot",
+            traverse="/{pubid}",
+        ),
         call("api.profile", "/api/profile"),
         call("api.profile_groups", "/api/profile/groups"),
         call("api.debug_token", "/api/debug-token"),

--- a/tests/unit/h/schemas/api/group_test.py
+++ b/tests/unit/h/schemas/api/group_test.py
@@ -1,5 +1,7 @@
 import pytest
+from webob.multidict import MultiDict
 
+from h.models.annotation import ModerationStatus
 from h.models.group import (
     AUTHORITY_PROVIDED_ID_MAX_LENGTH,
     GROUP_DESCRIPTION_MAX_LENGTH,
@@ -9,9 +11,11 @@ from h.models.group import (
 from h.schemas import ValidationError
 from h.schemas.api.group import (
     CreateGroupAPISchema,
+    FilterGroupAnnotationsSchema,
     GroupAPISchema,
     UpdateGroupAPISchema,
 )
+from h.schemas.util import validate_query_params
 
 DEFAULT_AUTHORITY = "hypothes.is"
 
@@ -191,6 +195,26 @@ class TestGroupAPISchema:
 
         assert schema.group_authority == "thirdparty.com"
         assert schema.default_authority == DEFAULT_AUTHORITY
+
+
+class TestFilterGroupAnnotationsSchema:
+    def test_it(self, schema):
+        data = MultiDict({"moderation_status": "pending"})
+
+        validated_data = validate_query_params(schema, data)
+
+        assert validated_data == {"moderation_status": ModerationStatus.PENDING}
+
+    def test_it_when_empty(self, schema):
+        data = MultiDict({})
+
+        validated_data = validate_query_params(schema, data)
+
+        assert validated_data == {"moderation_status": None}
+
+    @pytest.fixture
+    def schema(self):
+        return FilterGroupAnnotationsSchema()
 
 
 class TestCreateGroupAPISchema:

--- a/tests/unit/h/schemas/api/group_test.py
+++ b/tests/unit/h/schemas/api/group_test.py
@@ -199,7 +199,7 @@ class TestGroupAPISchema:
 
 class TestFilterGroupAnnotationsSchema:
     def test_it(self, schema):
-        data = MultiDict({"moderation_status": "pending"})
+        data = MultiDict({"moderation_status": "PENDING"})
 
         validated_data = validate_query_params(schema, data)
 

--- a/tests/unit/h/schemas/pagination_test.py
+++ b/tests/unit/h/schemas/pagination_test.py
@@ -1,8 +1,8 @@
 import pytest
-from webob.multidict import NestedMultiDict
+from webob.multidict import MultiDict, NestedMultiDict
 
 from h.schemas import ValidationError
-from h.schemas.pagination import PaginationQueryParamsSchema
+from h.schemas.pagination import Pagination, PaginationQueryParamsSchema
 from h.schemas.util import validate_query_params
 
 
@@ -49,3 +49,19 @@ class TestPaginationQueryParamsSchema:
     @pytest.fixture
     def schema(self):
         return PaginationQueryParamsSchema()
+
+
+class TestPagination:
+    @pytest.mark.parametrize(
+        "params,expected",
+        [
+            ({"page[number]": 1, "page[size]": 20}, (0, 20)),
+            ({"page[number]": 2, "page[size]": 20}, (20, 20)),
+            ({"page[number]": 3, "page[size]": 10}, (20, 10)),
+        ],
+    )
+    def test_from_params(self, params, expected):
+        pagination = Pagination.from_params(MultiDict(params))
+
+        assert pagination.offset == expected[0]
+        assert pagination.limit == expected[1]

--- a/tests/unit/h/services/annotation_read_test.py
+++ b/tests/unit/h/services/annotation_read_test.py
@@ -54,7 +54,7 @@ class TestAnnotationReadService:
         assert not query_counter.count
 
     def test_annotation_search_by_groupid(self, factories, db_session):
-        annotation = factories.Annotation(groupid="groupid")
+        annotation = factories.Annotation(groupid="groupid", shared=True)
 
         query = AnnotationReadService.annotation_search_query(
             groupid=annotation.groupid
@@ -65,13 +65,13 @@ class TestAnnotationReadService:
     def test_annotation_search_by_moderation_status_approved(
         self, factories, db_session
     ):
-        annotation_none = factories.Annotation()
+        annotation_none = factories.Annotation(shared=True)
         annotation_approved = factories.Annotation(
-            moderation_status=ModerationStatus.APPROVED
+            shared=True, moderation_status=ModerationStatus.APPROVED
         )
 
         query = AnnotationReadService.annotation_search_query(
-            moderation_status=ModerationStatus.APPROVED
+            moderation_status=ModerationStatus.APPROVED,
         )
 
         assert set(db_session.scalars(query).all()) == {
@@ -80,7 +80,9 @@ class TestAnnotationReadService:
         }
 
     def test_annotation_search_by_moderation_status(self, factories, db_session):
-        annotation = factories.Annotation(moderation_status=ModerationStatus.DENIED)
+        annotation = factories.Annotation(
+            moderation_status=ModerationStatus.DENIED, shared=True
+        )
 
         query = AnnotationReadService.annotation_search_query(
             moderation_status=ModerationStatus.DENIED
@@ -102,7 +104,7 @@ class TestAnnotationReadService:
         factories.Annotation(shared=True)
         factories.Annotation(shared=False)
 
-        query = AnnotationReadService.annotation_search_query()
+        query = AnnotationReadService.annotation_search_query(include_private=True)
 
         assert db_session.scalar(AnnotationReadService.count_query(query)) == 2
 

--- a/tests/unit/h/views/api/group_annotations_test.py
+++ b/tests/unit/h/views/api/group_annotations_test.py
@@ -1,0 +1,72 @@
+from unittest.mock import Mock, create_autospec
+
+import pytest
+from sqlalchemy import func, select
+
+from h.models import Annotation
+from h.traversal import (
+    GroupContext,
+)
+from h.views.api.group_annotations import list_annotations
+
+
+class TestGroupAnnotations:
+    def test_it(
+        self,
+        context,
+        pyramid_request,
+        AnnotationReadService,
+        Pagination,
+        factories,
+        annotation_json_service,
+        db_session,
+    ):
+        factories.Annotation.create_batch(3)
+        db_session.flush()
+        AnnotationReadService.annotation_search_query.return_value = select(Annotation)
+        AnnotationReadService.count_query.return_value = select(
+            func.count(Annotation.id)
+        )
+        Pagination.from_params.return_value = Mock(offset=0, limit=2)
+
+        response = list_annotations(context, pyramid_request)
+
+        Pagination.from_params.assert_called_once_with(pyramid_request.params)
+        assert response == {
+            "meta": {"page": {"total": 3}},
+            "data": [
+                annotation_json_service.present_for_user.return_value,
+                annotation_json_service.present_for_user.return_value,
+            ],
+        }
+
+    @pytest.fixture
+    def context(self, factories):
+        return create_autospec(
+            GroupContext, instance=True, spec_set=True, group=factories.Group()
+        )
+
+
+@pytest.fixture(autouse=True)
+def Pagination(mocker):
+    return mocker.patch(
+        "h.views.api.group_annotations.Pagination", autospec=True, spec_set=True
+    )
+
+
+@pytest.fixture(autouse=True)
+def AnnotationReadService(mocker):
+    return mocker.patch(
+        "h.views.api.group_annotations.AnnotationReadService",
+        autospec=True,
+        spec_set=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def GroupMembershipJSONPresenter(mocker):
+    return mocker.patch(
+        "h.views.api.group_members.GroupMembershipJSONPresenter",
+        autospec=True,
+        spec_set=True,
+    )

--- a/tests/unit/h/views/groups_test.py
+++ b/tests/unit/h/views/groups_test.py
@@ -100,6 +100,13 @@ class TestGroupCreateEditController:
                         "url": pyramid_request.route_url("api.group", id=group.pubid),
                         "headers": {"X-CSRF-Token": views.get_csrf_token.spy_return},
                     },
+                    "groupAnnotations": {
+                        "method": "GET",
+                        "url": pyramid_request.route_url(
+                            "api.group_annotations", pubid=group.pubid
+                        ),
+                        "headers": {"X-CSRF-Token": views.get_csrf_token.spy_return},
+                    },
                 },
                 "context": {
                     "group": {
@@ -154,5 +161,6 @@ def routes(pyramid_config):
     pyramid_config.add_route("group_read", "/g/{pubid}/{slug}")
     pyramid_config.add_route("api.group", "/api/group/{id}")
     pyramid_config.add_route("api.group_members", "/api/groups/{pubid}/members")
+    pyramid_config.add_route("api.group_annotations", "/api/groups/{pubid}/annotations")
     pyramid_config.add_route("api.group_member", "/api/groups/{pubid}/members/{userid}")
     pyramid_config.add_route("api.groups", "/api/groups")


### PR DESCRIPTION
This endpoint will support the "moderation" tab on the group config UI.

We can't use the search API directly because we want to avoid having to reindex all annos to add moderation information. Using the DB  directly here avoid that.

The endpoint uses the json_service to present the annotations. This already includes the `moderation_status` field since https://github.com/hypothesis/h/pull/9493 was merged.


### Testing

- Using cURL, list all annos in a group:

```
curl 'http://localhost:5000/api/groups/odyKZKd1/annotations?page%5Bnumber%5D=1&page%5Bsize%5D=20' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json; charset=UTF-8' \
 0 -b 'auth=AUTH' \
  -H 'If-None-Match: "O3uKCrxCBtbzscWREJJ5Vw"' \
  -H 'Referer: http://localhost:5000/groups/odyKZKd1/edit/members' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36' \
  -H 'X-CSRF-Token: 068d53313ff848f8826fd9e929250281' \
  -H 'sec-ch-ua: "Google Chrome";v="135", "Not-A.Brand";v="8", "Chromium";v="135"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "Linux"'

```


- Test filtering by moderation_status:

```
curl 'http://localhost:5000/api/groups/odyKZKd1/annotations?page%5Bnumber%5D=1&page%5Bsize%5D=20&moderation_status='APPROVED'' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json; charset=UTF-8' \
  -b 'auth=AUTH' \
  -H 'If-None-Match: "O3uKCrxCBtbzscWREJJ5Vw"' \
  -H 'Referer: http://localhost:5000/groups/odyKZKd1/edit/members' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36' \
  -H 'X-CSRF-Token: 068d53313ff848f8826fd9e929250281' \
  -H 'sec-ch-ua: "Google Chrome";v="135", "Not-A.Brand";v="8", "Chromium";v="135"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "Linux"'
```


