### PR TITLE
Use Declined label for annotations moderated as DENIED

### DIFF
--- a/h/static/scripts/group-forms/components/test/GroupModeration-test.js
+++ b/h/static/scripts/group-forms/components/test/GroupModeration-test.js
@@ -92,7 +92,7 @@ describe('GroupModeration', () => {
       {
         status: 'DENIED',
         expectedFallbackMessage:
-          'There are no Denied annotations in this group.',
+          'There are no Declined annotations in this group.',
       },
       {
         status: 'SPAM',

--- a/h/static/scripts/group-forms/components/test/ModerationStatusSelect-test.js
+++ b/h/static/scripts/group-forms/components/test/ModerationStatusSelect-test.js
@@ -24,7 +24,7 @@ describe('ModerationStatusSelect', () => {
     { selected: undefined, expectedText: 'All' },
     { selected: 'PENDING', expectedText: 'Pending' },
     { selected: 'APPROVED', expectedText: 'Approved' },
-    { selected: 'DENIED', expectedText: 'Denied' },
+    { selected: 'DENIED', expectedText: 'Declined' },
     { selected: 'SPAM', expectedText: 'Spam' },
   ].forEach(({ selected, expectedText }) => {
     it('shows selected option as button content', () => {
@@ -41,7 +41,7 @@ describe('ModerationStatusSelect', () => {
     });
   });
 
-  const commonOptions = ['Pending', 'Approved', 'Denied', 'Spam'];
+  const commonOptions = ['Pending', 'Approved', 'Declined', 'Spam'];
 
   [
     { mode: 'filter', expectedOptions: ['All', ...commonOptions] },

--- a/h/static/scripts/group-forms/utils/moderation-status.ts
+++ b/h/static/scripts/group-forms/utils/moderation-status.ts
@@ -3,7 +3,7 @@ import type { ModerationStatus } from './api';
 export const moderationStatusToLabel: Record<ModerationStatus, string> = {
   PENDING: 'Pending',
   APPROVED: 'Approved',
-  DENIED: 'Denied',
+  DENIED: 'Declined',
   SPAM: 'Spam',
 } as const;
 


### PR DESCRIPTION
As discussed in https://hypothes-is.slack.com/archives/C2C2U40LW/p1750754909758469, this PR changes the "Denied" wording in user-facing UIs to "Declined" for annotations with `DENIED` moderation status.

We are not changing for now the internal identifiers, as it requires changes in logic and entries in the database, so for now we'll accept this inconsistency.