### PR TITLE
Use a JWT for the OIDC/OAuth2 `state` param

### DIFF
--- a/.cookiecutter/includes/tox/setenv
+++ b/.cookiecutter/includes/tox/setenv
@@ -15,3 +15,4 @@ tests,functests: ELASTICSEARCH_URL = {env:ELASTICSEARCH_URL:http://localhost:920
 tests: ELASTICSEARCH_INDEX = {env:ELASTICSEARCH_INDEX:hypothesis-tests}
 functests: ELASTICSEARCH_INDEX = {env:ELASTICSEARCH_INDEX:hypothesis-functests}
 {tests,functests}: AUTHORITY = {env:AUTHORITY:example.com}
+{dev,tests,functests}: ORCID_OIDC_STATE_SIGNING_KEY=dev_orcid_oidc_state_signing_key

--- a/h/config.py
+++ b/h/config.py
@@ -149,6 +149,7 @@ def configure(environ=None, settings=None):  # noqa: PLR0915
     settings_manager.set("orcid_host", "ORCID_HOST")
     settings_manager.set("orcid_client_id", "ORCID_CLIENT_ID")
     settings_manager.set("orcid_client_secret", "ORCID_CLIENT_SECRET")
+    settings_manager.set("orcid_oidc_state_signing_key", "ORCID_OIDC_STATE_SIGNING_KEY")
 
     settings_manager.set(
         "h_api_auth_cookie_secret_key",

--- a/h/routes.py
+++ b/h/routes.py
@@ -304,5 +304,5 @@ def includeme(config):  # noqa: PLR0915
     )
 
     # ORCID
-    config.add_route("oidc.authorize.orcid", "/oidc/authorize/orcid")
+    config.add_route("oidc.connect.orcid", "/oidc/connect/orcid")
     config.add_route("oidc.redirect.orcid", "/oidc/redirect/orcid")

--- a/h/services/orcid_client.py
+++ b/h/services/orcid_client.py
@@ -97,7 +97,7 @@ def factory(_context, request) -> ORCIDClientService:
         host=settings["orcid_host"],
         client_id=settings["orcid_client_id"],
         client_secret=settings["orcid_client_secret"],
-        redirect_uri=request.route_url("orcid.oauth.callback"),
+        redirect_uri=request.route_url("oidc.redirect.orcid"),
         openid_client_service=request.find_service(OpenIDClientService),
         user_service=request.find_service(name="user"),
     )

--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -35,7 +35,7 @@
             {{ svg_icon('check', 'check-icon') }}
           </a>
         {% else %}
-          <a href="{{ request.route_path('orcid.oauth.authorize') }}" class="orcid-connect">
+          <a href="{{ request.route_path('oidc.connect.orcid') }}" class="orcid-connect">
             {{ svg_icon('orcid') }}
             <span>{% trans %} Connect {% endtrans %}<strong>ORCID iD</strong></span>
             {{ svg_icon('external', 'external-icon') }}

--- a/h/views/oidc.py
+++ b/h/views/oidc.py
@@ -70,13 +70,13 @@ def _decode_oauth2_state_param(state_param, key):
     return jwt.decode(state_param, key, algorithms=["HS256"])
 
 
-@view_defaults(request_method="GET", route_name="oidc.authorize.orcid")
-class ORCIDAuthorizeViews:
+@view_defaults(request_method="GET", route_name="oidc.connect.orcid")
+class ORCIDConnectViews:
     def __init__(self, request: Request) -> None:
         self._request = request
 
     @view_config(is_authenticated=True)
-    def authorize(self):
+    def connect(self):
         host = self._request.registry.settings["orcid_host"]
         client_id = self._request.registry.settings["orcid_client_id"]
         state_signing_key = self._request.registry.settings[

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -273,7 +273,7 @@ def test_includeme():
         call(
             "wordpress-plugin", "https://wordpress.org/plugins/hypothesis/", static=True
         ),
-        call("oidc.authorize.orcid", "/oidc/authorize/orcid"),
+        call("oidc.connect.orcid", "/oidc/connect/orcid"),
         call("oidc.redirect.orcid", "/oidc/redirect/orcid"),
     ]
 

--- a/tests/unit/h/views/oidc_test.py
+++ b/tests/unit/h/views/oidc_test.py
@@ -13,13 +13,13 @@ from h.services.jwt import TokenValidationError
 from h.views.oidc import ORCID_STATE_SESSION_KEY
 
 
-class TestORCIDAuthorizeViews:
-    def test_authorize(self, pyramid_request, secrets, signing_key):
+class TestORCIDConnectViews:
+    def test_connect(self, pyramid_request, secrets, signing_key):
         # This just needs to be a string (not a mock) so that it's
         # JSON-serializable, the tests don't care about the actual value.
         secrets.token_hex.return_value = "test_rfp"
 
-        result = views.ORCIDAuthorizeViews(pyramid_request).authorize()
+        result = views.ORCIDConnectViews(pyramid_request).connect()
 
         expected_state = jwt.encode(
             {"action": "connect", "rfp": secrets.token_hex.return_value},
@@ -52,7 +52,7 @@ class TestORCIDAuthorizeViews:
     def test_notfound(self, pyramid_request):
         pyramid_request.user = None
 
-        result = views.ORCIDAuthorizeViews(pyramid_request).notfound()
+        result = views.ORCIDConnectViews(pyramid_request).notfound()
 
         assert result == {}
 
@@ -71,7 +71,7 @@ class TestORCIDAuthorizeViews:
 
     @pytest.fixture(autouse=True)
     def routes(self, pyramid_config):
-        pyramid_config.add_route("oidc.authorize.orcid", "/oidc/authorize/orcid")
+        pyramid_config.add_route("oidc.connect.orcid", "/oidc/connect/orcid")
         pyramid_config.add_route("oidc.redirect.orcid", "/oidc/redirect/orcid")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ setenv =
     tests: ELASTICSEARCH_INDEX = {env:ELASTICSEARCH_INDEX:hypothesis-tests}
     functests: ELASTICSEARCH_INDEX = {env:ELASTICSEARCH_INDEX:hypothesis-functests}
     {tests,functests}: AUTHORITY = {env:AUTHORITY:example.com}
+    {dev,tests,functests}: ORCID_OIDC_STATE_SIGNING_KEY=dev_orcid_oidc_state_signing_key
 passenv =
     HOME
     PYTEST_ADDOPTS


### PR DESCRIPTION
Replace our OAuth 2.0/OIDC `state` param, which is currently just a random string, with a signed JWT containing both a random string and an `action` string which tells the single redirect URL what to do next after authenticating the user. Currently `"connect"` is the only action but `"login"` will be added in future.