### PR TITLE
Add description to pre-moderation control in groups form

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -6,7 +6,6 @@ import {
   LockFilledIcon,
   GlobeIcon,
   GlobeLockIcon,
-  Checkbox,
 } from '@hypothesis/frontend-shared';
 import { Config } from '../config';
 import type { Group } from '../config';
@@ -27,6 +26,7 @@ import TextField from './forms/TextField';
 import GroupFormHeader from './GroupFormHeader';
 import SaveStateIcon from './SaveStateIcon';
 import WarningDialog from './WarningDialog';
+import Checkbox from './forms/Checkbox';
 
 /**
  * Dialog that warns users about existing annotations in a group being exposed
@@ -308,6 +308,7 @@ export default function CreateEditGroupForm({
                 setPreModerated((e.target as HTMLInputElement).checked);
                 setSaveState('unsaved');
               }}
+              description="Moderators must approve new annotations before they are shown to group members."
             >
               Enable pre-moderation for this group.
             </Checkbox>

--- a/h/static/scripts/group-forms/components/forms/Checkbox.tsx
+++ b/h/static/scripts/group-forms/components/forms/Checkbox.tsx
@@ -1,0 +1,43 @@
+import type { CheckboxProps as BaseCheckboxProps } from '@hypothesis/frontend-shared';
+import { Checkbox as BaseCheckbox } from '@hypothesis/frontend-shared';
+import type { ComponentChildren } from 'preact';
+import { useId } from 'preact/hooks';
+
+export type CheckboxProps = Omit<BaseCheckboxProps, 'aria-describedby'> & {
+  /**
+   * Adds a description right under the checkbox and main content, aligned with
+   * the main content's left side.
+   */
+  description?: ComponentChildren;
+};
+
+/**
+ * Render a labeled checkbox input, with an optional description underneath.
+ */
+export default function Checkbox({
+  description,
+  children,
+  ...checkboxProps
+}: CheckboxProps) {
+  const descriptionId = useId();
+
+  return (
+    <div>
+      <BaseCheckbox
+        {...checkboxProps}
+        aria-describedby={description ? descriptionId : undefined}
+      >
+        <span className="text-grey-7">{children}</span>
+      </BaseCheckbox>
+      {description && (
+        <div
+          data-testid="description"
+          id={descriptionId}
+          className="text-grey-6 mt-1 ml-5"
+        >
+          {description}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/h/static/scripts/group-forms/components/forms/test/Checkbox-test.js
+++ b/h/static/scripts/group-forms/components/forms/test/Checkbox-test.js
@@ -1,0 +1,49 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import Checkbox from '../Checkbox';
+
+describe('Checkbox', () => {
+  function createComponent(props = {}) {
+    return mount(<Checkbox {...props}>Click me</Checkbox>);
+  }
+
+  ['This is the description', undefined].forEach(description => {
+    it('shows description when provided', () => {
+      const wrapper = createComponent({ description });
+      assert.equal(
+        wrapper.exists('[data-testid="description"]'),
+        !!description,
+      );
+    });
+  });
+
+  function idFromTestId(wrapper, testId) {
+    return wrapper.find(`[data-testid="${testId}"]`).prop('id');
+  }
+
+  [
+    // No description
+    {
+      props: {},
+      getExpectedDescribedBy: () => undefined,
+    },
+    // Description
+    {
+      props: { description: 'The description' },
+      getExpectedDescribedBy: wrapper => idFromTestId(wrapper, 'description'),
+    },
+  ].forEach(({ props, getExpectedDescribedBy }) => {
+    it('describes checkbox with description element', () => {
+      const wrapper = createComponent(props);
+
+      assert.equal(
+        wrapper.find('input[type="checkbox"]').prop('aria-describedby'),
+        getExpectedDescribedBy(wrapper),
+      );
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({ content: createComponent }),
+  );
+});


### PR DESCRIPTION
Follow up after https://github.com/hypothesis/h/pull/9473, which added a control to enable pre-moderation. This PR expands with a description to better explains what the option means.

This PR also adds a reusable component which is a checkbox with label and an optional description on a lighter font color underneath.

![image](https://github.com/user-attachments/assets/ea778d0d-0ad6-461b-ba36-e7475ea8a854)
