### PR TITLE
Improve accessibility of tab links on groups forms

### DIFF
--- a/h/static/scripts/forms-common/components/TabLinks.tsx
+++ b/h/static/scripts/forms-common/components/TabLinks.tsx
@@ -1,0 +1,48 @@
+import classnames from 'classnames';
+import type { ComponentChildren } from 'preact';
+import { Link as RouterLink, useRoute } from 'wouter-preact';
+
+export type TabLinkProps = {
+  href: string;
+  children: ComponentChildren;
+  testId?: string;
+};
+
+function TabLink({ children, href, testId }: TabLinkProps) {
+  const [selected] = useRoute(href);
+  return (
+    <RouterLink
+      href={href}
+      className={classnames({
+        'focus-visible-ring whitespace-nowrap flex items-center font-semibold rounded px-2 py-1 gap-x-2':
+          true,
+        'text-grey-1 bg-grey-7': selected,
+      })}
+      data-testid={testId}
+      aria-current={selected}
+      role="listitem"
+    >
+      {children}
+    </RouterLink>
+  );
+}
+
+export type TabLinksProps = {
+  children: ComponentChildren;
+};
+
+/**
+ * A list of navigation links styled as tabs.
+ *
+ * Individual links are created using {@link TabLinks.Link}. The tab which
+ * corresponds to the current route is displayed as selected.
+ */
+export default function TabLinks({ children }: TabLinksProps) {
+  return (
+    <div role="list" className="flex gap-x-2">
+      {children}
+    </div>
+  );
+}
+
+TabLinks.Link = TabLink;

--- a/h/static/scripts/group-forms/components/GroupFormHeader.tsx
+++ b/h/static/scripts/group-forms/components/GroupFormHeader.tsx
@@ -1,35 +1,10 @@
 import { Link } from '@hypothesis/frontend-shared';
-import classnames from 'classnames';
-import type { ComponentChildren } from 'preact';
 import { useContext } from 'preact/hooks';
-import { Link as RouterLink, useRoute } from 'wouter-preact';
 
+import TabLinks from '../../forms-common/components/TabLinks';
 import type { Group } from '../config';
 import { Config } from '../config';
 import { routes } from '../routes';
-
-type TabLinkProps = {
-  href: string;
-  children: ComponentChildren;
-  testId?: string;
-};
-
-function TabLink({ children, href, testId }: TabLinkProps) {
-  const [selected] = useRoute(href);
-  return (
-    <RouterLink
-      href={href}
-      className={classnames({
-        'focus-visible-ring whitespace-nowrap flex items-center font-semibold rounded px-2 py-1 gap-x-2':
-          true,
-        'text-grey-1 bg-grey-7': selected,
-      })}
-      data-testid={testId}
-    >
-      {children}
-    </RouterLink>
-  );
-}
 
 export type GroupFormHeaderProps = {
   group: Group | null;
@@ -75,21 +50,23 @@ export default function GroupFormHeader({
           {title}
         </h1>
         <div className="grow" />
-        {enableMembers && editLink && (
-          <TabLink testId="settings-link" href={editLink}>
-            Settings
-          </TabLink>
-        )}
-        {enableMembers && editMembersLinks && (
-          <TabLink testId="members-link" href={editMembersLinks}>
-            Members
-          </TabLink>
-        )}
-        {enableModeration && moderationLinks && (
-          <TabLink testId="moderation-link" href={moderationLinks}>
-            Moderation
-          </TabLink>
-        )}
+        <TabLinks>
+          {enableMembers && editLink && (
+            <TabLinks.Link testId="settings-link" href={editLink}>
+              Settings
+            </TabLinks.Link>
+          )}
+          {enableMembers && editMembersLinks && (
+            <TabLinks.Link testId="members-link" href={editMembersLinks}>
+              Members
+            </TabLinks.Link>
+          )}
+          {enableModeration && moderationLinks && (
+            <TabLinks.Link testId="moderation-link" href={moderationLinks}>
+              Moderation
+            </TabLinks.Link>
+          )}
+        </TabLinks>
       </div>
     </div>
   );


### PR DESCRIPTION
Extract the tab links from `GroupFormHeader` into a standalone component and improve accessibility by:

 - Marking the tabs as being part of a list
 - Setting `aria-current` on the link that corresponds to the current route

Visually there are no changes, but if you activate a screen reader, you'll see the links announced as a list and the visually selected tab is now marked as such. The pattern here follows the way the content type navigation links (All, Images etc.) are announced on eg. Google/Bing. We might consider using a tab widget approach in future, but that requires more significant changes.