### PR TITLE
Fix patching in ORCID view tests

### DIFF
--- a/h/views/api/orcid.py
+++ b/h/views/api/orcid.py
@@ -1,4 +1,3 @@
-import logging
 from urllib.parse import urlencode, urlunparse
 
 import sentry_sdk
@@ -12,17 +11,12 @@ from pyramid.view import (
     view_defaults,
 )
 
-from h import i18n
 from h.models.user_identity import IdentityProvider
 from h.schemas import ValidationError
 from h.schemas.oauth import OAuth2RedirectSchema
 from h.services import ORCIDClientService
 from h.services.exceptions import ExternalRequestError
 from h.services.jwt import TokenValidationError
-
-_ = i18n.TranslationString
-
-logger = logging.getLogger(__name__)
 
 
 @view_defaults(request_method="GET", route_name="orcid.oauth.authorize")


### PR DESCRIPTION
Fix the patch fixtures in `tests/unit/h/views/api/orcid_test.py`.

We don't want the unit tests for these views calling through to the real
`OAuth2RedirectSchema` code from `h/schemas/oauth.py`: that schema class
already has its own unit tests, and this results in the unit tests for
the views containing knowledge of internal implementation details of the
schema (specifically: the session key string that the schema uses to
store the OAuth 2 `state` param in the session). This in turn makes the
code hard to maintain because changes to the schema causes unit tests
for the views to start failing for unclear reasons.

Fix the patch fixtures in the view unit tests to avoid this: view
fixtures should always be defined at test module level, not within
classes, so that they always apply to all tests in the module rather
than some tests using the patched dependency and others confusingly
calling through to the real dependency.

Also added a `report_exception()` fixture that was missing entirely: the
view tests could have tried to make requests to Sentry!

While doing this I also spotted and removed some unused imports from the
views module.
