### PR TITLE
Avoid using Shadow DOM for groups forms

### DIFF
--- a/h/static/scripts/group-forms/components/AppRoot.tsx
+++ b/h/static/scripts/group-forms/components/AppRoot.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'preact/hooks';
+import { useState } from 'preact/hooks';
 import { Route, Switch } from 'wouter-preact';
 
 import Router from '../../forms-common/components/Router';
@@ -14,46 +14,31 @@ export type AppRootProps = {
 };
 
 export default function AppRoot({ config }: AppRootProps) {
-  const stylesheetLinks = useMemo(
-    () =>
-      config.styles.map((stylesheetURL, index) => (
-        <link
-          key={`${stylesheetURL}${index}`}
-          rel="stylesheet"
-          href={stylesheetURL}
-        />
-      )),
-    [config],
-  );
-
   // Saved group details. Extracted out of `config` so we can update them after
   // saving changes to the backend.
   const [group, setGroup] = useState(config.context.group);
 
   return (
-    <>
-      {stylesheetLinks}
-      <Config.Provider value={config}>
-        <Router>
-          <Switch>
-            <Route path={routes.groups.new}>
-              <CreateEditGroupForm group={group} onUpdateGroup={setGroup} />
-            </Route>
-            <Route path={routes.groups.edit}>
-              <CreateEditGroupForm group={group} onUpdateGroup={setGroup} />
-            </Route>
-            <Route path={routes.groups.editMembers}>
-              <EditGroupMembersForm group={group!} />
-            </Route>
-            <Route path={routes.groups.moderation}>
-              <GroupModeration group={group!} />
-            </Route>
-            <Route>
-              <h1 data-testid="unknown-route">Page not found</h1>
-            </Route>
-          </Switch>
-        </Router>
-      </Config.Provider>
-    </>
+    <Config.Provider value={config}>
+      <Router>
+        <Switch>
+          <Route path={routes.groups.new}>
+            <CreateEditGroupForm group={group} onUpdateGroup={setGroup} />
+          </Route>
+          <Route path={routes.groups.edit}>
+            <CreateEditGroupForm group={group} onUpdateGroup={setGroup} />
+          </Route>
+          <Route path={routes.groups.editMembers}>
+            <EditGroupMembersForm group={group!} />
+          </Route>
+          <Route path={routes.groups.moderation}>
+            <GroupModeration group={group!} />
+          </Route>
+          <Route>
+            <h1 data-testid="unknown-route">Page not found</h1>
+          </Route>
+        </Switch>
+      </Router>
+    </Config.Provider>
   );
 }

--- a/h/static/scripts/group-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/group-forms/components/test/AppRoot-test.js
@@ -36,14 +36,6 @@ describe('AppRoot', () => {
     return mount(<AppRoot config={config} />);
   }
 
-  it('renders style links', () => {
-    config.styles = ['/static/styles/foo.css'];
-    const links = createComponent().find('link');
-    assert.equal(links.length, 1);
-    assert.equal(links.at(0).prop('rel'), 'stylesheet');
-    assert.equal(links.at(0).prop('href'), '/static/styles/foo.css');
-  });
-
   /** Navigate to `path`, run `callback` and then reset the location. */
   function navigate(path, callback) {
     history.pushState({}, null, path);

--- a/h/static/scripts/group-forms/index.tsx
+++ b/h/static/scripts/group-forms/index.tsx
@@ -5,10 +5,9 @@ import AppRoot from './components/AppRoot';
 import type { ConfigObject } from './config';
 
 function init() {
-  const shadowHost = document.querySelector('#group-form')!;
-  const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+  const container = document.querySelector('#group-form')!;
   const config = readConfig<ConfigObject>();
-  render(<AppRoot config={config} />, shadowRoot);
+  render(<AppRoot config={config} />, container);
 }
 
 init();

--- a/h/templates/groups/create_edit.html.jinja2
+++ b/h/templates/groups/create_edit.html.jinja2
@@ -3,10 +3,8 @@
 {% block styles %}
   {{ super() }}
 
-  {# Avoid a "flash of unstyled content" by preloading the stylesheets that
-     will be used by the Preact app within its Shadow DOM. #}
   {% for url in asset_urls('forms_css') %}
-    <link rel="preload" href={{ url }} as="style" />
+    <link rel="stylesheet" href="{{ url }}">
   {% endfor %}
 {% endblock %}
 


### PR DESCRIPTION
Shadow DOM was used to isolate the Preact/Tailwind-based group forms from the legacy site CSS. However this also results in us needing to deal with Shadow DOM quirks like loading styles being more fiddly and autofocus not working in Safari/Firefox [^1]. The group forms app works fine without the style isolation, so just remove it for now.

[^1]: https://github.com/hypothesis/h/pull/9596#issuecomment-2922175483