### PR TITLE
Manually focus input field on mount if `autofocus` prop is set

### DIFF
--- a/h/static/scripts/group-forms/components/forms/TextField.tsx
+++ b/h/static/scripts/group-forms/components/forms/TextField.tsx
@@ -1,5 +1,5 @@
 import { Input, Textarea } from '@hypothesis/frontend-shared';
-import { useId, useState } from 'preact/hooks';
+import { useEffect, useId, useRef, useState } from 'preact/hooks';
 
 import Label from './Label';
 
@@ -97,17 +97,29 @@ export default function TextField({
 
   const InputComponent = type === 'input' ? Input : Textarea;
 
+  // Apply autofocus. We do this ourselves rather than use the input's
+  // `autofocus` attribute to work around an issue with autofocus not being
+  // applied to elements in Shadow DOM in Safari and Firefox.
+  // See https://github.com/hypothesis/h/pull/9596#issuecomment-2922175483.
+  const inputRef = useRef<HTMLElement>();
+  useEffect(() => {
+    if (autofocus) {
+      inputRef.current?.focus();
+    }
+    // This will also trigger if `autofocus` changes after mount. That's OK.
+  }, [autofocus]);
+
   return (
     <div>
       <Label htmlFor={id} text={label} required={required} />
       <InputComponent
         id={id}
+        elementRef={inputRef}
         onInput={handleInput}
         onChange={handleChange}
         error={error}
         value={value}
         classes={classes}
-        autofocus={autofocus}
         autocomplete="off"
         required={required}
       />

--- a/h/static/scripts/group-forms/components/forms/test/TextField-test.js
+++ b/h/static/scripts/group-forms/components/forms/test/TextField-test.js
@@ -79,6 +79,13 @@ describe('TextField', () => {
     );
   });
 
+  it('focuses input field on mount if `autofocus` is set', () => {
+    const wrapper = mount(<TextField value="" autofocus />, {
+      connected: true,
+    });
+    assert.equal(document.activeElement, wrapper.find('input').getDOMNode());
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({


### PR DESCRIPTION
Fix an issue where input fields with the `autofocus` prop were not auto-focused after the initial render in some browsers (Safari and Firefox). The solution is to manually focus the control instead.

**Testing:**

1. Go to https://hypothes.is/groups/new in Safari or Firefox and observe that the "Name" field is *not* auto-focused. It is in Chrome.
2. Go to http://localhost:5000/groups/new in Safari or Firefox and verify that the "Name" field is auto-focused