### PR TITLE
Port login page to Preact

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,7 @@ gulp.task('build-legacy-css', () =>
 );
 
 gulp.task('build-tailwind-css', () =>
-  buildCSS(['./h/static/styles/group-forms.css'], { tailwindConfig }),
+  buildCSS(['./h/static/styles/forms.css'], { tailwindConfig }),
 );
 
 gulp.task('build-css', gulp.parallel('build-legacy-css', 'build-tailwind-css'));

--- a/h/assets.ini
+++ b/h/assets.ini
@@ -25,11 +25,15 @@ help_page_css =
   styles/icomoon.css
   styles/help-page.css
 
-group_forms_css =
-  styles/group-forms.css
+# Styles for Tailwind / Preact-based apps
+forms_css =
+  styles/forms.css
 
 group_forms_js =
   scripts/group-forms.bundle.js
+
+login_forms_js =
+  scripts/login-forms.bundle.js
 
 orcid_css =
   styles/orcid.css

--- a/h/static/scripts/group-forms/components/forms/TextField.tsx
+++ b/h/static/scripts/group-forms/components/forms/TextField.tsx
@@ -1,6 +1,7 @@
 import { Input, Textarea } from '@hypothesis/frontend-shared';
 import { useId, useState } from 'preact/hooks';
 
+import ErrorNotice from '../ErrorNotice';
 import Label from './Label';
 
 function CharacterCounter({
@@ -29,6 +30,12 @@ export type TextFieldProps = {
   /** The DOM element to render. */
   type?: 'input' | 'textarea';
 
+  /** The type of input element, e.g., "text", "password", etc. */
+  inputType?: 'text' | 'password';
+
+  /** Name of the input field. */
+  name?: string;
+
   /** Current value of the input. */
   value: string;
 
@@ -55,11 +62,17 @@ export type TextFieldProps = {
   /** True if this is a required field. */
   required?: boolean;
 
+  /** True if the required indicator should be shown next to the label. */
+  showRequired?: boolean;
+
   /** True if the field should be automatically focused on first render. */
   autofocus?: boolean;
 
   /** Additional classes to apply to the input element. */
   classes?: string;
+
+  /** Optional error message for the field. */
+  fieldError?: string;
 };
 
 /**
@@ -68,14 +81,18 @@ export type TextFieldProps = {
  */
 export default function TextField({
   type = 'input',
+  inputType,
   value,
   onChangeValue,
   minLength = 0,
   maxLength,
   label,
   required = false,
+  showRequired = required,
   autofocus = false,
   classes = '',
+  name,
+  fieldError = '',
 }: TextFieldProps) {
   const id = useId();
   const [hasCommitted, setHasCommitted] = useState(false);
@@ -99,7 +116,7 @@ export default function TextField({
 
   return (
     <div>
-      <Label htmlFor={id} text={label} required={required} />
+      <Label htmlFor={id} text={label} required={showRequired} />
       <InputComponent
         id={id}
         onInput={handleInput}
@@ -110,6 +127,8 @@ export default function TextField({
         autofocus={autofocus}
         autocomplete="off"
         required={required}
+        name={name}
+        type={inputType}
       />
       {typeof maxLength === 'number' && (
         <CharacterCounter
@@ -117,6 +136,11 @@ export default function TextField({
           limit={maxLength}
           error={Boolean(error)}
         />
+      )}
+      {fieldError && !hasCommitted && (
+        <div className="mt-1">
+          <ErrorNotice message={fieldError} />
+        </div>
       )}
     </div>
   );

--- a/h/static/scripts/login-forms/components/AppRoot.tsx
+++ b/h/static/scripts/login-forms/components/AppRoot.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from 'preact/hooks';
+import { Route, Switch } from 'wouter-preact';
+
+import Router from '../../group-forms/components/Router';
+import type { ConfigObject } from '../config';
+import { Config } from '../config';
+import { routes } from '../routes';
+import LoginForm from './LoginForm';
+
+export type AppRootProps = {
+  config: ConfigObject;
+};
+
+export default function AppRoot({ config }: AppRootProps) {
+  const stylesheetLinks = useMemo(
+    () =>
+      config.styles.map((stylesheetURL, index) => (
+        <link
+          key={`${stylesheetURL}${index}`}
+          rel="stylesheet"
+          href={stylesheetURL}
+        />
+      )),
+    [config],
+  );
+
+  return (
+    <>
+      {stylesheetLinks}
+      <Config.Provider value={config}>
+        <Router>
+          <Switch>
+            <Route path={routes.login}>
+              <LoginForm />
+            </Route>
+            <Route>
+              <h1 data-testid="unknown-route">Page not found</h1>
+            </Route>
+          </Switch>
+        </Router>
+      </Config.Provider>
+    </>
+  );
+}

--- a/h/static/scripts/login-forms/components/LoginForm.tsx
+++ b/h/static/scripts/login-forms/components/LoginForm.tsx
@@ -1,0 +1,64 @@
+import { Button } from '@hypothesis/frontend-shared';
+import { useContext, useState } from 'preact/hooks';
+
+import FormContainer from '../../group-forms/components/forms/FormContainer';
+import TextField from '../../group-forms/components/forms/TextField';
+import { Config } from '../config';
+import { routes } from '../routes';
+
+export default function LoginForm() {
+  const config = useContext(Config)!;
+
+  const [username, setUsername] = useState(config.formData?.username ?? '');
+  const [password, setPassword] = useState(config.formData?.password ?? '');
+
+  return (
+    <FormContainer>
+      <form
+        action={routes.login}
+        method="POST"
+        data-testid="form"
+        className="max-w-[530px] mx-auto flex flex-col gap-y-4"
+      >
+        <input type="hidden" name="csrf_token" value={config.csrfToken} />
+        <TextField
+          type="input"
+          name="username"
+          value={username}
+          fieldError={config.formErrors?.username ?? ''}
+          onChangeValue={setUsername}
+          label="Username / email"
+          autofocus
+          required
+          showRequired={false}
+        />
+        <TextField
+          type="input"
+          inputType="password"
+          name="password"
+          value={password}
+          fieldError={config.formErrors?.password ?? ''}
+          onChangeValue={setPassword}
+          label="Password"
+          required
+          showRequired={false}
+        />
+        <div className="text-right">
+          <a
+            href={routes.forgotPassword}
+            className="text-grey-5 text-sm underline"
+            data-testid="forgot-password-link"
+          >
+            Forgot your password?
+          </a>
+        </div>
+        <div className="mb-8 pt-2 flex items-center gap-x-4">
+          <div className="grow" />
+          <Button type="submit" variant="primary" data-testid="button">
+            Log in
+          </Button>
+        </div>
+      </form>
+    </FormContainer>
+  );
+}

--- a/h/static/scripts/login-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/login-forms/components/test/AppRoot-test.js
@@ -1,0 +1,85 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { useContext } from 'preact/hooks';
+
+import { Config } from '../../config';
+import { $imports, default as AppRoot } from '../AppRoot';
+
+describe('AppRoot', () => {
+  let configContext;
+
+  const config = { styles: [] };
+
+  beforeEach(() => {
+    const mockComponent = name => {
+      function MockRoute() {
+        configContext = useContext(Config);
+        return null;
+      }
+      MockRoute.displayName = name;
+      return MockRoute;
+    };
+
+    configContext = null;
+
+    $imports.$mock({
+      './LoginForm': mockComponent('LoginForm'),
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  function createComponent() {
+    return mount(<AppRoot config={config} />);
+  }
+
+  it('renders style links', () => {
+    config.styles = ['/static/styles/foo.css'];
+
+    const links = createComponent().find('link');
+
+    assert.equal(links.length, 1);
+    assert.equal(links.at(0).prop('rel'), 'stylesheet');
+    assert.equal(links.at(0).prop('href'), '/static/styles/foo.css');
+  });
+
+  /** Navigate to `path`, run `callback` and then reset the location. */
+  function navigate(path, callback) {
+    history.pushState({}, null, path);
+    try {
+      callback();
+    } finally {
+      history.back();
+    }
+  }
+
+  it('passes config to route', () => {
+    navigate('/login', () => {
+      createComponent();
+
+      assert.strictEqual(configContext, config);
+    });
+  });
+
+  [
+    {
+      path: '/Login',
+      selector: 'LoginForm',
+    },
+  ].forEach(({ path, selector }) => {
+    it(`renders expected component for URL (${path})`, () => {
+      navigate(path, () => {
+        const wrapper = createComponent();
+        const component = wrapper.find(selector);
+
+        assert.isTrue(component.exists());
+      });
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({ content: createComponent }),
+  );
+});

--- a/h/static/scripts/login-forms/components/test/LoginForm-test.js
+++ b/h/static/scripts/login-forms/components/test/LoginForm-test.js
@@ -1,0 +1,125 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+
+import { Config } from '../../config';
+import { routes } from '../../routes';
+import { $imports, default as LoginForm } from '../LoginForm';
+
+describe('LoginForm', () => {
+  let fakeConfig;
+
+  beforeEach(() => {
+    fakeConfig = {
+      csrfToken: 'fake-csrf-token',
+      formData: {
+        username: '',
+        password: '',
+      },
+      formErrors: {},
+    };
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  const getElements = wrapper => {
+    return {
+      form: wrapper.find('form[data-testid="form"]'),
+      csrfInput: wrapper.find('input[name="csrf_token"]'),
+      usernameField: wrapper.find('TextField[name="username"]'),
+      passwordField: wrapper.find('TextField[name="password"]'),
+      forgotPasswordLink: wrapper.find('a[data-testid="forgot-password-link"]'),
+    };
+  };
+
+  const createWrapper = () => {
+    const wrapper = mount(
+      <Config.Provider value={fakeConfig}>
+        <LoginForm />
+      </Config.Provider>,
+    );
+    const elements = getElements(wrapper);
+    return { wrapper, elements };
+  };
+
+  it('renders the login form', () => {
+    const { elements } = createWrapper();
+    const {
+      form,
+      csrfInput,
+      usernameField,
+      passwordField,
+      forgotPasswordLink,
+    } = elements;
+
+    assert.equal(form.prop('action'), routes.login);
+    assert.equal(csrfInput.prop('value'), fakeConfig.csrfToken);
+    assert.equal(usernameField.prop('value'), '');
+    assert.equal(passwordField.prop('value'), '');
+    assert.equal(forgotPasswordLink.prop('href'), routes.forgotPassword);
+  });
+
+  it('displays form errors', () => {
+    fakeConfig.formErrors = {
+      username: 'Invalid username',
+      password: 'Invalid password',
+    };
+
+    const { elements } = createWrapper();
+    const { usernameField, passwordField } = elements;
+
+    assert.equal(
+      usernameField.prop('fieldError'),
+      fakeConfig.formErrors.username,
+    );
+    assert.equal(
+      passwordField.prop('fieldError'),
+      fakeConfig.formErrors.password,
+    );
+  });
+
+  it('pre-fills form fields from formData', () => {
+    fakeConfig.formData = {
+      username: 'testuser',
+      password: 'testpassword',
+    };
+
+    const { elements } = createWrapper();
+    const { usernameField, passwordField } = elements;
+
+    assert.equal(usernameField.prop('value'), fakeConfig.formData.username);
+    assert.equal(passwordField.prop('value'), fakeConfig.formData.password);
+  });
+
+  it('updates username when input changes', () => {
+    const { wrapper, elements } = createWrapper();
+    const username = 'testuser';
+
+    act(() => {
+      elements.usernameField.prop('onChangeValue')(username);
+    });
+    wrapper.update();
+    const updatedElements = getElements(wrapper);
+
+    assert.equal(updatedElements.usernameField.prop('value'), username);
+  });
+
+  it('updates password when input changes', () => {
+    const { wrapper, elements } = createWrapper();
+    const password = 'newpassword';
+
+    act(() => {
+      elements.passwordField.prop('onChangeValue')(password);
+    });
+    wrapper.update();
+    const updatedElements = getElements(wrapper);
+
+    assert.equal(updatedElements.passwordField.prop('value'), password);
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({ content: () => createWrapper().wrapper }),
+  );
+});

--- a/h/static/scripts/login-forms/config.ts
+++ b/h/static/scripts/login-forms/config.ts
@@ -1,0 +1,20 @@
+import { createContext } from 'preact';
+
+export type ConfigObject = {
+  /** The URLs of the app's CSS stylesheets. */
+  styles: string[];
+  csrfToken: string;
+  formErrors?: Record<string, string>;
+  formData?: Record<string, string>;
+};
+
+/** Return the frontend config from the page's <script class="js-config">. */
+export function readConfig(): ConfigObject {
+  try {
+    return JSON.parse(document.querySelector('.js-config')!.textContent!);
+  } catch {
+    throw new Error('Failed to parse frontend configuration');
+  }
+}
+
+export const Config = createContext<ConfigObject | null>(null);

--- a/h/static/scripts/login-forms/index.tsx
+++ b/h/static/scripts/login-forms/index.tsx
@@ -1,0 +1,13 @@
+import { render } from 'preact';
+
+import AppRoot from './components/AppRoot';
+import { readConfig } from './config';
+
+function init() {
+  const shadowHost = document.querySelector('#login-form')!;
+  const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+  const config = readConfig();
+  render(<AppRoot config={config} />, shadowRoot);
+}
+
+init();

--- a/h/static/scripts/login-forms/routes.ts
+++ b/h/static/scripts/login-forms/routes.ts
@@ -1,0 +1,11 @@
+/**
+ * URL patterns for routes that the frontend router needs to match or
+ * dynamically generate links for.
+ *
+ * These must be synchronized with h/routes.py.
+ */
+export const routes = {
+  login: '/login',
+  forgotPassword: '/forgot-password',
+  signup: '/signup',
+};

--- a/h/static/scripts/login-forms/test/config-test.js
+++ b/h/static/scripts/login-forms/test/config-test.js
@@ -1,0 +1,40 @@
+import { readConfig } from '../config';
+
+describe('readConfig', () => {
+  let expectedConfig;
+  let configEl;
+
+  beforeEach(() => {
+    expectedConfig = {
+      styles: ['/static/foo.css'],
+    };
+    configEl = document.createElement('script');
+    configEl.className = 'js-config';
+    configEl.type = 'application/json';
+    configEl.textContent = JSON.stringify(expectedConfig);
+    document.body.appendChild(configEl);
+  });
+
+  afterEach(() => {
+    configEl.remove();
+  });
+
+  it('should throw if the .js-config object is missing', () => {
+    configEl.remove();
+    assert.throws(() => {
+      readConfig();
+    }, 'Failed to parse frontend configuration');
+  });
+
+  it('should throw if the config cannot be parsed', () => {
+    configEl.textContent = 'not valid JSON';
+    assert.throws(() => {
+      readConfig();
+    }, 'Failed to parse frontend configuration');
+  });
+
+  it('should return the parsed configuration', () => {
+    const config = readConfig();
+    assert.deepEqual(config, expectedConfig);
+  });
+});

--- a/h/static/styles/forms.css
+++ b/h/static/styles/forms.css
@@ -1,4 +1,4 @@
-/* CSS entry point for the 'new group' app. */
+/* CSS entry point for the Preact apps. */
 
 @tailwind base;
 @tailwind components;

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -1,5 +1,40 @@
-{% extends "h:templates/accounts/base.html.jinja2" %}
+{% extends "h:templates/layouts/base.html.jinja2" %}
 
 {% block page_title %}Log in{% endblock %}
 
-{% set signup_message = "Don't have a Hypothesis account?" %}
+{% block header %}
+  {% include "h:templates/includes/logo-header.html.jinja2" %}
+{% endblock %}
+
+{% block styles %}
+  {{ super() }}
+
+  {# Avoid a "flash of unstyled content" by preloading the stylesheets that
+     will be used by the Preact app within its Shadow DOM. #}
+  {% for url in asset_urls('forms_css') %}
+    <link rel="preload" href={{ url }} as="style"/>
+  {% endfor %}
+{% endblock %}
+
+{% block content %}
+  <div class="form-container">
+    <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
+
+    <h1 class="form-header">Log in</h1>
+    <div id="login-form"></div>
+    <footer class="form-footer">
+      <span style="font-size: 0.875rem">
+        Don't have a Hypothesis account?
+        <a class="link--footer" href="{{ request.route_path('signup') }}">Sign up</a>
+      </span>
+    </footer>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+
+  {% for url in asset_urls('login_forms_js') %}
+    <script type="module" src="{{ url }}"></script>
+  {% endfor %}
+{% endblock %}

--- a/h/templates/groups/create_edit.html.jinja2
+++ b/h/templates/groups/create_edit.html.jinja2
@@ -5,7 +5,7 @@
 
   {# Avoid a "flash of unstyled content" by preloading the stylesheets that
      will be used by the Preact app within its Shadow DOM. #}
-  {% for url in asset_urls('group_forms_css') %}
+  {% for url in asset_urls('forms_css') %}
     <link rel="preload" href={{ url }} as="style" />
   {% endfor %}
 {% endblock %}

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -62,7 +62,7 @@ class GroupCreateEditController:
             }
 
         js_config = {
-            "styles": self.request.registry["assets_env"].urls("group_forms_css"),
+            "styles": self.request.registry["assets_env"].urls("forms_css"),
             "api": {
                 "createGroup": api_config("api.groups", "POST"),
             },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -47,6 +47,8 @@ export default [
   bundleConfig('site', 'h/static/scripts/site.js'),
   // Preact app for creating new private groups.
   bundleConfig('group-forms', 'h/static/scripts/group-forms/index.tsx'),
+  // Preact app for the login pages.
+  bundleConfig('login-forms', 'h/static/scripts/login-forms/index.tsx'),
   // Admin areas of the site
   bundleConfig('admin-site', 'h/static/scripts/admin-site.js'),
   // Header script inserted inline at the top of the page

--- a/tests/functional/accounts_test.py
+++ b/tests/functional/accounts_test.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 
@@ -95,7 +97,12 @@ class TestAccountSettings:
     @pytest.fixture
     def app(self, app, user):
         res = app.get("/login")
-        res.form["username"] = user.username
-        res.form["password"] = "pass"  # noqa: S105
-        res.form.submit()
+        js_config = json.loads(res.html.find("script", class_="js-config").text)
+
+        params = {
+            "username": user.username,
+            "password": "pass",
+            "csrf_token": js_config["csrfToken"],
+        }
+        app.post("/login", params=params)
         return app

--- a/tests/functional/client_login_test.py
+++ b/tests/functional/client_login_test.py
@@ -84,12 +84,16 @@ class TestLoginFlow:
 
         return url.geturl(), query
 
-    @classmethod
     def login(cls, app, user):
         res = app.get("/login")
-        res.form["username"] = user.username
-        res.form["password"] = "pass"  # noqa: S105
-        res.form.submit()
+        js_config = json.loads(res.html.find("script", class_="js-config").text)
+
+        params = {
+            "username": user.username,
+            "password": "pass",
+            "csrf_token": js_config["csrfToken"],
+        }
+        app.post("/login", params=params)
 
     @pytest.fixture
     def params(self, authclient):

--- a/tests/functional/fixtures/authentication.py
+++ b/tests/functional/fixtures/authentication.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 __all__ = (
@@ -24,9 +26,14 @@ def login_user(db_session, app, user):
         db_session.commit()
 
         login_page = app.get("/login")
-        login_page.form["username"] = user.username
-        login_page.form["password"] = "pass"  # noqa: S105
-        login_page.form.submit()
+        js_config = json.loads(login_page.html.find("script", class_="js-config").text)
+
+        params = {
+            "username": user.username,
+            "password": "pass",
+            "csrf_token": js_config["csrfToken"],
+        }
+        app.post("/login", params=params)
 
     return login_user
 

--- a/tests/unit/h/conftest.py
+++ b/tests/unit/h/conftest.py
@@ -42,6 +42,9 @@ class FakeInvalid:
     def __init__(self, errors):
         self.errors = errors
 
+    def asdict(self):
+        return self.errors
+
 
 @pytest.fixture
 def cli():

--- a/tests/unit/h/views/groups_test.py
+++ b/tests/unit/h/views/groups_test.py
@@ -21,7 +21,7 @@ class TestGroupCreateEditController:
 
         result = controller.create()
 
-        assets_env.urls.assert_called_once_with("group_forms_css")
+        assets_env.urls.assert_called_once_with("forms_css")
         views.get_csrf_token.assert_called_once_with(pyramid_request)
         assert result == {
             "page_title": (
@@ -59,7 +59,7 @@ class TestGroupCreateEditController:
 
         result = controller.edit()
 
-        assets_env.urls.assert_called_once_with("group_forms_css")
+        assets_env.urls.assert_called_once_with("forms_css")
         views.get_csrf_token.assert_called_once_with(pyramid_request)
         annotation_stats_service.total_group_annotation_count.assert_called_once_with(
             group.pubid, unshared=False


### PR DESCRIPTION
Refs https://github.com/hypothesis/h/issues/9588

Here we port login page to react in a hybrid way.
React app renders the form, but we actually submit it. And POST request is handled by the backend.
Login form controller is mostly based on group form controller.
For now it only affects regular login and open authorization popup login still uses Jinja2 for easier porting, which we'll address next.
Reusable components like text field will need to be lifted up from group form app.

Testing
===
- Go to `/login` page
- Try logging with valid and invalid credentials
- Go to `/login?for_oauth=true` page
- Try logging with valid and invalid credentials to make sure it continues to work as before