### PR TITLE
Generalize query concept in callAPI helper

### DIFF
--- a/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
+++ b/h/static/scripts/group-forms/components/EditGroupMembersForm.tsx
@@ -10,9 +10,14 @@ import { useCallback, useContext, useEffect, useState } from 'preact/hooks';
 
 import { Config } from '../config';
 import type { APIConfig, Group } from '../config';
-import type { GroupMember, GroupMembersResponse, Role } from '../utils/api';
+import { paginationToParams } from '../utils/api';
 import { callAPI } from '../utils/api';
-import type { APIError } from '../utils/api';
+import type {
+  APIError,
+  GroupMember,
+  GroupMembersResponse,
+  Role,
+} from '../utils/api';
 import ErrorNotice from './ErrorNotice';
 import GroupFormHeader from './GroupFormHeader';
 import WarningDialog from './WarningDialog';
@@ -90,11 +95,11 @@ async function fetchMembers(
 ): Promise<{ total: number; members: MemberRow[] }> {
   const { pageNumber, pageSize, signal } = options;
   const { url, method, headers } = api;
+  const query = paginationToParams({ pageNumber, pageSize });
   const { meta, data }: GroupMembersResponse = await callAPI(url, {
     headers,
-    pageSize,
+    query,
     method,
-    pageNumber,
     signal,
   });
 

--- a/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
+++ b/h/static/scripts/group-forms/components/test/EditGroupMembersForm-test.js
@@ -309,8 +309,10 @@ describe('EditGroupMembersForm', () => {
       fakeCallAPI,
       '/api/groups/1234/members',
       sinon.match({
-        pageNumber: 2,
-        pageSize: pageSize,
+        query: {
+          'page[number]': 2,
+          'page[size]': pageSize,
+        },
       }),
     );
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/h/issues/9545

This PR removes the `pageNumber` and `pageSize` options from the `callAPI` function, and replaces it with a more generic `query` record option.

The concept of a query is going to be needed anyway, and keeping multiple ways to pass query parameters makes it more complex to consolidate what ends up being sent, in case the same parameter is passed in more than one way.

The logic to convert `pageNumber` and `pageSize` into what the server expects is still useful, so I have provided a helper function that creates a query record from those values, avoiding the need to duplicate the same logic over and over, and centralizing the business logic in one place.