### PR TITLE
Create dropdown to filter for moderation status

### DIFF
--- a/h/static/scripts/group-forms/components/GroupModeration.tsx
+++ b/h/static/scripts/group-forms/components/GroupModeration.tsx
@@ -1,5 +1,9 @@
+import { useState } from 'preact/hooks';
+
 import type { Group } from '../config';
 import GroupFormHeader from './GroupFormHeader';
+import type { ModerationStatus } from './ModerationStatusSelect';
+import ModerationStatusSelect from './ModerationStatusSelect';
 import FormContainer from './forms/FormContainer';
 
 export type GroupModerationProps = {
@@ -8,9 +12,19 @@ export type GroupModerationProps = {
 };
 
 export default function GroupModeration({ group }: GroupModerationProps) {
+  const [filterStatus, setFilterStatus] = useState<
+    ModerationStatus | undefined
+  >('pending');
+
   return (
     <FormContainer>
       <GroupFormHeader title="Moderate group" group={group} />
+      <div className="flex justify-end">
+        <ModerationStatusSelect
+          selected={filterStatus}
+          onChange={setFilterStatus}
+        />
+      </div>
       <p>Moderate group {group.name}</p>
       <p>
         <i>TODO Annotations list</i>

--- a/h/static/scripts/group-forms/components/ModerationStatusSelect.tsx
+++ b/h/static/scripts/group-forms/components/ModerationStatusSelect.tsx
@@ -1,0 +1,63 @@
+import type { IconComponent } from '@hypothesis/frontend-shared';
+import {
+  FilterIcon,
+  CautionIcon,
+  RestrictedIcon,
+  CheckAllIcon,
+  DottedCircleIcon,
+  Select,
+} from '@hypothesis/frontend-shared';
+
+export type ModerationStatus = 'pending' | 'approved' | 'denied' | 'spam';
+
+export type ModerationStatusSelectProps = {
+  selected?: ModerationStatus;
+  onChange: (status?: ModerationStatus) => void;
+};
+
+type Option = {
+  icon: IconComponent;
+  label: string;
+};
+
+const options = new Map<ModerationStatus, Option>([
+  ['pending', { label: 'Pending', icon: DottedCircleIcon }],
+  ['approved', { label: 'Approved', icon: CheckAllIcon }],
+  ['denied', { label: 'Denied', icon: RestrictedIcon }],
+  ['spam', { label: 'Spam', icon: CautionIcon }],
+]);
+
+export default function ModerationStatusSelect({
+  selected,
+  onChange,
+}: ModerationStatusSelectProps) {
+  const selectedName = selected ? options.get(selected)?.label : undefined;
+
+  return (
+    <Select
+      value={selected}
+      onChange={onChange}
+      alignListbox="right"
+      containerClasses="!w-auto"
+      aria-label="Moderation status"
+      buttonContent={
+        <div className="flex gap-x-1.5 items-center">
+          <FilterIcon />
+          {selectedName ?? 'All'}
+        </div>
+      }
+    >
+      <Select.Option value={undefined} classes="text-grey-7">
+        All
+      </Select.Option>
+      {[...options.entries()].map(([status, { label, icon: Icon }]) => (
+        <Select.Option key={status} value={status}>
+          <div className="flex gap-x-1.5 items-center text-grey-7">
+            <Icon />
+            {label}
+          </div>
+        </Select.Option>
+      ))}
+    </Select>
+  );
+}

--- a/h/static/scripts/group-forms/components/test/GroupModeration-test.js
+++ b/h/static/scripts/group-forms/components/test/GroupModeration-test.js
@@ -1,4 +1,4 @@
-import { mount } from '@hypothesis/frontend-testing';
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
 
 import GroupModeration from '../GroupModeration';
 
@@ -14,4 +14,33 @@ describe('GroupModeration', () => {
       'Moderate group',
     );
   });
+
+  describe('moderation status filter', () => {
+    it('shows pending status initially', () => {
+      const wrapper = createComponent();
+      assert.equal(
+        wrapper.find('ModerationStatusSelect').prop('selected'),
+        'pending',
+      );
+    });
+
+    ['approved', 'denied', 'spam'].forEach(newStatus => {
+      it('changes selected status on ModerationStatusSelect change', () => {
+        const wrapper = createComponent();
+
+        wrapper.find('ModerationStatusSelect').props().onChange(newStatus);
+        wrapper.update();
+
+        assert.equal(
+          wrapper.find('ModerationStatusSelect').prop('selected'),
+          newStatus,
+        );
+      });
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({ content: () => createComponent() }),
+  );
 });

--- a/h/static/scripts/group-forms/components/test/ModerationStatusSelect-test.js
+++ b/h/static/scripts/group-forms/components/test/ModerationStatusSelect-test.js
@@ -1,0 +1,63 @@
+import {
+  checkAccessibility,
+  mount,
+  waitForElement,
+} from '@hypothesis/frontend-testing';
+
+import ModerationStatusSelect from '../ModerationStatusSelect';
+
+describe('ModerationStatusSelect', () => {
+  let fakeOnChange;
+
+  beforeEach(() => {
+    fakeOnChange = sinon.stub();
+  });
+
+  function createComponent(selected) {
+    return mount(
+      <ModerationStatusSelect selected={selected} onChange={fakeOnChange} />,
+      { connected: true },
+    );
+  }
+
+  [
+    { selected: undefined, expectedText: 'All' },
+    { selected: 'pending', expectedText: 'Pending' },
+    { selected: 'approved', expectedText: 'Approved' },
+    { selected: 'denied', expectedText: 'Denied' },
+    { selected: 'spam', expectedText: 'Spam' },
+  ].forEach(({ selected, expectedText }) => {
+    it('shows selected option as button content', () => {
+      const wrapper = createComponent(selected);
+      assert.equal(wrapper.text(), expectedText);
+    });
+
+    it('calls onChange when changing selected item', () => {
+      const wrapper = createComponent();
+
+      assert.notCalled(fakeOnChange);
+      wrapper.find('Select').props().onChange(selected);
+      assert.calledWith(fakeOnChange, selected);
+    });
+  });
+
+  it('shows expected list of options', async () => {
+    const wrapper = createComponent();
+
+    // Open listbox
+    wrapper.find('button').simulate('click');
+    const options = await waitForElement(wrapper, '[role="option"]');
+
+    assert.lengthOf(options, 5);
+    assert.equal(options.at(0).text(), 'All');
+    assert.equal(options.at(1).text(), 'Pending');
+    assert.equal(options.at(2).text(), 'Approved');
+    assert.equal(options.at(3).text(), 'Denied');
+    assert.equal(options.at(4).text(), 'Spam');
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({ content: () => createComponent() }),
+  );
+});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/preset-react": "^7.26.3",
     "@babel/preset-typescript": "^7.27.0",
     "@hypothesis/frontend-build": "^4.0.0",
-    "@hypothesis/frontend-shared": "^9.1.0",
+    "@hypothesis/frontend-shared": "^9.4.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1985,15 +1985,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "@hypothesis/frontend-shared@npm:9.1.0"
+"@hypothesis/frontend-shared@npm:^9.4.0":
+  version: 9.4.0
+  resolution: "@hypothesis/frontend-shared@npm:9.4.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: 97a8590c9fa1aa7df63711a49c7b50563a65a3dfa2aa5f50ed3b7f9c33167734146afb2ad49fe7da216a4030f7a9bdb3b036059cc2258a13c74a73fc6ca9d8d3
+  checksum: 65a09edb7fae7b718909c00ccc2d2b6786b204540b93e7186af987f609b142350c9a8079d6bb67d366dff7da7a58b82c9543bc292cdf396d8a00d86c08556a94
   languageName: node
   linkType: hard
 
@@ -6736,7 +6736,7 @@ __metadata:
     "@babel/preset-react": ^7.26.3
     "@babel/preset-typescript": ^7.27.0
     "@hypothesis/frontend-build": ^4.0.0
-    "@hypothesis/frontend-shared": ^9.1.0
+    "@hypothesis/frontend-shared": ^9.4.0
     "@hypothesis/frontend-testing": ^1.6.0
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.3


### PR DESCRIPTION
Part of #9546 

This PR adds a dropdown to the group moderation page, which will be used to determine the status that should be used to filter the list of annotations to moderate. It is currently a no-op though.

This new component will likely be used also to change the moderation status on individual annotations, with a few prop API changes.

![image](https://github.com/user-attachments/assets/021fea57-38a0-4f7c-bc35-034f9218e448)

https://github.com/user-attachments/assets/bd16510e-513e-4fcb-84dc-ec97f382bec0

