### PR TITLE
Remove shadow DOM use from login forms

### DIFF
--- a/h/static/scripts/login-forms/components/AppRoot.tsx
+++ b/h/static/scripts/login-forms/components/AppRoot.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'preact/hooks';
 import { Route, Switch } from 'wouter-preact';
 
 import Router from '../../group-forms/components/Router';
@@ -12,21 +11,8 @@ export type AppRootProps = {
 };
 
 export default function AppRoot({ config }: AppRootProps) {
-  const stylesheetLinks = useMemo(
-    () =>
-      config.styles.map((stylesheetURL, index) => (
-        <link
-          key={`${stylesheetURL}${index}`}
-          rel="stylesheet"
-          href={stylesheetURL}
-        />
-      )),
-    [config],
-  );
-
   return (
     <>
-      {stylesheetLinks}
       <Config.Provider value={config}>
         <Router>
           <Switch>

--- a/h/static/scripts/login-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/login-forms/components/test/AppRoot-test.js
@@ -1,4 +1,4 @@
-import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { mount } from '@hypothesis/frontend-testing';
 import { useContext } from 'preact/hooks';
 
 import { Config } from '../../config';
@@ -7,7 +7,7 @@ import { $imports, default as AppRoot } from '../AppRoot';
 describe('AppRoot', () => {
   let configContext;
 
-  const config = { styles: [] };
+  const config = { csrfToken: 'fake-csrf-token' };
 
   beforeEach(() => {
     const mockComponent = name => {
@@ -33,16 +33,6 @@ describe('AppRoot', () => {
   function createComponent() {
     return mount(<AppRoot config={config} />);
   }
-
-  it('renders style links', () => {
-    config.styles = ['/static/styles/foo.css'];
-
-    const links = createComponent().find('link');
-
-    assert.equal(links.length, 1);
-    assert.equal(links.at(0).prop('rel'), 'stylesheet');
-    assert.equal(links.at(0).prop('href'), '/static/styles/foo.css');
-  });
 
   /** Navigate to `path`, run `callback` and then reset the location. */
   function navigate(path, callback) {
@@ -77,9 +67,4 @@ describe('AppRoot', () => {
       });
     });
   });
-
-  it(
-    'should pass a11y checks',
-    checkAccessibility({ content: createComponent }),
-  );
 });

--- a/h/static/scripts/login-forms/config.ts
+++ b/h/static/scripts/login-forms/config.ts
@@ -1,8 +1,6 @@
 import { createContext } from 'preact';
 
 export type ConfigObject = {
-  /** The URLs of the app's CSS stylesheets. */
-  styles: string[];
   csrfToken: string;
   formErrors?: Record<string, string>;
   formData?: Record<string, string>;

--- a/h/static/scripts/login-forms/index.tsx
+++ b/h/static/scripts/login-forms/index.tsx
@@ -4,10 +4,9 @@ import AppRoot from './components/AppRoot';
 import { readConfig } from './config';
 
 function init() {
-  const shadowHost = document.querySelector('#login-form')!;
-  const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+  const container = document.querySelector('#login-form')!;
   const config = readConfig();
-  render(<AppRoot config={config} />, shadowRoot);
+  render(<AppRoot config={config} />, container);
 }
 
 init();

--- a/h/static/scripts/login-forms/test/config-test.js
+++ b/h/static/scripts/login-forms/test/config-test.js
@@ -6,7 +6,7 @@ describe('readConfig', () => {
 
   beforeEach(() => {
     expectedConfig = {
-      styles: ['/static/foo.css'],
+      csrfToken: 'fake-csrf-token',
     };
     configEl = document.createElement('script');
     configEl.className = 'js-config';

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -9,10 +9,8 @@
 {% block styles %}
   {{ super() }}
 
-  {# Avoid a "flash of unstyled content" by preloading the stylesheets that
-     will be used by the Preact app within its Shadow DOM. #}
   {% for url in asset_urls('forms_css') %}
-    <link rel="preload" href={{ url }} as="style"/>
+    <link rel="stylesheet" href={{ url }} as="style"/>
   {% endfor %}
 {% endblock %}
 


### PR DESCRIPTION
Refs #9589 
Refs https://hypothes-is.slack.com/archives/C1M8NH76X/p1748606499140319?thread_ts=1748441830.117379&cid=C1M8NH76X

Shadow DOM can break autofocus and for our own login page there is no need to isolate the React component.