### PR TITLE
Use group name as main heading in group forms, if available

### DIFF
--- a/h/static/scripts/group-forms/components/GroupFormHeader.tsx
+++ b/h/static/scripts/group-forms/components/GroupFormHeader.tsx
@@ -33,6 +33,8 @@ function TabLink({ children, href, testId }: TabLinkProps) {
 
 export type GroupFormHeaderProps = {
   group: Group | null;
+
+  /** Fallback title used if there is no group. */
   title: string;
 };
 
@@ -72,7 +74,7 @@ export default function GroupFormHeader({
       )}
       <div className="flex gap-x-2 py-2 items-center">
         <h1 className="text-grey-7 text-xl/none" data-testid="header">
-          {title}
+          {group?.name ?? title}
         </h1>
         <div className="grow" />
         {enableMembers && editLink && (

--- a/h/static/scripts/group-forms/components/test/GroupFormHeader-test.js
+++ b/h/static/scripts/group-forms/components/test/GroupFormHeader-test.js
@@ -24,14 +24,26 @@ describe('GroupFormHeader', () => {
 
   const group = {
     pubid: 'abc123',
+    name: 'Group title',
     link: 'https://anno.co/groups/abc123',
   };
 
   const getLink = (wrapper, name) => wrapper.find(`a[data-testid="${name}"]`);
 
-  it('renders title', () => {
-    const header = createHeader({ title: 'Create a new group' });
-    assert.equal(header.find('h1').text(), 'Create a new group');
+  [
+    {
+      group: null,
+      title: 'Create a new group',
+      expected: 'Create a new group',
+    },
+
+    { group, title: 'Edit group', expected: group.name },
+  ].forEach(({ group, expected, title }) => {
+    it('renders title', () => {
+      const header = createHeader({ group, title });
+      const displayedTitle = header.find('h1').text();
+      assert.equal(displayedTitle, expected);
+    });
   });
 
   it('does not show activity link or tabs if no group', () => {


### PR DESCRIPTION
When viewing the Members or Moderation tabs of the group forms, the group name was not displayed anywhere on the page. Since the current tab is already indicated by styling of links on the right, it is more useful to use the group name as the main heading.

**Testing:**

1. Go to http://localhost:5000/groups/new. The title should be the same as before.
2. Go to any of the tabs under http://localhost:5000/groups/ViWnzLE3/. The title should be the group name. If you edit the group name and save, the title should update.