### PR TITLE
Load group annotations in the moderation queue

### DIFF
--- a/h/static/scripts/group-forms/components/GroupModeration.tsx
+++ b/h/static/scripts/group-forms/components/GroupModeration.tsx
@@ -1,10 +1,71 @@
+import { Spinner } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
 import { useState } from 'preact/hooks';
 
 import type { Group } from '../config';
+import { useGroupAnnotations } from '../hooks/use-group-annotations';
+import type { APIAnnotationData } from '../utils/api';
 import GroupFormHeader from './GroupFormHeader';
 import type { ModerationStatus } from './ModerationStatusSelect';
 import ModerationStatusSelect from './ModerationStatusSelect';
 import FormContainer from './forms/FormContainer';
+
+type AnnotationListProps = {
+  filterStatus?: ModerationStatus;
+  classes?: string | string[];
+};
+
+function AnnotationList({ filterStatus, classes }: AnnotationListProps) {
+  const { loading, annotations } = useGroupAnnotations({ filterStatus });
+
+  return (
+    <section className={classnames('flex flex-col gap-y-2', classes)}>
+      <AnnotationListContent
+        loading={loading}
+        annotations={annotations}
+        filterStatus={filterStatus}
+      />
+    </section>
+  );
+}
+
+type AnnotationListContentProps = AnnotationListProps & {
+  loading: boolean;
+  annotations: APIAnnotationData[];
+};
+
+function AnnotationListContent({
+  loading,
+  annotations,
+  filterStatus,
+}: AnnotationListContentProps) {
+  if (loading) {
+    return (
+      <div className="mx-auto">
+        <Spinner size="md" />
+      </div>
+    );
+  }
+
+  if (annotations.length === 0) {
+    return (
+      <div
+        className="border rounded p-2 text-center"
+        data-testid="annotations-fallback-message"
+      >
+        {filterStatus === 'PENDING'
+          ? 'You are all set!'
+          : 'No annotations found for selected status'}
+      </div>
+    );
+  }
+
+  return annotations.map(anno => (
+    <article key={anno.id} className="border rounded p-2">
+      {anno.text}
+    </article>
+  ));
+}
 
 export type GroupModerationProps = {
   /** The group to be moderated */
@@ -15,7 +76,6 @@ export default function GroupModeration({ group }: GroupModerationProps) {
   const [filterStatus, setFilterStatus] = useState<
     ModerationStatus | undefined
   >('PENDING');
-
   return (
     <FormContainer>
       <GroupFormHeader title="Moderate group" group={group} />
@@ -25,10 +85,7 @@ export default function GroupModeration({ group }: GroupModerationProps) {
           onChange={setFilterStatus}
         />
       </div>
-      <p>Moderate group {group.name}</p>
-      <p>
-        <i>TODO Annotations list</i>
-      </p>
+      <AnnotationList filterStatus={filterStatus} classes="mt-4" />
     </FormContainer>
   );
 }

--- a/h/static/scripts/group-forms/hooks/test/use-group-annotations-test.js
+++ b/h/static/scripts/group-forms/hooks/test/use-group-annotations-test.js
@@ -1,0 +1,95 @@
+import { mount, waitFor } from '@hypothesis/frontend-testing';
+
+import { Config } from '../../config';
+import { useGroupAnnotations, $imports } from '../use-group-annotations';
+
+describe('useGroupAnnotations', () => {
+  let fakeConfig;
+  let fakeFetchGroupAnnotations;
+  let lastGroupAnnotations;
+
+  beforeEach(() => {
+    fakeConfig = {
+      api: {
+        groupAnnotations: {},
+      },
+    };
+    fakeFetchGroupAnnotations = sinon.stub().resolves([]);
+    lastGroupAnnotations = undefined;
+
+    $imports.$mock({
+      '../utils/api/fetch-group-annotations': {
+        fetchGroupAnnotations: fakeFetchGroupAnnotations,
+      },
+    });
+  });
+
+  function TestComponent({ filterStatus }) {
+    lastGroupAnnotations = useGroupAnnotations({ filterStatus });
+  }
+
+  function createComponent(filterStatus) {
+    mount(
+      <Config.Provider value={fakeConfig}>
+        <TestComponent filterStatus={filterStatus} />
+      </Config.Provider>,
+    );
+  }
+
+  [null, { api: {} }].forEach(config => {
+    it('throws if groupAnnotations API info is not available', () => {
+      fakeConfig = config;
+      let error;
+
+      try {
+        createComponent();
+      } catch (e) {
+        error = e;
+      }
+
+      assert.equal(error?.message, 'groupAnnotations API config missing');
+    });
+  });
+
+  ['PENDING', 'APPROVED', 'DENIED', 'SPAM'].forEach(moderationStatus => {
+    it('sets error when fetchGroupAnnotations rejects', async () => {
+      const errorMessage = 'Something went wrong';
+      fakeFetchGroupAnnotations.rejects(new Error(errorMessage));
+
+      createComponent(moderationStatus);
+
+      assert.calledWith(
+        fakeFetchGroupAnnotations,
+        {},
+        sinon.match({ moderationStatus }),
+      );
+
+      await waitFor(() => lastGroupAnnotations.error === errorMessage);
+      assert.isFalse(lastGroupAnnotations.loading);
+    });
+  });
+
+  it('sets loading before starting to fetch annotations', async () => {
+    createComponent();
+
+    // Loading is initially true, and eventually it is set to false
+    assert.isTrue(lastGroupAnnotations.loading);
+    await waitFor(() => !lastGroupAnnotations.loading);
+  });
+
+  const arrayOfSize = size => Array.from({ length: size }, () => ({}));
+
+  [arrayOfSize(5), arrayOfSize(50), arrayOfSize(1)].forEach(annotations => {
+    it('sets annotations as resolved by fetchGroupAnnotations', async () => {
+      fakeFetchGroupAnnotations.resolves(annotations);
+      createComponent();
+
+      // The amount of annotations is initially 0, and then eventually changes
+      // to the loaded ones
+      assert.lengthOf(lastGroupAnnotations.annotations, 0);
+      await waitFor(
+        () => lastGroupAnnotations.annotations.length === annotations.length,
+      );
+    });
+  });
+});

--- a/h/static/scripts/group-forms/hooks/use-group-annotations.tsx
+++ b/h/static/scripts/group-forms/hooks/use-group-annotations.tsx
@@ -1,0 +1,45 @@
+import { useContext, useEffect, useState } from 'preact/hooks';
+
+import type { ModerationStatus } from '../components/ModerationStatusSelect';
+import { Config } from '../config';
+import type { APIAnnotationData } from '../utils/api';
+import { fetchGroupAnnotations } from '../utils/api/fetch-group-annotations';
+
+export type GroupAnnotationsOptions = {
+  filterStatus?: ModerationStatus;
+};
+
+export type GroupAnnotationsResult = {
+  loading: boolean;
+  error?: string;
+  annotations: APIAnnotationData[];
+};
+
+export function useGroupAnnotations({
+  filterStatus,
+}: GroupAnnotationsOptions): GroupAnnotationsResult {
+  const config = useContext(Config);
+  const [annotations, setAnnotations] = useState<APIAnnotationData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    if (!config?.api.groupAnnotations) {
+      throw new Error('groupAnnotations API config missing');
+    }
+    const abort = new AbortController();
+
+    setLoading(true);
+    fetchGroupAnnotations(config.api.groupAnnotations, {
+      signal: abort.signal,
+      moderationStatus: filterStatus,
+    })
+      .then(setAnnotations)
+      .catch((e: any) => setError(e.message))
+      .finally(() => setLoading(false));
+
+    return () => abort.abort();
+  }, [config?.api.groupAnnotations, filterStatus]);
+
+  return { annotations, loading, error };
+}

--- a/h/static/scripts/group-forms/utils/api/fetch-group-annotations.ts
+++ b/h/static/scripts/group-forms/utils/api/fetch-group-annotations.ts
@@ -1,0 +1,32 @@
+import type { APIAnnotationData, GroupAnnotationsResponse } from '.';
+import { callAPI, paginationToParams } from '.';
+import type { ModerationStatus } from '../../components/ModerationStatusSelect';
+import type { APIConfig } from '../../config';
+
+export type FetchGroupAnnotationsOptions = {
+  signal: AbortSignal;
+  pageNumber?: number;
+  moderationStatus?: ModerationStatus;
+};
+
+export async function fetchGroupAnnotations(
+  { url, headers, method }: APIConfig,
+  { signal, pageNumber = 1, moderationStatus }: FetchGroupAnnotationsOptions,
+): Promise<APIAnnotationData[]> {
+  const query: Record<string, string | number> = paginationToParams({
+    pageNumber,
+    pageSize: 20,
+  });
+  if (moderationStatus) {
+    query.moderation_status = moderationStatus;
+  }
+
+  const resp = await callAPI<GroupAnnotationsResponse>(url, {
+    headers,
+    method,
+    query,
+    signal,
+  });
+
+  return resp.data;
+}

--- a/h/static/scripts/group-forms/utils/api/index.ts
+++ b/h/static/scripts/group-forms/utils/api/index.ts
@@ -65,6 +65,20 @@ export type PaginatedResponse<Item> = {
  */
 export type GroupMembersResponse = PaginatedResponse<GroupMember>;
 
+/**
+ * Represents an annotation as returned by the h API.
+ * API docs: https://h.readthedocs.io/en/latest/api-reference/#tag/annotations
+ */
+export type APIAnnotationData = {
+  id?: string;
+  text: string;
+};
+
+/**
+ * Response to group annotations API
+ */
+export type GroupAnnotationsResponse = PaginatedResponse<APIAnnotationData>;
+
 /** An error response from the h API:
  * https://h.readthedocs.io/en/latest/api-reference/v2/#section/Hypothesis-API/Errors
  */

--- a/h/static/scripts/group-forms/utils/api/test/api-test.js
+++ b/h/static/scripts/group-forms/utils/api/test/api-test.js
@@ -1,4 +1,4 @@
-import { callAPI, APIError, paginationToParams } from '../api';
+import { callAPI, APIError, paginationToParams } from '..';
 
 describe('callAPI', () => {
   const url = 'https://api.example.com/foo';

--- a/h/static/scripts/group-forms/utils/api/test/fetch-group-annotations-test.js
+++ b/h/static/scripts/group-forms/utils/api/test/fetch-group-annotations-test.js
@@ -1,0 +1,68 @@
+import { fetchGroupAnnotations, $imports } from '../fetch-group-annotations';
+
+describe('fetch-group-annotations', () => {
+  let fakeCallAPI;
+
+  beforeEach(() => {
+    fakeCallAPI = sinon.stub().resolves({ data: [] });
+
+    $imports.$mock({
+      '.': {
+        callAPI: fakeCallAPI,
+      },
+    });
+  });
+
+  [
+    {
+      pageNumber: 10,
+      moderationStatus: 'APPROVED',
+      expectedQuery: {
+        'page[number]': 10,
+        'page[size]': 20,
+        moderation_status: 'APPROVED',
+      },
+    },
+    {
+      moderationStatus: 'SPAM',
+      expectedQuery: {
+        'page[number]': 1,
+        'page[size]': 20,
+        moderation_status: 'SPAM',
+      },
+    },
+    {
+      pageNumber: 5,
+      expectedQuery: {
+        'page[number]': 5,
+        'page[size]': 20,
+      },
+    },
+    {
+      expectedQuery: {
+        'page[number]': 1,
+        'page[size]': 20,
+      },
+    },
+  ].forEach(({ pageNumber = 1, moderationStatus, expectedQuery }) => {
+    it('calls API with expected parameters', async () => {
+      const { signal } = new AbortController();
+
+      await fetchGroupAnnotations(
+        {
+          url: '/api/groups/abc123/annotations',
+          method: 'GET',
+          headers: {},
+        },
+        { signal, pageNumber, moderationStatus },
+      );
+
+      assert.calledWith(fakeCallAPI, '/api/groups/abc123/annotations', {
+        signal,
+        query: expectedQuery,
+        method: 'GET',
+        headers: {},
+      });
+    });
+  });
+});


### PR DESCRIPTION
Part of #9545 

This PR adds the basic logic to load the annotations for the active group in the moderation tab, filtering by selected status.

This PR does not cover the next topics, that will be addressed separately:

1. Load more than one page. Only the first one is loaded.
2. Style annotation cards properly, and indicate their moderation status. This just renders annotations text unprocessed as a placeholder.
3. Allow annotations statuses to be changed.
4. Display errors produced while loading annotations.

https://github.com/user-attachments/assets/74ef605f-2725-4e60-b30f-1c9b825d3964

> The screen recording above has been captured using network throttling, so that the loading state was obvious.

### Testing steps

1. Create some annotations in one group.
2. Go to http://localhost:5000/users/devdata_admin and login as `devdata_admin` if needed.
3. Select the group where the annotations were created from the dropdown.
5. Click "Edit group".
6. Click on the "Moderation" tab.
7. You should see the annotations which status is "Pending", or a message on the lines of "You are all set" if none exist.
8. Change the moderation status. The annotations should be reloaded to match selection.

### TODO

- [x] Add tests