### PR TITLE
Fix logo position in login popup

### DIFF
--- a/h/static/scripts/login-forms/components/LoginForm.tsx
+++ b/h/static/scripts/login-forms/components/LoginForm.tsx
@@ -1,5 +1,4 @@
 import { Button, Link } from '@hypothesis/frontend-shared';
-import classnames from 'classnames';
 import { useContext } from 'preact/hooks';
 
 import FormContainer from '../../forms-common/components/FormContainer';
@@ -24,12 +23,7 @@ export default function LoginForm() {
       <form
         method="POST"
         data-testid="form"
-        className={classnames({
-          'max-w-[530px] mx-auto flex flex-col': true,
-          'gap-y-4': !config.forOAuth,
-          // Use a more compact layout in the OAuth popup window.
-          'gap-y-2': config.forOAuth,
-        })}
+        className="max-w-[530px] mx-auto flex flex-col gap-y-4"
       >
         <input type="hidden" name="csrf_token" value={config.csrfToken} />
         <TextField

--- a/h/static/styles/components/_form.scss
+++ b/h/static/styles/components/_form.scss
@@ -61,6 +61,7 @@
 }
 
 .form-header__logo {
+  display: inline;
   color: color.$grey-6;
   margin-left: 5px;
   vertical-align: middle;


### PR DESCRIPTION
The logo should appear on the same line as the title. However introducing Tailwind's base styles to the form caused the default `display` value for SVGs to change from `inline` to `block` [^1].

With this issue fixed we can remove the custom vertical spacing between fields in the login form. I think the spacing adjustment was originally introduced because in Misha's browser something was reducing the amount of vertical space available. I remember he was using Brave and so re-checked that. It looks fine in Chrome, Safari and Firefox too with the default spacing.

[^1]: https://tailwindcss.com/docs/preflight#images-are-block-level

**Before:**

<img width="495" alt="Login before" src="https://github.com/user-attachments/assets/1ada0933-b5b9-4c6f-b450-eb85e588dcf0" />

**After:**

<img width="500" alt="Login after v3" src="https://github.com/user-attachments/assets/8c7b43fb-fa52-4768-a7db-290595a79dd9" />

