### PR TITLE
Split HiddenFilter into HiddenFilter and NipsaFilter

### DIFF
--- a/h/search/core.py
+++ b/h/search/core.py
@@ -52,6 +52,7 @@ class Search:
             query.AuthFilter(request),
             query.GroupFilter(request),
             query.UserFilter(),
+            query.NIPSAFilter(request),
             query.HiddenFilter(request),
             query.AnyMatcher(),
             query.TagsMatcher(),


### PR DESCRIPTION
While these two filters behave similarly we are planning to add new functionality to the moderation feature (hidden annotations) so it makes sense now to split them out.