### PR TITLE
Add HTTP service

### DIFF
--- a/h/services/http.py
+++ b/h/services/http.py
@@ -1,0 +1,69 @@
+from requests import RequestException, Response, Session  # noqa: A005
+
+from h.services.exceptions import ExternalRequestError
+
+HTTP_SERVICE_TIMEOUT = 10
+
+
+class HTTPService:
+    """Send HTTP requests with `requests` and receive the responses."""
+
+    def __init__(self) -> None:
+        # A session is used so that cookies are persisted across
+        # requests and urllib3 connection pooling is used (which means that
+        # underlying TCP connections are re-used when making multiple requests
+        # to the same host, e.g. pagination).
+
+        # See https://docs.python-requests.org/en/latest/user/advanced/#session-objects
+        self._session = Session()
+
+    @property
+    def session(self) -> Session:
+        return self._session
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        timeout: float | tuple[float, float] = HTTP_SERVICE_TIMEOUT,
+        **kwargs,
+    ) -> Response:
+        """
+        Send a request with `requests` and return the response object.
+
+        This method accepts the same arguments as `requests.Session.request`
+        with the same meaning which can be seen here:
+
+        https://requests.readthedocs.io/en/latest/api/#requests.Session.request
+
+        :raises ExternalRequestError: For any request-based failure or if the
+            response is an error (4xx or 5xx response).
+        """
+        response = None
+
+        try:
+            response = self._session.request(method, url, timeout=timeout, **kwargs)
+            response.raise_for_status()
+        except RequestException as err:
+            raise ExternalRequestError(request=err.request, response=response) from err
+
+        return response
+
+    def get(self, *args, **kwargs) -> Response:
+        return self.request("GET", *args, **kwargs)
+
+    def put(self, *args, **kwargs) -> Response:
+        return self.request("PUT", *args, **kwargs)
+
+    def post(self, *args, **kwargs) -> Response:
+        return self.request("POST", *args, **kwargs)
+
+    def patch(self, *args, **kwargs) -> Response:
+        return self.request("PATCH", *args, **kwargs)
+
+    def delete(self, *args, **kwargs) -> Response:
+        return self.request("DELETE", *args, **kwargs)
+
+
+def factory(_context, _request) -> HTTPService:
+    return HTTPService()

--- a/tests/unit/h/services/http_test.py
+++ b/tests/unit/h/services/http_test.py
@@ -1,0 +1,90 @@
+from unittest.mock import create_autospec, sentinel
+
+import pytest
+import requests
+from requests import RequestException
+
+from h.services.exceptions import ExternalRequestError
+from h.services.http import (
+    HTTP_SERVICE_TIMEOUT,
+    HTTPService,
+    factory,
+)
+
+
+class TestHTTPService:
+    def test_request(self, svc, passed_args):
+        response = svc.request(sentinel.method, sentinel.url, **passed_args)
+
+        svc.session.request.assert_called_once_with(
+            sentinel.method, sentinel.url, **passed_args
+        )
+        assert response == svc.session.request.return_value
+
+    @pytest.mark.parametrize("method", ["get", "put", "post", "patch", "delete"])
+    def test_convenience_methods(self, svc, method, passed_args):
+        response = getattr(svc, method.lower())(sentinel.url, **passed_args)
+
+        svc.session.request.assert_called_once_with(
+            method.upper(), sentinel.url, **passed_args
+        )
+        assert response == svc.session.request.return_value
+
+    def test_request_defaults(self, svc):
+        svc.request(sentinel.method, sentinel.url)
+
+        svc.session.request.assert_called_once_with(
+            sentinel.method, sentinel.url, timeout=HTTP_SERVICE_TIMEOUT
+        )
+
+    def test_it_raises_if_sending_the_request_fails(self, svc):
+        svc.session.request.side_effect = RequestException(
+            request=sentinel.err_request, response=sentinel.err_response
+        )
+
+        with pytest.raises(ExternalRequestError) as exc_info:
+            svc.request("GET", "https://example.com")
+
+        assert exc_info.value.request == sentinel.err_request
+        assert exc_info.value.response is None
+
+    def test_it_raises_if_the_response_is_an_error(self, svc):
+        response = svc.session.request.return_value
+        response.raise_for_status.side_effect = RequestException(
+            request=sentinel.err_request, response=sentinel.err_response
+        )
+
+        with pytest.raises(ExternalRequestError) as exc_info:
+            svc.request("GET", "https://example.com")
+
+        assert exc_info.value.request == sentinel.err_request
+        assert exc_info.value.response == response
+
+    @pytest.fixture
+    def passed_args(self):
+        return {
+            "headers": sentinel.headers,
+            "params": sentinel.params,
+            "json": sentinel.json,
+            "data": sentinel.data,
+            "auth": sentinel.auth,
+            "timeout": sentinel.timeout,
+        }
+
+    @pytest.fixture
+    def svc(self):
+        svc = HTTPService()
+        svc._session = create_autospec(requests.Session, instance=True, spec_set=True)  # noqa: SLF001
+        return svc
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, HTTPService):
+        svc = factory(sentinel.context, pyramid_request)
+
+        HTTPService.assert_called_once_with()
+        assert svc == HTTPService.return_value
+
+    @pytest.fixture(autouse=True)
+    def HTTPService(self, patch):
+        return patch("h.services.http.HTTPService")


### PR DESCRIPTION
Closes #9538 
Requires #9544
Refs https://github.com/hypothesis/h/pull/9487

Here we add HTTP service so that it's easier to make requests to outside of H.
Until now we were mostly making requests to H, but not from it to somewhere else. And now, starting with ORCID and later with other SSO providers it makes sense to have that.
Mostly follows LMS version.