### PR TITLE
Warn about usernames that start or end with periods in signup form

### DIFF
--- a/h/static/scripts/forms-common/components/TextField.tsx
+++ b/h/static/scripts/forms-common/components/TextField.tsx
@@ -42,6 +42,9 @@ export type TextFieldProps = {
   /** Callback invoked when the field's value is changed. */
   onChangeValue: (newValue: string) => void;
 
+  /** Callback invoked when the field's value is committed. */
+  onCommitValue?: (newValue: string) => void;
+
   /**
    * Minimum number of characters that this field must have.
    *
@@ -84,6 +87,7 @@ export default function TextField({
   inputType,
   value,
   onChangeValue,
+  onCommitValue,
   minLength = 0,
   maxLength,
   label,
@@ -96,14 +100,6 @@ export default function TextField({
 }: TextFieldProps) {
   const id = useId();
   const [hasCommitted, setHasCommitted] = useState(false);
-
-  const handleInput = (e: InputEvent) => {
-    onChangeValue((e.target as HTMLInputElement).value);
-  };
-
-  const handleChange = () => {
-    setHasCommitted(true);
-  };
 
   let error = '';
   if (typeof maxLength === 'number' && [...value].length > maxLength) {
@@ -119,8 +115,13 @@ export default function TextField({
       <Label htmlFor={id} text={label} required={showRequired} />
       <InputComponent
         id={id}
-        onInput={handleInput}
-        onChange={handleChange}
+        onInput={e => {
+          onChangeValue((e.target as HTMLInputElement).value);
+        }}
+        onChange={e => {
+          onCommitValue?.((e.target as HTMLInputElement).value);
+          setHasCommitted(true);
+        }}
         error={error}
         value={value}
         classes={classes}

--- a/h/static/scripts/forms-common/components/test/TextField-test.js
+++ b/h/static/scripts/forms-common/components/test/TextField-test.js
@@ -64,6 +64,19 @@ describe('TextField', () => {
     assert.calledWith(onChange, 'foo');
   });
 
+  it('invokes callback when text is committed', () => {
+    const onChange = sinon.stub();
+    const onCommit = sinon.stub();
+    const wrapper = mount(
+      <TextField value="" onChangeValue={onChange} onCommitValue={onCommit} />,
+    );
+
+    wrapper.find('input').getDOMNode().value = 'foo';
+    wrapper.find('input').simulate('change');
+
+    assert.calledWith(onCommit, 'foo');
+  });
+
   it('defers checking for too few characters until first commit', () => {
     const wrapper = mount(<TextField value="" minLength={5} />);
 

--- a/h/static/scripts/forms-common/test/form-value-test.js
+++ b/h/static/scripts/forms-common/test/form-value-test.js
@@ -27,6 +27,34 @@ describe('useFormValue', () => {
     assert.isTrue(lastValue.changed);
   });
 
+  it('returns new value after commit', () => {
+    const wrapper = mount(<TestWidget initial="foo" />);
+
+    lastValue.commit('new-value');
+    wrapper.update(); // Flush render
+
+    assert.equal(lastValue.value, 'new-value');
+    assert.isUndefined(lastValue.error);
+    assert.isTrue(lastValue.changed);
+  });
+
+  it('updates committed state', () => {
+    const validate = sinon.stub();
+    const opts = { validate };
+    const wrapper = mount(<TestWidget initial="foo" opts={opts} />);
+    assert.isTrue(lastValue.committed);
+
+    lastValue.update('new-val');
+    wrapper.update();
+    assert.isFalse(lastValue.committed);
+    assert.calledWith(validate, 'new-val', false);
+
+    lastValue.commit('new-value');
+    wrapper.update();
+    assert.isTrue(lastValue.committed);
+    assert.calledWith(validate, 'new-value', true);
+  });
+
   it('returns form error', () => {
     const opts = {
       initialError: 'Server error',

--- a/h/static/scripts/login-forms/components/SignupForm.tsx
+++ b/h/static/scripts/login-forms/components/SignupForm.tsx
@@ -13,9 +13,12 @@ export default function SignupForm() {
 
   const username = useFormValue(config.formData?.username ?? '', {
     initialError: config.formErrors?.username,
-    validate: username => {
+    validate: (username, committed) => {
       if (!username.match(/^[A-Za-z0-9_.]*$/)) {
         return 'Must have only letters, numbers, periods and underscores.';
+      }
+      if (committed && (username.startsWith('.') || username.endsWith('.'))) {
+        return 'May not start or end with a period.';
       }
       return undefined;
     },
@@ -48,6 +51,7 @@ export default function SignupForm() {
           value={username.value}
           fieldError={username.error}
           onChangeValue={username.update}
+          onCommitValue={username.commit}
           label="Username"
           minLength={3}
           maxLength={30}

--- a/h/static/scripts/login-forms/components/test/SignupForm-test.js
+++ b/h/static/scripts/login-forms/components/test/SignupForm-test.js
@@ -147,12 +147,24 @@ describe('SignupForm', () => {
       username: 'foo@bar',
       error: 'Must have only letters, numbers, periods and underscores.',
     },
-  ].forEach(({ username, error }) => {
+    {
+      username: 'foo.',
+      error: undefined,
+    },
+    {
+      username: 'foo.',
+      commit: true,
+      error: 'May not start or end with a period.',
+    },
+  ].forEach(({ username, error, commit }) => {
     it('shows error if username contains invalid characters', () => {
       const { wrapper, elements } = createWrapper();
 
       act(() => {
         elements.usernameField.prop('onChangeValue')(username);
+        if (commit) {
+          elements.usernameField.prop('onCommitValue')(username);
+        }
       });
       wrapper.update();
       const updatedElements = getElements(wrapper);


### PR DESCRIPTION
Warn the user about usernames that are invalid because they start or end with periods, but only after the username field is committed (ie. loses focus).

The first commit changes `TextField`/`useFormValue` to support tracking whether a field value is committed and applying different validation rules. The second commit uses this to enhance validation of usernames in the signup form.

**Testing:**

1. Go to http://localhost:5000/signup.
2. Enter "foo.bar." as a username. No warning will be shown while the field has focus.
3. Focus another field. A warning about the username being invalid will be shown.