### PR TITLE
Warn when pre-moderation checkbox is changed and page is reloaded or navigated away

### DIFF
--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -109,9 +109,8 @@ export default function CreateEditGroupForm({
   const [groupType, setGroupType] = useState<GroupType>(
     group?.type ?? 'private',
   );
-  const [preModerated, setPreModerated] = useState(
-    group?.pre_moderated ?? false,
-  );
+  const initiallyPreModerated = group?.pre_moderated ?? false;
+  const [preModerated, setPreModerated] = useState(initiallyPreModerated);
 
   // Set when the user selects a new group type if confirmation is required.
   // Cleared after confirmation.
@@ -305,9 +304,10 @@ export default function CreateEditGroupForm({
             <Checkbox
               data-testid="pre-moderation"
               checked={preModerated}
-              onChange={e =>
-                setPreModerated((e.target as HTMLInputElement).checked)
-              }
+              onChange={e => {
+                setPreModerated((e.target as HTMLInputElement).checked);
+                setSaveState('unsaved');
+              }}
             >
               Enable pre-moderation for this group.
             </Checkbox>

--- a/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
@@ -90,6 +90,21 @@ describe('CreateEditGroupForm', () => {
     };
   };
 
+  const preModerationCheckbox = wrapper =>
+    wrapper.find('Checkbox[data-testid="pre-moderation"]');
+
+  const isPreModerationEnabled = wrapper =>
+    preModerationCheckbox(wrapper).prop('checked');
+
+  const changePreModerationCheckbox = (wrapper, checked) => {
+    act(() =>
+      preModerationCheckbox(wrapper).props().onChange({
+        target: { checked },
+      }),
+    );
+    wrapper.update();
+  };
+
   const createWrapper = (props = {}) => {
     const wrapper = mount(
       <Config.Provider value={config}>
@@ -226,12 +241,6 @@ describe('CreateEditGroupForm', () => {
   });
 
   describe('pre-moderation', () => {
-    const preModerationCheckbox = wrapper =>
-      wrapper.find('Checkbox[data-testid="pre-moderation"]');
-
-    const isModerationEnabled = wrapper =>
-      preModerationCheckbox(wrapper).prop('checked');
-
     [true, false].forEach(moderationEnabled => {
       it('shows pre-moderation checkbox when group moderation is enabled', () => {
         config.features.group_moderation = moderationEnabled;
@@ -248,14 +257,9 @@ describe('CreateEditGroupForm', () => {
       config.features.group_moderation = true;
       const { wrapper } = createWrapper();
 
-      assert.isFalse(isModerationEnabled(wrapper));
-      preModerationCheckbox(wrapper)
-        .props()
-        .onChange({
-          target: { checked: true },
-        });
-      wrapper.update();
-      assert.isTrue(isModerationEnabled(wrapper));
+      assert.isFalse(isPreModerationEnabled(wrapper));
+      changePreModerationCheckbox(wrapper, true);
+      assert.isTrue(isPreModerationEnabled(wrapper));
     });
   });
 
@@ -466,6 +470,15 @@ describe('CreateEditGroupForm', () => {
       act(() => warning.prop('onConfirm')());
       wrapper.update();
       assert.isFalse(savedConfirmationShowing(wrapper));
+    });
+
+    it('marks form as unsaved if pre-moderation checkbox changes', () => {
+      config.features.group_moderation = true;
+      const { wrapper } = createWrapper();
+
+      assert.isFalse(navigateWarningActive());
+      changePreModerationCheckbox(wrapper, true);
+      assert.isTrue(navigateWarningActive());
     });
   });
 


### PR DESCRIPTION
When the pre-moderation checkbox value is changed while editing a group, display a warning if the page is reloaded or the user tries to navigate somewhere else before saving the changes.

### Test steps

1. Go to http://localhost:5000/users/devdata_admin, and login as `devdata_admin` if needed.
2. Select a group from the "Groups" dropdwn. Then click "Edit group" (If there are no groups, create one and repeat steps 1 and 2).
3. Change the value of the "pre-moderation" checkbox and try to reload the page. You should be warned that there are unsaved changes.
4. Change the value again to the initial one. You should now be able to reload the page with no warnings.