### PR TITLE
Allow nullable moderator_id on ModerationLog

### DIFF
--- a/h/migrations/versions/81a5daab8bfc_allow_null_moderator_id_on_moderationlog.py
+++ b/h/migrations/versions/81a5daab8bfc_allow_null_moderator_id_on_moderationlog.py
@@ -1,0 +1,19 @@
+"""Allow null moderator_id on ModerationLog."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "81a5daab8bfc"
+down_revision = "077e087027b1"
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "moderation_log", "moderator_id", existing_type=sa.INTEGER(), nullable=True
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "moderation_log", "moderator_id", existing_type=sa.INTEGER(), nullable=False
+    )

--- a/h/models/moderation_log.py
+++ b/h/models/moderation_log.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING, Optional
+
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import (
     Mapped,
@@ -10,17 +12,22 @@ from h.db import Base, types
 from h.db.mixins_dataclasses import AutoincrementingIntegerID, CreatedMixin
 from h.models.annotation import ModerationStatus
 
+if TYPE_CHECKING:
+    from h.models import Annotation, User
+
 
 class ModerationLog(Base, AutoincrementingIntegerID, CreatedMixin, MappedAsDataclass):
     __tablename__ = "moderation_log"
 
-    moderator_id: Mapped[int] = mapped_column(ForeignKey("user.id", ondelete="CASCADE"))
-    moderator = relationship("User")
-
-    annotation_id: Mapped[types.URLSafeUUID] = mapped_column(
-        ForeignKey("annotation.id", ondelete="CASCADE"), index=True
-    )
-    annotation = relationship("Annotation")
+    moderator: Mapped[Optional["User"]] = relationship("User")
+    annotation: Mapped["Annotation"] = relationship("Annotation")
 
     old_moderation_status: Mapped[ModerationStatus | None] = mapped_column()
     new_moderation_status: Mapped[ModerationStatus] = mapped_column()
+
+    moderator_id: Mapped[int | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), default=None
+    )
+    annotation_id: Mapped[types.URLSafeUUID] = mapped_column(
+        ForeignKey("annotation.id", ondelete="CASCADE"), index=True, default=None
+    )

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -29,10 +29,10 @@ class AnnotationModerationService:
         if status and status != annotation.moderation_status:
             self._session.add(
                 ModerationLog(
-                    annotation_id=annotation.id,
+                    annotation=annotation,
                     old_moderation_status=annotation.moderation_status,
                     new_moderation_status=status.value,
-                    moderator_id=user.id,
+                    moderator=user,
                 )
             )
             annotation.moderation_status = status


### PR DESCRIPTION
For moderation status changes that happen as a result of the annotation author creating/editing an annotation we'll keep the moderator_id as NULL.

This is opposed to moderation changes made by a moderator, for which we want to store the moderator_id.



See: https://github.com/hypothesis/h/pull/9523#discussion_r2070402139 for the main motivation for this change.