### PR TITLE
Add `target.description` to annotation API

### DIFF
--- a/docs/_extra/api-reference/schemas/annotation-create.yaml
+++ b/docs/_extra/api-reference/schemas/annotation-create.yaml
@@ -78,6 +78,13 @@ Annotation:
               properties:
                 "type":
                   type: string
+          description:
+            type: string
+            description: >
+              An optional text description of the annotation's target.
+              For image annotations (where the annotation's target is a
+              selected area of an image) the Hypothesis client uses this
+              description as alt text for the thumbnail preview of the target.
     references:
       type: array
       description: Annotation IDs for any annotations this annotation references (e.g. is a reply to)

--- a/docs/_extra/api-reference/schemas/annotation.yaml
+++ b/docs/_extra/api-reference/schemas/annotation.yaml
@@ -167,6 +167,13 @@ Annotation:
                       type: string
                     index: number
                     label: string
+          description:
+            type: string
+            description: >
+              An optional text description of the annotation's target.
+              For image annotations (where the annotation's target is a
+              selected area of an image) the Hypothesis client uses this
+              description as alt text for the thumbnail preview of the target.
     document:
       type: object
       required:

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -163,6 +163,9 @@ class Annotation(Base):
         "ModerationLog", back_populates="annotation"
     )
 
+    #: An optional text description of the annotation target.
+    target_description = sa.Column(sa.UnicodeText)
+
     @property
     def uuid(self):
         """
@@ -189,6 +192,10 @@ class Annotation(Base):
     @property
     def target(self):
         target = {"source": self.target_uri}
+
+        if self.target_description is not None:
+            target["description"] = self.target_description
+
         if self.target_selectors:
             target["selector"] = self.target_selectors
 

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -92,7 +92,10 @@ class AnnotationSchema(JSONSchema):
                 "type": "array",
                 "items": {
                     "type": "object",
-                    "properties": {"selector": copy.deepcopy(SELECTOR_SCHEMA)},
+                    "properties": {
+                        "description": {"type": "string", "maxLength": 250},
+                        "selector": copy.deepcopy(SELECTOR_SCHEMA),
+                    },
                 },
             },
             "text": {"type": "string"},
@@ -160,9 +163,9 @@ class CreateAnnotationSchema:
             new_appstruct["shared"] = False
 
         if "target" in appstruct:
-            new_appstruct["target_selectors"] = _target_selectors(
-                appstruct.pop("target")
-            )
+            targets = appstruct.pop("target")
+            new_appstruct["target_description"] = _target_description(targets)
+            new_appstruct["target_selectors"] = _target_selectors(targets)
 
         # Replies always get the same groupid as their parent. The parent's
         # groupid is added to the reply annotation later by the storage code.
@@ -215,9 +218,9 @@ class UpdateAnnotationSchema:
             )
 
         if "target" in appstruct:
-            new_appstruct["target_selectors"] = _target_selectors(
-                appstruct.pop("target")
-            )
+            targets = appstruct.pop("target")
+            new_appstruct["target_description"] = _target_description(targets)
+            new_appstruct["target_selectors"] = _target_selectors(targets)
 
         # Fields that are allowed to be updated and that have the same internal
         # and external name.
@@ -318,6 +321,13 @@ def _target_selectors(targets):
                     )
 
     return selectors
+
+
+def _target_description(targets) -> str | None:
+    if targets:
+        return targets[0].get("description", None)
+
+    return None
 
 
 class SearchParamsSchema(colander.Schema):

--- a/tests/unit/h/models/annotation_test.py
+++ b/tests/unit/h/models/annotation_test.py
@@ -72,15 +72,30 @@ def test_thread_root_id_returns_first_reference_if_many_references():
 class TestTarget:
     def test_it(self, factories):
         annotation = factories.Annotation.build()
+        annotation.target_description = "test_description"
 
         assert annotation.target == [
-            {"source": annotation.target_uri, "selector": annotation.target_selectors}
+            {
+                "source": annotation.target_uri,
+                "description": "test_description",
+                "selector": annotation.target_selectors,
+            }
         ]
 
     def test_it_with_no_selectors(self, factories):
         annotation = factories.Annotation.build(target_selectors=[])
 
         assert "selector" not in annotation.target
+
+    def test_it_with_no_description(self, factories):
+        annotation = factories.Annotation.build()
+
+        assert annotation.target == [
+            {
+                "source": annotation.target_uri,
+                "selector": annotation.target_selectors,
+            }
+        ]
 
 
 def test_text_setter_renders_markdown(markdown_render):


### PR DESCRIPTION
Depends on: https://github.com/hypothesis/h/pull/9583

Testing:

Go to http://localhost:5000/account/developer and generate a developer key then call the API to create an annotation with a target description:

```terminal
httpx --method POST http://localhost:5000/api/annotations \
      --headers Authorization 'Bearer 6879-***' \
      --json '{"uri": "https://example.com", "target": [{"description": "THIS IS THE ALT TEXT", "selector": [{"type": "RangeSelector", "startContainer": "...", "startOffset": 42, "endContainer": "...", "endOffset": 42}, {"type": "TextPositionSelector", "start": 42, "end": 42}, {"type": "TextQuoteSelector", "exact": "...", "prefix": "..."}]}]}'
```

Your annotation should be created successfully and you should see your alt text in the `target[0].description` field in the response.

If you `GET` your annotation you should see your alt text in the `target[0].description` field in the response.

You should be able to update the alt text by `PATCH`'ing your annotation, for example:

```
httpx --method PATCH http://localhost:5000/api/annotations/ANNOTATION_ID \
      --headers Authorization 'Bearer 6879-***' \
      --json '{"target": [{"description": "UPDATED ALT TEXT"}]}'
```

If you look in the DB (`make sql`) you should see your alt text in the `annotation.target_description` column.

It should still be possible to create annotations without sending the target description parameter and in this case `target[0].description` should be omitted from the API's responses. For example try creating annotations with the client.