### PR TITLE
Don't require authentication for reindex API

### DIFF
--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -171,7 +171,6 @@ def delete(context, request):
     versions=["v1", "v2"],
     route_name="api.annotation.reindex",
     request_method="POST",
-    permission=Permission.Annotation.UPDATE,
     link_name="annotation.reindex",
     description="Reindex an annotation",
 )


### PR DESCRIPTION
https://github.com/hypothesis/h/pull/9573 added an API endpoint for
synchronously indexing an annotation (that already exists in the DB)
into Elasticsearch:

    POST /api/annotations/ANNOTATION_ID/reindex

This API is only available in dev and tests, if the `h.dev` setting is
not enabled (via the `DEV` envvar) then the API is disabled and 404s.

The motivation for adding this API is for functest code that adds
annotations to the DB directly (e.g. by using test factories) rather
than by calling the create-annotation API: the annotations will have
been added to the DB but not to Elasticsearch and will not show up in
any subsequent search API responses that the tests may receive.

The idea originated in this Slack thread:

https://hypothes-is.slack.com/archives/C1MA4E9B9/p1747232419483719?thread_ts=1747231219.009989&cid=C1MA4E9B9

The reindex API currently requires requests to be authenticated as the
author of the annotation. It's inconvenient for test code to have to
provide this authentication and it seems unnecessary given that the API
is only available in dev/tests.

This commit therefore removes any authentication requirement from this
API endpoint, making it more convenient for tests to call.

A problem with this approach would be if any of the code called by the
reindex API were to access information about the authenticated user. It
doesn't look like any of the code does do so, so I think we're fine.
