### PR TITLE
Remove `dt` alias for `datetime`

### DIFF
--- a/h/search/query.py
+++ b/h/search/query.py
@@ -1,4 +1,4 @@
-from datetime import datetime as dt
+from datetime import datetime
 
 from dateutil import tz
 from dateutil.parser import parse
@@ -142,7 +142,7 @@ class Sorter:
         except ValueError:
             try:
                 date = parse(str_value, default=DEFAULT_DATE)
-                return dt.timestamp(date) * 1000
+                return datetime.timestamp(date) * 1000
 
             except ValueError:
                 pass

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -1,6 +1,5 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
-from dateutil import tz
 from dateutil.parser import parse
 from elasticsearch_dsl import Q
 from elasticsearch_dsl.query import SimpleQueryString
@@ -13,7 +12,7 @@ LIMIT_DEFAULT = 20
 # Elasticsearch requires offset + limit must be <= 10,000.
 LIMIT_MAX = 200
 OFFSET_MAX = 9800
-DEFAULT_DATE = dt(1970, 1, 1, 0, 0, 0, 0).replace(tzinfo=tz.tzutc())  # noqa: DTZ001
+DEFAULT_DATE = datetime(1970, 1, 1, 0, 0, 0, 0, tzinfo=UTC)
 
 
 def popall(multidict, key):


### PR DESCRIPTION
Random refactoring extracted from https://github.com/hypothesis/h/pull/9485: remove the `dt` alias for `datetime`, just call at `datetime`.

Also use `datetime.UTC` not `tz.tzutc()`