### PR TITLE
Set `moduleSideEffects: false` in Rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,6 +39,16 @@ function bundleConfig(name, entryFile) {
       commonjs(),
       ...prodPlugins,
     ],
+
+    treeshake: {
+      // Assume that modules do not have side effects and can be safely removed
+      // from a bundle if unused.
+      //
+      // This is important when importing small pieces of functionality from
+      // packages like @hypothesis/annotation-ui with a large total footprint
+      // (including dependencies). See https://github.com/hypothesis/h/issues/9709.
+      moduleSideEffects: false,
+    },
   };
 }
 


### PR DESCRIPTION
This will enable Rollup to exclude code from @hypothesis/annotation-ui from the group-forms bundle if that code is only used by a dynamic import. There are large dependencies (KaTex and Showdown) that, in future, we only want to load when needed. See also [`moduleSideEffects` docs](https://rollupjs.org/configuration-options/#treeshake-modulesideeffects).

At present the effect of this change is to make the login-forms bundle smaller (51KB -> 40KB) but the other bundles are all the same size as before. There should be no functional changes.

Part of https://github.com/hypothesis/h/issues/9709