### PR TITLE
Add reply indicator for annotations that are replies

### DIFF
--- a/h/static/scripts/group-forms/components/AnnotationCard.tsx
+++ b/h/static/scripts/group-forms/components/AnnotationCard.tsx
@@ -11,6 +11,7 @@ import {
   CardContent,
   ExternalIcon,
   Link,
+  ReplyIcon,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useContext, useMemo, useState } from 'preact/hooks';
@@ -57,6 +58,7 @@ export default function AnnotationCard({
       },
     [config.context.group],
   );
+  const isReply = (annotation.references ?? []).length > 0;
 
   const updateModerationStatus = useUpdateModerationStatus(annotation);
   const [moderationSaveState, setModerationSaveState] = useState<SaveState>({
@@ -100,12 +102,22 @@ export default function AnnotationCard({
                 withEditedTimestamp={annotation.updated !== annotation.created}
               />
             </div>
-            {group && (
-              <div className="flex gap-x-1 items-baseline flex-wrap-reverse">
-                <AnnotationGroupInfo group={group} />
-                <AnnotationDocument annotation={annotation} />
-              </div>
-            )}
+            <div className="flex gap-x-1 items-baseline flex-wrap-reverse">
+              {group && (
+                <>
+                  <AnnotationGroupInfo group={group} />
+                  <AnnotationDocument annotation={annotation} />
+                </>
+              )}
+              {isReply && (
+                <div
+                  className="ml-auto flex items-center gap-x-1"
+                  data-testid="reply-indicator"
+                >
+                  <ReplyIcon /> This is a reply
+                </div>
+              )}
+            </div>
           </header>
 
           <StyledText>

--- a/h/static/scripts/group-forms/components/AnnotationCard.tsx
+++ b/h/static/scripts/group-forms/components/AnnotationCard.tsx
@@ -97,6 +97,7 @@ export default function AnnotationCard({
               <AnnotationTimestamps
                 annotationCreated={annotation.created}
                 annotationUpdated={annotation.updated}
+                withEditedTimestamp={annotation.updated !== annotation.created}
               />
             </div>
             {group && (

--- a/h/static/scripts/group-forms/components/test/AnnotationCard-test.js
+++ b/h/static/scripts/group-forms/components/test/AnnotationCard-test.js
@@ -113,15 +113,30 @@ describe('AnnotationCard', () => {
     });
   });
 
-  it('renders annotation dates in AnnotationTimestamps', () => {
-    fakeAnnotation.created = '2025-01-01';
-    fakeAnnotation.updated = '2025-01-05';
+  [
+    { created: '2025-01-01', updated: '2025-01-01' },
+    { created: '2025-01-01', updated: '2025-01-05' },
+  ].forEach(({ created, updated }) => {
+    it('renders annotation dates in AnnotationTimestamps', () => {
+      fakeAnnotation.created = created;
+      fakeAnnotation.updated = updated;
 
-    const wrapper = createComponent();
-    const timestamps = wrapper.find('AnnotationTimestamps');
+      const wrapper = createComponent();
+      const timestamps = wrapper.find('AnnotationTimestamps');
 
-    assert.equal(timestamps.prop('annotationCreated'), fakeAnnotation.created);
-    assert.equal(timestamps.prop('annotationUpdated'), fakeAnnotation.updated);
+      assert.equal(
+        timestamps.prop('annotationCreated'),
+        fakeAnnotation.created,
+      );
+      assert.equal(
+        timestamps.prop('annotationUpdated'),
+        fakeAnnotation.updated,
+      );
+      assert.equal(
+        timestamps.prop('withEditedTimestamp'),
+        fakeAnnotation.created !== fakeAnnotation.updated,
+      );
+    });
   });
 
   [{ tags: [] }, { tags: ['foo', 'bar', 'baz'] }].forEach(({ tags }) => {

--- a/h/static/scripts/group-forms/components/test/AnnotationCard-test.js
+++ b/h/static/scripts/group-forms/components/test/AnnotationCard-test.js
@@ -219,6 +219,22 @@ describe('AnnotationCard', () => {
     );
   });
 
+  [
+    { references: undefined, showsReplyIndicator: false },
+    { references: [], showsReplyIndicator: false },
+    { references: ['1', '2'], showsReplyIndicator: true },
+  ].forEach(({ references, showsReplyIndicator }) => {
+    it('adds reply indicator for annotations that are replies', () => {
+      fakeAnnotation.references = references;
+      const wrapper = createComponent();
+
+      assert.equal(
+        wrapper.exists('[data-testid="reply-indicator"]'),
+        showsReplyIndicator,
+      );
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({ content: () => createComponent() }),

--- a/h/static/scripts/group-forms/utils/api/index.ts
+++ b/h/static/scripts/group-forms/utils/api/index.ts
@@ -138,6 +138,7 @@ export type APIAnnotationData = Annotation & {
   id: string;
   text: string;
 
+  references?: string[];
   mentions: Mention[];
   tags: string[];
 


### PR DESCRIPTION
Closes #9669 

Since the moderation queue displays a flat list of annotations, add a reply indicator to replies, so that they are easier to identify.

![image](https://github.com/user-attachments/assets/17ab45a9-f2fb-41b5-8ae9-310ef074a340)

I also took the opportunity to include the date in which annotations were edited, in case they were, as this was overlooked in some of the previous pieces of work.