### PR TITLE
Make usernames on annotation cards link to user activity page

### DIFF
--- a/h/static/scripts/group-forms/components/AnnotationCard.tsx
+++ b/h/static/scripts/group-forms/components/AnnotationCard.tsx
@@ -18,7 +18,7 @@ import { useCallback, useContext, useMemo, useState } from 'preact/hooks';
 
 import { Config } from '../config';
 import { useUpdateModerationStatus } from '../hooks/use-update-moderation-status';
-import { quote, username } from '../utils/annotation-metadata';
+import { quote, username as getUsername } from '../utils/annotation-metadata';
 import type { APIAnnotationData, ModerationStatus } from '../utils/api';
 import AnnotationDocument from './AnnotationDocument';
 import ModerationStatusSelect from './ModerationStatusSelect';
@@ -43,10 +43,9 @@ export default function AnnotationCard({
   onStatusChange,
 }: AnnotationCardProps) {
   const config = useContext(Config)!;
+  const username = getUsername(annotation.user);
   const user =
-    annotation.user_info?.display_name ??
-    username(annotation.user) ??
-    annotation.user;
+    annotation.user_info?.display_name ?? username ?? annotation.user;
   const group = useMemo(
     () =>
       config.context.group && {
@@ -83,6 +82,10 @@ export default function AnnotationCard({
     [onStatusChange, updateModerationStatus],
   );
 
+  const userLink = username
+    ? config.routes['activity.user_search'].replace(':username', username)
+    : undefined;
+
   return useMemo(
     () => (
       <article>
@@ -96,7 +99,7 @@ export default function AnnotationCard({
           <CardContent>
             <header className="w-full">
               <div className="flex gap-x-1 items-center justify-between">
-                <AnnotationUser displayName={user} />
+                <AnnotationUser displayName={user} authorLink={userLink} />
                 <AnnotationTimestamps
                   annotationCreated={annotation.created}
                   annotationUpdated={annotation.updated}
@@ -199,6 +202,7 @@ export default function AnnotationCard({
       moderationSaveState,
       onModerationStatusChange,
       user,
+      userLink,
     ],
   );
 }

--- a/h/static/scripts/group-forms/components/test/AnnotationCard-test.js
+++ b/h/static/scripts/group-forms/components/test/AnnotationCard-test.js
@@ -16,6 +16,9 @@ describe('AnnotationCard', () => {
   beforeEach(() => {
     fakeConfig = {
       context: {},
+      routes: {
+        'activity.user_search': 'https://example.com/users/:username',
+      },
     };
     fakeAnnotation = {
       tags: [],
@@ -68,6 +71,7 @@ describe('AnnotationCard', () => {
       userInfo: undefined,
       annotationUser: 'acct:foo@example.com',
       expectedDisplayName: 'foo',
+      expectedLink: 'https://example.com/users/foo',
     },
     {
       userInfo: {
@@ -75,25 +79,28 @@ describe('AnnotationCard', () => {
       },
       annotationUser: 'acct:foo@example.com',
       expectedDisplayName: 'Jane Doe',
+      expectedLink: 'https://example.com/users/foo',
     },
     {
       userInfo: undefined,
       annotationUser: 'invalid',
       expectedDisplayName: 'invalid',
+      expectedLink: undefined,
     },
-  ].forEach(({ userInfo, annotationUser, expectedDisplayName }) => {
-    it('renders expected username', () => {
-      fakeAnnotation.user_info = userInfo;
-      fakeAnnotation.user = annotationUser;
+  ].forEach(
+    ({ userInfo, annotationUser, expectedDisplayName, expectedLink }) => {
+      it('renders expected username and profile link', () => {
+        fakeAnnotation.user_info = userInfo;
+        fakeAnnotation.user = annotationUser;
 
-      const wrapper = createComponent();
+        const wrapper = createComponent();
 
-      assert.equal(
-        wrapper.find('AnnotationUser').prop('displayName'),
-        expectedDisplayName,
-      );
-    });
-  });
+        const userHeader = wrapper.find('AnnotationUser');
+        assert.equal(userHeader.prop('displayName'), expectedDisplayName);
+        assert.equal(userHeader.prop('authorLink'), expectedLink);
+      });
+    },
+  );
 
   [
     { group: null, shouldRenderGroupInfo: false },

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -42,6 +42,9 @@ export type ConfigObject = {
     group_moderation: boolean;
     pre_moderation: boolean;
   };
+  routes: {
+    'activity.user_search': string;
+  };
 };
 
 export const Config = createContext<ConfigObject | null>(null);

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -4,6 +4,7 @@ from pyramid.view import view_config, view_defaults
 
 from h import i18n
 from h.security import Permission
+from h.views.api.helpers.url_template import route_url_template
 
 _ = i18n.TranslationString
 
@@ -77,6 +78,11 @@ class GroupCreateEditController:
                 "group_type": self.request.feature("group_type"),
                 "group_moderation": self.request.feature("group_moderation"),
                 "pre_moderation": self.request.feature("pre_moderation"),
+            },
+            "routes": {
+                "activity.user_search": route_url_template(
+                    self.request, "activity.user_search"
+                ),
             },
         }
 


### PR DESCRIPTION
Make the username on each annotation card in the moderation view link to the corresponding `/users/:username` page.

Generation of links works similarly to the Hypothesis client: the backend provides a URL template which the client renders for each annotation card.

Fixes https://github.com/hypothesis/h/issues/9695