### PR TITLE
Animate removal of items from moderation list

### DIFF
--- a/h/static/scripts/group-forms/components/GroupModeration.tsx
+++ b/h/static/scripts/group-forms/components/GroupModeration.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from '@hypothesis/frontend-shared';
+import { Slider, Spinner } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
@@ -29,8 +29,13 @@ type AnnotationListProps = {
 };
 
 function AnnotationList({ filterStatus, classes }: AnnotationListProps) {
-  const { loadNextPage, annotations, loading, updateAnnotationStatus } =
-    useGroupAnnotations({ filterStatus });
+  const {
+    loadNextPage,
+    annotations,
+    loading,
+    removedAnnotations,
+    updateAnnotationStatus,
+  } = useGroupAnnotations({ filterStatus });
 
   const lastScrollPosition = useRef(0);
   useEffect(() => {
@@ -64,6 +69,7 @@ function AnnotationList({ filterStatus, classes }: AnnotationListProps) {
         loading={loading}
         annotations={annotations}
         onAnnotationStatusChange={updateAnnotationStatus}
+        removedAnnotations={removedAnnotations}
       />
     </section>
   );
@@ -77,6 +83,7 @@ type AnnotationListContentProps = {
     annotationId: string,
     moderationStatus: ModerationStatus,
   ) => void;
+  removedAnnotations: Set<string>;
 };
 
 function AnnotationListContent({
@@ -84,6 +91,7 @@ function AnnotationListContent({
   annotations,
   filterStatus,
   onAnnotationStatusChange,
+  removedAnnotations,
 }: AnnotationListContentProps) {
   if (annotations && annotations.length === 0) {
     return (
@@ -108,15 +116,18 @@ function AnnotationListContent({
   return (
     <>
       {annotations?.map(anno => (
-        <AnnotationCard
+        <Slider
           key={anno.id}
-          annotation={anno}
-          onStatusChange={moderationStatus => {
-            if (anno.id) {
+          direction={removedAnnotations.has(anno.id) ? 'out' : 'in'}
+          delay="0.5s"
+        >
+          <AnnotationCard
+            annotation={anno}
+            onStatusChange={moderationStatus => {
               onAnnotationStatusChange(anno.id, moderationStatus);
-            }
-          }}
-        />
+            }}
+          />
+        </Slider>
       ))}
       {loading && (
         <div className="mx-auto mt-3">

--- a/h/static/scripts/group-forms/components/test/GroupModeration-test.js
+++ b/h/static/scripts/group-forms/components/test/GroupModeration-test.js
@@ -18,6 +18,7 @@ describe('GroupModeration', () => {
       loading: true,
       loadNextPage: fakeLoadNextPage,
       updateAnnotationStatus: fakeUpdateAnnotationStatus,
+      removedAnnotations: new Set(),
     });
 
     $imports.$mock(mockImportedComponents());
@@ -119,7 +120,11 @@ describe('GroupModeration', () => {
         { id: '2', text: 'Second annotation' },
         { id: '3', text: 'Third annotation' },
       ];
-      fakeUseGroupAnnotations.returns({ loading: false, annotations });
+      fakeUseGroupAnnotations.returns({
+        loading: false,
+        annotations,
+        removedAnnotations: new Set(),
+      });
 
       const wrapper = createComponent();
       const annotationNodes = wrapper
@@ -162,6 +167,7 @@ describe('GroupModeration', () => {
           loading: false,
           annotations,
           updateAnnotationStatus: fakeUpdateAnnotationStatus,
+          removedAnnotations: new Set(),
         });
 
         const wrapper = createComponent();
@@ -176,6 +182,33 @@ describe('GroupModeration', () => {
           );
         });
       });
+    });
+
+    it('wraps annotations in Slider components to animate removal', () => {
+      const annotations = [
+        { id: '1', text: 'First annotation' },
+        { id: '2', text: 'Second annotation' },
+      ];
+      const removedAnnotations = new Set(['2']);
+      fakeUseGroupAnnotations.returns({
+        loading: false,
+        annotations,
+        removedAnnotations,
+        updateAnnotationStatus: fakeUpdateAnnotationStatus,
+      });
+
+      const wrapper = createComponent();
+      const sliders = wrapper.find('Slider');
+
+      assert.lengthOf(sliders, annotations.length);
+
+      // First annotation should have 'in' direction (not removed)
+      assert.equal(sliders.at(0).prop('direction'), 'in');
+      assert.equal(sliders.at(0).prop('delay'), '0.5s');
+
+      // Second annotation should have 'out' direction (removed)
+      assert.equal(sliders.at(1).prop('direction'), 'out');
+      assert.equal(sliders.at(1).prop('delay'), '0.5s');
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/preset-typescript": "^7.27.0",
     "@hypothesis/annotation-ui": "^0.4.0",
     "@hypothesis/frontend-build": "^4.0.0",
-    "@hypothesis/frontend-shared": "^9.5.1",
+    "@hypothesis/frontend-shared": "^9.6.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,15 +2009,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^9.5.1":
-  version: 9.5.1
-  resolution: "@hypothesis/frontend-shared@npm:9.5.1"
+"@hypothesis/frontend-shared@npm:^9.6.0":
+  version: 9.6.0
+  resolution: "@hypothesis/frontend-shared@npm:9.6.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: 4f8396226dc48be3c010cd4769b06b1b76d1bfb4d085b2f6790e57b080902c8174c46ad085ee7cefffebc1b67dad6385c92eb5deeb744029f7c3e377878d0bed
+  checksum: c8deb84e367469c27cc32cfcca3b5aae9bf0ebd75467ab98b9a6bb2c6fe75bc9995b13875afde8f94cdec488c9cb0672e21736e18bf0f60d5c8d56c20bd8b4e2
   languageName: node
   linkType: hard
 
@@ -6881,7 +6881,7 @@ __metadata:
     "@babel/preset-typescript": ^7.27.0
     "@hypothesis/annotation-ui": ^0.4.0
     "@hypothesis/frontend-build": ^4.0.0
-    "@hypothesis/frontend-shared": ^9.5.1
+    "@hypothesis/frontend-shared": ^9.6.0
     "@hypothesis/frontend-testing": ^1.7.1
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.3


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/frontend-shared/pull/2026.**~~

When the user changes the moderation status of an annotation, and has a filter other than "All" selected, show the annotation briefly with the new state before animating it out. This serves as a confirmation to the user of the action that was performed.

This kind of animation for item removal follows a similar pattern to that used in various mail and reminder apps (eg. when archiving emails or marking TODOs as done).

Fixes https://github.com/hypothesis/h/issues/9670

https://github.com/user-attachments/assets/20572732-98ff-409e-be82-b8abedd6a420