### PR TITLE
Take `pre_moderated` on group creation

### DIFF
--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -68,6 +68,7 @@ def create(request):
         "userid": request.user.userid,
         "description": appstruct.get("description", None),
         "groupid": groupid,
+        "pre_moderated": appstruct.get("pre_moderated", False),
     }
 
     if group_type == "private":

--- a/tests/unit/h/views/api/groups_test.py
+++ b/tests/unit/h/views/api/groups_test.py
@@ -90,12 +90,14 @@ class TestCreate:
                     "name": sentinel.name,
                     "description": sentinel.description,
                     "type": "private",
+                    "pre_moderated": False,
                 },
                 call.create_private_group(
                     name=sentinel.name,
                     userid=sentinel.userid,
                     description=sentinel.description,
                     groupid=None,
+                    pre_moderated=False,
                 ),
             ),
             (
@@ -105,6 +107,7 @@ class TestCreate:
                     userid=sentinel.userid,
                     description=None,
                     groupid=None,
+                    pre_moderated=False,
                 ),
             ),
         ],
@@ -136,6 +139,7 @@ class TestCreate:
                     "name": sentinel.name,
                     "description": sentinel.description,
                     "type": "restricted",
+                    "pre_moderated": True,
                 },
                 call.create_restricted_group(
                     name=sentinel.name,
@@ -143,6 +147,7 @@ class TestCreate:
                     scopes=[],
                     description=sentinel.description,
                     groupid=None,
+                    pre_moderated=True,
                 ),
             ),
             (
@@ -153,6 +158,7 @@ class TestCreate:
                     scopes=[],
                     description=None,
                     groupid=None,
+                    pre_moderated=False,
                 ),
             ),
         ],
@@ -183,6 +189,7 @@ class TestCreate:
                     "name": sentinel.name,
                     "description": sentinel.description,
                     "type": "open",
+                    "pre_moderated": True,
                 },
                 call.create_open_group(
                     name=sentinel.name,
@@ -190,6 +197,7 @@ class TestCreate:
                     scopes=[],
                     description=sentinel.description,
                     groupid=None,
+                    pre_moderated=True,
                 ),
             ),
             (
@@ -200,6 +208,7 @@ class TestCreate:
                     scopes=[],
                     description=None,
                     groupid=None,
+                    pre_moderated=False,
                 ),
             ),
         ],


### PR DESCRIPTION
## Testing

- Using curl, create a new group

```
curl 'http://localhost:5000/api/groups' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json; charset=UTF-8' \
  -b 'auth=AUTH' \
  -H 'Origin: http://localhost:5000' \
  -H 'Referer: http://localhost:5000/groups/new' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36' \
  -H 'X-CSRF-Token: 068d53313ff848f8826fd9e929250281' \
  -H 'sec-ch-ua: "Google Chrome";v="135", "Not-A.Brand";v="8", "Chromium";v="135"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "Linux"' \
  --data-raw '{"name":"New group","description":"description","type":"private"}'
```

- The resulting group will have pre_moderated=False
- Repeat the test passing `pre_moderated=true` and `false`.