### PR TITLE
Warn earlier if username contains disallowed characters

### DIFF
--- a/h/static/scripts/forms-common/components/TextField.tsx
+++ b/h/static/scripts/forms-common/components/TextField.tsx
@@ -137,7 +137,7 @@ export default function TextField({
           error={Boolean(error)}
         />
       )}
-      {fieldError && !hasCommitted && (
+      {fieldError && (
         <div className="mt-1">
           <ErrorNotice message={fieldError} />
         </div>

--- a/h/static/scripts/forms-common/form-value.ts
+++ b/h/static/scripts/forms-common/form-value.ts
@@ -1,0 +1,67 @@
+import { useState, useCallback } from 'preact/hooks';
+
+export type FormValueOptions<T> = {
+  /**
+   * Validate a form value. The callback returns undefined if the form is
+   * valid or an error otherwise.
+   *
+   * If the value is invalid, this will be reflected in {@link FormValue.error}.
+   * Whether validation succeeds or fails, {@link FormValue.value} will be updated.
+   *
+   * The purpose of client-side validation is to notify a user sooner about
+   * invalid form values. The server must always perform its own validation,
+   * and client-side validation may be a subset of what the server checks.
+   */
+  validate?: (value: T) => string | undefined;
+
+  /**
+   * The error from when the form was last submitted.
+   *
+   * This is used if the form value has not been changed since it was submitted.
+   */
+  initialError?: string;
+};
+
+export type FormValue<T> = {
+  /** Current form field value. */
+  value: T;
+
+  /** Update the form value. This will change {@link FormValue.changed} to `true`. */
+  update: (value: T) => void;
+
+  /** True if the value has been changed via {@link FormValue.update} since it was last submitted. */
+  changed: boolean;
+
+  /** Current validation error. */
+  error?: string;
+};
+
+/**
+ * Utility to manage the state for a form field value.
+ *
+ * This keeps track of:
+ *
+ *  - The current value
+ *  - Whether the value has changed since the form was last submitted
+ *  - The validation error for the field, which may come from a submission, or
+ *    local validation.
+ */
+export function useFormValue<T>(
+  initial: T,
+  opts: FormValueOptions<T> = {},
+): FormValue<T> {
+  const [value, setValue] = useState(initial);
+  const [changed, setChanged] = useState(false);
+  const update = useCallback((value: T) => {
+    setValue(value);
+    setChanged(true);
+  }, []);
+
+  let error;
+  if (changed) {
+    error = opts.validate?.(value);
+  } else {
+    error = opts.initialError;
+  }
+  return { value, update, changed, error };
+}

--- a/h/static/scripts/forms-common/test/form-value-test.js
+++ b/h/static/scripts/forms-common/test/form-value-test.js
@@ -1,0 +1,46 @@
+import { mount } from '@hypothesis/frontend-testing';
+
+import { useFormValue } from '../form-value';
+
+describe('useFormValue', () => {
+  let lastValue;
+  function TestWidget({ initial, opts }) {
+    lastValue = useFormValue(initial, opts);
+    return <div />;
+  }
+
+  it('returns initial value', () => {
+    mount(<TestWidget initial="foo" />);
+    assert.equal(lastValue.value, 'foo');
+    assert.isUndefined(lastValue.error);
+    assert.isFalse(lastValue.changed);
+  });
+
+  it('returns new value after update', () => {
+    const wrapper = mount(<TestWidget initial="foo" />);
+
+    lastValue.update('new-value');
+    wrapper.update(); // Flush render
+
+    assert.equal(lastValue.value, 'new-value');
+    assert.isUndefined(lastValue.error);
+    assert.isTrue(lastValue.changed);
+  });
+
+  it('returns form error', () => {
+    const opts = {
+      initialError: 'Server error',
+      validate: value => (value === 'invalid' ? 'Client error' : undefined),
+    };
+    const wrapper = mount(<TestWidget initial="foo" opts={opts} />);
+    assert.equal(lastValue.error, 'Server error');
+
+    lastValue.update('invalid');
+    wrapper.update(); // Flush render
+    assert.equal(lastValue.error, 'Client error');
+
+    lastValue.update('valid');
+    wrapper.update(); // Flush render
+    assert.isUndefined(lastValue.error);
+  });
+});

--- a/h/static/scripts/login-forms/components/LoginForm.tsx
+++ b/h/static/scripts/login-forms/components/LoginForm.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
-import { useContext, useState } from 'preact/hooks';
+import { useContext } from 'preact/hooks';
 
 import FormContainer from '../../forms-common/components/FormContainer';
 import TextField from '../../forms-common/components/TextField';
+import { useFormValue } from '../../forms-common/form-value';
 import { Config } from '../config';
 import type { LoginConfigObject } from '../config';
 import { routes } from '../routes';
@@ -11,8 +12,12 @@ import { routes } from '../routes';
 export default function LoginForm() {
   const config = useContext(Config) as LoginConfigObject;
 
-  const [username, setUsername] = useState(config.formData?.username ?? '');
-  const [password, setPassword] = useState(config.formData?.password ?? '');
+  const username = useFormValue(config.formData?.username ?? '', {
+    initialError: config.formErrors?.username,
+  });
+  const password = useFormValue(config.formData?.password ?? '', {
+    initialError: config.formErrors?.password,
+  });
 
   return (
     <FormContainer>
@@ -30,9 +35,9 @@ export default function LoginForm() {
         <TextField
           type="input"
           name="username"
-          value={username}
-          fieldError={config.formErrors?.username ?? ''}
-          onChangeValue={setUsername}
+          value={username.value}
+          fieldError={username.error}
+          onChangeValue={username.update}
           label="Username / email"
           autofocus
           required
@@ -42,9 +47,9 @@ export default function LoginForm() {
           type="input"
           inputType="password"
           name="password"
-          value={password}
-          fieldError={config.formErrors?.password ?? ''}
-          onChangeValue={setPassword}
+          value={password.value}
+          fieldError={password.error}
+          onChangeValue={password.update}
           label="Password"
           required
           showRequired={false}

--- a/h/static/scripts/login-forms/components/SignupForm.tsx
+++ b/h/static/scripts/login-forms/components/SignupForm.tsx
@@ -1,24 +1,32 @@
 import { Button } from '@hypothesis/frontend-shared';
-import { useContext, useState } from 'preact/hooks';
+import { useContext } from 'preact/hooks';
 
 import Checkbox from '../../forms-common/components/Checkbox';
 import FormContainer from '../../forms-common/components/FormContainer';
 import TextField from '../../forms-common/components/TextField';
+import { useFormValue } from '../../forms-common/form-value';
 import { Config } from '../config';
 import type { SignupConfigObject } from '../config';
 
 export default function SignupForm() {
   const config = useContext(Config) as SignupConfigObject;
 
-  const [username, setUsername] = useState(config.formData?.username ?? '');
-  const [email, setEmail] = useState(config.formData?.email ?? '');
-  const [password, setPassword] = useState(config.formData?.password ?? '');
-  const [privacyAccepted, setPrivacyAccepted] = useState(
+  const username = useFormValue(config.formData?.username ?? '', {
+    initialError: config.formErrors?.username,
+  });
+  const email = useFormValue(config.formData?.email ?? '', {
+    initialError: config.formErrors?.email,
+  });
+  const password = useFormValue(config.formData?.password ?? '', {
+    initialError: config.formErrors?.password,
+  });
+  const privacyAccepted = useFormValue(
     config.formData?.privacy_accepted ?? false,
+    {
+      initialError: config.formErrors?.privacy_accepted,
+    },
   );
-  const [commsOptIn, setCommsOptIn] = useState(
-    config.formData?.comms_opt_in ?? false,
-  );
+  const commsOptIn = useFormValue(config.formData?.comms_opt_in ?? false);
 
   return (
     <FormContainer>
@@ -31,9 +39,9 @@ export default function SignupForm() {
         <TextField
           type="input"
           name="username"
-          value={username}
-          fieldError={config.formErrors?.username ?? ''}
-          onChangeValue={setUsername}
+          value={username.value}
+          fieldError={username.error}
+          onChangeValue={username.update}
           label="Username"
           minLength={3}
           maxLength={30}
@@ -44,9 +52,9 @@ export default function SignupForm() {
         <TextField
           type="input"
           name="email"
-          value={email}
-          fieldError={config.formErrors?.email ?? ''}
-          onChangeValue={setEmail}
+          value={email.value}
+          fieldError={email.error}
+          onChangeValue={email.update}
           label="Email address"
           required
           showRequired={false}
@@ -55,9 +63,9 @@ export default function SignupForm() {
           type="input"
           inputType="password"
           name="password"
-          value={password}
-          fieldError={config.formErrors?.password ?? ''}
-          onChangeValue={setPassword}
+          value={password.value}
+          fieldError={password.error}
+          onChangeValue={password.update}
           label="Password"
           minLength={8}
           required
@@ -65,15 +73,15 @@ export default function SignupForm() {
         />
         <Checkbox
           data-testid="privacy-accepted"
-          checked={privacyAccepted}
+          checked={privacyAccepted.value}
           name="privacy_accepted"
           // Backend form validation expects the string "true" rather than the
           // HTML form default of "on".
           value="true"
           onChange={e => {
-            setPrivacyAccepted((e.target as HTMLInputElement).checked);
+            privacyAccepted.update((e.target as HTMLInputElement).checked);
           }}
-          error={config.formErrors?.privacy_accepted ?? ''}
+          error={privacyAccepted.error}
           required
         >
           I have read and agree to the{' '}
@@ -95,13 +103,13 @@ export default function SignupForm() {
         </Checkbox>
         <Checkbox
           data-testid="comms-opt-in"
-          checked={commsOptIn}
+          checked={commsOptIn.value}
           name="comms_opt_in"
           // Backend form validation expects the string "true" rather than the
           // HTML form default of "on".
           value="true"
           onChange={e => {
-            setCommsOptIn((e.target as HTMLInputElement).checked);
+            commsOptIn.update((e.target as HTMLInputElement).checked);
           }}
         >
           I would like to receive news about annotation and Hypothesis.

--- a/h/static/scripts/login-forms/components/SignupForm.tsx
+++ b/h/static/scripts/login-forms/components/SignupForm.tsx
@@ -13,6 +13,12 @@ export default function SignupForm() {
 
   const username = useFormValue(config.formData?.username ?? '', {
     initialError: config.formErrors?.username,
+    validate: username => {
+      if (!username.match(/^[A-Za-z0-9_.]*$/)) {
+        return 'Must have only letters, numbers, periods and underscores.';
+      }
+      return undefined;
+    },
   });
   const email = useFormValue(config.formData?.email ?? '', {
     initialError: config.formErrors?.email,

--- a/h/static/scripts/login-forms/components/test/SignupForm-test.js
+++ b/h/static/scripts/login-forms/components/test/SignupForm-test.js
@@ -138,6 +138,29 @@ describe('SignupForm', () => {
     assert.equal(updatedElements.usernameField.prop('value'), username);
   });
 
+  [
+    {
+      username: 'testuser',
+      error: undefined,
+    },
+    {
+      username: 'foo@bar',
+      error: 'Must have only letters, numbers, periods and underscores.',
+    },
+  ].forEach(({ username, error }) => {
+    it('shows error if username contains invalid characters', () => {
+      const { wrapper, elements } = createWrapper();
+
+      act(() => {
+        elements.usernameField.prop('onChangeValue')(username);
+      });
+      wrapper.update();
+      const updatedElements = getElements(wrapper);
+
+      assert.equal(updatedElements.usernameField.prop('fieldError'), error);
+    });
+  });
+
   it('updates email when input changes', () => {
     const { wrapper, elements } = createWrapper();
     const email = 'test@example.com';


### PR DESCRIPTION
In https://github.com/hypothesis/h/pull/9623 the signup form was converted to the new Preact + Tailwind components. A piece of functionality that was lost was the info icon next to the username field indicating the character constraints on usernames. This PR adds that back, but in a different way by showing a warning if the user enters disallowed characters.

The first commit adds a `useFormValue` hook which simplifies keeping track of the current value and error for a form field, combining the initial value + error from the server with local updates. It changes the login and signup forms to use these for all fields.

The second commit uses the client-side validation functionality of the hook to show a warning immediately if a user enters a username with invalid characters.

**Testing:**

1. Go to http://localhost:5000/signup
2. Enter a value in the username which contains disallowed characters (not matching `A-Za-z0-9_.`). You should see an error appear immediately.