### PR TITLE
Add endpoint to set the moderation of an annotation

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -127,6 +127,12 @@ def includeme(config):  # noqa: PLR0915
         traverse="/{id}",
     )
     config.add_route(
+        "api.annotation_moderation",
+        "/api/annotations/{id:[A-Za-z0-9_-]{20,22}}/moderation",
+        factory="h.traversal:AnnotationRoot",
+        traverse="/{id}",
+    )
+    config.add_route(
         "api.annotation.jsonld",
         "/api/annotations/{id:[A-Za-z0-9_-]{20,22}}.jsonld",
         factory="h.traversal:AnnotationRoot",

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -1,12 +1,14 @@
 """Schema for validating API group resources."""
 
+import colander
+
 from h.i18n import TranslationString as _
 from h.models.group import (
     GROUP_DESCRIPTION_MAX_LENGTH,
     GROUP_NAME_MAX_LENGTH,
     GROUP_NAME_MIN_LENGTH,
 )
-from h.schemas.api.moderation import ModerationStatusMixin
+from h.schemas.api.moderation import ModerationStatusNode
 from h.schemas.base import JSONSchema, ValidationError
 from h.util.group import GROUPID_PATTERN, split_groupid
 
@@ -23,8 +25,10 @@ GROUP_SCHEMA_PROPERTIES = {
 }
 
 
-class FilterGroupAnnotationsSchema(ModerationStatusMixin):
+class FilterGroupAnnotationsSchema(colander.Schema):
     """Schema for validating filter-group-annotations API data."""
+
+    moderation_status = ModerationStatusNode(missing=None)
 
 
 class GroupAPISchema(JSONSchema):

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -1,14 +1,12 @@
 """Schema for validating API group resources."""
 
-import colander
-
 from h.i18n import TranslationString as _
-from h.models.annotation import ModerationStatus
 from h.models.group import (
     GROUP_DESCRIPTION_MAX_LENGTH,
     GROUP_NAME_MAX_LENGTH,
     GROUP_NAME_MIN_LENGTH,
 )
+from h.schemas.api.moderation import ModerationStatusMixin
 from h.schemas.base import JSONSchema, ValidationError
 from h.util.group import GROUPID_PATTERN, split_groupid
 
@@ -25,18 +23,8 @@ GROUP_SCHEMA_PROPERTIES = {
 }
 
 
-class FilterGroupAnnotationsSchema(colander.Schema):
-    moderation_status = colander.SchemaNode(
-        colander.String(),
-        validator=colander.OneOf(["APPROVED", "PENDING", "DENIED", "SPAM"]),
-        missing=None,
-    )
-
-    def validator(self, _node, cstruct):
-        moderation_status = cstruct.get("moderation_status")
-
-        if moderation_status:
-            cstruct["moderation_status"] = ModerationStatus(moderation_status)
+class FilterGroupAnnotationsSchema(ModerationStatusMixin):
+    """Schema for validating filter-group-annotations API data."""
 
 
 class GroupAPISchema(JSONSchema):

--- a/h/schemas/api/moderation.py
+++ b/h/schemas/api/moderation.py
@@ -1,0 +1,37 @@
+from datetime import UTC
+
+import colander
+from pyramid import httpexceptions
+
+from h.models.annotation import ModerationStatus
+
+
+class ModerationStatusNode(colander.SchemaNode):
+    schema_type = colander.String
+    validator = colander.OneOf(["APPROVED", "PENDING", "DENIED", "SPAM"])
+
+    def deserialize(self, cstruct):
+        return ModerationStatus(cstruct) if cstruct else None
+
+
+class ChangeAnnotationModerationStatusSchema(colander.Schema):
+    """Schema for validating change-annotation-moderation-status API data."""
+
+    moderation_status = ModerationStatusNode()
+    annotation_updated = colander.SchemaNode(
+        colander.DateTime(),
+        description="Sentinel value to avoid conflicting updates. It should match the current value of annotation.updated",
+    )
+
+    def __init__(self, annotation):
+        super().__init__()
+
+        self._annotation = annotation
+
+    def validator(self, _node, cstruct):
+        # Annotations are updated in the DB without timezone but they are implicitly UTC
+        annotation_updated = self._annotation.updated.replace(tzinfo=UTC).timestamp()
+        if annotation_updated != cstruct["annotation_updated"].timestamp():
+            raise httpexceptions.HTTPConflict(
+                explanation="The annotation has been updated since the moderation status was set."
+            )

--- a/h/schemas/util.py
+++ b/h/schemas/util.py
@@ -2,6 +2,7 @@ import colander
 from webob.multidict import MultiDict
 
 from h.schemas.base import ValidationError
+from h.views.api.helpers.json_payload import json_payload
 
 
 def _colander_exception_msg(exc):
@@ -46,7 +47,7 @@ def _dict_to_multidict(dict_):
     return result
 
 
-def validate_query_params(schema, params):
+def validate_query_params(schema: colander.Schema, params: MultiDict) -> MultiDict:
     """
     Validate query parameters using a Colander schema.
 
@@ -55,10 +56,7 @@ def validate_query_params(schema, params):
     a sequence.
 
     :param schema: Colander schema to validate data with.
-    :type schema: colander.Schema
     :param params: Query parameter dict, usually `request.params`.
-    :type params: webob.multidict.MultiDict
-    :rtype: webob.multidict.MultiDict
     :raises ValidationError:
     """
     param_dict = _multidict_to_dict(schema, params)
@@ -69,3 +67,20 @@ def validate_query_params(schema, params):
         raise ValidationError(_colander_exception_msg(err)) from err
 
     return _dict_to_multidict(parsed)
+
+
+def validate_json(schema: colander.Schema, request) -> dict:
+    """
+    Validate JSON data using a Colander schema.
+
+    :param schema: Colander schema to validate data with.
+    :param data: JSON data to validate.
+    :raises ValidationError:
+    """
+    data = json_payload(request)
+    try:
+        parsed = schema.deserialize(data)
+    except colander.Invalid as err:
+        raise ValidationError(_colander_exception_msg(err)) from err
+
+    return parsed

--- a/h/security/policy/_api_cookie.py
+++ b/h/security/policy/_api_cookie.py
@@ -12,6 +12,10 @@ COOKIE_AUTHENTICATABLE_API_REQUESTS = [
     ("api.group_member", "PATCH"),  # Edit group membership.
     ("api.group_member", "DELETE"),  # Remove group member.
     ("api.group_annotations", "GET"),  # List of a group's annotations.
+    (
+        "api.annotation_moderation",
+        "PATCH",
+    ),  # Change the moderation status of an annotation.
 ]
 
 

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -1,6 +1,8 @@
 from pyramid.httpexceptions import HTTPNoContent
 
 from h import events
+from h.schemas.api.moderation import ChangeAnnotationModerationStatusSchema
+from h.schemas.util import validate_query_params
 from h.security import Permission
 from h.services import AnnotationWriteService
 from h.views.api.config import api_config
@@ -40,3 +42,26 @@ def unhide(context, request):
     request.notify_after_commit(event)
 
     return HTTPNoContent()
+
+
+@api_config(
+    versions=["v1", "v2"],
+    route_name="api.annotation_moderation",
+    request_method="PATCH",
+    link_name="annotation_moderation",
+    permission=Permission.Annotation.MODERATE,
+)
+def change_annotation_moderation_status(context, request):
+    params = validate_query_params(
+        ChangeAnnotationModerationStatusSchema(), request.params
+    )
+    status = params["moderation_status"]
+    request.find_service(name="annotation_moderation").set_status(
+        context.annotation, request.user, status
+    )
+    event = events.AnnotationEvent(request, context.annotation.id, "update")
+    request.notify_after_commit(event)
+
+    return request.find_service(name="annotation_json").present_for_user(
+        annotation=context.annotation, user=request.user
+    )

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -2,7 +2,7 @@ from pyramid.httpexceptions import HTTPNoContent
 
 from h import events
 from h.schemas.api.moderation import ChangeAnnotationModerationStatusSchema
-from h.schemas.util import validate_query_params
+from h.schemas.util import validate_json
 from h.security import Permission
 from h.services import AnnotationWriteService
 from h.views.api.config import api_config
@@ -49,11 +49,10 @@ def unhide(context, request):
     route_name="api.annotation_moderation",
     request_method="PATCH",
     link_name="annotation_moderation",
-    permission=Permission.Annotation.MODERATE,
 )
 def change_annotation_moderation_status(context, request):
-    params = validate_query_params(
-        ChangeAnnotationModerationStatusSchema(), request.params
+    params = validate_json(
+        ChangeAnnotationModerationStatusSchema(context.annotation), request
     )
     status = params["moderation_status"]
     request.find_service(name="annotation_moderation").set_status(

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -123,6 +123,12 @@ def test_includeme():
             traverse="/{id}",
         ),
         call(
+            "api.annotation_moderation",
+            "/api/annotations/{id:[A-Za-z0-9_-]{20,22}}/moderation",
+            factory="h.traversal:AnnotationRoot",
+            traverse="/{id}",
+        ),
+        call(
             "api.annotation.jsonld",
             "/api/annotations/{id:[A-Za-z0-9_-]{20,22}}.jsonld",
             factory="h.traversal:AnnotationRoot",

--- a/tests/unit/h/views/api/moderation_test.py
+++ b/tests/unit/h/views/api/moderation_test.py
@@ -1,10 +1,12 @@
+from datetime import UTC, datetime
 from unittest import mock
 
 import pytest
+from pyramid import httpexceptions
 from pyramid.httpexceptions import HTTPNoContent
-from webob.multidict import MultiDict
 
 from h.models import ModerationStatus
+from h.schemas.base import ValidationError
 from h.traversal import AnnotationContext
 from h.views.api import moderation as views
 
@@ -66,8 +68,9 @@ class TestChangeAnnotationModerationStatus:
         annotation_json_service,
         events,
         annotation,
+        valid_payload,
     ):
-        pyramid_request.params = MultiDict({"moderation_status": "SPAM"})
+        pyramid_request.json_body = valid_payload
 
         response = views.change_annotation_moderation_status(
             annotation_context, pyramid_request
@@ -87,10 +90,61 @@ class TestChangeAnnotationModerationStatus:
         )
         assert response == annotation_json_service.present_for_user.return_value
 
+    @pytest.mark.parametrize(
+        "annotation_updated,message",
+        [
+            (None, "annotation_updated: Required"),
+            ("BAD DATE", "annotation_updated: Invalid date"),
+        ],
+    )
+    def test_invalid_annotation_updated(
+        self,
+        valid_payload,
+        annotation_updated,
+        message,
+        annotation_context,
+        pyramid_request,
+    ):
+        valid_payload["annotation_updated"] = annotation_updated
+        pyramid_request.json_body = valid_payload
+
+        with pytest.raises(ValidationError) as excinfo:
+            views.change_annotation_moderation_status(
+                annotation_context, pyramid_request
+            )
+
+        assert str(excinfo.value) == message
+
+    def test_outdated(
+        self,
+        valid_payload,
+        annotation_context,
+        pyramid_request,
+    ):
+        valid_payload["annotation_updated"] = "2020-10-01T12:00:00Z"
+        pyramid_request.json_body = valid_payload
+
+        with pytest.raises(httpexceptions.HTTPConflict) as excinfo:
+            views.change_annotation_moderation_status(
+                annotation_context, pyramid_request
+            )
+
+        assert (
+            str(excinfo.value)
+            == "The annotation has been updated since the moderation status was set."
+        )
+
+    @pytest.fixture
+    def valid_payload(self, annotation):
+        return {
+            "moderation_status": "SPAM",
+            "annotation_updated": annotation.updated.isoformat(),
+        }
+
 
 @pytest.fixture
 def annotation(factories):
-    return factories.Annotation()
+    return factories.Annotation(updated=datetime(2023, 10, 1, 12, 0, 0, tzinfo=UTC))
 
 
 @pytest.fixture


### PR DESCRIPTION
The endpoint will set the moderation status unconditionally.

This is required by the new moderation queue functionality.


#### Testing

- Using the new group annotations API endpoint fetch a list of a group annotations, see: https://github.com/hypothesis/h/pull/9495


- Construct a cURL command to change the annotation status, copy the annotation updated value from the API response:

```
curl  'http://localhost:5000/api/annotations/o0vd4CZxEfC4XdNMBYsOAg/moderation' -X PATCH \
  -H 'Content-Type: application/json' \
  -H 'Accept: */*' \
  -H 'x-csrf-token: TOKEN' \
  -b 'auth=AUTH' \
  --data '{"annotation_updated":"2025-05-01T09:50:08.051754+00:00", "moderation_status": "APPROVED"}'
```


- Query moderation log for example to check the changes, in `make sql`:

```select * from moderation_log`


```
id                    | 22
moderator_id          | 3
annotation_id         | a34bdde0-2671-11f0-b85d-d34c058b0e02
old_moderation_status | SPAM
new_moderation_status | APPROVED
created               | 2025-05-05 09:16:29.643943
```



