### PR TITLE
Port signup page to preact

### DIFF
--- a/h/static/scripts/forms-common/components/Checkbox.tsx
+++ b/h/static/scripts/forms-common/components/Checkbox.tsx
@@ -3,12 +3,16 @@ import { Checkbox as BaseCheckbox } from '@hypothesis/frontend-shared';
 import type { ComponentChildren } from 'preact';
 import { useId } from 'preact/hooks';
 
+import ErrorNotice from './ErrorNotice';
+
 export type CheckboxProps = Omit<BaseCheckboxProps, 'aria-describedby'> & {
   /**
    * Adds a description right under the checkbox and main content, aligned with
    * the main content's left side.
    */
   description?: ComponentChildren;
+  /** Optional error message for the checkbox. */
+  error?: string;
 };
 
 /**
@@ -17,6 +21,7 @@ export type CheckboxProps = Omit<BaseCheckboxProps, 'aria-describedby'> & {
 export default function Checkbox({
   description,
   children,
+  error = '',
   ...checkboxProps
 }: CheckboxProps) {
   const descriptionId = useId();
@@ -36,6 +41,11 @@ export default function Checkbox({
           className="text-grey-6 mt-1 ml-5"
         >
           {description}
+        </div>
+      )}
+      {error && (
+        <div className="mt-1">
+          <ErrorNotice message={error} />
         </div>
       )}
     </div>

--- a/h/static/scripts/login-forms/components/AppRoot.tsx
+++ b/h/static/scripts/login-forms/components/AppRoot.tsx
@@ -5,6 +5,7 @@ import type { ConfigObject } from '../config';
 import { Config } from '../config';
 import { routes } from '../routes';
 import LoginForm from './LoginForm';
+import SignupForm from './SignupForm';
 
 export type AppRootProps = {
   config: ConfigObject;
@@ -18,6 +19,9 @@ export default function AppRoot({ config }: AppRootProps) {
           <Switch>
             <Route path={routes.login}>
               <LoginForm />
+            </Route>
+            <Route path={routes.signup}>
+              <SignupForm />
             </Route>
             <Route>
               <h1 data-testid="unknown-route">Page not found</h1>

--- a/h/static/scripts/login-forms/components/LoginForm.tsx
+++ b/h/static/scripts/login-forms/components/LoginForm.tsx
@@ -5,10 +5,11 @@ import { useContext, useState } from 'preact/hooks';
 import FormContainer from '../../forms-common/components/FormContainer';
 import TextField from '../../forms-common/components/TextField';
 import { Config } from '../config';
+import type { LoginConfigObject } from '../config';
 import { routes } from '../routes';
 
 export default function LoginForm() {
-  const config = useContext(Config)!;
+  const config = useContext(Config) as LoginConfigObject;
 
   const [username, setUsername] = useState(config.formData?.username ?? '');
   const [password, setPassword] = useState(config.formData?.password ?? '');

--- a/h/static/scripts/login-forms/components/SignupForm.tsx
+++ b/h/static/scripts/login-forms/components/SignupForm.tsx
@@ -1,0 +1,118 @@
+import { Button } from '@hypothesis/frontend-shared';
+import { useContext, useState } from 'preact/hooks';
+
+import Checkbox from '../../forms-common/components/Checkbox';
+import FormContainer from '../../forms-common/components/FormContainer';
+import TextField from '../../forms-common/components/TextField';
+import { Config } from '../config';
+import type { SignupConfigObject } from '../config';
+
+export default function SignupForm() {
+  const config = useContext(Config) as SignupConfigObject;
+
+  const [username, setUsername] = useState(config.formData?.username ?? '');
+  const [email, setEmail] = useState(config.formData?.email ?? '');
+  const [password, setPassword] = useState(config.formData?.password ?? '');
+  const [privacyAccepted, setPrivacyAccepted] = useState(
+    config.formData?.privacy_accepted ?? false,
+  );
+  const [commsOptIn, setCommsOptIn] = useState(
+    config.formData?.comms_opt_in ?? false,
+  );
+
+  return (
+    <FormContainer>
+      <form
+        method="POST"
+        data-testid="form"
+        className="max-w-[530px] mx-auto flex flex-col gap-y-4"
+      >
+        <input type="hidden" name="csrf_token" value={config.csrfToken} />
+        <TextField
+          type="input"
+          name="username"
+          value={username}
+          fieldError={config.formErrors?.username ?? ''}
+          onChangeValue={setUsername}
+          label="Username"
+          minLength={3}
+          maxLength={30}
+          autofocus
+          required
+          showRequired={false}
+        />
+        <TextField
+          type="input"
+          name="email"
+          value={email}
+          fieldError={config.formErrors?.email ?? ''}
+          onChangeValue={setEmail}
+          label="Email address"
+          required
+          showRequired={false}
+        />
+        <TextField
+          type="input"
+          inputType="password"
+          name="password"
+          value={password}
+          fieldError={config.formErrors?.password ?? ''}
+          onChangeValue={setPassword}
+          label="Password"
+          minLength={8}
+          required
+          showRequired={false}
+        />
+        <Checkbox
+          data-testid="privacy-accepted"
+          checked={privacyAccepted}
+          name="privacy_accepted"
+          // Backend form validation expects the string "true" rather than the
+          // HTML form default of "on".
+          value="true"
+          onChange={e => {
+            setPrivacyAccepted((e.target as HTMLInputElement).checked);
+          }}
+          error={config.formErrors?.privacy_accepted ?? ''}
+          required
+        >
+          I have read and agree to the{' '}
+          <a className="link" href="https://web.hypothes.is/privacy/">
+            privacy policy
+          </a>
+          ,{' '}
+          <a className="link" href="https://web.hypothes.is/terms-of-service/">
+            terms of service
+          </a>
+          , and{' '}
+          <a
+            className="link"
+            href="https://web.hypothes.is/community-guidelines/"
+          >
+            community guidelines
+          </a>
+          .
+        </Checkbox>
+        <Checkbox
+          data-testid="comms-opt-in"
+          checked={commsOptIn}
+          name="comms_opt_in"
+          // Backend form validation expects the string "true" rather than the
+          // HTML form default of "on".
+          value="true"
+          onChange={e => {
+            setCommsOptIn((e.target as HTMLInputElement).checked);
+          }}
+        >
+          I would like to receive news about annotation and Hypothesis.
+        </Checkbox>
+        <div className="pt-2 flex items-center gap-x-4">
+          <div className="grow" />
+          <Button type="submit" variant="primary" data-testid="submit-button">
+            Sign up
+          </Button>
+        </div>
+      </form>
+    </FormContainer>
+  );
+}

--- a/h/static/scripts/login-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/login-forms/components/test/AppRoot-test.js
@@ -57,6 +57,10 @@ describe('AppRoot', () => {
       path: '/Login',
       selector: 'LoginForm',
     },
+    {
+      path: '/signup',
+      selector: 'SignupForm',
+    },
   ].forEach(({ path, selector }) => {
     it(`renders expected component for URL (${path})`, () => {
       navigate(path, () => {

--- a/h/static/scripts/login-forms/components/test/SignupForm-test.js
+++ b/h/static/scripts/login-forms/components/test/SignupForm-test.js
@@ -1,0 +1,197 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+
+import { Config } from '../../config';
+import { $imports, default as SignupForm } from '../SignupForm';
+
+describe('SignupForm', () => {
+  let fakeConfig;
+
+  beforeEach(() => {
+    fakeConfig = {
+      csrfToken: 'fake-csrf-token',
+      formData: {
+        username: '',
+        email: '',
+        password: '',
+        privacy_accepted: false,
+        comms_opt_in: false,
+      },
+      formErrors: {},
+    };
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  const getElements = wrapper => {
+    return {
+      form: wrapper.find('form[data-testid="form"]'),
+      csrfInput: wrapper.find('input[name="csrf_token"]'),
+      usernameField: wrapper.find('TextField[name="username"]'),
+      emailField: wrapper.find('TextField[name="email"]'),
+      passwordField: wrapper.find('TextField[name="password"]'),
+      privacyCheckbox: wrapper.find('Checkbox[data-testid="privacy-accepted"]'),
+      commsCheckbox: wrapper.find('Checkbox[data-testid="comms-opt-in"]'),
+      submitButton: wrapper.find('Button[data-testid="submit-button"]'),
+    };
+  };
+
+  const createWrapper = () => {
+    const wrapper = mount(
+      <Config.Provider value={fakeConfig}>
+        <SignupForm />
+      </Config.Provider>,
+    );
+    const elements = getElements(wrapper);
+    return { wrapper, elements };
+  };
+
+  it('renders signup form', () => {
+    const { elements } = createWrapper();
+    const {
+      csrfInput,
+      usernameField,
+      emailField,
+      passwordField,
+      privacyCheckbox,
+      commsCheckbox,
+    } = elements;
+
+    assert.equal(csrfInput.prop('value'), fakeConfig.csrfToken);
+    assert.equal(usernameField.prop('value'), '');
+    assert.equal(emailField.prop('value'), '');
+    assert.equal(passwordField.prop('value'), '');
+    assert.isFalse(privacyCheckbox.prop('checked'));
+    assert.isFalse(commsCheckbox.prop('checked'));
+  });
+
+  it('displays form errors', () => {
+    fakeConfig.formErrors = {
+      username: 'Invalid username',
+      email: 'Invalid email',
+      password: 'Invalid password',
+      privacy_accepted: 'You must accept the privacy policy',
+    };
+
+    const { elements } = createWrapper();
+    const { usernameField, emailField, passwordField, privacyCheckbox } =
+      elements;
+
+    assert.equal(
+      usernameField.prop('fieldError'),
+      fakeConfig.formErrors.username,
+    );
+    assert.equal(emailField.prop('fieldError'), fakeConfig.formErrors.email);
+    assert.equal(
+      passwordField.prop('fieldError'),
+      fakeConfig.formErrors.password,
+    );
+    assert.equal(
+      privacyCheckbox.prop('error'),
+      fakeConfig.formErrors.privacy_accepted,
+    );
+  });
+
+  it('pre-fills form fields from formData', () => {
+    fakeConfig.formData = {
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'testpassword',
+      privacy_accepted: true,
+      comms_opt_in: true,
+    };
+
+    const { elements } = createWrapper();
+    const {
+      usernameField,
+      emailField,
+      passwordField,
+      privacyCheckbox,
+      commsCheckbox,
+    } = elements;
+
+    assert.equal(usernameField.prop('value'), fakeConfig.formData.username);
+    assert.equal(emailField.prop('value'), fakeConfig.formData.email);
+    assert.equal(passwordField.prop('value'), fakeConfig.formData.password);
+    assert.equal(
+      privacyCheckbox.prop('checked'),
+      fakeConfig.formData.privacy_accepted,
+    );
+    assert.equal(
+      commsCheckbox.prop('checked'),
+      fakeConfig.formData.comms_opt_in,
+    );
+  });
+
+  it('updates username when input changes', () => {
+    const { wrapper, elements } = createWrapper();
+    const username = 'testuser';
+
+    act(() => {
+      elements.usernameField.prop('onChangeValue')(username);
+    });
+    wrapper.update();
+    const updatedElements = getElements(wrapper);
+
+    assert.equal(updatedElements.usernameField.prop('value'), username);
+  });
+
+  it('updates email when input changes', () => {
+    const { wrapper, elements } = createWrapper();
+    const email = 'test@example.com';
+
+    act(() => {
+      elements.emailField.prop('onChangeValue')(email);
+    });
+    wrapper.update();
+    const updatedElements = getElements(wrapper);
+
+    assert.equal(updatedElements.emailField.prop('value'), email);
+  });
+
+  it('updates password when input changes', () => {
+    const { wrapper, elements } = createWrapper();
+    const password = 'newpassword';
+
+    act(() => {
+      elements.passwordField.prop('onChangeValue')(password);
+    });
+    wrapper.update();
+    const updatedElements = getElements(wrapper);
+
+    assert.equal(updatedElements.passwordField.prop('value'), password);
+  });
+
+  it('updates privacy checkbox when clicked', () => {
+    const { wrapper, elements } = createWrapper();
+    const input = elements.privacyCheckbox.find('input');
+    act(() => {
+      input.getDOMNode().checked = true;
+      input.simulate('change');
+    });
+    wrapper.update();
+    const updatedElements = getElements(wrapper);
+
+    assert.isTrue(updatedElements.privacyCheckbox.prop('checked'));
+  });
+
+  it('updates communication opt-in checkbox when clicked', () => {
+    const { wrapper, elements } = createWrapper();
+    const input = elements.commsCheckbox.find('input');
+    act(() => {
+      input.getDOMNode().checked = true;
+      input.simulate('change');
+    });
+    wrapper.update();
+    const updatedElements = getElements(wrapper);
+
+    assert.isTrue(updatedElements.commsCheckbox.prop('checked'));
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({ content: () => createWrapper().wrapper }),
+  );
+});

--- a/h/static/scripts/login-forms/config.ts
+++ b/h/static/scripts/login-forms/config.ts
@@ -1,10 +1,39 @@
 import { createContext } from 'preact';
 
-export type ConfigObject = {
+export type ConfigBase = {
   csrfToken: string;
-  formErrors?: Record<string, string>;
-  formData?: Record<string, string>;
+};
+
+/** Data passed to frontend for login form. */
+export type LoginConfigObject = ConfigBase & {
+  formErrors?: {
+    username?: string;
+    password?: string;
+  };
+  formData?: {
+    username?: string;
+    password?: string;
+  };
   forOAuth?: boolean;
 };
+
+/** Data passed to frontend for signup form. */
+export type SignupConfigObject = ConfigBase & {
+  formErrors?: {
+    username?: string;
+    password?: string;
+    email?: string;
+    privacy_accepted?: string;
+  };
+  formData?: {
+    username: string;
+    password: string;
+    email: string;
+    privacy_accepted: boolean;
+    comms_opt_in: boolean;
+  };
+};
+
+export type ConfigObject = LoginConfigObject | SignupConfigObject;
 
 export const Config = createContext<ConfigObject | null>(null);

--- a/h/templates/accounts/signup-post.html.jinja2
+++ b/h/templates/accounts/signup-post.html.jinja2
@@ -1,16 +1,53 @@
-{% extends "h:templates/accounts/base.html.jinja2" %}
+{% extends "h:templates/layouts/base.html.jinja2" %}
 
 {% block page_title %}{{ heading|default("Sign up for Hypothesis") }}{% endblock %}
 
-{% set form_message %}
-  {% if not form %}
-    {% if message %}<p>{{ message }}</p>{% endif %}
+{% block header %}
+  {% include "h:templates/includes/logo-header.html.jinja2" %}
+{% endblock %}
 
-    <p>Please check your email and open the link to activate your account.</p>
+{% block styles %}
+  {{ super() }}
 
-    <p>If you don't receive your activation link within a few minutes, send an
-    email to <a href="mailto:support@hypothes.is">support@hypothes.is</a></p>
-  {% endif %}
-{% endset %}
+  {% for url in asset_urls('forms_css') %}
+    <link rel="stylesheet" href="{{ url }}">
+  {% endfor %}
+{% endblock %}
 
-{% set login_message = "Already activated your account?" %}
+{% block content %}
+  <div class="form-container">
+    <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
+
+    <h1 class="form-header">
+      {{ self.page_title() }}
+    </h1>
+    {% if not js_config.get("formData") %}
+      <div class="form-description">
+        {% if message %}<p>{{ message }}</p>{% endif %}
+
+        <p>Please check your email and open the link to activate your account.</p>
+
+        <p>If you don't receive your activation link within a few minutes, send an
+          email to <a href="mailto:support@hypothes.is">support@hypothes.is</a></p>
+      </div>
+    {% else %}
+      <div id="login-form"></div>
+    {% endif %}
+    <footer class="form-footer">
+      {% if not js_config.get("formData") %}
+        Already activated your account?
+      {% else %}
+        Already have an account?
+      {% endif %}
+      <a class="link--footer" href="{{ request.route_path('login') }}">Log in</a>
+    </footer>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+
+  {% for url in asset_urls('login_forms_js') %}
+    <script type="module" src="{{ url }}"></script>
+  {% endfor %}
+{% endblock %}

--- a/h/templates/accounts/signup.html.jinja2
+++ b/h/templates/accounts/signup.html.jinja2
@@ -1,5 +1,38 @@
-{% extends "h:templates/accounts/base.html.jinja2" %}
+{% extends "h:templates/layouts/base.html.jinja2" %}
 
 {% block page_title %}Sign up for Hypothesis{% endblock %}
 
-{% set login_message = "Already have an account?" %}
+{% block header %}
+  {% include "h:templates/includes/logo-header.html.jinja2" %}
+{% endblock %}
+
+{% block styles %}
+  {{ super() }}
+
+  {% for url in asset_urls('forms_css') %}
+    <link rel="stylesheet" href="{{ url }}">
+  {% endfor %}
+{% endblock %}
+
+{% block content %}
+  <div class="form-container">
+    <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
+
+    <h1 class="form-header">Sign up for Hypothesis</h1>
+    <div id="login-form"></div>
+    <footer class="form-footer">
+      <span>
+        Already have an account?
+        <a class="link--footer" href="{{ request.route_path('login') }}">Log in</a>
+      </span>
+    </footer>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+
+  {% for url in asset_urls('login_forms_js') %}
+    <script type="module" src="{{ url }}"></script>
+  {% endfor %}
+{% endblock %}


### PR DESCRIPTION
Refs https://github.com/hypothesis/h/issues/9622
Refs https://github.com/hypothesis/h/pull/9589

Here we port signup page to react in a hybrid way.
React app renders the form, but we actually submit it. And POST request is handled by the backend.

Testing
===
- Go to `http://localhost:5000/signup`
- Try signing up with valid or invalid data