### PR TITLE
Add `GroupService.groups_readable_by()`

### DIFF
--- a/h/search/query.py
+++ b/h/search/query.py
@@ -219,10 +219,13 @@ class GroupFilter:
         self.group_service = request.find_service(name="group")
 
     def __call__(self, search, params):
-        # Remove parameter if passed, preventing it being passed to default query
-        group_ids = popall(params, "group") or None
-        groups = self.group_service.groupids_readable_by(self.user, group_ids)
-        return search.filter("terms", group=groups)
+        # Remove parameter if passed, preventing it being passed to default query.
+        groupids = popall(params, "group") or None
+
+        user_readable_groupids = [
+            g.pubid for g in self.group_service.groups_readable_by(self.user, groupids)
+        ]
+        return search.filter("terms", group=user_readable_groupids)
 
 
 class UriCombinedWildcardFilter:

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -117,11 +117,6 @@ class GroupService:
 
         return self.session.scalars(query)
 
-    def groupids_readable_by(self, user, group_ids=None):
-        """Return a list of groupids for which the user has read access."""
-
-        return [g.pubid for g in self.groups_readable_by(user, group_ids)]
-
     def groupids_created_by(self, user):
         """
         Return a list of pubids which the user created.

--- a/tests/unit/h/search/conftest.py
+++ b/tests/unit/h/search/conftest.py
@@ -2,14 +2,20 @@ from unittest import mock
 
 import pytest
 
+from h.models import Group
 from h.services.group import GroupService
 from h.services.search_index import SearchIndexService
 
 
 @pytest.fixture
-def group_service(pyramid_config):
+def world_group(db_session):
+    return db_session.query(Group).filter_by(pubid="__world__").one()
+
+
+@pytest.fixture
+def group_service(pyramid_config, world_group):
     group_service = mock.create_autospec(GroupService, instance=True, spec_set=True)
-    group_service.groupids_readable_by.return_value = ["__world__"]
+    group_service.groups_readable_by.return_value = [world_group]
     pyramid_config.register_service(group_service, name="group")
     return group_service
 

--- a/tests/unit/h/search/query_test.py
+++ b/tests/unit/h/search/query_test.py
@@ -364,25 +364,26 @@ class TestGroupFilter:
         self, search, Annotation, groups, group_service, pyramid_request
     ):
         group_pubids = [group.pubid for group in groups]
-        group_service.groupids_readable_by.return_value = group_pubids
+        group_service.groups_readable_by.return_value = groups
         Annotation(groupid="other_group")
         annotation_ids = [Annotation(groupid=pubid).id for pubid in group_pubids]
 
         result = search.run(MultiDict(("group", pubid) for pubid in group_pubids))
 
-        group_service.groupids_readable_by.assert_called_with(
+        group_service.groups_readable_by.assert_called_with(
             pyramid_request.user, group_ids=group_pubids
         )
         assert sorted(result.annotation_ids) == sorted(annotation_ids)
 
     def test_matches_only_annotations_in_groups_readable_by_user(
-        self, search, Annotation, group_service
+        self, search, Annotation, group_service, factories
     ):
-        group_service.groupids_readable_by.return_value = ["readable_group"]
+        readable_group = factories.Group()
+        group_service.groups_readable_by.return_value = [readable_group]
         Annotation(groupid="unreadable_group", shared=True)
         annotation_ids = [
-            Annotation(groupid="readable_group").id,
-            Annotation(groupid="readable_group").id,
+            Annotation(groupid=readable_group.pubid).id,
+            Annotation(groupid=readable_group.pubid).id,
         ]
 
         result = search.run(MultiDict({}))


### PR DESCRIPTION
Add a new method `GroupService.groups_readable_by()` which returns group objects, in addition to retaining existing `GroupService.groupids_readable_by()` which only returns IDs.

Nothing calls the new method yet, the first caller will be added in https://github.com/hypothesis/h/pull/9485.

This is a standalone addition that was extracted from https://github.com/hypothesis/h/pull/9485.

Since the existing unittests already work by calling `groupids_readable_by()`, and `groupids_readable_by()` is now a wrapper for the new `group_readable_by()`, it's not necessary to add any new unittests and there's still 100% coverage.