### PR TITLE
Hard-code JWT algorithms

### DIFF
--- a/h/services/jwt.py
+++ b/h/services/jwt.py
@@ -17,7 +17,9 @@ class JWTService:
     LEEWAY = datetime.timedelta(seconds=10)
 
     @classmethod
-    def decode_token(cls, token: str, key_set_url: str) -> dict[str, Any]:
+    def decode_token(
+        cls, token: str, key_set_url: str, algorithms: list[str]
+    ) -> dict[str, Any]:
         try:
             unverified_header = jwt.get_unverified_header(token)
             unverified_payload = jwt.decode(token, options={"verify_signature": False})
@@ -29,7 +31,6 @@ class JWTService:
             msg = "Missing 'kid' value in JWT header"
             raise TokenValidationError(msg)
 
-        alg = unverified_header["alg"]
         iss, aud = unverified_payload.get("iss"), unverified_payload.get("aud")
 
         try:
@@ -41,7 +42,7 @@ class JWTService:
                 token,
                 key=signing_key.key,
                 audience=aud,
-                algorithms=[alg],
+                algorithms=algorithms,
                 leeway=cls.LEEWAY,
             )
         except PyJWTError as err:

--- a/h/services/orcid_client.py
+++ b/h/services/orcid_client.py
@@ -12,6 +12,19 @@ from h.services.user import UserService
 logger = logging.getLogger(__name__)
 
 
+# The list of algorithms that we allow authorization servers to use to
+# digitally sign and/or encrypt OpenID Connect ID tokens.
+#
+# The JWT spec leaves it up to the application (us) to specify the list of
+# acceptable algorithms when decoding a JWT. You don't (for example) read the
+# algorithm from the JWT's `alg` header as this would allow an attacker to
+# inject the "None" algorithm or get up to other mischief.
+#
+# The OpenID Connect spec says that ID tokens SHOULD be signed and/or encrypted
+# with RS256.
+OIDC_ALLOWED_JWT_ALGORITHMS = ["RS256"]
+
+
 class ORCIDClientService:
     def __init__(  # noqa: PLR0913
         self,
@@ -41,7 +54,9 @@ class ORCIDClientService:
 
     def get_orcid(self, authorization_code: str) -> str | None:
         id_token = self._get_id_token(authorization_code)
-        decoded_id_token = JWTService.decode_token(id_token, self.key_set_url)
+        decoded_id_token = JWTService.decode_token(
+            id_token, self.key_set_url, OIDC_ALLOWED_JWT_ALGORITHMS
+        )
         return decoded_id_token.get("sub")
 
     def add_identity(self, user: User, orcid: str) -> None:

--- a/tests/unit/h/services/orcid_client_test.py
+++ b/tests/unit/h/services/orcid_client_test.py
@@ -23,7 +23,7 @@ class TestORCIDClientService:
             authorization_code=sentinel.authorization_code,
         )
         JWTService.decode_token.assert_called_once_with(
-            sentinel.id_token, service.key_set_url
+            sentinel.id_token, service.key_set_url, ["RS256"]
         )
 
     def test_get_orcid_returns_none_if_sub_missing(


### PR DESCRIPTION
You're not supposed to read the algorithm from the JWT itself because
this can lead to security vulnerabilities. For example (from the PyJWT
docs):

> Do not compute the algorithms parameter based on the `alg` from the
> token itself, or on any other data that an attacker may be able to
> influence, as that might expose you to various vulnerabilities (see
> RFC 8725 §2.1). Instead, either hard-code a fixed value for
> algorithms, or configure it in the same place you configure the key.
> Make sure not to mix symmetric and asymmetric algorithms that
> interpret the key in different ways (e.g. HS* and RS*).

https://pyjwt.readthedocs.io/en/stable/api.html#jwt.decode

Or RFC 8725 (JSON Web Token Best Current Practices):

> Signed JSON Web Tokens carry an explicit indication of the signing
> algorithm, in the form of the "alg" Header Parameter, to facilitate
> cryptographic agility. This, in conjunction with design flaws in some
> libraries and applications, has led to several attacks:
>
> * The algorithm can be changed to "none" by an attacker, and some
>   libraries would trust this value and "validate" the JWT without
>   checking any signature.
> * An "RS256" (RSA, 2048 bit) parameter value can be changed into
>   "HS256" (HMAC, SHA-256), and some libraries would try to
>   validate the signature using HMAC-SHA256 and using the RSA public
>   key as the HMAC shared secret (see [McLean] and [CVE-2015-9235]).

And from the JWT spec itself:

> it is an application decision which algorithms may be used in a given
> context. Even if a JWT can be successfully validated, unless the
> algorithms used in the JWT are acceptable to the application, it
> SHOULD reject the JWT.

https://datatracker.ietf.org/doc/html/rfc7519#section-7.2

It's up to PyJWT to verfiy that the `alg` claim in the JWT matches one
of the hard-coded allowed algorithms that our application passes to
PyJWT and to use that matching algorithm to decode the JWT.

For the hard-coded list of algorithms I have gone for just one
algorithm: `["RS256"]`. I made this decision based on this from the ID
Token Validation section of the OpenID Connect spec:

> The alg value SHOULD be the default of RS256 or the algorithm sent by
> the Client in the `id_token_signed_response_alg` parameter during
> Registration.

https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation

SHOULD is not the same as MUST but ORCID currently seems to use RS256 so
that's all we need. We can add more algorithms to the list as we need
them.

We don't use any `id_token_signed_response_alg` parameter so I don't
think that applies to us.

The OpenID Connect spec elsewhere says <q>The alg value SHOULD be the
default of RS256. It MAY also be ES256.</q> but that's in a section
about validating self-issued ID tokens and I don't think there are any
self-issued token in our context.
