### PR TITLE
Clear the functests search index when clearing the DB

### DIFF
--- a/tests/functional/api/bulk/action_test.py
+++ b/tests/functional/api/bulk/action_test.py
@@ -10,7 +10,7 @@ from h.models import Group, GroupMembership, User
 pytestmark = pytest.mark.usefixtures("init_elasticsearch")
 
 
-@pytest.mark.usefixtures("with_clean_db")
+@pytest.mark.usefixtures("with_clean_db_and_search_index")
 class TestBulk:
     AUTHORITY = "lms.hypothes.is"
 

--- a/tests/functional/api/bulk/annotation_test.py
+++ b/tests/functional/api/bulk/annotation_test.py
@@ -5,7 +5,7 @@ import pytest
 from h.models import GroupMembership
 
 
-@pytest.mark.usefixtures("with_clean_db")
+@pytest.mark.usefixtures("with_clean_db_and_search_index")
 class TestBulkAnnotation:
     def test_it_requires_authentication(self, make_request):
         response = make_request(headers={"bad_auth": "BAD"}, expect_errors=True)

--- a/tests/functional/bin/run_data_task_test.py
+++ b/tests/functional/bin/run_data_task_test.py
@@ -11,7 +11,7 @@ from tests.functional.conftest import TEST_ENVIRONMENT
 
 class TestRunSQLTask:
     # We use "clean DB" here to ensure the schema is created
-    @pytest.mark.usefixtures("with_clean_db")
+    @pytest.mark.usefixtures("with_clean_db_and_search_index")
     def test_reporting_tasks(self, environ):
         for task_name in (
             # Run all the jobs in one line in the order they are expected to

--- a/tests/unit/h/conftest.py
+++ b/tests/unit/h/conftest.py
@@ -67,6 +67,12 @@ from h.services.user_update import UserUpdateService
 from tests.common import factories as common_factories
 
 
+@pytest.fixture
+def es_client(es_client, clear_search_index):
+    yield es_client
+    clear_search_index()
+
+
 class DummyFeature:
     """
     A dummy feature flag looker-upper.


### PR DESCRIPTION
For speed h does not normally clear the DB between functests unless the
test has `@pytest.mark.parametrize("with_clean_db")`, see:
https://github.com/hypothesis/h/pull/6845

At the time when this change was made the _search index_ was still being
cleared before each functest which makes no sense: the search API will
not return an annotation if it's not in the search index, even if the
annotation is in the DB. If you aren't going to clear the DB before each
functest, you shouldn't clear the search index either.

A later PR accidentally broke the
`always_delete_all_elasticsearch_documents` fixture so that the search
index wasn't actually being cleared between functests anyway, see:
https://github.com/hypothesis/h/pull/9636

This commit:

1. Removes the broken `always_delete_all_elasticsearch_documents`
   fixture: it doesn't do anything, and since we don't clear the DB
   between tests it doesn't make sense to clear the search index either.
2. Replaces the `with_clean_db` fixture with
   `with_clean_db_and_search_index`: it doesn't make sense to clear the
   DB without also clearing the search index.

Longer-term I think we probably want to find a fast way to clear both
the DB and search index before each functional test.
