### PR TITLE
Increase contrast of "Forgot your password" link

### DIFF
--- a/h/static/scripts/login-forms/components/LoginForm.tsx
+++ b/h/static/scripts/login-forms/components/LoginForm.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@hypothesis/frontend-shared';
+import { Button, Link } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useContext } from 'preact/hooks';
 
@@ -55,13 +55,14 @@ export default function LoginForm() {
           showRequired={false}
         />
         <div className="text-right">
-          <a
+          <Link
             href={routes.forgotPassword}
-            className="text-grey-5 text-sm underline"
+            underline="always"
+            variant="text-light"
             data-testid="forgot-password-link"
           >
             Forgot your password?
-          </a>
+          </Link>
         </div>
         <div className="mb-8 pt-2 flex items-center gap-x-4">
           {config.forOAuth && (


### PR DESCRIPTION
Change this link to use the `text-color-text-light` color, which is an alias for `text-grey-6`, the text color used for the rest of the form.

**Before:**

<img width="551" alt="Before" src="https://github.com/user-attachments/assets/1337b013-c0e3-4b3b-ab67-bce3cf7a0e0f" />

**After:**

<img width="577" alt="After" src="https://github.com/user-attachments/assets/f066791d-dafb-48fd-a979-40a402022f4f" />
