### PR TITLE
Connect an ORCID to an existing hypothesis account

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -142,6 +142,11 @@ def configure(environ=None, settings=None):  # noqa: PLR0915
         "mailchimp_user_actions_subaccount", "MAILCHIMP_USER_ACTIONS_SUBACCOUNT"
     )
 
+    # ORCID settings
+    settings_manager.set("orcid_host", "ORCID_HOST")
+    settings_manager.set("orcid_client_id", "ORCID_CLIENT_ID")
+    settings_manager.set("orcid_client_secret", "ORCID_CLIENT_SECRET")
+
     settings_manager.set(
         "h_api_auth_cookie_secret_key",
         "H_API_AUTH_COOKIE_SECRET_KEY",

--- a/h/routes.py
+++ b/h/routes.py
@@ -292,3 +292,7 @@ def includeme(config):  # noqa: PLR0915
     config.add_route(
         "wordpress-plugin", "https://wordpress.org/plugins/hypothesis/", static=True
     )
+
+    # ORCID
+    config.add_route("orcid.oauth.authorize", "/orcid/oauth/authorize")
+    config.add_route("orcid.oauth.callback", "/orcid/oauth/callback")

--- a/h/services/exceptions.py
+++ b/h/services/exceptions.py
@@ -41,6 +41,11 @@ class ExternalRequestError(Exception):
         return self._response
 
     @property
+    def validation_errors(self) -> dict[str, str] | None:
+        """Return the validation errors."""
+        return self._validation_errors
+
+    @property
     def url(self) -> str | None:
         """Return the request's URL."""
         return getattr(self._request, "url", None)

--- a/h/services/jwt.py
+++ b/h/services/jwt.py
@@ -6,9 +6,11 @@ import jwt
 from jwt import PyJWKClient
 from jwt.exceptions import PyJWTError
 
-from h.schemas import ValidationError
-
 JWK_CLIENT_TIMEOUT = 10
+
+
+class TokenValidationError(Exception):
+    """Decoding or validating a JWT failed."""
 
 
 class JWTService:
@@ -21,11 +23,11 @@ class JWTService:
             unverified_payload = jwt.decode(token, options={"verify_signature": False})
         except PyJWTError as err:
             msg = "Invalid JWT {err}"
-            raise ValidationError(msg) from err
+            raise TokenValidationError(msg) from err
 
         if not unverified_header.get("kid"):
             msg = "Missing 'kid' value in JWT header"
-            raise ValidationError(msg)
+            raise TokenValidationError(msg)
 
         alg = unverified_header["alg"]
         iss, aud = unverified_payload.get("iss"), unverified_payload.get("aud")
@@ -44,7 +46,7 @@ class JWTService:
             )
         except PyJWTError as err:
             msg = f"Invalid JWT for: {iss}, {aud}. {err}"
-            raise ValidationError(msg) from err
+            raise TokenValidationError(msg) from err
 
     @staticmethod
     @lru_cache(maxsize=256)

--- a/h/services/openid_client.py
+++ b/h/services/openid_client.py
@@ -2,19 +2,9 @@ import logging
 from typing import Any
 
 from h.schemas.oauth import OpenIDTokenData, RetrieveOpenIDTokenSchema
-from h.services.http import ExternalRequestError, HTTPService
+from h.services.http import HTTPService
 
 logger = logging.getLogger(__name__)
-
-
-class OpenIDTokenError(ExternalRequestError):
-    """
-    A problem with an Open ID token for an external API.
-
-    This is raised when we don't have an access token for the current user or
-    when our access token doesn't work (e.g. because it's expired or been
-    revoked).
-    """
 
 
 class OpenIDClientService:

--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -8,6 +8,21 @@
     {{ email_form }}
     {{ password_form }}
   </div>
+
+  {% if log_in_with_orcid %}
+    {% if orcid %}
+      <h3>{% trans %} ORCiD connected{% endtrans %}: <a href="{{ orcid_url }}" target="_blank">{{ orcid }}</a></h3>
+    {% else %}
+      <a class="btn" style="display: inline-flex;" href="{{ request.route_path('orcid.oauth.authorize') }}">
+        {% trans %} Connect with ORCiD {% endtrans %}
+      </a>
+      <p class="text">
+        {% trans %}
+          Connecting your ORCiD enables you to log in to Hypothesis with ORCiD, instead of your Hypothesis password.
+        {% endtrans %}
+      </p>
+    {% endif %}
+  {% endif %}
 {% endblock page_content %}
 
 {% block form_footer_right %}

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -29,7 +29,7 @@ from h.schemas.forms.accounts import (
     ResetCode,
     ResetPasswordSchema,
 )
-from h.services import SubscriptionService
+from h.services import ORCIDClientService, SubscriptionService
 from h.services.email import TaskData
 from h.tasks import email
 from h.util.view import json_view
@@ -467,10 +467,22 @@ class AccountController:
         password_form = self.forms["password"].render()
         email_form = self.forms["email"].render({"email": email})
 
+        feature_service = self.request.find_service(name="feature")
+        log_in_with_orcid = feature_service.enabled("log_in_with_orcid")
+        orcid = orcid_url = None
+        if log_in_with_orcid:
+            orcid_client = self.request.find_service(ORCIDClientService)
+            orcid_identity = orcid_client.get_identity(self.request.user)
+            orcid = orcid_identity.provider_unique_id if orcid_identity else None
+            orcid_url = orcid_client.orcid_url(orcid)
+
         return {
             "email": email,
             "email_form": email_form,
             "password_form": password_form,
+            "log_in_with_orcid": log_in_with_orcid,
+            "orcid": orcid,
+            "orcid_url": orcid_url,
         }
 
 

--- a/h/views/api/orcid.py
+++ b/h/views/api/orcid.py
@@ -1,0 +1,167 @@
+import logging
+from urllib.parse import urlencode, urlunparse
+
+import sentry_sdk
+from h_pyramid_sentry import report_exception
+from pyramid.httpexceptions import HTTPFound, HTTPUnauthorized
+from pyramid.request import Request
+from pyramid.view import (
+    exception_view_config,
+    notfound_view_config,
+    view_config,
+    view_defaults,
+)
+
+from h import i18n
+from h.models.user_identity import IdentityProvider
+from h.schemas import ValidationError
+from h.schemas.oauth import RetrieveOAuthCallbackSchema
+from h.services import ORCIDClientService
+from h.services.exceptions import ExternalRequestError
+from h.services.jwt import TokenValidationError
+
+_ = i18n.TranslationString
+
+logger = logging.getLogger(__name__)
+
+
+@view_defaults(request_method="GET", route_name="orcid.oauth.authorize")
+class AuthorizeViews:
+    def __init__(self, request: Request) -> None:
+        self._request = request
+
+    @view_config(is_authenticated=True)
+    def authorize(self):
+        host = self._request.registry.settings["orcid_host"]
+        client_id = self._request.registry.settings["orcid_client_id"]
+        state = RetrieveOAuthCallbackSchema(self._request).state_param()
+
+        params = {
+            "client_id": client_id,
+            "response_type": "code",
+            "redirect_uri": self._request.route_url("orcid.oauth.callback"),
+            "state": state,
+            "scope": "openid",
+        }
+        return HTTPFound(
+            location=urlunparse(
+                (
+                    "https",
+                    host,
+                    "oauth/authorize",
+                    "",
+                    urlencode(params),
+                    "",
+                )
+            )
+        )
+
+    @notfound_view_config()
+    def notfound(self):
+        return HTTPUnauthorized()
+
+
+class AccessDeniedError(Exception):
+    """The user denied us access to their ORCID account."""
+
+
+class UserConflictError(Exception):
+    """A different Hypothesis user is already connected to this ORCiD."""
+
+
+@view_defaults(request_method="GET", route_name="orcid.oauth.callback")
+class CallbackViews:
+    def __init__(self, request: Request) -> None:
+        self._request = request
+        self._orcid_client = request.find_service(ORCIDClientService)
+        self._user_service = request.find_service(name="user")
+
+    @view_config(is_authenticated=True)
+    def callback(self):
+        try:
+            callback_data = RetrieveOAuthCallbackSchema(self._request).validate(
+                dict(self._request.params)
+            )
+        except ValidationError as err:
+            if self._request.params.get("error") == "access_denied":
+                # The user clicked the deny button on ORCID's page.
+                raise AccessDeniedError from err
+
+            # We received an invalid or unexpected redirect from ORCID.
+            raise
+
+        orcid = self._orcid_client.get_orcid(callback_data["code"])
+
+        already_connected_user = self._user_service.fetch_by_identity(
+            IdentityProvider.ORCID, orcid
+        )
+
+        # Oops, this ORCiD is already connected to a *different* Hypothesis
+        # account.
+        if already_connected_user and already_connected_user != self._request.user:
+            raise UserConflictError
+
+        if not already_connected_user:
+            # This ORCiD isn't connected to a Hypothesis account yet.
+            # Let's go ahead and connect it to the user's account.
+            self._orcid_client.add_identity(self._request.user, orcid)
+
+        self._request.session.flash(
+            "You can now use your ORCiD to log in to Hypothesis.", "success"
+        )
+        return HTTPFound(location=self._request.route_url("account"))
+
+    @notfound_view_config()
+    def notfound(self):
+        return HTTPUnauthorized()
+
+    @exception_view_config(context=ValidationError)
+    def invalid(self):
+        self._request.session.flash("Received an invalid redirect from ORCID!", "error")
+        return HTTPFound(location=self._request.route_url("account"))
+
+    @exception_view_config(context=TokenValidationError)
+    def invalid_token(self):
+        self._request.session.flash("Received an invalid token from ORCID!", "error")
+        return HTTPFound(location=self._request.route_url("account"))
+
+    @exception_view_config(context=AccessDeniedError)
+    def denied(self):
+        self._request.session.flash("The user clicked the deny button!", "error")
+        return HTTPFound(location=self._request.route_url("account"))
+
+    @exception_view_config(context=ExternalRequestError)
+    def external_request(self):
+        handle_external_request_error(self._request.exception)
+        self._request.session.flash("Request to ORCID failed!", "error")
+        return HTTPFound(location=self._request.route_url("account"))
+
+    @exception_view_config(context=UserConflictError)
+    def user_conflict_error(self):
+        self._request.session.flash(
+            "A different Hypothesis user is already connected to this ORCiD!", "error"
+        )
+        return HTTPFound(location=self._request.route_url("account"))
+
+
+def handle_external_request_error(exception: ExternalRequestError) -> None:
+    sentry_sdk.set_context(
+        "request",
+        {
+            "method": exception.method,
+            "url": exception.url,
+            "body": exception.request_body,
+        },
+    )
+    sentry_sdk.set_context(
+        "response",
+        {
+            "status_code": exception.status_code,
+            "reason": exception.reason,
+            "body": exception.response_body,
+        },
+    )
+    if exception.validation_errors:
+        sentry_sdk.set_context("validation_errors", exception.validation_errors)
+
+    report_exception()

--- a/tests/common/fixtures/services.py
+++ b/tests/common/fixtures/services.py
@@ -7,6 +7,7 @@ from h.services import (
     MentionService,
     NotificationService,
     OpenIDClientService,
+    ORCIDClientService,
 )
 from h.services.analytics import AnalyticsService
 from h.services.annotation_authority_queue import AnnotationAuthorityQueueService
@@ -89,6 +90,7 @@ __all__ = (
     "notification_service",
     "oauth_provider_service",
     "openid_client_service",
+    "orcid_client_service",
     "organization_service",
     "queue_service",
     "search_index",
@@ -364,3 +366,8 @@ def http_service(mock_service):
 @pytest.fixture
 def openid_client_service(mock_service):
     return mock_service(OpenIDClientService)
+
+
+@pytest.fixture
+def orcid_client_service(mock_service):
+    return mock_service(ORCIDClientService)

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -263,6 +263,8 @@ def test_includeme():
         call(
             "wordpress-plugin", "https://wordpress.org/plugins/hypothesis/", static=True
         ),
+        call("orcid.oauth.authorize", "/orcid/oauth/authorize"),
+        call("orcid.oauth.callback", "/orcid/oauth/callback"),
     ]
 
     # Test each one one at a time to make it a bit easier to spot which one

--- a/tests/unit/h/schemas/oauth_test.py
+++ b/tests/unit/h/schemas/oauth_test.py
@@ -1,7 +1,47 @@
 import pytest
 
 from h.schemas import ValidationError
-from h.schemas.oauth import RetrieveOpenIDTokenSchema
+from h.schemas.oauth import RetrieveOAuthCallbackSchema, RetrieveOpenIDTokenSchema
+
+
+class TestRetrieveOAuthCallbackSchema:
+    def test_validate(self, pyramid_request, schema):
+        data = {"code": "test-code", "state": "test-state"}
+        pyramid_request.session["oauth2_state"] = data["state"]
+
+        result = schema.validate(data)
+
+        assert result == data
+
+    def test_validate_with_invalid_state(self, pyramid_request, schema):
+        data = {"code": "test-code", "state": "test-state"}
+        pyramid_request.session["oauth2_state"] = "different-test-state"
+
+        with pytest.raises(ValidationError, match="Invalid oauth state"):
+            schema.validate(data)
+
+    def test_validate_with_missing_state(self, schema):
+        data = {"state": "test-state"}
+
+        with pytest.raises(ValidationError, match="Invalid oauth state"):
+            schema.validate(data)
+
+    def test_state_param_generates_token(self, pyramid_request, schema, secrets):
+        state_token = "test-token"  # noqa: S105
+        secrets.token_hex.return_value = state_token
+
+        result = schema.state_param()
+
+        assert result == state_token
+        assert pyramid_request.session["oauth2_state"] == state_token
+
+    @pytest.fixture
+    def schema(self, pyramid_request):
+        return RetrieveOAuthCallbackSchema(pyramid_request)
+
+    @pytest.fixture(autouse=True)
+    def secrets(self, patch):
+        return patch("h.schemas.oauth.secrets")
 
 
 class TestRetrieveOpenIDTokenSchema:

--- a/tests/unit/h/services/exceptions_test.py
+++ b/tests/unit/h/services/exceptions_test.py
@@ -66,6 +66,7 @@ class TestExternalRequestError:
         assert err.reason is None
         assert err.response_body is None
         assert not err.is_timeout
+        assert not err.validation_errors
 
     @pytest.mark.parametrize(
         "message,request_,response,validation_errors,cause,expected",

--- a/tests/unit/h/services/jwt_test.py
+++ b/tests/unit/h/services/jwt_test.py
@@ -3,8 +3,7 @@ from unittest.mock import sentinel
 import pytest
 from jwt.exceptions import InvalidTokenError
 
-from h.schemas import ValidationError
-from h.services.jwt import JWK_CLIENT_TIMEOUT, JWTService
+from h.services.jwt import JWK_CLIENT_TIMEOUT, JWTService, TokenValidationError
 
 
 class TestJWTService:
@@ -30,19 +29,21 @@ class TestJWTService:
     def test_decode_token_with_no_kid(self, jwt):
         jwt.get_unverified_header.return_value = {"alg": "RS256"}
 
-        with pytest.raises(ValidationError, match="Missing 'kid' value in JWT header"):
+        with pytest.raises(
+            TokenValidationError, match="Missing 'kid' value in JWT header"
+        ):
             JWTService.decode_token(sentinel.token, sentinel.key_set_url)
 
     def test_decode_token_with_invalid_jwt_header(self, jwt):
         jwt.get_unverified_header.side_effect = InvalidTokenError()
 
-        with pytest.raises(ValidationError, match="Invalid JWT"):
+        with pytest.raises(TokenValidationError, match="Invalid JWT"):
             JWTService.decode_token(sentinel.token, sentinel.key_set_url)
 
     def test_decode_token_with_invalid_jwt(self, jwt):
         jwt.decode.side_effect = [{"aud": "AUD", "iss": "ISS"}, InvalidTokenError()]
 
-        with pytest.raises(ValidationError, match="Invalid JWT"):
+        with pytest.raises(TokenValidationError, match="Invalid JWT"):
             JWTService.decode_token(sentinel.token, sentinel.key_set_url)
 
     @pytest.fixture(autouse=True)

--- a/tests/unit/h/views/api/orcid_test.py
+++ b/tests/unit/h/views/api/orcid_test.py
@@ -1,0 +1,284 @@
+from unittest.mock import MagicMock, Mock, call, sentinel
+from urllib.parse import urlencode, urlunparse
+
+import pytest
+from pyramid.httpexceptions import HTTPFound, HTTPUnauthorized
+
+import h.views.api.orcid as views
+from h.models.user_identity import IdentityProvider
+from h.schemas import ValidationError
+from h.services.exceptions import ExternalRequestError
+from h.services.jwt import TokenValidationError
+
+
+class TestAuthorizeViews:
+    def test_authorize(self, pyramid_request):
+        result = views.AuthorizeViews(pyramid_request).authorize()
+
+        assert isinstance(result, HTTPFound)
+        params = {
+            "client_id": sentinel.client_id,
+            "response_type": "code",
+            "redirect_uri": pyramid_request.route_url("orcid.oauth.callback"),
+            "state": sentinel.state_param,
+            "scope": "openid",
+        }
+        assert result.location == urlunparse(
+            (
+                "https",
+                IdentityProvider.ORCID,
+                "oauth/authorize",
+                "",
+                urlencode(params),
+                "",
+            )
+        )
+
+    def test_notfound(self, pyramid_request):
+        pyramid_request.user = None
+
+        result = views.AuthorizeViews(pyramid_request).notfound()
+
+        assert isinstance(result, HTTPUnauthorized)
+        assert result.location is None
+
+    @pytest.fixture(autouse=True)
+    def RetrieveOAuthCallbackSchema(self, patch):
+        mock = patch("h.views.api.orcid.RetrieveOAuthCallbackSchema")
+        mock.return_value.state_param.return_value = sentinel.state_param
+        return mock
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request, factories):
+        pyramid_request.user = factories.User()
+        pyramid_request.registry.settings.update(
+            {
+                "orcid_host": IdentityProvider.ORCID,
+                "orcid_client_id": sentinel.client_id,
+                "orcid_client_secret": sentinel.client_secret,
+            }
+        )
+        return pyramid_request
+
+    @pytest.fixture(autouse=True)
+    def routes(self, pyramid_config):
+        pyramid_config.add_route("orcid.oauth.authorize", "/orcid/oauth/authorize")
+        pyramid_config.add_route("orcid.oauth.callback", "/orcid/oauth/callback")
+
+
+@pytest.mark.usefixtures("orcid_client_service", "user_service")
+class TestCallbackViews:
+    def test_it(self, pyramid_request, orcid_client_service, user_service, user):
+        orcid = orcid_client_service.get_orcid.return_value
+        user_service.fetch_by_identity.return_value = None
+
+        result = views.CallbackViews(pyramid_request).callback()
+
+        assert isinstance(result, HTTPFound)
+        assert result.location == pyramid_request.route_url("account")
+        orcid_client_service.get_orcid.assert_called_once_with(
+            pyramid_request.params["code"]
+        )
+        orcid_client_service.add_identity.assert_called_once_with(user, orcid)
+        pyramid_request.session.flash.assert_called_once_with(
+            "You can now use your ORCiD to log in to Hypothesis.", "success"
+        )
+
+    def test_it_raises_validation_error(self, pyramid_request):
+        pyramid_request.params = {}
+
+        with pytest.raises(ValidationError):
+            views.CallbackViews(pyramid_request).callback()
+
+    def test_it_raises_access_denied_error(self, pyramid_request):
+        pyramid_request.params = {"error": "access_denied"}
+
+        with pytest.raises(views.AccessDeniedError):
+            views.CallbackViews(pyramid_request).callback()
+
+    def test_it_raises_token_validation_error(
+        self, pyramid_request, orcid_client_service
+    ):
+        orcid_client_service.get_orcid.side_effect = TokenValidationError(
+            "Invalid token"
+        )
+
+        with pytest.raises(TokenValidationError):
+            views.CallbackViews(pyramid_request).callback()
+
+    def test_it_raises_external_request_error(
+        self, pyramid_request, orcid_client_service
+    ):
+        orcid_client_service.get_orcid.side_effect = ExternalRequestError(
+            "External request failed"
+        )
+
+        with pytest.raises(ExternalRequestError):
+            views.CallbackViews(pyramid_request).callback()
+
+    def test_it_raises_user_conflict_error(
+        self, pyramid_request, user_service, factories
+    ):
+        other_user = factories.User()
+        user_service.fetch_by_identity.return_value = other_user
+
+        with pytest.raises(views.UserConflictError):
+            views.CallbackViews(pyramid_request).callback()
+
+    def test_it_is_already_connected(
+        self, pyramid_request, orcid_client_service, user_service, user
+    ):
+        user_service.fetch_by_identity.return_value = user
+
+        result = views.CallbackViews(pyramid_request).callback()
+
+        assert isinstance(result, HTTPFound)
+        assert result.location == pyramid_request.route_url("account")
+        orcid_client_service.get_orcid.assert_called_once_with(
+            pyramid_request.params["code"]
+        )
+        orcid_client_service.add_identity.assert_not_called()
+        pyramid_request.session.flash.assert_called_once_with(
+            "You can now use your ORCiD to log in to Hypothesis.", "success"
+        )
+
+    def test_notfound(self, pyramid_request):
+        result = views.CallbackViews(pyramid_request).notfound()
+
+        assert isinstance(result, HTTPUnauthorized)
+        assert result.location is None
+
+    def test_invalid(self, pyramid_request):
+        result = views.CallbackViews(pyramid_request).invalid()
+
+        assert isinstance(result, HTTPFound)
+        assert result.location == pyramid_request.route_url("account")
+        pyramid_request.session.flash.assert_called_once_with(
+            "Received an invalid redirect from ORCID!", "error"
+        )
+
+    def test_invalid_token(self, pyramid_request):
+        result = views.CallbackViews(pyramid_request).invalid_token()
+
+        assert isinstance(result, HTTPFound)
+        assert result.location == pyramid_request.route_url("account")
+        pyramid_request.session.flash.assert_called_once_with(
+            "Received an invalid token from ORCID!", "error"
+        )
+
+    def test_denied(self, pyramid_request):
+        result = views.CallbackViews(pyramid_request).denied()
+
+        assert isinstance(result, HTTPFound)
+        assert result.location == pyramid_request.route_url("account")
+        pyramid_request.session.flash.assert_called_once_with(
+            "The user clicked the deny button!", "error"
+        )
+
+    def test_external_request(self, pyramid_request, handle_external_request_error):
+        pyramid_request.exception = ExternalRequestError(
+            "External request failed", validation_errors={"foo": ["bar"]}
+        )
+        result = views.CallbackViews(pyramid_request).external_request()
+
+        assert isinstance(result, HTTPFound)
+        assert result.location == pyramid_request.route_url("account")
+        pyramid_request.session.flash.assert_called_once_with(
+            "Request to ORCID failed!", "error"
+        )
+        handle_external_request_error.assert_called_once_with(pyramid_request.exception)
+
+    def test_user_conflict_error(self, pyramid_request):
+        result = views.CallbackViews(pyramid_request).user_conflict_error()
+
+        assert isinstance(result, HTTPFound)
+        pyramid_request.session.flash.assert_called_once_with(
+            "A different Hypothesis user is already connected to this ORCiD!", "error"
+        )
+        assert result.location == pyramid_request.route_url("account")
+
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User()
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request, user):
+        pyramid_request.user = user
+        state = "test_state"
+        pyramid_request.params = {"code": "test_code", "state": state}
+        pyramid_request.session["oauth2_state"] = state
+        pyramid_request.session.flash = Mock()
+        return pyramid_request
+
+    @pytest.fixture(autouse=True)
+    def routes(self, pyramid_config):
+        pyramid_config.add_route("account", "/account/settings")
+        pyramid_config.add_route("index", "/")
+
+    @pytest.fixture(autouse=True)
+    def handle_external_request_error(self, patch):
+        return patch("h.views.api.orcid.handle_external_request_error")
+
+
+class TestHandleExternalRequestError:
+    def test_it(self, sentry_sdk):
+        exception = ExternalRequestError(
+            message="External request failed",
+            request=MagicMock(),
+            response=MagicMock(),
+        )
+
+        views.handle_external_request_error(exception)
+
+        assert sentry_sdk.set_context.call_args_list == [
+            call(
+                "request",
+                {
+                    "method": exception.method,
+                    "url": exception.url,
+                    "body": exception.request_body,
+                },
+            ),
+            call(
+                "response",
+                {
+                    "status_code": exception.status_code,
+                    "reason": exception.reason,
+                    "body": exception.response_body,
+                },
+            ),
+        ]
+
+    def test_it_with_validation_errors(self, sentry_sdk):
+        exception = ExternalRequestError(
+            message="External request failed",
+            request=MagicMock(),
+            response=MagicMock(),
+            validation_errors={"foo": ["bar"]},
+        )
+
+        views.handle_external_request_error(exception)
+
+        assert sentry_sdk.set_context.call_args_list == [
+            call(
+                "request",
+                {
+                    "method": exception.method,
+                    "url": exception.url,
+                    "body": exception.request_body,
+                },
+            ),
+            call(
+                "response",
+                {
+                    "status_code": exception.status_code,
+                    "reason": exception.reason,
+                    "body": exception.response_body,
+                },
+            ),
+            call("validation_errors", exception.validation_errors),
+        ]
+
+    @pytest.fixture(autouse=True)
+    def sentry_sdk(self, patch):
+        return patch("h.views.api.orcid.sentry_sdk")

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,9 @@ passenv =
     dev: NEW_RELIC_APP_NAME
     dev: NODE_ENV
     dev: PROXY_AUTH
+    dev: ORCID_HOST
+    dev: ORCID_CLIENT_ID
+    dev: ORCID_CLIENT_SECRET
     {tests,functests}: DATABASE_URL
     {tests,functests}: ELASTICSEARCH_URL
     functests: BROKER_URL


### PR DESCRIPTION
Refs #9561 
Refs https://github.com/hypothesis/h/pull/9487

Will address prettifying the connect button in a follow-up PR.
For now it's displayed only if feature flag is enabled so it doesn't affect users at large.

ORCID needs proper redirect URL, so I've added http://hypothesis.local:5000/ in there.
Add this line to `/etc/hosts` to make it work locally.
`127.0.0.1  hypothesis.local`
And local testing will need to be done on this page.

In order to test this PR one needs to sign up for a [sandbox ORCID account](https://sandbox.orcid.org/register).
For some reason they only allow [mailinator emails](https://info.orcid.org/documentation/integration-guide/sandbox-testing-server/) there.

Testing
===
- Enable `log_in_with_orcid` feature
- Run `make devdata` to load ORCID sandbox credentials
- Log in as `devdata_admin` for example
- Go to http://hypothesis.local:5000/account/settings
- Click connect with ORCID
- Authorize ORCID client on ORCID site for your account
- Observe `ORCiD connected` on the settings page
- Run `make sql` and confirm that there's a new identity in there
`select * from user_identity`