### PR TITLE
Add moderation selection dropdown to moderation queue

### DIFF
--- a/h/static/scripts/group-forms/components/AnnotationCard.tsx
+++ b/h/static/scripts/group-forms/components/AnnotationCard.tsx
@@ -19,6 +19,7 @@ import { Config } from '../config';
 import { quote, username } from '../utils/annotation-metadata';
 import type { APIAnnotationData } from '../utils/api';
 import AnnotationDocument from './AnnotationDocument';
+import ModerationStatusSelect from './ModerationStatusSelect';
 
 export type AnnotationCardProps = {
   annotation: APIAnnotationData;
@@ -100,8 +101,13 @@ export default function AnnotationCard({ annotation }: AnnotationCardProps) {
             </ul>
           )}
 
-          <footer className="flex items-center justify-between">
-            <div />
+          <footer className="flex items-end justify-between">
+            <ModerationStatusSelect
+              onChange={/* istanbul ignore next */ () => {}}
+              selected={annotation.moderation_status}
+              mode="select"
+              alignListbox="left"
+            />
             <div className="flex items-center gap-1">
               <Link
                 variant="text-light"

--- a/h/static/scripts/group-forms/components/GroupModeration.tsx
+++ b/h/static/scripts/group-forms/components/GroupModeration.tsx
@@ -130,6 +130,7 @@ export default function GroupModeration({ group }: GroupModerationProps) {
         <ModerationStatusSelect
           selected={filterStatus}
           onChange={setFilterStatus}
+          mode="filter"
         />
       </div>
       <AnnotationList filterStatus={filterStatus} classes="mt-4" />

--- a/h/static/scripts/group-forms/components/ModerationStatusSelect.tsx
+++ b/h/static/scripts/group-forms/components/ModerationStatusSelect.tsx
@@ -7,6 +7,8 @@ import {
   DottedCircleIcon,
   Select,
 } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import { Fragment } from 'preact';
 
 import type { ModerationStatus } from '../utils/api';
 import { moderationStatusToLabel } from '../utils/moderation-status';
@@ -14,6 +16,14 @@ import { moderationStatusToLabel } from '../utils/moderation-status';
 export type ModerationStatusSelectProps = {
   selected?: ModerationStatus;
   onChange: (status?: ModerationStatus) => void;
+  alignListbox?: 'right' | 'left';
+
+  /**
+   * Determines the behavior of this control:
+   *  - `filter`: Used to filter a list of annotations by moderation status.
+   *  - `select`: Used to set the moderation status of a specific annotation.
+   */
+  mode: 'filter' | 'select';
 };
 
 type Option = {
@@ -34,26 +44,38 @@ const options = new Map<ModerationStatus, Option>([
 export default function ModerationStatusSelect({
   selected,
   onChange,
+  alignListbox = 'right',
+  mode,
 }: ModerationStatusSelectProps) {
-  const selectedName = selected ? options.get(selected)?.label : undefined;
+  const selectedName = selected ? options.get(selected)!.label : undefined;
+  const SelectedIcon = selected ? options.get(selected)!.icon : Fragment;
 
   return (
     <Select
       value={selected}
       onChange={onChange}
-      alignListbox="right"
+      alignListbox={alignListbox}
       containerClasses="!w-auto"
+      buttonClasses={classnames(
+        mode === 'select' && {
+          '!bg-green-light !text-green-dark': selected === 'APPROVED',
+          '!bg-yellow-light !text-yellow-dark': selected === 'SPAM',
+          '!bg-red-light !text-red-dark': selected === 'DENIED',
+        },
+      )}
       aria-label="Moderation status"
       buttonContent={
         <div className="flex gap-x-1.5 items-center">
-          <FilterIcon />
+          {mode === 'filter' ? <FilterIcon /> : <SelectedIcon />}
           {selectedName ?? 'All'}
         </div>
       }
     >
-      <Select.Option value={undefined} classes="text-grey-7">
-        All
-      </Select.Option>
+      {mode === 'filter' && (
+        <Select.Option value={undefined} classes="text-grey-7">
+          All
+        </Select.Option>
+      )}
       {[...options.entries()].map(([status, { label, icon: Icon }]) => (
         <Select.Option key={status} value={status}>
           <div className="flex gap-x-1.5 items-center text-grey-7">

--- a/h/static/scripts/group-forms/components/test/AnnotationCard-test.js
+++ b/h/static/scripts/group-forms/components/test/AnnotationCard-test.js
@@ -1,4 +1,8 @@
-import { mockImportedComponents, mount } from '@hypothesis/frontend-testing';
+import {
+  checkAccessibility,
+  mockImportedComponents,
+  mount,
+} from '@hypothesis/frontend-testing';
 
 import { Config } from '../../config';
 import AnnotationCard, { $imports } from '../AnnotationCard';
@@ -13,7 +17,9 @@ describe('AnnotationCard', () => {
     };
     fakeAnnotation = {
       tags: [],
-      links: {},
+      links: {
+        incontext: 'https://example.com',
+      },
       target: [
         {
           selector: [
@@ -136,4 +142,21 @@ describe('AnnotationCard', () => {
     const wrapper = createComponent();
     assert.equal(wrapper.find('blockquote').text(), 'The quote');
   });
+
+  ['PENDING', 'APPROVED', 'DENIED', 'SPAM'].forEach(status => {
+    it("renders ModerationStatusSelect with annotation's status", () => {
+      fakeAnnotation.moderation_status = status;
+      const wrapper = createComponent();
+
+      assert.equal(
+        wrapper.find('ModerationStatusSelect').prop('selected'),
+        status,
+      );
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({ content: () => createComponent() }),
+  );
 });

--- a/h/static/scripts/group-forms/components/test/ModerationStatusSelect-test.js
+++ b/h/static/scripts/group-forms/components/test/ModerationStatusSelect-test.js
@@ -13,9 +13,9 @@ describe('ModerationStatusSelect', () => {
     fakeOnChange = sinon.stub();
   });
 
-  function createComponent(selected) {
+  function createComponent(props = {}) {
     return mount(
-      <ModerationStatusSelect selected={selected} onChange={fakeOnChange} />,
+      <ModerationStatusSelect onChange={fakeOnChange} {...props} />,
       { connected: true },
     );
   }
@@ -28,7 +28,7 @@ describe('ModerationStatusSelect', () => {
     { selected: 'SPAM', expectedText: 'Spam' },
   ].forEach(({ selected, expectedText }) => {
     it('shows selected option as button content', () => {
-      const wrapper = createComponent(selected);
+      const wrapper = createComponent({ selected });
       assert.equal(wrapper.text(), expectedText);
     });
 
@@ -41,19 +41,37 @@ describe('ModerationStatusSelect', () => {
     });
   });
 
-  it('shows expected list of options', async () => {
-    const wrapper = createComponent();
+  const commonOptions = ['Pending', 'Approved', 'Denied', 'Spam'];
 
-    // Open listbox
-    wrapper.find('button').simulate('click');
-    const options = await waitForElement(wrapper, '[role="option"]');
+  [
+    { mode: 'filter', expectedOptions: ['All', ...commonOptions] },
+    { mode: 'select', expectedOptions: commonOptions },
+  ].forEach(({ mode, expectedOptions }) => {
+    it('shows expected list of options', async () => {
+      const wrapper = createComponent({ mode });
 
-    assert.lengthOf(options, 5);
-    assert.equal(options.at(0).text(), 'All');
-    assert.equal(options.at(1).text(), 'Pending');
-    assert.equal(options.at(2).text(), 'Approved');
-    assert.equal(options.at(3).text(), 'Denied');
-    assert.equal(options.at(4).text(), 'Spam');
+      // Open listbox
+      wrapper.find('button').simulate('click');
+      const options = await waitForElement(wrapper, '[role="option"]');
+
+      assert.lengthOf(options, expectedOptions.length);
+      expectedOptions.forEach((option, index) => {
+        assert.equal(options.at(index).text(), option);
+      });
+    });
+  });
+
+  [
+    { mode: 'filter', expectedIcon: 'FilterIcon' },
+    { mode: 'select', selected: 'PENDING', expectedIcon: 'DottedCircleIcon' },
+    { mode: 'select', selected: 'APPROVED', expectedIcon: 'CheckAllIcon' },
+    { mode: 'select', selected: 'DENIED', expectedIcon: 'RestrictedIcon' },
+    { mode: 'select', selected: 'SPAM', expectedIcon: 'CautionIcon' },
+  ].forEach(({ mode, selected, expectedIcon }) => {
+    it('shows expected icon in toggle button', () => {
+      const wrapper = createComponent({ mode, selected });
+      assert.isTrue(wrapper.exists(expectedIcon));
+    });
   });
 
   it(


### PR DESCRIPTION
Part of #9547 

Add a moderation selection control to all annotations in the moderation queue.

This control indicates its current moderation status, and uses a different color palette for every possible value.

The control will also be used to change the annotation moderation status in a follow-up PR, but for now it is no-op.

https://github.com/user-attachments/assets/c7e568d8-2c76-4ec4-8cf8-3dfc3c106c96
 