### PR TITLE
Don't make page a required parameter to list group annotations

### DIFF
--- a/h/views/api/group_annotations.py
+++ b/h/views/api/group_annotations.py
@@ -15,7 +15,6 @@ from h.views.api.config import api_config
     link_name="group.annotations.read",
     description="Fetch a list of all annotations of a group",
     permission=Permission.Group.MODERATE,
-    request_param="page[number]",
 )
 def list_annotations(context: GroupContext, request):
     pagination = Pagination.from_params(request.params)


### PR DESCRIPTION
This copied over from the membership list endpoint, which uses the presence of the page parameters to determine if we are using the new or the legacy endpoint.