### PR TITLE
ORCiD => ORCID

### DIFF
--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -21,7 +21,7 @@
           <div style="position: relative;">
             <div class="form-input__label js-tooltip"
                  style="position: static;"
-                 aria-label="Connecting your ORCiD enables you to log in to Hypothesis with ORCiD, instead of your Hypothesis password.">
+                 aria-label="Connecting your ORCID enables you to log in to Hypothesis with ORCID, instead of your Hypothesis password.">
               Connect your account
               <i class="form-input__hint-icon">{{ svg_icon('info_icon') }}</i>
             </div>
@@ -37,7 +37,7 @@
         {% else %}
           <a href="{{ request.route_path('orcid.oauth.authorize') }}" class="orcid-connect">
             {{ svg_icon('orcid') }}
-            <span>{% trans %} Connect {% endtrans %}<strong>ORCiD</strong></span>
+            <span>{% trans %} Connect {% endtrans %}<strong>ORCID</strong></span>
             {{ svg_icon('external', 'external-icon') }}
           </a>
         {% endif %}

--- a/h/views/api/orcid.py
+++ b/h/views/api/orcid.py
@@ -69,7 +69,7 @@ class AccessDeniedError(Exception):
 
 
 class UserConflictError(Exception):
-    """A different Hypothesis user is already connected to this ORCiD."""
+    """A different Hypothesis user is already connected to this ORCID."""
 
 
 @view_defaults(request_method="GET", route_name="orcid.oauth.callback")
@@ -99,17 +99,17 @@ class CallbackViews:
             IdentityProvider.ORCID, orcid
         )
 
-        # Oops, this ORCiD is already connected to a *different* Hypothesis
+        # Oops, this ORCID is already connected to a *different* Hypothesis
         # account.
         if already_connected_user and already_connected_user != self._request.user:
             raise UserConflictError
 
         if not already_connected_user:
-            # This ORCiD isn't connected to a Hypothesis account yet.
+            # This ORCID isn't connected to a Hypothesis account yet.
             # Let's go ahead and connect it to the user's account.
             self._orcid_client.add_identity(self._request.user, orcid)
 
-        self._request.session.flash("ORCiD connected ✓", "success")
+        self._request.session.flash("ORCID connected ✓", "success")
         return HTTPFound(location=self._request.route_url("account"))
 
     @notfound_view_config(
@@ -143,7 +143,7 @@ class CallbackViews:
     @exception_view_config(context=UserConflictError)
     def user_conflict_error(self):
         self._request.session.flash(
-            "A different Hypothesis user is already connected to this ORCiD!", "error"
+            "A different Hypothesis user is already connected to this ORCID!", "error"
         )
         return HTTPFound(location=self._request.route_url("account"))
 

--- a/tests/unit/h/views/api/orcid_test.py
+++ b/tests/unit/h/views/api/orcid_test.py
@@ -80,7 +80,7 @@ class TestCallbackViews:
         )
         orcid_client_service.add_identity.assert_called_once_with(user, orcid)
         pyramid_request.session.flash.assert_called_once_with(
-            "ORCiD connected ✓", "success"
+            "ORCID connected ✓", "success"
         )
 
     def test_it_raises_validation_error(self, pyramid_request):
@@ -138,7 +138,7 @@ class TestCallbackViews:
         )
         orcid_client_service.add_identity.assert_not_called()
         pyramid_request.session.flash.assert_called_once_with(
-            "ORCiD connected ✓", "success"
+            "ORCID connected ✓", "success"
         )
 
     def test_notfound(self, pyramid_request):
@@ -191,7 +191,7 @@ class TestCallbackViews:
 
         assert isinstance(result, HTTPFound)
         pyramid_request.session.flash.assert_called_once_with(
-            "A different Hypothesis user is already connected to this ORCiD!", "error"
+            "A different Hypothesis user is already connected to this ORCID!", "error"
         )
         assert result.location == pyramid_request.route_url("account")
 


### PR DESCRIPTION
Although ORCID is stylized as "ORCiD" in the logo, the text form of the word is "ORCID" everywhere on https://info.orcid.org.
