### PR TITLE
Enable Sentry's "releases" feature in WebSocket

### DIFF
--- a/h/streamer/app.py
+++ b/h/streamer/app.py
@@ -1,5 +1,6 @@
 import pyramid
 
+from h._version import get_version
 from h.config import configure
 from h.security import StreamerPolicy
 from h.sentry_filters import SENTRY_FILTERS
@@ -45,6 +46,16 @@ def create_app(_global_config, **settings):
         {
             "h_pyramid_sentry.filters": SENTRY_FILTERS,
             "h_pyramid_sentry.celery_support": True,
+            # Enable Sentry's "Releases" feature, see:
+            # https://docs.sentry.io/platforms/python/configuration/options/#release
+            #
+            # h_pyramid_sentry passes any h_pyramid_sentry.init.* Pyramid settings
+            # through to sentry_sdk.init(), see:
+            # https://github.com/hypothesis/h-pyramid-sentry?tab=readme-ov-file#settings
+            #
+            # For the full list of options that sentry_sdk.init() supports see:
+            # https://docs.sentry.io/platforms/python/configuration/options/
+            "h_pyramid_sentry.init.release": get_version(),
         }
     )
 

--- a/tests/unit/h/streamer/app_test.py
+++ b/tests/unit/h/streamer/app_test.py
@@ -9,13 +9,14 @@ from h.streamer.app import create_app
 
 class TestIncludeMe:
     @pytest.mark.usefixtures("configure")
-    def test_it_configures_pyramid_sentry_plugin(self, config):
+    def test_it_configures_pyramid_sentry_plugin(self, config, get_version):
         create_app(None)
 
         config.add_settings.assert_any_call(
             {
                 "h_pyramid_sentry.filters": SENTRY_FILTERS,
                 "h_pyramid_sentry.celery_support": True,
+                "h_pyramid_sentry.init.release": get_version.return_value,
             }
         )
 
@@ -29,3 +30,8 @@ class TestIncludeMe:
         configure.return_value = config
 
         return configure
+
+
+@pytest.fixture(autouse=True)
+def get_version(patch):
+    return patch("h.streamer.app.get_version")


### PR DESCRIPTION
The releases feature is useful in itself, and this should also stop the
"discarded session update because of missing release" messages that
`sentry_sdk` is logging all the time.
