### PR TITLE
Parametrize OAuth 2 session state key

### DIFF
--- a/h/views/api/orcid.py
+++ b/h/views/api/orcid.py
@@ -28,7 +28,7 @@ class AuthorizeViews:
     def authorize(self):
         host = self._request.registry.settings["orcid_host"]
         client_id = self._request.registry.settings["orcid_client_id"]
-        state = OAuth2RedirectSchema(self._request).state_param()
+        state = OAuth2RedirectSchema(self._request, "orcid.oidc").state_param()
 
         params = {
             "client_id": client_id,
@@ -76,7 +76,7 @@ class CallbackViews:
     @view_config(is_authenticated=True)
     def callback(self):
         try:
-            callback_data = OAuth2RedirectSchema(self._request).validate(
+            callback_data = OAuth2RedirectSchema(self._request, "orcid.oidc").validate(
                 dict(self._request.params)
             )
         except ValidationError as err:


### PR DESCRIPTION
As part of our implementation of OAuth 2.0 we generate a `state` param
(random string) that's used for CSRF protection: we pass a copy of this
`state` param to the authorization provider (ORCID, Google or Facebook)
and stash another copy of the `state` param in the Pyramid session (so
in a browser cookie). When the authorization server redirects the
browser back to us it sends us back the `state` param that we gave it in
a query string. We check that this returned `state` param matches the
copy that we stashed in the session cookie.

**Problem:** the key that we use to stash the `state` param in the
session cookie is hardcoded to `"oauth2_state"`. This could potentially
result in us caching a `state` param for one provider (ORCID, Google or
Facebook) then trying to use that `state` param when validating a
redirect request from another provider.

**Solution:** parametrize the key so that a different key can be used
for each provider: `"orcid.oidc.state"`, `"google.oidc.state"`, etc
(currently ORCID is the only provider implemented).

Testing instructions as in https://github.com/hypothesis/h/pull/9677