### PR TITLE
Use a darker text color for annotation card text

### DIFF
--- a/h/static/scripts/group-forms/components/AnnotationCard.tsx
+++ b/h/static/scripts/group-forms/components/AnnotationCard.tsx
@@ -80,6 +80,7 @@ export default function AnnotationCard({ annotation }: AnnotationCardProps) {
             mentions={annotation.mentions}
             mentionMode="username"
             mentionsEnabled
+            classes="text-color-text"
           />
 
           {annotation.tags.length > 0 && (


### PR DESCRIPTION
To match the styles in the sidebar, and help being able to tell the quote and the text of an annotation apart, this PR sets a darker text color for the annotation text.

Before:
![image](https://github.com/user-attachments/assets/d7dd991c-696b-4208-b4c9-82054f989c9d)

After:
![Captura desde 2025-06-26 15-37-17](https://github.com/user-attachments/assets/0f646ae4-1455-4101-a7e2-ebd59278876a)
