### PR TITLE
Add `image_descriptions` feature flag

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -17,6 +17,7 @@ FEATURES = {
     "group_moderation": "Allow users to moderate annotations in groups",
     "group_type": "Allow users to choose group type in new group forms",
     "html_image_annotation": "Support image annotations in HTML",
+    "image_descriptions": "Allow users to enter descriptions for image annotations",
     "pdf_custom_text_layer": "Use custom text layer in PDFs for improved text selection",
     "pdf_image_annotation": "Support image annotations in PDFs",
     "styled_highlight_clusters": "Style different clusters of highlights in the client",


### PR DESCRIPTION
This will be used for a feature that enables users to enter descriptions (aka. captions, alt-text) for image annotations.

Only the client UI is behind the flag, the field for reading/writing the description in the API is always available.