### PR TITLE
Exclude status line from TextField layout size by default

### DIFF
--- a/h/static/scripts/forms-common/components/TextField.tsx
+++ b/h/static/scripts/forms-common/components/TextField.tsx
@@ -1,4 +1,5 @@
 import { Input, Textarea } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
 import { useId, useState } from 'preact/hooks';
 
 import ErrorNotice from './ErrorNotice';
@@ -76,6 +77,15 @@ export type TextFieldProps = {
 
   /** Optional error message for the field. */
   fieldError?: string;
+
+  /**
+   * Whether the status line, containing the character count, affects the layout
+   * size.
+   *
+   * This defaults to false, so that fields in a vertical layout have the same
+   * vertical spacing if some fields have a status line and some do not.
+   */
+  includeStatusLineInLayout?: boolean;
 };
 
 /**
@@ -97,6 +107,7 @@ export default function TextField({
   classes = '',
   name,
   fieldError = '',
+  includeStatusLineInLayout = false,
 }: TextFieldProps) {
   const id = useId();
   const [hasCommitted, setHasCommitted] = useState(false);
@@ -111,7 +122,7 @@ export default function TextField({
   const InputComponent = type === 'input' ? Input : Textarea;
 
   return (
-    <div>
+    <div className="relative">
       <Label htmlFor={id} text={label} required={showRequired} />
       <InputComponent
         id={id}
@@ -131,13 +142,21 @@ export default function TextField({
         name={name}
         type={inputType}
       />
-      {typeof maxLength === 'number' && (
-        <CharacterCounter
-          value={[...value].length}
-          limit={maxLength}
-          error={Boolean(error)}
-        />
-      )}
+      <div
+        className={classnames(
+          includeStatusLineInLayout ? 'relative' : 'absolute',
+          'w-full',
+        )}
+        data-testid="status-line"
+      >
+        {typeof maxLength === 'number' && (
+          <CharacterCounter
+            value={[...value].length}
+            limit={maxLength}
+            error={Boolean(error)}
+          />
+        )}
+      </div>
       {fieldError && (
         <div className="mt-1">
           <ErrorNotice message={fieldError} />

--- a/h/static/scripts/forms-common/components/test/TextField-test.js
+++ b/h/static/scripts/forms-common/components/test/TextField-test.js
@@ -92,6 +92,17 @@ describe('TextField', () => {
     );
   });
 
+  [true, false].forEach(include => {
+    it('includes status line in layout if `includeStatusLineInLayout` is set', () => {
+      const wrapper = mount(
+        <TextField value="" includeStatusLineInLayout={include} />,
+      );
+      const statusLine = wrapper.find('[data-testid="status-line"]');
+      assert.equal(statusLine.hasClass('relative'), include);
+      assert.equal(statusLine.hasClass('absolute'), !include);
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({


### PR DESCRIPTION
Change TextField layout so that, by default, the status line containing the character counter does not take up space in the layout. This keeps the spacing between fields in a form consistent if some have counters and others do not.

If a TextField with a char count is followed immediately by component that does have content in the top right corner, they may need to change this by setting the `includeStatusLineInLayout` prop.

Fixes https://github.com/hypothesis/h/issues/9634.