### PR TITLE
Prevent moderation status changes on stale annotations

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -132,6 +132,12 @@ def includeme(config):  # noqa: PLR0915
         factory="h.traversal:AnnotationRoot",
         traverse="/{id}",
     )
+    config.add_route(
+        "api.annotation_moderation",
+        "/api/annotations/{id:[A-Za-z0-9_-]{20,22}}/moderation",
+        factory="h.traversal:AnnotationRoot",
+        traverse="/{id}",
+    )
 
     config.add_route("api.bulk.action", "/api/bulk", request_method="POST")
     config.add_route(

--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -1,12 +1,14 @@
 """Schema for validating API group resources."""
 
+import colander
+
 from h.i18n import TranslationString as _
 from h.models.group import (
     GROUP_DESCRIPTION_MAX_LENGTH,
     GROUP_NAME_MAX_LENGTH,
     GROUP_NAME_MIN_LENGTH,
 )
-from h.schemas.api.moderation import ModerationStatusMixin
+from h.schemas.api.moderation import ModerationStatusNode
 from h.schemas.base import JSONSchema, ValidationError
 from h.util.group import GROUPID_PATTERN, split_groupid
 
@@ -23,8 +25,10 @@ GROUP_SCHEMA_PROPERTIES = {
 }
 
 
-class FilterGroupAnnotationsSchema(ModerationStatusMixin):
+class FilterGroupAnnotationsSchema(colander.Schema):
     """Schema for validating filter-group-annotations API data."""
+
+    moderation_status = ModerationStatusNode(missing=None)
 
 
 class GroupAPISchema(JSONSchema):

--- a/h/schemas/api/moderation.py
+++ b/h/schemas/api/moderation.py
@@ -1,0 +1,36 @@
+import colander
+
+from h.models.annotation import ModerationStatus
+
+
+class ModerationStatusNode(colander.SchemaNode):
+    schema_type = colander.String
+    validator = colander.OneOf(["APPROVED", "PENDING", "DENIED", "SPAM"])
+
+    def deserialize(self, cstruct):
+        return ModerationStatus(cstruct) if cstruct else None
+
+
+class ChangeAnnotationModerationStatusSchema(colander.Schema):
+    """Schema for validating change-annotation-moderation-status API data."""
+
+    moderation_status = ModerationStatusNode()
+    annotation_updated = colander.SchemaNode(
+        colander.DateTime(),
+        description="Sentinel value to avoid conflicting updates. It should be match the current value of annotation.updated",
+    )
+
+    def __init__(self, annotation):
+        super().__init__()
+
+        self._annotation = annotation
+
+    def validator(self, node, cstruct):
+        if (
+            self._annotation.updated.timestamp()
+            != cstruct["annotation_updated"].timestamp()
+        ):
+            raise colander.Invalid(
+                node.children[1],  # annotation_updated
+                "The annotation has been updated since the moderation status was set.",
+            )

--- a/h/schemas/util.py
+++ b/h/schemas/util.py
@@ -2,6 +2,7 @@ import colander
 from webob.multidict import MultiDict
 
 from h.schemas.base import ValidationError
+from h.views.api.helpers.json_payload import json_payload
 
 
 def _colander_exception_msg(exc):
@@ -46,7 +47,7 @@ def _dict_to_multidict(dict_):
     return result
 
 
-def validate_query_params(schema, params):
+def validate_query_params(schema: colander.Schema, params: MultiDict) -> MultiDict:
     """
     Validate query parameters using a Colander schema.
 
@@ -55,10 +56,7 @@ def validate_query_params(schema, params):
     a sequence.
 
     :param schema: Colander schema to validate data with.
-    :type schema: colander.Schema
     :param params: Query parameter dict, usually `request.params`.
-    :type params: webob.multidict.MultiDict
-    :rtype: webob.multidict.MultiDict
     :raises ValidationError:
     """
     param_dict = _multidict_to_dict(schema, params)
@@ -69,3 +67,20 @@ def validate_query_params(schema, params):
         raise ValidationError(_colander_exception_msg(err)) from err
 
     return _dict_to_multidict(parsed)
+
+
+def validate_json(schema: colander.Schema, request) -> dict:
+    """
+    Validate JSON data using a Colander schema.
+
+    :param schema: Colander schema to validate data with.
+    :param data: JSON data to validate.
+    :raises ValidationError:
+    """
+    data = json_payload(request)
+    try:
+        parsed = schema.deserialize(data)
+    except colander.Invalid as err:
+        raise ValidationError(_colander_exception_msg(err)) from err
+
+    return parsed

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -2,7 +2,7 @@ from pyramid.httpexceptions import HTTPNoContent
 
 from h import events
 from h.schemas.api.moderation import ChangeAnnotationModerationStatusSchema
-from h.schemas.util import validate_query_params
+from h.schemas.util import validate_json
 from h.security import Permission
 from h.services import AnnotationWriteService
 from h.views.api.config import api_config
@@ -52,8 +52,8 @@ def unhide(context, request):
     permission=Permission.Annotation.MODERATE,
 )
 def change_annotation_moderation_status(context, request):
-    params = validate_query_params(
-        ChangeAnnotationModerationStatusSchema(), request.params
+    params = validate_json(
+        ChangeAnnotationModerationStatusSchema(context.annotation), request
     )
     status = params["moderation_status"]
     request.find_service(name="annotation_moderation").set_status(

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -123,6 +123,12 @@ def test_includeme():
             traverse="/{id}",
         ),
         call(
+            "api.annotation_moderation",
+            "/api/annotations/{id:[A-Za-z0-9_-]{20,22}}/moderation",
+            factory="h.traversal:AnnotationRoot",
+            traverse="/{id}",
+        ),
+        call(
             "api.annotation.jsonld",
             "/api/annotations/{id:[A-Za-z0-9_-]{20,22}}.jsonld",
             factory="h.traversal:AnnotationRoot",


### PR DESCRIPTION
The new moderation status endpoint takes a sentinel updated date value that should match the current updated date of the annotation.