### PR TITLE
Add @trivago/prettier-plugin-sort-imports to keep imports sorted

### DIFF
--- a/h/static/scripts/base/sentry.ts
+++ b/h/static/scripts/base/sentry.ts
@@ -4,7 +4,6 @@
  * Logging requires the Sentry DSN and Hypothesis version to be provided via the
  * app's settings object.
  */
-
 import * as Sentry from '@sentry/browser';
 
 export type SentryConfig = {

--- a/h/static/scripts/controllers/autosuggest-dropdown-controller.js
+++ b/h/static/scripts/controllers/autosuggest-dropdown-controller.js
@@ -1,7 +1,5 @@
 import { Controller } from '../base/controller';
-
 import { setElementState } from '../util/dom';
-
 import updateHelper from '../util/update-helpers.js';
 
 const ENTER = 13;

--- a/h/static/scripts/controllers/dropdown-menu-controller.js
+++ b/h/static/scripts/controllers/dropdown-menu-controller.js
@@ -1,5 +1,4 @@
 import { Controller } from '../base/controller';
-
 import { setElementState } from '../util/dom';
 
 /**

--- a/h/static/scripts/controllers/index.js
+++ b/h/static/scripts/controllers/index.js
@@ -8,14 +8,13 @@
  * classes for "common" controls that are useful on both the admin and
  * user-facing sites.
  */
-
 import { CharacterLimitController } from './character-limit-controller';
-import { CopyButtonController } from './copy-button-controller';
 import { ConfirmSubmitController } from './confirm-submit-controller';
+import { CopyButtonController } from './copy-button-controller';
 import { DisableOnSubmitController } from './disable-on-submit-controller';
 import { DropdownMenuController } from './dropdown-menu-controller';
-import { FormController } from './form-controller';
 import { FormCancelController } from './form-cancel-controller';
+import { FormController } from './form-controller';
 import { FormInputController } from './form-input-controller';
 import { FormSelectOnFocusController } from './form-select-onfocus-controller';
 import { InputAutofocusController } from './input-autofocus-controller';

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -4,7 +4,6 @@ import { Controller } from '../base/controller';
 import { cloneTemplate } from '../util/dom';
 import { getLozengeValues, shouldLozengify } from '../util/search-text-parser';
 import { stripMarks } from '../util/string';
-
 import { AutosuggestDropdownController } from './autosuggest-dropdown-controller';
 import { LozengeController } from './lozenge-controller';
 

--- a/h/static/scripts/group-forms/components/AppRoot.tsx
+++ b/h/static/scripts/group-forms/components/AppRoot.tsx
@@ -1,13 +1,13 @@
-import { Route, Switch } from 'wouter-preact';
 import { useMemo, useState } from 'preact/hooks';
+import { Route, Switch } from 'wouter-preact';
 
-import CreateEditGroupForm from './CreateEditGroupForm';
-import EditGroupMembersForm from './EditGroupMembersForm';
-import Router from './Router';
 import type { ConfigObject } from '../config';
 import { Config } from '../config';
 import { routes } from '../routes';
+import CreateEditGroupForm from './CreateEditGroupForm';
+import EditGroupMembersForm from './EditGroupMembersForm';
 import GroupModeration from './GroupModeration';
+import Router from './Router';
 
 export type AppRootProps = {
   config: ConfigObject;

--- a/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/group-forms/components/CreateEditGroupForm.tsx
@@ -1,5 +1,3 @@
-import { useContext, useEffect, useId, useState } from 'preact/hooks';
-
 import {
   Button,
   RadioGroup,
@@ -7,6 +5,8 @@ import {
   GlobeIcon,
   GlobeLockIcon,
 } from '@hypothesis/frontend-shared';
+import { useContext, useEffect, useId, useState } from 'preact/hooks';
+
 import { Config } from '../config';
 import type { Group } from '../config';
 import { callAPI } from '../utils/api';
@@ -19,14 +19,14 @@ import { pluralize } from '../utils/pluralize';
 import { setLocation } from '../utils/set-location';
 import { useUnsavedChanges } from '../utils/unsaved-changes';
 import ErrorNotice from './ErrorNotice';
-import FormContainer from './forms/FormContainer';
-import Star from './forms/Star';
-import Label from './forms/Label';
-import TextField from './forms/TextField';
 import GroupFormHeader from './GroupFormHeader';
 import SaveStateIcon from './SaveStateIcon';
 import WarningDialog from './WarningDialog';
 import Checkbox from './forms/Checkbox';
+import FormContainer from './forms/FormContainer';
+import Label from './forms/Label';
+import Star from './forms/Star';
+import TextField from './forms/TextField';
 
 /**
  * Dialog that warns users about existing annotations in a group being exposed

--- a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
+++ b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
@@ -13,10 +13,10 @@ import type { APIConfig, Group } from '../config';
 import type { GroupMember, GroupMembersResponse, Role } from '../utils/api';
 import { callAPI } from '../utils/api';
 import type { APIError } from '../utils/api';
-import FormContainer from './forms/FormContainer';
 import ErrorNotice from './ErrorNotice';
 import GroupFormHeader from './GroupFormHeader';
 import WarningDialog from './WarningDialog';
+import FormContainer from './forms/FormContainer';
 
 type TableColumn<Row> = {
   field: keyof Row;

--- a/h/static/scripts/group-forms/components/GroupFormHeader.tsx
+++ b/h/static/scripts/group-forms/components/GroupFormHeader.tsx
@@ -1,12 +1,12 @@
 import { Link } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
+import { useContext } from 'preact/hooks';
 import { Link as RouterLink, useRoute } from 'wouter-preact';
 
 import type { Group } from '../config';
 import { Config } from '../config';
 import { routes } from '../routes';
-import { useContext } from 'preact/hooks';
 
 type TabLinkProps = {
   href: string;

--- a/h/static/scripts/group-forms/components/GroupModeration.tsx
+++ b/h/static/scripts/group-forms/components/GroupModeration.tsx
@@ -1,5 +1,5 @@
-import GroupFormHeader from './GroupFormHeader';
 import type { Group } from '../config';
+import GroupFormHeader from './GroupFormHeader';
 import FormContainer from './forms/FormContainer';
 
 export type GroupModerationProps = {

--- a/h/static/scripts/group-forms/components/Router.tsx
+++ b/h/static/scripts/group-forms/components/Router.tsx
@@ -1,10 +1,10 @@
-import { Router as BaseRouter } from 'wouter-preact';
-import { useBrowserLocation } from 'wouter-preact/use-browser-location';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useState } from 'preact/hooks';
+import { Router as BaseRouter } from 'wouter-preact';
+import { useBrowserLocation } from 'wouter-preact/use-browser-location';
 
-import WarningDialog from './WarningDialog';
 import { hasUnsavedChanges } from '../utils/unsaved-changes';
+import WarningDialog from './WarningDialog';
 
 export type RouterProps = {
   children: ComponentChildren;

--- a/h/static/scripts/group-forms/components/forms/TextField.tsx
+++ b/h/static/scripts/group-forms/components/forms/TextField.tsx
@@ -1,5 +1,5 @@
-import { useId, useState } from 'preact/hooks';
 import { Input, Textarea } from '@hypothesis/frontend-shared';
+import { useId, useState } from 'preact/hooks';
 
 import Label from './Label';
 

--- a/h/static/scripts/group-forms/components/forms/test/Checkbox-test.js
+++ b/h/static/scripts/group-forms/components/forms/test/Checkbox-test.js
@@ -1,4 +1,5 @@
 import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+
 import Checkbox from '../Checkbox';
 
 describe('Checkbox', () => {

--- a/h/static/scripts/group-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/group-forms/components/test/AppRoot-test.js
@@ -1,8 +1,8 @@
 import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
 import { useContext } from 'preact/hooks';
 
-import { $imports, default as AppRoot } from '../AppRoot';
 import { Config } from '../../config';
+import { $imports, default as AppRoot } from '../AppRoot';
 
 describe('AppRoot', () => {
   let configContext;

--- a/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
+++ b/h/static/scripts/group-forms/components/test/CreateEditGroupForm-test.js
@@ -1,17 +1,16 @@
-import { act } from 'preact/test-utils';
 import {
   checkAccessibility,
   delay,
   mount,
   waitForElement,
 } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
 
+import { Config } from '../../config';
 import {
   $imports,
   default as CreateEditGroupForm,
 } from '../CreateEditGroupForm';
-
-import { Config } from '../../config';
 
 describe('CreateEditGroupForm', () => {
   let config;

--- a/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
+++ b/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
@@ -1,3 +1,4 @@
+import { Select } from '@hypothesis/frontend-shared';
 import {
   checkAccessibility,
   delay,
@@ -5,11 +6,10 @@ import {
   waitFor,
   waitForElement,
 } from '@hypothesis/frontend-testing';
-import { Select } from '@hypothesis/frontend-shared';
 import { act } from 'preact/test-utils';
 
-import { APIError } from '../../utils/api';
 import { Config } from '../../config';
+import { APIError } from '../../utils/api';
 import {
   $imports,
   default as EditGroupMembersForm,

--- a/h/static/scripts/group-forms/components/test/GroupFormHeader-test.js
+++ b/h/static/scripts/group-forms/components/test/GroupFormHeader-test.js
@@ -1,7 +1,7 @@
 import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
 
-import GroupFormHeader from '../GroupFormHeader';
 import { Config } from '../../config';
+import GroupFormHeader from '../GroupFormHeader';
 
 describe('GroupFormHeader', () => {
   let config;

--- a/h/static/scripts/group-forms/components/test/GroupModeration-test.js
+++ b/h/static/scripts/group-forms/components/test/GroupModeration-test.js
@@ -1,4 +1,5 @@
 import { mount } from '@hypothesis/frontend-testing';
+
 import GroupModeration from '../GroupModeration';
 
 describe('GroupModeration', () => {

--- a/h/static/scripts/group-forms/components/test/Router-test.js
+++ b/h/static/scripts/group-forms/components/test/Router-test.js
@@ -1,6 +1,6 @@
 import { mount } from '@hypothesis/frontend-testing';
-import { Link } from 'wouter-preact';
 import { act } from 'preact/test-utils';
+import { Link } from 'wouter-preact';
 
 import { $imports, default as Router } from '../Router';
 

--- a/h/static/scripts/group-forms/components/test/SaveStateIcon-test.js
+++ b/h/static/scripts/group-forms/components/test/SaveStateIcon-test.js
@@ -1,4 +1,5 @@
 import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+
 import SaveStateIcon from '../SaveStateIcon';
 
 describe('SaveStateIcon', () => {

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -1,4 +1,5 @@
 import { createContext } from 'preact';
+
 import type { GroupType } from './utils/api';
 
 export type APIConfig = {

--- a/h/static/scripts/group-forms/utils/test/unsaved-changes-test.js
+++ b/h/static/scripts/group-forms/utils/test/unsaved-changes-test.js
@@ -1,4 +1,5 @@
 import { mount } from '@hypothesis/frontend-testing';
+
 import { useUnsavedChanges, hasUnsavedChanges } from '../unsaved-changes';
 
 function TestUseUnsavedChanges({ unsaved, fakeWindow }) {

--- a/h/static/scripts/header.js
+++ b/h/static/scripts/header.js
@@ -2,7 +2,6 @@
 //
 // This should be a small script which does things like setting up flags to
 // indicate that scripting is active, send analytics events etc.
-
 import { EnvironmentFlags } from './base/environment-flags';
 
 window.envFlags = new EnvironmentFlags(document.documentElement);

--- a/h/static/scripts/post-auth.js
+++ b/h/static/scripts/post-auth.js
@@ -5,7 +5,6 @@
  * It communicates the auth code back to the web app which initiated
  * authorization.
  */
-
 import { settings } from './base/settings';
 
 const appSettings = settings(document);

--- a/h/static/scripts/tests/controllers/character-limit-controller-test.js
+++ b/h/static/scripts/tests/controllers/character-limit-controller-test.js
@@ -1,5 +1,4 @@
 import { CharacterLimitController } from '../../controllers/character-limit-controller';
-
 import * as util from './util';
 
 describe('CharacterLimitController', () => {

--- a/h/static/scripts/tests/controllers/confirm-submit-controller-test.js
+++ b/h/static/scripts/tests/controllers/confirm-submit-controller-test.js
@@ -1,5 +1,4 @@
 import { ConfirmSubmitController } from '../../controllers/confirm-submit-controller';
-
 import * as util from './util';
 
 describe('ConfirmSubmitController', () => {

--- a/h/static/scripts/tests/controllers/copy-button-controller-test.js
+++ b/h/static/scripts/tests/controllers/copy-button-controller-test.js
@@ -1,5 +1,4 @@
 import { CopyButtonController } from '../../controllers/copy-button-controller';
-
 import { setupComponent } from './util';
 
 describe('CopyButtonController', () => {

--- a/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
+++ b/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
@@ -1,5 +1,4 @@
 import { DropdownMenuController } from '../../controllers/dropdown-menu-controller';
-
 import * as util from './util';
 
 const TEMPLATE = [

--- a/h/static/scripts/tests/controllers/form-input-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-input-controller-test.js
@@ -1,5 +1,4 @@
 import { FormInputController } from '../../controllers/form-input-controller';
-
 import { setupComponent } from './util';
 
 describe('FormInputController', () => {

--- a/h/static/scripts/tests/controllers/input-autofocus-controller-test.js
+++ b/h/static/scripts/tests/controllers/input-autofocus-controller-test.js
@@ -1,5 +1,4 @@
 import { InputAutofocusController } from '../../controllers/input-autofocus-controller';
-
 import { setupComponent } from './util';
 
 /**

--- a/h/static/scripts/tests/controllers/list-input-controller-test.js
+++ b/h/static/scripts/tests/controllers/list-input-controller-test.js
@@ -1,5 +1,4 @@
 import { ListInputController } from '../../controllers/list-input-controller';
-
 import { setupComponent } from './util';
 
 describe('ListInputController', () => {

--- a/h/static/scripts/tests/controllers/lozenge-controller-test.js
+++ b/h/static/scripts/tests/controllers/lozenge-controller-test.js
@@ -1,5 +1,4 @@
 import { LozengeController } from '../../controllers/lozenge-controller';
-
 import lozengeTemplate from './lozenge-template';
 import { setupComponent } from './util';
 

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -1,5 +1,4 @@
 import { SearchBucketController } from '../../controllers/search-bucket-controller';
-
 import * as util from './util';
 
 const TEMPLATE = `<div class="js-search-bucket">

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@hypothesis/frontend-testing": "^1.6.0",
+    "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@vitest/browser": "^3.1.2",
     "@vitest/coverage-istanbul": "^3.1.2",
     "@vitest/eslint-plugin": "^1.1.43",
@@ -84,7 +85,14 @@
   "browserslist": "chrome 92, firefox 90, safari 14.1",
   "prettier": {
     "arrowParens": "avoid",
-    "singleQuote": true
+    "singleQuote": true,
+    "importOrder": [
+      "^[./]"
+    ],
+    "importOrderSeparation": true,
+    "plugins": [
+      "@trivago/prettier-plugin-sort-imports"
+    ]
   },
   "packageManager": "yarn@3.6.1"
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,5 +1,6 @@
 import { SummaryReporter } from '@hypothesis/frontend-testing/vitest';
 import { defineConfig } from 'vitest/config';
+
 import { excludeFromCoverage } from './rollup-tests.config.js';
 
 export default defineConfig({

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,6 +108,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.26.5, @babel/generator@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/generator@npm:7.27.1"
+  dependencies:
+    "@babel/parser": ^7.27.1
+    "@babel/types": ^7.27.1
+    "@jridgewell/gen-mapping": ^0.3.5
+    "@jridgewell/trace-mapping": ^0.3.25
+    jsesc: ^3.0.2
+  checksum: d5e220eb20aca1d93aef85c4c716237f84c5aab7d3ed8dfeb7060dcd73d20c593a687fe74cfb6d3dc1604ef9faff2ca24e6cfdb1af18e03e3a5f9f63a04c0bdc
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.27.0":
   version: 7.27.0
   resolution: "@babel/generator@npm:7.27.0"
@@ -118,19 +131,6 @@ __metadata:
     "@jridgewell/trace-mapping": ^0.3.25
     jsesc: ^3.0.2
   checksum: cdb6e3e8441241321192275f7a1265b6d610b44d57ae3bbb6047cb142849fd2ace1e15d5ee0685337e152f5d8760babd3ab898b6e5065e4b344006d2f0da759f
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/generator@npm:7.27.1"
-  dependencies:
-    "@babel/parser": ^7.27.1
-    "@babel/types": ^7.27.1
-    "@jridgewell/gen-mapping": ^0.3.5
-    "@jridgewell/trace-mapping": ^0.3.25
-    jsesc: ^3.0.2
-  checksum: d5e220eb20aca1d93aef85c4c716237f84c5aab7d3ed8dfeb7060dcd73d20c593a687fe74cfb6d3dc1604ef9faff2ca24e6cfdb1af18e03e3a5f9f63a04c0bdc
   languageName: node
   linkType: hard
 
@@ -574,6 +574,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 062a4e6d51553603253990c84e051ed48671a55b9d4e9caf2eff9dc888465070a0cfd288a467dbf0d99507781ea4a835b5606e32ddc0319f1b9273f913676829
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.26.7":
+  version: 7.27.2
+  resolution: "@babel/parser@npm:7.27.2"
+  dependencies:
+    "@babel/types": ^7.27.1
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 1ac70a75028f1cc10eefb10ed2d83cf700ca3e1ddb4cf556a003fc5c4ca53ae83350bbb8065020fcc70d476fcf7bf1c17191b72384f719614ae18397142289cf
   languageName: node
   linkType: hard
 
@@ -1569,7 +1580,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.27.1":
+"@babel/traverse@npm:^7.26.7, @babel/traverse@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/traverse@npm:7.27.1"
   dependencies:
@@ -1615,7 +1626,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.27.1":
+"@babel/types@npm:^7.26.7, @babel/types@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/types@npm:7.27.1"
   dependencies:
@@ -2820,6 +2831,32 @@ __metadata:
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
   checksum: ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
+  languageName: node
+  linkType: hard
+
+"@trivago/prettier-plugin-sort-imports@npm:^5.2.2":
+  version: 5.2.2
+  resolution: "@trivago/prettier-plugin-sort-imports@npm:5.2.2"
+  dependencies:
+    "@babel/generator": ^7.26.5
+    "@babel/parser": ^7.26.7
+    "@babel/traverse": ^7.26.7
+    "@babel/types": ^7.26.7
+    javascript-natural-sort: ^0.7.1
+    lodash: ^4.17.21
+  peerDependencies:
+    "@vue/compiler-sfc": 3.x
+    prettier: 2.x - 3.x
+    prettier-plugin-svelte: 3.x
+    svelte: 4.x || 5.x
+  peerDependenciesMeta:
+    "@vue/compiler-sfc":
+      optional: true
+    prettier-plugin-svelte:
+      optional: true
+    svelte:
+      optional: true
+  checksum: c409bdcbaf8f6efed1e2f5d75523b63ad4b1e7c8a0780774a0ef04288e1f7579879a8ce26f9f626452399e09a92e093e0713709ddfd2234476d9004bf27920b8
   languageName: node
   linkType: hard
 
@@ -6706,6 +6743,7 @@ __metadata:
     "@rollup/plugin-node-resolve": ^16.0.1
     "@rollup/plugin-terser": ^0.4.4
     "@sentry/browser": ^8.51.0
+    "@trivago/prettier-plugin-sort-imports": ^5.2.2
     "@vitest/browser": ^3.1.2
     "@vitest/coverage-istanbul": ^3.1.2
     "@vitest/eslint-plugin": ^1.1.43
@@ -7763,6 +7801,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"javascript-natural-sort@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "javascript-natural-sort@npm:0.7.1"
+  checksum: 161e2c512cc7884bc055a582c6645d9032cab88497a76123d73cb23bfb03d97a04cf7772ecdb8bd3366fc07192c2f996366f479f725c23ef073fffe03d6a586a
+  languageName: node
+  linkType: hard
+
 "jiti@npm:^1.21.6":
   version: 1.21.6
   resolution: "jiti@npm:1.21.6"
@@ -8028,6 +8073,13 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
+  languageName: node
+  linkType: hard
+
+"lodash@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash@npm:4.17.21"
+  checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
During the review of another PR we realized this project was missing `@trivago/prettier-plugin-sort-imports`, that we use in other projects to keep a consistent list of imports.

This PR adds it as a dev dependency, enables it and fixes the formatting in all files.