### PR TITLE
Automatic transitions between moderation states

### DIFF
--- a/h/events.py
+++ b/h/events.py
@@ -1,7 +1,12 @@
+from typing import Literal
+
+AnnotationAction = Literal["create", "update", "delete"]
+
+
 class AnnotationEvent:
     """An event representing an action on an annotation."""
 
-    def __init__(self, request, annotation_id, action):
+    def __init__(self, request, annotation_id, action: AnnotationAction):
         self.request = request
         self.annotation_id = annotation_id
         self.action = action

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -1,6 +1,5 @@
-from h.models import Annotation, User
-from h.models.annotation import ModerationStatus
-from h.models.moderation_log import ModerationLog
+from h.events import AnnotationAction
+from h.models import Annotation, ModerationLog, ModerationStatus, User
 
 
 class AnnotationModerationService:
@@ -23,7 +22,10 @@ class AnnotationModerationService:
         return {a.id for a in query if a.is_hidden}
 
     def set_status(
-        self, annotation: Annotation, user: User, status: ModerationStatus | None
+        self,
+        annotation: Annotation,
+        status: ModerationStatus | None,
+        user: User | None = None,
     ) -> None:
         """Set the moderation status for an annotation."""
         if status and status != annotation.moderation_status:
@@ -37,12 +39,40 @@ class AnnotationModerationService:
             )
             annotation.moderation_status = status
 
-    def update_status(self, annotation: Annotation) -> None:
+    def update_status(self, action: AnnotationAction, annotation: Annotation) -> None:
+        """Change the moderation status of an annotation based on the action taken."""
+        new_status = None
+
         if not annotation.moderation_status and annotation.shared:
             # If an annotation is not private but doesn't have a moderation status
             # it means that the moderation status hasn't been migrated yet.
             # Set the default `APPROVED` status
-            annotation.moderation_status = ModerationStatus.APPROVED
+            if action == "update":
+                # If the annotation was updated we want to record this in the moderation log
+                self.set_status(annotation, ModerationStatus.APPROVED)
+            else:
+                annotation.moderation_status = ModerationStatus.APPROVED
+
+        if not annotation.shared:
+            return
+
+        pre_moderated = annotation.group.pre_moderated
+        if action == "create":
+            if pre_moderated:
+                new_status = ModerationStatus.PENDING
+            else:
+                new_status = ModerationStatus.APPROVED
+        elif action == "update":
+            if (
+                pre_moderated
+                and annotation.moderation_status == ModerationStatus.APPROVED
+            ):
+                new_status = ModerationStatus.PENDING
+
+            if annotation.moderation_status == ModerationStatus.DENIED:
+                new_status = ModerationStatus.PENDING
+
+        self.set_status(annotation, new_status)
 
 
 def annotation_moderation_service_factory(_context, request):

--- a/h/services/annotation_write.py
+++ b/h/services/annotation_write.py
@@ -80,7 +80,7 @@ class AnnotationWriteService:
             created=annotation.created,
             updated=annotation.updated,
         )
-        self._moderation_service.update_status(annotation)
+        self._moderation_service.update_status("create", annotation)
 
         self._db.add(annotation)
         self.upsert_annotation_slim(annotation)
@@ -144,7 +144,7 @@ class AnnotationWriteService:
                 document.get("document_uri_dicts", {}),
                 updated=annotation.updated,
             )
-        self._moderation_service.update_status(annotation)
+        self._moderation_service.update_status("update", annotation)
         self.upsert_annotation_slim(annotation)
 
         if annotation_metadata:
@@ -169,7 +169,7 @@ class AnnotationWriteService:
         """Hides  an annotation marking it it as "moderated"."""
         if not annotation.is_hidden:
             self._moderation_service.set_status(
-                annotation, user, Annotation.ModerationStatus.DENIED
+                annotation, Annotation.ModerationStatus.DENIED, user
             )
 
         self.upsert_annotation_slim(annotation)
@@ -177,7 +177,7 @@ class AnnotationWriteService:
     def unhide(self, annotation: Annotation, user: User):
         """Remove the moderation status of an annotation."""
         self._moderation_service.set_status(
-            annotation, user, Annotation.ModerationStatus.APPROVED
+            annotation, Annotation.ModerationStatus.APPROVED, user
         )
         self.upsert_annotation_slim(annotation)
 

--- a/tests/unit/h/services/annotation_moderation_test.py
+++ b/tests/unit/h/services/annotation_moderation_test.py
@@ -25,14 +25,14 @@ class TestAnnotationModerationService:
     def test_set_status_with_None_status_doesnt_change_it(self, svc, annotation, user):
         annotation.moderation_status = ModerationStatus.APPROVED
 
-        svc.set_status(annotation, user, None)
+        svc.set_status(annotation, None, user)
 
         assert annotation.moderation_status is ModerationStatus.APPROVED
 
     def test_set_status_with_same_status_doesnt_change_it(self, svc, annotation, user):
         annotation.moderation_status = ModerationStatus.APPROVED
 
-        svc.set_status(annotation, user, ModerationStatus.APPROVED)
+        svc.set_status(annotation, ModerationStatus.APPROVED, user)
 
         assert annotation.moderation_status is ModerationStatus.APPROVED
         assert annotation.moderation_log == []
@@ -40,7 +40,7 @@ class TestAnnotationModerationService:
     def test_set_status(self, svc, annotation, user):
         annotation.moderation_status = ModerationStatus.APPROVED
 
-        svc.set_status(annotation, user, ModerationStatus.DENIED)
+        svc.set_status(annotation, ModerationStatus.DENIED, user)
 
         assert annotation.moderation_status is ModerationStatus.DENIED
         assert annotation.moderation_log[0].annotation_id == annotation.id
@@ -56,18 +56,128 @@ class TestAnnotationModerationService:
 
     @pytest.mark.parametrize("moderation_status", [None, ModerationStatus.APPROVED])
     @pytest.mark.parametrize("shared", [False, True])
+    @pytest.mark.parametrize("action", ["create", "update"])
     def test_update_status_initializes_moderation_status(
-        self, svc, annotation, moderation_status, shared
+        self, svc, annotation, moderation_status, shared, action
     ):
         annotation.moderation_status = moderation_status
         annotation.shared = shared
 
-        svc.update_status(annotation)
+        svc.update_status(action, annotation)
 
         if not moderation_status and shared:
             assert annotation.moderation_status == ModerationStatus.APPROVED
+            if action == "create":
+                assert not annotation.moderation_log
+            else:
+                assert annotation.moderation_log
         else:
             assert annotation.moderation_status == moderation_status
+
+    @pytest.mark.parametrize(
+        "action,is_private,pre_moderation_enabled,existing_status,expected_status",
+        [
+            # When a new annotation is created:
+            # If the group has pre-moderation disabled the annotation's initial moderation state should be Approved.
+            ("create", False, False, None, ModerationStatus.APPROVED),
+            # If the group has pre-moderation enabled the annotation's initial moderation state should be Pending.
+            ("create", False, True, None, ModerationStatus.PENDING),
+            # When an Approved annotation is edited:
+            # If the group has pre-moderation disabled the moderation state doesn't change
+            (
+                "update",
+                False,
+                False,
+                ModerationStatus.APPROVED,
+                ModerationStatus.APPROVED,
+            ),
+            # If the group has pre-moderation enabled the moderation state changes to Pending
+            (
+                "update",
+                False,
+                True,
+                ModerationStatus.APPROVED,
+                ModerationStatus.PENDING,
+            ),
+            # When a Denied annotation is edited the moderation state changes to Pending
+            # (whether pre-moderation is disabled or enabled)
+            ("update", False, True, ModerationStatus.DENIED, ModerationStatus.PENDING),
+            (
+                "update",
+                False,
+                False,
+                ModerationStatus.DENIED,
+                ModerationStatus.PENDING,
+            ),
+            # When a Pending annotation is edited its moderation state doesn't change
+            # (whether pre-moderation is disabled or enabled)
+            (
+                "update",
+                False,
+                False,
+                ModerationStatus.PENDING,
+                ModerationStatus.PENDING,
+            ),
+            (
+                "update",
+                False,
+                True,
+                ModerationStatus.PENDING,
+                ModerationStatus.PENDING,
+            ),
+            # When a Spam annotation is edited its moderation state doesn't change
+            # (whether pre-moderation is disabled or enabled)
+            ("update", False, False, ModerationStatus.SPAM, ModerationStatus.SPAM),
+            ("update", False, True, ModerationStatus.SPAM, ModerationStatus.SPAM),
+            # When a new private annotation is created the annotation's initial moderation state should be NULL.
+            # This is the same whether pre-moderation is enabled or disabled.
+            ("create", True, False, None, None),
+            ("create", True, True, None, None),
+            # Editing a private annotation does not change its moderation state as long as the annotation remains private:
+            # A private annotation whose state is NULL will remain NULL if edited.
+            ("update", True, False, None, None),
+            # A private annotation whose state is Pending will remain Pending if edited.
+            (
+                "update",
+                True,
+                False,
+                ModerationStatus.PENDING,
+                ModerationStatus.PENDING,
+            ),
+            # A private annotation whose state is Approved will remain Approved if edited.
+            (
+                "update",
+                True,
+                False,
+                ModerationStatus.APPROVED,
+                ModerationStatus.APPROVED,
+            ),
+            # A private annotation whose state is Denied will remain Denied if edited.
+            ("update", True, False, ModerationStatus.DENIED, ModerationStatus.DENIED),
+            # A private annotation whose state is Spam will remain Spam if edited.
+            ("update", True, False, ModerationStatus.SPAM, ModerationStatus.SPAM),
+            # We don't change the moderation status of annotations when they are deleted
+            ("delete", False, False, ModerationStatus.SPAM, ModerationStatus.SPAM),
+        ],
+    )
+    def test_update_status(
+        self,
+        svc,
+        action,
+        is_private,
+        pre_moderation_enabled,
+        existing_status,
+        expected_status,
+        factories,
+    ):
+        group = factories.Group(pre_moderated=pre_moderation_enabled)
+        annotation = factories.Annotation(
+            moderation_status=existing_status, shared=not is_private, group=group
+        )
+
+        svc.update_status(action, annotation)
+
+        assert annotation.moderation_status == expected_status
 
     @pytest.fixture(autouse=True)
     def moderated_annotations(self, factories):

--- a/tests/unit/h/services/annotation_write_test.py
+++ b/tests/unit/h/services/annotation_write_test.py
@@ -44,7 +44,7 @@ class TestAnnotationWriteService:
             schedule_in=60,
         )
         mention_service.update_mentions.assert_called_once_with(anno)
-        moderation_service.update_status.assert_called_once_with(anno)
+        moderation_service.update_status.assert_called_once_with("create", anno)
 
         assert anno == Any.instance_of(Annotation).with_attrs(
             {
@@ -131,7 +131,7 @@ class TestAnnotationWriteService:
             {"uri": 1},
             updated=anno.updated,
         )
-        moderation_service.update_status.assert_called_once_with(anno)
+        moderation_service.update_status.assert_called_once_with("update", anno)
 
         queue_service.add_by_id.assert_called_once_with(
             "sync_annotation",
@@ -224,7 +224,7 @@ class TestAnnotationWriteService:
         svc.hide(annotation, user)
 
         moderation_service.set_status.assert_called_once_with(
-            annotation, user, Annotation.ModerationStatus.DENIED
+            annotation, Annotation.ModerationStatus.DENIED, user
         )
 
     def test_hide_does_not_modify_an_already_hidden_annotation(
@@ -240,7 +240,7 @@ class TestAnnotationWriteService:
         svc.unhide(annotation, user)
 
         moderation_service.set_status.assert_called_once_with(
-            annotation, user, Annotation.ModerationStatus.APPROVED
+            annotation, Annotation.ModerationStatus.APPROVED, user
         )
 
     def test_upsert_annotation_slim_with_deleted_group(self, annotation, svc):


### PR DESCRIPTION
Change the moderation status on annotation creation and edits based on the current status and whether or not pre moderation is enabled on the annotation's group.


### Testing

I'm doing a basic sanity check of some  cases. We should do the full suite of test once the moderation UI is ready.


- Create new private annotation

moderation_status is null

- Edit it

moderation_status remains null


- Edit the anno and make it shared (post it into a group)

moderation_status changes to approved

- Enable pre moderation on the group. This should be possible via the UI in `main`.

- Edit the annotation again. Moderation status changes to pending.

- See the log of these changes in moderation_log