### PR TITLE
Add "Log in with ORCID" function

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -305,4 +305,5 @@ def includeme(config):  # noqa: PLR0915
 
     # ORCID
     config.add_route("oidc.connect.orcid", "/oidc/connect/orcid")
+    config.add_route("oidc.login.orcid", "/oidc/login/orcid")
     config.add_route("oidc.redirect.orcid", "/oidc/redirect/orcid")

--- a/h/static/scripts/login-forms/components/LoginForm.tsx
+++ b/h/static/scripts/login-forms/components/LoginForm.tsx
@@ -71,6 +71,9 @@ export default function LoginForm() {
           </Button>
         </div>
       </Form>
+      {config.features.log_in_with_orcid && (
+        <a href={routes.loginWithORCID}>Continue with ORCID</a>
+      )}
     </FormContainer>
   );
 }

--- a/h/static/scripts/login-forms/components/test/LoginForm-test.js
+++ b/h/static/scripts/login-forms/components/test/LoginForm-test.js
@@ -16,6 +16,9 @@ describe('LoginForm', () => {
         password: '',
       },
       formErrors: {},
+      features: {
+        log_in_with_orcid: true,
+      },
     };
   });
 

--- a/h/static/scripts/login-forms/config.ts
+++ b/h/static/scripts/login-forms/config.ts
@@ -15,6 +15,9 @@ export type LoginConfigObject = ConfigBase & {
     password?: string;
   };
   forOAuth?: boolean;
+  features: {
+    log_in_with_orcid: boolean;
+  };
 };
 
 /** Data passed to frontend for signup form. */

--- a/h/static/scripts/login-forms/routes.ts
+++ b/h/static/scripts/login-forms/routes.ts
@@ -8,4 +8,5 @@ export const routes = {
   login: '/login',
   forgotPassword: '/forgot-password',
   signup: '/signup',
+  loginWithORCID: '/oidc/login/orcid',
 };

--- a/h/views/helpers.py
+++ b/h/views/helpers.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pyramid.security import remember
+
+from h.accounts.events import LoginEvent
+
+if TYPE_CHECKING:
+    from pyramid.request import Request
+
+    from h.models import User
+
+
+def login(user: User, request: Request):
+    """Log the browser session in to `user`'s account.
+
+    The calling view must ensure that the returned headers are included in the
+    response. For example if returning a response object:
+
+        headers = login(user, request)
+        return HTTPFound(location, headers=headers)
+
+    If not directly returning a response object (for example when using a
+    template renderer so the view just returns a dict of template variables):
+
+        headers = login(user, request)
+        request.response.headers.extend(headers)
+        return template_variables
+
+    """
+    user.last_login_date = datetime.now(tz=UTC)  # type: ignore[assignment]
+    request.registry.notify(LoginEvent(request, user))
+    headers = remember(request, user.userid)
+    return headers

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -274,6 +274,7 @@ def test_includeme():
             "wordpress-plugin", "https://wordpress.org/plugins/hypothesis/", static=True
         ),
         call("oidc.connect.orcid", "/oidc/connect/orcid"),
+        call("oidc.login.orcid", "/oidc/login/orcid"),
         call("oidc.redirect.orcid", "/oidc/redirect/orcid"),
     ]
 

--- a/tests/unit/h/views/helpers_test.py
+++ b/tests/unit/h/views/helpers_test.py
@@ -1,0 +1,63 @@
+from datetime import UTC, datetime
+from unittest.mock import create_autospec, sentinel
+
+import pytest
+from freezegun import freeze_time
+
+from h.accounts.events import LoginEvent
+from h.views import helpers
+from h.views.helpers import login
+
+
+class TestLogin:
+    def test_login(
+        self,
+        factories,
+        frozen_time,
+        login_event_subscriber,
+        mocker,
+        pyramid_config,
+        pyramid_request,
+    ):
+        pyramid_config.testing_securitypolicy(remember_result=sentinel.headers)
+        mocker.spy(helpers, "remember")
+        user = factories.User(last_login_date=datetime(1970, 1, 1, tzinfo=UTC))
+
+        headers = login(user, pyramid_request)
+
+        assert user.last_login_date == frozen_time.astimezone(UTC)
+        login_event_subscriber.assert_called_once_with(
+            self.LoginEventMatcher(pyramid_request, user)
+        )
+        helpers.remember.assert_called_once_with(pyramid_request, user.userid)
+        assert headers == sentinel.headers
+
+    class LoginEventMatcher:
+        def __init__(self, request, user):
+            self.request = request
+            self.user = user
+
+        def __eq__(self, other):
+            return all(
+                [
+                    isinstance(other, LoginEvent),
+                    other.request == self.request,
+                    other.user == self.user,
+                ]
+            )
+
+    @pytest.fixture
+    def login_event_subscriber(self, pyramid_config):
+        def spec(event):
+            """Mock specification for login_event_subscriber below."""
+
+        login_event_subscriber = create_autospec(spec)
+
+        pyramid_config.add_subscriber(login_event_subscriber, LoginEvent)
+
+        return login_event_subscriber
+
+    @pytest.fixture
+    def frozen_time(self):
+        with freeze_time("2012-01-14 03:21:34") as frozen_time_factory:
+            yield frozen_time_factory()

--- a/tests/unit/h/views/oidc_test.py
+++ b/tests/unit/h/views/oidc_test.py
@@ -1,28 +1,40 @@
-from unittest.mock import MagicMock, Mock, call, sentinel
+from unittest.mock import MagicMock, call, sentinel
 from urllib.parse import urlencode, urlunparse
 
 import jwt
 import pytest
-from pyramid.httpexceptions import HTTPFound
 
-import h.views.oidc as views
 from h.models.user_identity import IdentityProvider
 from h.schemas import ValidationError
+from h.schemas.oauth import InvalidOAuth2StateParamError
 from h.services.exceptions import ExternalRequestError
-from h.services.jwt import TokenValidationError
-from h.views.oidc import ORCID_STATE_SESSION_KEY
+from h.views.oidc import (
+    ORCID_STATE_SESSION_KEY,
+    AccessDeniedError,
+    ORCIDConnectAndLoginViews,
+    ORCIDRedirectViews,
+    UserConflictError,
+    handle_external_request_error,
+)
 
 
-class TestORCIDConnectViews:
-    def test_connect(self, pyramid_request, secrets, signing_key):
-        # This just needs to be a string (not a mock) so that it's
-        # JSON-serializable, the tests don't care about the actual value.
-        secrets.token_hex.return_value = "test_rfp"
+class TestORCIDAndLoginViews:
+    @pytest.mark.parametrize(
+        "route_name,expected_action",
+        [
+            ("oidc.connect.orcid", "connect"),
+            ("oidc.login.orcid", "login"),
+        ],
+    )
+    def test_connect_or_login(
+        self, pyramid_request, secrets, signing_key, route_name, expected_action
+    ):
+        pyramid_request.matched_route.name = route_name
 
-        result = views.ORCIDConnectViews(pyramid_request).connect()
+        result = ORCIDConnectAndLoginViews(pyramid_request).connect_or_login()
 
         expected_state = jwt.encode(
-            {"action": "connect", "rfp": secrets.token_hex.return_value},
+            {"action": expected_action, "rfp": secrets.token_hex.return_value},
             signing_key,
             algorithm="HS256",
         )
@@ -52,7 +64,7 @@ class TestORCIDConnectViews:
     def test_notfound(self, pyramid_request):
         pyramid_request.user = None
 
-        result = views.ORCIDConnectViews(pyramid_request).notfound()
+        result = ORCIDConnectAndLoginViews(pyramid_request).notfound()
 
         assert result == {}
 
@@ -74,158 +86,256 @@ class TestORCIDConnectViews:
         pyramid_config.add_route("oidc.connect.orcid", "/oidc/connect/orcid")
         pyramid_config.add_route("oidc.redirect.orcid", "/oidc/redirect/orcid")
 
+    @pytest.fixture(autouse=True)
+    def secrets(self, secrets):
+        # This just needs to be a string (not a mock) so that it's
+        # JSON-serializable, the tests don't care about the actual value.
+        secrets.token_hex.return_value = "test_rfp"
+        return secrets
+
 
 @pytest.mark.usefixtures("orcid_client_service", "user_service")
 class TestORCIDRedirectViews:
-    def test_when_account_not_yet_connected(
+    @pytest.mark.usefixtures(
+        "with_both_connect_and_login_actions",
+        "assert_no_account_connection_was_added",
+        "assert_user_was_not_logged_in",
+        "assert_no_success_message_was_flashed",
+    )
+    def test_redirect_when_theres_no_state_in_the_session(self, pyramid_request, views):
+        del pyramid_request.session[ORCID_STATE_SESSION_KEY]
+
+        with pytest.raises(InvalidOAuth2StateParamError):
+            views.redirect()
+
+    @pytest.mark.usefixtures("with_both_connect_and_login_actions")
+    def test_redirect_validates_the_request_params(
+        self, pyramid_request, views, OAuth2RedirectSchema
+    ):
+        views.redirect()
+
+        OAuth2RedirectSchema.validate.assert_called_once_with(
+            pyramid_request.params, sentinel.state
+        )
+
+    @pytest.mark.usefixtures(
+        "with_both_connect_and_login_actions",
+        "assert_state_removed_from_session",
+        "assert_no_account_connection_was_added",
+        "assert_user_was_not_logged_in",
+        "assert_no_success_message_was_flashed",
+    )
+    @pytest.mark.parametrize(
+        "params,expected_exception_class",
+        [
+            ({"error": "access_denied"}, AccessDeniedError),
+            ({"error": "something_else"}, ValidationError),
+            ({}, ValidationError),
+        ],
+    )
+    def test_redirect_when_validation_error(
         self,
         pyramid_request,
-        orcid_client_service,
-        user_service,
-        user,
+        views,
         OAuth2RedirectSchema,
+        params,
+        expected_exception_class,
     ):
-        pyramid_request.session[ORCID_STATE_SESSION_KEY] = sentinel.state
-        user_service.fetch_by_identity.return_value = None
+        OAuth2RedirectSchema.validate.side_effect = ValidationError()
+        pyramid_request.params = params
 
-        result = views.ORCIDRedirectViews(pyramid_request).redirect()
+        with pytest.raises(expected_exception_class) as exc_info:
+            views.redirect()
 
-        assert ORCID_STATE_SESSION_KEY not in pyramid_request.session
-        OAuth2RedirectSchema.validate.assert_called_once_with(
-            dict(pyramid_request.params), sentinel.state
-        )
+        assert OAuth2RedirectSchema.validate.side_effect in [
+            exc_info.value,
+            exc_info.value.__cause__,
+        ]
+
+    @pytest.mark.usefixtures(
+        "with_both_connect_and_login_actions",
+        "assert_state_removed_from_session",
+        "assert_no_account_connection_was_added",
+        "assert_user_was_not_logged_in",
+        "assert_no_success_message_was_flashed",
+    )
+    def test_redirect_if_state_jwt_fails_to_decode(self, OAuth2RedirectSchema, views):
+        OAuth2RedirectSchema.validate.return_value["state"] = "not_a_jwt"
+
+        # This is deliberately not handled because it should never happen: the
+        # code has already tested that the `state` query param that we received
+        # from the authentication server matches the copy that we stashed in
+        # the session, so the state should always decode without errors.
+        with pytest.raises(jwt.exceptions.DecodeError):
+            views.redirect()
+
+    @pytest.mark.usefixtures("with_both_connect_and_login_actions")
+    def test_redirect_gets_the_users_orcid_id(self, views, orcid_client_service):
+        views.redirect()
+
         orcid_client_service.get_orcid.assert_called_once_with(sentinel.code)
+
+    @pytest.mark.usefixtures(
+        "with_both_connect_and_login_actions",
+        "assert_state_removed_from_session",
+        "assert_no_account_connection_was_added",
+        "assert_user_was_not_logged_in",
+        "assert_no_success_message_was_flashed",
+    )
+    def test_redirect_when_getting_orcid_id_fails(self, views, orcid_client_service):
+        class TestError(Exception):
+            pass
+
+        orcid_client_service.get_orcid.side_effect = TestError
+
+        with pytest.raises(TestError):
+            views.redirect()
+
+    @pytest.mark.usefixtures("with_both_connect_and_login_actions")
+    def test_redirect_fetches_the_hypothesis_uiser(self, views, user_service):
+        views.redirect()
+
         user_service.fetch_by_identity.assert_called_once_with(
             IdentityProvider.ORCID, sentinel.orcid_id
         )
+
+    @pytest.mark.usefixtures(
+        "with_connect_action",
+        "assert_state_removed_from_session",
+        "assert_no_account_connection_was_added",
+        "assert_user_was_not_logged_in",
+        "assert_no_success_message_was_flashed",
+    )
+    def test_redirect_when_action_connect_and_a_different_account_is_already_connected(
+        self, user_service, views
+    ):
+        user_service.fetch_by_identity.return_value = sentinel.other_user
+
+        with pytest.raises(UserConflictError):
+            views.redirect()
+
+    @pytest.mark.usefixtures("with_connect_action")
+    @pytest.mark.usefixtures(
+        "assert_state_removed_from_session",
+        "assert_success_message_was_flashed",
+        "assert_user_was_not_logged_in",
+    )
+    def test_redirect_when_action_connect_and_account_not_yet_connected(
+        self, pyramid_request, orcid_client_service, user_service, user, views, matchers
+    ):
+        user_service.fetch_by_identity.return_value = None
+
+        result = views.redirect()
+
         orcid_client_service.add_identity.assert_called_once_with(
             user, sentinel.orcid_id
         )
-        pyramid_request.session.flash.assert_called_once_with(
-            "ORCID iD connected ✓", "success"
-        )
-        assert isinstance(result, HTTPFound)
-        assert result.location == pyramid_request.route_url("account")
+        assert result == matchers.Redirect302To(pyramid_request.route_url("account"))
 
-    def test_when_account_already_connected(
-        self, pyramid_request, orcid_client_service, user_service
+    @pytest.mark.usefixtures(
+        "with_connect_action",
+        "assert_state_removed_from_session",
+        "assert_success_message_was_flashed",
+        "assert_no_account_connection_was_added",
+        "assert_user_was_not_logged_in",
+    )
+    def test_redirect_when_action_connect_and_account_already_connected(
+        self, pyramid_request, user_service, views, matchers
     ):
         user_service.fetch_by_identity.return_value = pyramid_request.user
 
-        result = views.ORCIDRedirectViews(pyramid_request).redirect()
+        result = views.redirect()
 
-        orcid_client_service.add_identity.assert_not_called()
-        pyramid_request.session.flash.assert_called_once_with(
-            "ORCID iD connected ✓", "success"
-        )
-        assert isinstance(result, HTTPFound)
-        assert result.location == pyramid_request.route_url("account")
+        assert result == matchers.Redirect302To(pyramid_request.route_url("account"))
 
-    def test_when_already_connected_to_a_different_account(
-        self, pyramid_request, orcid_client_service, user_service
+    @pytest.mark.usefixtures(
+        "with_login_action",
+        "assert_state_removed_from_session",
+        "assert_no_account_connection_was_added",
+        "assert_user_was_not_logged_in",
+        "assert_no_success_message_was_flashed",
+    )
+    def test_redirect_when_action_login_and_no_connected_user_exists(
+        self, views, user_service
     ):
-        pyramid_request.session[ORCID_STATE_SESSION_KEY] = sentinel.state
-        user_service.fetch_by_identity.return_value = sentinel.other_user
+        user_service.fetch_by_identity.return_value = None
 
-        with pytest.raises(views.UserConflictError):
-            views.ORCIDRedirectViews(pyramid_request).redirect()
+        with pytest.raises(RuntimeError):
+            views.redirect()
 
-        orcid_client_service.add_identity.assert_not_called()
-
-    def test_when_schema_raises_access_denied_error(
-        self, pyramid_request, orcid_client_service, OAuth2RedirectSchema
+    @pytest.mark.usefixtures(
+        "with_login_action",
+        "assert_state_removed_from_session",
+        "assert_no_account_connection_was_added",
+        "assert_no_success_message_was_flashed",
+    )
+    def test_redirect_when_action_login_and_connected_user_exists(
+        self, views, login, user, pyramid_request
     ):
-        OAuth2RedirectSchema.validate.side_effect = ValidationError()
-        pyramid_request.params = {"error": "access_denied"}
+        login.return_value = [
+            ("headername1", "headervalue1"),
+            ("headername2", "headervalue2"),
+        ]
+        response = views.redirect()
 
-        with pytest.raises(views.AccessDeniedError) as exc_info:
-            views.ORCIDRedirectViews(pyramid_request).redirect()
+        login.assert_called_once_with(user, pyramid_request)
+        assert all(header in response.headerlist for header in login.return_value)
 
-        orcid_client_service.add_identity.assert_not_called()
-        assert exc_info.value.__cause__ == OAuth2RedirectSchema.validate.side_effect
-
-    def test_when_schema_raises_other_validation_error(
-        self, pyramid_request, orcid_client_service, OAuth2RedirectSchema
-    ):
-        OAuth2RedirectSchema.validate.side_effect = ValidationError()
-
-        with pytest.raises(views.ValidationError) as exc_info:
-            views.ORCIDRedirectViews(pyramid_request).redirect()
-
-        orcid_client_service.add_identity.assert_not_called()
-        assert exc_info.value == OAuth2RedirectSchema.validate.side_effect
-
-    def test_when_token_validation_error(self, pyramid_request, orcid_client_service):
-        orcid_client_service.get_orcid.side_effect = TokenValidationError
-
-        with pytest.raises(TokenValidationError):
-            views.ORCIDRedirectViews(pyramid_request).redirect()
-
-        orcid_client_service.add_identity.assert_not_called()
-
-    def test_when_external_request_error(self, pyramid_request, orcid_client_service):
-        orcid_client_service.get_orcid.side_effect = ExternalRequestError
-
-        with pytest.raises(ExternalRequestError):
-            views.ORCIDRedirectViews(pyramid_request).redirect()
-
-        orcid_client_service.add_identity.assert_not_called()
-
-    def test_notfound(self, pyramid_request):
-        result = views.ORCIDRedirectViews(pyramid_request).notfound()
+    def test_notfound(self, pyramid_request, views):
+        result = views.notfound()
 
         assert pyramid_request.response.status_int == 401
         assert result == {}
 
-    def test_invalid(self, pyramid_request):
-        result = views.ORCIDRedirectViews(pyramid_request).invalid()
+    def test_invalid(self, pyramid_request, views, matchers):
+        result = views.invalid()
 
-        assert isinstance(result, HTTPFound)
-        assert result.location == pyramid_request.route_url("account")
-        pyramid_request.session.flash.assert_called_once_with(
-            "Received an invalid redirect from ORCID!", "error"
-        )
+        assert result == matchers.Redirect302To(pyramid_request.route_url("account"))
+        assert pyramid_request.session.peek_flash("error") == [
+            "Received an invalid redirect from ORCID!"
+        ]
 
-    def test_invalid_token(self, pyramid_request):
-        result = views.ORCIDRedirectViews(pyramid_request).invalid_token()
+    def test_invalid_token(self, pyramid_request, views, matchers):
+        result = views.invalid_token()
 
-        assert isinstance(result, HTTPFound)
-        assert result.location == pyramid_request.route_url("account")
-        pyramid_request.session.flash.assert_called_once_with(
-            "Received an invalid token from ORCID!", "error"
-        )
+        assert result == matchers.Redirect302To(pyramid_request.route_url("account"))
+        assert pyramid_request.session.peek_flash("error") == [
+            "Received an invalid token from ORCID!"
+        ]
 
-    def test_denied(self, pyramid_request):
-        result = views.ORCIDRedirectViews(pyramid_request).denied()
+    def test_denied(self, pyramid_request, views, matchers):
+        result = views.denied()
 
-        assert isinstance(result, HTTPFound)
-        assert result.location == pyramid_request.route_url("account")
-        pyramid_request.session.flash.assert_called_once_with(
-            "The user clicked the deny button!", "error"
-        )
+        assert result == matchers.Redirect302To(pyramid_request.route_url("account"))
+        assert pyramid_request.session.peek_flash("error") == [
+            "The user clicked the deny button!"
+        ]
 
-    def test_external_request(self, pyramid_request, handle_external_request_error):
+    def test_external_request(
+        self, pyramid_request, handle_external_request_error, views, matchers
+    ):
         pyramid_request.exception = ExternalRequestError(
             "External request failed", validation_errors={"foo": ["bar"]}
         )
-        result = views.ORCIDRedirectViews(pyramid_request).external_request()
+        result = views.external_request()
 
-        assert isinstance(result, HTTPFound)
-        assert result.location == pyramid_request.route_url("account")
-        pyramid_request.session.flash.assert_called_once_with(
-            "Request to ORCID failed!", "error"
-        )
+        assert result == matchers.Redirect302To(pyramid_request.route_url("account"))
+        assert pyramid_request.session.peek_flash("error") == [
+            "Request to ORCID failed!"
+        ]
         handle_external_request_error.assert_called_once_with(pyramid_request.exception)
 
-    def test_user_conflict_error(self, pyramid_request):
-        result = views.ORCIDRedirectViews(pyramid_request).user_conflict_error()
+    def test_user_conflict_error(self, pyramid_request, views, matchers):
+        result = views.user_conflict_error()
 
-        assert isinstance(result, HTTPFound)
-        pyramid_request.session.flash.assert_called_once_with(
-            "A different Hypothesis user is already connected to this ORCID iD!",
-            "error",
-        )
-        assert result.location == pyramid_request.route_url("account")
+        assert result == matchers.Redirect302To(pyramid_request.route_url("account"))
+        assert pyramid_request.session.peek_flash("error") == [
+            "A different Hypothesis user is already connected to this ORCID iD!"
+        ]
+
+    @pytest.fixture
+    def views(self, pyramid_request):
+        return ORCIDRedirectViews(pyramid_request)
 
     @pytest.fixture
     def user(self, factories):
@@ -234,33 +344,92 @@ class TestORCIDRedirectViews:
     @pytest.fixture
     def pyramid_request(self, pyramid_request, user, signing_key):
         pyramid_request.user = user
-        pyramid_request.session.flash = Mock()
+        pyramid_request.session[ORCID_STATE_SESSION_KEY] = sentinel.state
         pyramid_request.registry.settings.update(
             {"orcid_oidc_state_signing_key": signing_key}
         )
         return pyramid_request
 
-    @pytest.fixture(autouse=True)
-    def routes(self, pyramid_config):
-        pyramid_config.add_route("account", "/account/settings")
-        pyramid_config.add_route("index", "/")
+    @pytest.fixture
+    def assert_state_removed_from_session(self, pyramid_request):
+        """Assert that the `state` param was removed from the browser session.
 
-    @pytest.fixture(autouse=True)
-    def handle_external_request_error(self, patch):
-        return patch("h.views.oidc.handle_external_request_error")
+        The redirect() view should always delete the single-use `state` from
+        the browser session.
+        """
+        yield
+        assert ORCID_STATE_SESSION_KEY not in pyramid_request.session
+
+    @pytest.fixture
+    def assert_success_message_was_flashed(self, pyramid_request):
+        yield
+        assert pyramid_request.session.peek_flash("success") == ["ORCID iD connected ✓"]
+
+    @pytest.fixture
+    def assert_no_success_message_was_flashed(self, pyramid_request):
+        yield
+        assert pyramid_request.session.peek_flash("success") == []
+
+    @pytest.fixture(params=["connect", "login"])
+    def with_both_connect_and_login_actions(self, request, set_action):
+        """Run the test with both the "connect" and "login" actions.
+
+        Tests using this fixture will be run twice: once with the "connect"
+        action and once with the "login" action.
+        """
+        set_action(request.param)
+
+    @pytest.fixture
+    def with_connect_action(self, set_action):
+        """Run the test with the "connect" action."""
+        set_action("connect")
+
+    @pytest.fixture
+    def with_login_action(self, set_action):
+        """Run the test with the "login" action."""
+        set_action("login")
+
+    @pytest.fixture
+    def set_action(self, OAuth2RedirectSchema, signing_key):
+        def set_action(action: str):
+            """Set the `action` string in the JWT `state` param to `action`."""
+            OAuth2RedirectSchema.validate.return_value = {
+                "code": sentinel.code,
+                "state": jwt.encode({"action": action}, signing_key, algorithm="HS256"),
+            }
+
+        return set_action
+
+    @pytest.fixture
+    def assert_no_account_connection_was_added(self, orcid_client_service):
+        """Assert that no ORCID iD->Hypothesis account connection was added."""
+        yield
+        orcid_client_service.add_identity.assert_not_called()
+
+    @pytest.fixture
+    def assert_user_was_not_logged_in(self, login):
+        """Assert that the browser session was not logged in."""
+        yield
+        login.assert_not_called()
 
     @pytest.fixture
     def orcid_client_service(self, orcid_client_service):
         orcid_client_service.get_orcid.return_value = sentinel.orcid_id
         return orcid_client_service
 
+    @pytest.fixture
+    def user_service(self, user_service, user):
+        user_service.fetch_by_identity.return_value = user
+        return user_service
+
     @pytest.fixture(autouse=True)
-    def OAuth2RedirectSchema(self, OAuth2RedirectSchema, signing_key):
-        OAuth2RedirectSchema.validate.return_value = {
-            "code": sentinel.code,
-            "state": jwt.encode({"action": "connect"}, signing_key, algorithm="HS256"),
-        }
-        return OAuth2RedirectSchema
+    def routes(self, pyramid_config):
+        pyramid_config.add_route("activity.user_search", "/users/{username}")
+        pyramid_config.add_route("account", "/account/settings")
+
+    @pytest.fixture(autouse=True)
+    def handle_external_request_error(self, patch):
+        return patch("h.views.oidc.handle_external_request_error")
 
 
 class TestHandleExternalRequestError:
@@ -271,7 +440,7 @@ class TestHandleExternalRequestError:
             response=MagicMock(),
         )
 
-        views.handle_external_request_error(exception)
+        handle_external_request_error(exception)
 
         assert sentry_sdk.set_context.call_args_list == [
             call(
@@ -300,7 +469,7 @@ class TestHandleExternalRequestError:
             validation_errors={"foo": ["bar"]},
         )
 
-        views.handle_external_request_error(exception)
+        handle_external_request_error(exception)
 
         assert sentry_sdk.set_context.call_args_list == [
             call(
@@ -346,3 +515,8 @@ def OAuth2RedirectSchema(patch):
 @pytest.fixture(autouse=True)
 def secrets(patch):
     return patch("h.views.oidc.secrets")
+
+
+@pytest.fixture(autouse=True)
+def login(patch):
+    return patch("h.views.oidc.login")


### PR DESCRIPTION
This adds a __Continue with ORCID__ button to the login page that logs you straight into your ORCID-connected Hypothesis account without entering your Hypothesis password.

So far this only works for existing Hypothesis accounts that're already connected to an ORCID iD: you first need to log in with a password, go to `/account/settings` and connect an ORCID iD, then log out, _then_ you can test the _Continue with ORCID_ button.

Future work will add support for logging in with ORCID when you don't have a Hypothesis account yet (by creating a passwordless account for you and connecting it to your ORCID iD). This is much more complicated.

Testing:

1. Go to <http://hypothesis.local:5000/login>: if the `log_in_with_orcid` feature flag is disabled you should **not** see the **Continue with ORCID** button.
2. Log in as `devdata_admin`, go to <http://hypothesis.local:5000/admin/features>, and enable the `log_in_with_orcid` feature flag.
3. Now go to <http://hypothesis.local:5000/account/settings> and connect your ORCID iD.
4. Log out
5. Go to <http://hypothesis.local:5000/login> and you should see the **Continue with ORCID** button and be able to use it to log in to `devdata_admin`'s account.

Note that while the button on the login page is feature flagged, and so is the **Connect ORCID iD** button on the `/account/settings` page, the actual views that these buttons link to are not feature flagged so in theory someone could trigger the feature on production by entering URLs into their browser's location bar manually. We could feature flag the views as well but I think it's fine. LMS has [a nice way of feature flagging views](https://github.com/hypothesis/lms/blob/065262769d819febf0105f82247cd6a0f8640142/lms/extensions/feature_flags/views/_predicates.py#L12-L49) (`@view_config(..., feature="foo")`) but h doesn't have this.