### PR TITLE
Use "ORCID iD" when appropriate

### DIFF
--- a/h/accounts/util.py
+++ b/h/accounts/util.py
@@ -38,16 +38,16 @@ def validate_orcid(orcid):
     Verify that an ORCID identifier conforms to the structure described at
     http://support.orcid.org/knowledgebase/articles/116780-structure-of-the-orcid-identifier
 
-    Returns the normalized ORCID if successfully parsed or raises a ValueError
+    Returns the normalized ORCID iD if successfully parsed or raises a ValueError
     otherwise.
     """
     orcid_regex = r"\A[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]\Z"
 
     if not re.match(orcid_regex, orcid):
-        raise ValueError(f"The format of this ORCID is incorrect: {orcid}")  # noqa: EM102, TRY003
+        raise ValueError(f"The format of this ORCID iD is incorrect: {orcid}")  # noqa: EM102, TRY003
 
     if _orcid_checksum_digit(orcid[:-1]) != orcid[-1:]:
-        raise ValueError(f"{orcid} is not a valid ORCID")  # noqa: EM102, TRY003
+        raise ValueError(f"{orcid} is not a valid ORCID iD")  # noqa: EM102, TRY003
 
     return True
 
@@ -59,7 +59,7 @@ def _orcid_checksum_digit(orcid):
     Translated from the example ISO 7064 checksum implementation at
     http://support.orcid.org/knowledgebase/articles/116780-structure-of-the-orcid-identifier
 
-    :param orcid: ORCID ID consisting of hyphens and digits, assumed to be in
+    :param orcid: ORCID iD consisting of hyphens and digits, assumed to be in
                   the correct format.
     """
     total = 0

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -197,7 +197,7 @@ class User(Base):
     #: The user's URI/link on the web
     uri = sa.Column(sa.UnicodeText())
 
-    #: The user's ORCID ID
+    #: The user's ORCID iD
     orcid = sa.Column(sa.UnicodeText())
 
     #: Is this user an admin member?

--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -21,7 +21,7 @@
           <div style="position: relative;">
             <div class="form-input__label js-tooltip"
                  style="position: static;"
-                 aria-label="Connecting your ORCID enables you to log in to Hypothesis with ORCID, instead of your Hypothesis password.">
+                 aria-label="Connecting your ORCID iD enables you to log in to Hypothesis with ORCID, instead of your Hypothesis password.">
               Connect your account
               <i class="form-input__hint-icon">{{ svg_icon('info_icon') }}</i>
             </div>
@@ -37,7 +37,7 @@
         {% else %}
           <a href="{{ request.route_path('orcid.oauth.authorize') }}" class="orcid-connect">
             {{ svg_icon('orcid') }}
-            <span>{% trans %} Connect {% endtrans %}<strong>ORCID</strong></span>
+            <span>{% trans %} Connect {% endtrans %}<strong>ORCID iD</strong></span>
             {{ svg_icon('external', 'external-icon') }}
           </a>
         {% endif %}

--- a/h/views/api/orcid.py
+++ b/h/views/api/orcid.py
@@ -65,11 +65,11 @@ class AuthorizeViews:
 
 
 class AccessDeniedError(Exception):
-    """The user denied us access to their ORCID account."""
+    """The user denied us access to their ORCID record."""
 
 
 class UserConflictError(Exception):
-    """A different Hypothesis user is already connected to this ORCID."""
+    """A different Hypothesis user is already connected to this ORCID iD."""
 
 
 @view_defaults(request_method="GET", route_name="orcid.oauth.callback")
@@ -99,17 +99,17 @@ class CallbackViews:
             IdentityProvider.ORCID, orcid
         )
 
-        # Oops, this ORCID is already connected to a *different* Hypothesis
+        # Oops, this ORCID iD is already connected to a *different* Hypothesis
         # account.
         if already_connected_user and already_connected_user != self._request.user:
             raise UserConflictError
 
         if not already_connected_user:
-            # This ORCID isn't connected to a Hypothesis account yet.
+            # This ORCID iD isn't connected to a Hypothesis account yet.
             # Let's go ahead and connect it to the user's account.
             self._orcid_client.add_identity(self._request.user, orcid)
 
-        self._request.session.flash("ORCID connected ✓", "success")
+        self._request.session.flash("ORCID iD connected ✓", "success")
         return HTTPFound(location=self._request.route_url("account"))
 
     @notfound_view_config(
@@ -143,7 +143,8 @@ class CallbackViews:
     @exception_view_config(context=UserConflictError)
     def user_conflict_error(self):
         self._request.session.flash(
-            "A different Hypothesis user is already connected to this ORCID!", "error"
+            "A different Hypothesis user is already connected to this ORCID iD!",
+            "error",
         )
         return HTTPFound(location=self._request.route_url("account"))
 

--- a/tests/unit/h/schemas/forms/accounts/edit_profile_test.py
+++ b/tests/unit/h/schemas/forms/accounts/edit_profile_test.py
@@ -20,11 +20,11 @@ class TestEditProfileSchema:
         )
 
     def test_rejects_invalid_orcid(self, pyramid_csrf_request, validate_orcid):
-        validate_orcid.side_effect = ValueError("Invalid ORCID")
+        validate_orcid.side_effect = ValueError("Invalid ORCID iD")
         schema = EditProfileSchema().bind(request=pyramid_csrf_request)
         with pytest.raises(colander.Invalid) as exc:
             schema.deserialize({"orcid": "abcdef"})
-        assert exc.value.asdict()["orcid"] == "Invalid ORCID"
+        assert exc.value.asdict()["orcid"] == "Invalid ORCID iD"
 
     def test_rejects_invalid_url(self, pyramid_csrf_request, validate_url):
         validate_url.side_effect = ValueError("Invalid URL")

--- a/tests/unit/h/views/accounts_test.py
+++ b/tests/unit/h/views/accounts_test.py
@@ -836,7 +836,7 @@ class TestEditProfileController:
         user = pyramid_request.user
         user.display_name = "Jim Smith"
         user.description = "Job Description"
-        user.orcid = "ORCID ID"
+        user.orcid = "ORCID iD"
         user.uri = "http://foo.org"
         user.location = "Paris"
 
@@ -846,7 +846,7 @@ class TestEditProfileController:
             "form": {
                 "display_name": "Jim Smith",
                 "description": "Job Description",
-                "orcid": "ORCID ID",
+                "orcid": "ORCID iD",
                 "link": "http://foo.org",
                 "location": "Paris",
             }
@@ -861,7 +861,7 @@ class TestEditProfileController:
             {
                 "display_name": "Jim Smith",
                 "description": "Job Description",
-                "orcid": "ORCID ID",
+                "orcid": "ORCID iD",
                 "link": "http://foo.org",
                 "location": "Paris",
             }
@@ -870,7 +870,7 @@ class TestEditProfileController:
 
         assert user.display_name == "Jim Smith"
         assert user.description == "Job Description"
-        assert user.orcid == "ORCID ID"
+        assert user.orcid == "ORCID iD"
         assert user.uri == "http://foo.org"
         assert user.location == "Paris"
 

--- a/tests/unit/h/views/api/orcid_test.py
+++ b/tests/unit/h/views/api/orcid_test.py
@@ -80,7 +80,7 @@ class TestCallbackViews:
         )
         orcid_client_service.add_identity.assert_called_once_with(user, orcid)
         pyramid_request.session.flash.assert_called_once_with(
-            "ORCID connected ✓", "success"
+            "ORCID iD connected ✓", "success"
         )
 
     def test_it_raises_validation_error(self, pyramid_request):
@@ -138,7 +138,7 @@ class TestCallbackViews:
         )
         orcid_client_service.add_identity.assert_not_called()
         pyramid_request.session.flash.assert_called_once_with(
-            "ORCID connected ✓", "success"
+            "ORCID iD connected ✓", "success"
         )
 
     def test_notfound(self, pyramid_request):
@@ -191,7 +191,8 @@ class TestCallbackViews:
 
         assert isinstance(result, HTTPFound)
         pyramid_request.session.flash.assert_called_once_with(
-            "A different Hypothesis user is already connected to this ORCID!", "error"
+            "A different Hypothesis user is already connected to this ORCID iD!",
+            "error",
         )
         assert result.location == pyramid_request.route_url("account")
 


### PR DESCRIPTION
"ORCID" always refers to the organization, never to an identifier. We should say "ORCID iD" (yes, with a lowercase i) or "ORCID identifier" whenever we mean to refer to an identifier. See: https://info.orcid.org/brand-guidelines/.

Also "ORCID record" or "ORCID profile" should be used to refer to the information that ORCID holds about a particular user, i.e. "The user's ORCID record" not just "The user's ORCID".
