### PR TITLE
Remove invalid `as` attribute on `<link>` tag

### DIFF
--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -10,7 +10,7 @@
   {{ super() }}
 
   {% for url in asset_urls('forms_css') %}
-    <link rel="stylesheet" href={{ url }} as="style"/>
+    <link rel="stylesheet" href="{{ url }}">
   {% endfor %}
 {% endblock %}
 


### PR DESCRIPTION
Per MDN [^1] "This attribute is required when rel="preload" has been set on the <link> element, optional when rel="modulepreload" has been set, and otherwise should not be used."

Also remove necessary closing slash (`<link>` is a void element) and add missing attribute quotes.

[^1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#as