### PR TITLE
re-add `docker network create dbs`

### DIFF
--- a/.cookiecutter/includes/docker-compose/tail.yml
+++ b/.cookiecutter/includes/docker-compose/tail.yml
@@ -1,6 +1,6 @@
 networks:
   # This external network allows FDW connections between H, LMS and report DBs.
   # To avoid having unnecessary dependencies between the projects
-  # the network is created with `docker network crate dbs` in each project's Makefile (make services)
+  # the network is created with `docker network create dbs` in each project's Makefile (make services)
   dbs:
     external: true

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ $(call help,make help,print this help message)
 $(call help,make services,start the services that the app needs)
 services: args?=up -d --wait
 services: python
+	@docker network create dbs 2>/dev/null || true
 	@docker compose $(args)
 
 .PHONY: db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,6 @@ services:
 networks:
   # This external network allows FDW connections between H, LMS and report DBs.
   # To avoid having unnecessary dependencies between the projects
-  # the network is created with `docker network crate dbs` in each project's Makefile (make services)
+  # the network is created with `docker network create dbs` in each project's Makefile (make services)
   dbs:
     external: true


### PR DESCRIPTION
The code to create the dbs network has a storied past:
- added https://github.com/hypothesis/h/pull/7673
- removed abbe35ccbb
- added again c2a4fe73d
- removed again eb998e11 when cookiecutter was applied to h but didn't include this code.

The docker-compose.yml says this network should be created automatically (although there's a misspelling there, fixed here as a bonus), and without this network, trying to follow the dev environment setup if this network had not already been created results in a cryptic error.

Of course, the real fix would be to address this in the cookiecutter to prevent this from
being overwritten the next time that might be applied, so I'll make a pull request there, too.