### PR TITLE
Clear search index *before* unittests

### DIFF
--- a/tests/unit/h/conftest.py
+++ b/tests/unit/h/conftest.py
@@ -69,8 +69,8 @@ from tests.common import factories as common_factories
 
 @pytest.fixture
 def es_client(es_client, clear_search_index):
-    yield es_client
     clear_search_index()
+    return es_client
 
 
 class DummyFeature:


### PR DESCRIPTION
Clear the search index *before* each unittest rather than after, as this
seems more robust. See:

https://github.com/hypothesis/h/pull/9638#discussion_r2161035439
