### PR TITLE
Update base font size of old h UI to match the new forms

### DIFF
--- a/h/static/styles/components/_annotation-card.scss
+++ b/h/static/styles/components/_annotation-card.scss
@@ -132,13 +132,13 @@
 }
 
 .annotation-card__quote {
+  @include typography.font-normal;
+
   padding: 0 10px;
   overflow-wrap: break-word;
-  color: color.$grey-4;
+  color: color.$grey-5;
   font-family: sans-serif;
-  font-size: 12px;
   font-style: italic;
-  letter-spacing: 0.1px;
   border-left: 3px solid color.$grey-3;
   margin-bottom: 10px;
   margin-left: 0;

--- a/h/static/styles/components/_lozenge.scss
+++ b/h/static/styles/components/_lozenge.scss
@@ -7,8 +7,6 @@
   color: color.$grey-6;
   border-radius: 2px;
   margin-left: 10px;
-  margin-top: 15px;
-  height: 22px;
   max-width: 55%;
 }
 

--- a/h/static/styles/components/_search-bar.scss
+++ b/h/static/styles/components/_search-bar.scss
@@ -11,6 +11,8 @@
   border-radius: 2px;
   display: flex;
   flex-wrap: wrap;
+  padding: 3px 7px;
+  align-items: center;
 
   // scope absolute positioned elements
   position: relative;
@@ -23,8 +25,8 @@
 
   // Add spacing to left of input field for search icon
   padding-left: 7px;
-  padding-top: 18px;
-  padding-bottom: 18px;
+  padding-top: 12px;
+  padding-bottom: 12px;
   padding-right: 3px;
 
   // prevent the search input from being squashed
@@ -50,13 +52,11 @@
   width: calc(100% - 24px);
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .search-bar__icon {
   flex-shrink: 0;
-  height: 14px;
-  margin-left: 7px;
-  margin-top: 18px;
   color: color.$grey-5;
 }
 

--- a/h/static/styles/core/_typography.scss
+++ b/h/static/styles/core/_typography.scss
@@ -10,15 +10,22 @@ $sans-font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande',
   sans-serif !default;
 $mono-font-family: Open Sans Mono, Menlo, DejaVu Sans Mono, monospace !default;
 
-// Standard font sizes
-$normal-font-size: 13px;
-$normal-line-height: 15px;
+// Standard font sizes. These align with Tailwind's font sizes for better
+// consistency with the Preact + Tailwind-based UI.
+//
+// See https://tailwindcss.com/docs/font-size.
 
-$big-font-size: 17px;
-$big-line-height: 22px;
+// Matches Tailwind's `text-sm`
+$normal-font-size: 0.875rem;
+$normal-line-height: calc(1.25 / 0.875);
 
-$small-font-size: 11px;
-$small-line-height: 12px;
+// Matches Tailwind's `text-base`
+$big-font-size: 1rem;
+$big-line-height: calc(1.5 / 1);
+
+// Matches Tailwind's `text-xs`
+$small-font-size: 0.75rem;
+$small-line-height: calc(1 / 0.75);
 
 $title-font-size: 19px;
 $subtitle-font-size: 15px;
@@ -36,14 +43,11 @@ $touch-input-font-size: 16px;
 @mixin font-small {
   font-size: $small-font-size;
   line-height: $small-line-height;
-  font-weight: 400;
-  letter-spacing: 0.2px;
 }
 
 @mixin font-normal {
   font-size: $normal-font-size;
   line-height: $normal-line-height;
-  font-weight: 400;
 }
 
 @mixin font-big {


### PR DESCRIPTION
The new Preact + Tailwind forms use `text-sm` (14px / 0.875rem) as the base font size whereas the older UI used a base size of 13px. This updates the older UI to use a font size and line height that match `text-sm`, for better consistency between the old and new parts of the site. In the process I had to redo some styling of the search bar so that it works with a range of font sizes.

Before:

<img width="1224" alt="h site smaller font" src="https://github.com/user-attachments/assets/dabfbf84-2316-4f6d-8b4a-3b0a28dc7d10" />

After:

<img width="1231" alt="h site larger font" src="https://github.com/user-attachments/assets/290435a1-5934-4e93-ab58-f489b4787a75" />

