### PR TITLE
Display a different group annotations fallback per status

### DIFF
--- a/h/static/scripts/group-forms/components/GroupModeration.tsx
+++ b/h/static/scripts/group-forms/components/GroupModeration.tsx
@@ -5,6 +5,7 @@ import { useState } from 'preact/hooks';
 import type { Group } from '../config';
 import { useGroupAnnotations } from '../hooks/use-group-annotations';
 import type { APIAnnotationData } from '../utils/api';
+import { moderationStatusToLabel } from '../utils/moderation-status';
 import GroupFormHeader from './GroupFormHeader';
 import type { ModerationStatus } from './ModerationStatusSelect';
 import ModerationStatusSelect from './ModerationStatusSelect';
@@ -53,9 +54,16 @@ function AnnotationListContent({
         className="border rounded p-2 text-center"
         data-testid="annotations-fallback-message"
       >
-        {filterStatus === 'PENDING'
-          ? 'You are all set!'
-          : 'No annotations found for selected status'}
+        {!filterStatus && 'There are no annotations in this group.'}
+        {filterStatus && (
+          <>
+            There are no{' '}
+            <span className="lowercase">
+              {moderationStatusToLabel[filterStatus]}
+            </span>{' '}
+            annotations in this group.
+          </>
+        )}
       </div>
     );
   }

--- a/h/static/scripts/group-forms/components/ModerationStatusSelect.tsx
+++ b/h/static/scripts/group-forms/components/ModerationStatusSelect.tsx
@@ -8,6 +8,8 @@ import {
   Select,
 } from '@hypothesis/frontend-shared';
 
+import { moderationStatusToLabel } from '../utils/moderation-status';
+
 export type ModerationStatus = 'PENDING' | 'APPROVED' | 'DENIED' | 'SPAM';
 
 export type ModerationStatusSelectProps = {
@@ -21,10 +23,13 @@ type Option = {
 };
 
 const options = new Map<ModerationStatus, Option>([
-  ['PENDING', { label: 'Pending', icon: DottedCircleIcon }],
-  ['APPROVED', { label: 'Approved', icon: CheckAllIcon }],
-  ['DENIED', { label: 'Denied', icon: RestrictedIcon }],
-  ['SPAM', { label: 'Spam', icon: CautionIcon }],
+  [
+    'PENDING',
+    { label: moderationStatusToLabel.PENDING, icon: DottedCircleIcon },
+  ],
+  ['APPROVED', { label: moderationStatusToLabel.APPROVED, icon: CheckAllIcon }],
+  ['DENIED', { label: moderationStatusToLabel.DENIED, icon: RestrictedIcon }],
+  ['SPAM', { label: moderationStatusToLabel.SPAM, icon: CautionIcon }],
 ]);
 
 export default function ModerationStatusSelect({

--- a/h/static/scripts/group-forms/components/test/GroupModeration-test.js
+++ b/h/static/scripts/group-forms/components/test/GroupModeration-test.js
@@ -62,18 +62,28 @@ describe('GroupModeration', () => {
     });
 
     [
-      { status: 'PENDING', expectedFallbackMessage: 'You are all set!' },
+      {
+        status: undefined,
+        expectedFallbackMessage: 'There are no annotations in this group.',
+      },
+      {
+        status: 'PENDING',
+        expectedFallbackMessage:
+          'There are no Pending annotations in this group.',
+      },
       {
         status: 'APPROVED',
-        expectedFallbackMessage: 'No annotations found for selected status',
+        expectedFallbackMessage:
+          'There are no Approved annotations in this group.',
       },
       {
         status: 'DENIED',
-        expectedFallbackMessage: 'No annotations found for selected status',
+        expectedFallbackMessage:
+          'There are no Denied annotations in this group.',
       },
       {
         status: 'SPAM',
-        expectedFallbackMessage: 'No annotations found for selected status',
+        expectedFallbackMessage: 'There are no Spam annotations in this group.',
       },
     ].forEach(({ status, expectedFallbackMessage }) => {
       it('shows fallback message when no annotations exist', () => {

--- a/h/static/scripts/group-forms/utils/moderation-status.ts
+++ b/h/static/scripts/group-forms/utils/moderation-status.ts
@@ -1,0 +1,10 @@
+import type { ModerationStatus } from '../components/ModerationStatusSelect';
+
+export const moderationStatusToLabel: Record<ModerationStatus, string> = {
+  PENDING: 'Pending',
+  APPROVED: 'Approved',
+  DENIED: 'Denied',
+  SPAM: 'Spam',
+} as const;
+
+Object.freeze(moderationStatusToLabel);


### PR DESCRIPTION
[As discussed](https://hypothes-is.slack.com/archives/C2C2U40LW/p1747818733428699) with the rest of the team, display a different fallback message when loading group annotations for every possible moderation status.

https://github.com/user-attachments/assets/72ea1469-8fd1-45a9-9d93-9fd940334702

