### PR TITLE
Require login to view user profiles

### DIFF
--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -349,6 +349,21 @@ class UserSearchController(SearchController):
             "orcid": self.user.orcid,
         }
 
+        if not self.request.user and (self.user.nipsa or annotation_count == 0):
+            # To avoid linking to potentially spammy or NIPSA'd user profiles
+            # we don't link to the user profile if the user is not logged in
+            # We redirect to the login page instead
+            return httpexceptions.HTTPSeeOther(
+                location=self.request.route_url(
+                    "login",
+                    _query={
+                        "next": self.request.route_url(
+                            "activity.user_search", username=self.user.username
+                        )
+                    },
+                )
+            )
+
         if self.request.user == self.user:
             result["user"]["edit_url"] = self.request.route_url("account_profile")
 


### PR DESCRIPTION
Only for user profiles that are NIPSA or have no activity.

Spammers have found they can create user profiles, with bios and URLs, that are spammy. The approach in this commits  is meant to be a small change that should prevent a high number of spam profiles appearing.


### Testing

- I'm using `devdata_user` and `devdata_admin` but any user would do

- Open http://localhost:5000/users/devdata_user as `devdata_user` you'll see the profile page.

- Do the same in an incognito window, you'll also see it.
- Mark the user as nipsa-ed on http://localhost:5000/admin/nipsa. The profile is still visible while logged.

- While logged out the profile page is not visible, filling in the login details redirect you back to the profile page.


