### PR TITLE
Remove hypothesis usage from parser and redirect tests

### DIFF
--- a/h/search/parser.py
+++ b/h/search/parser.py
@@ -48,7 +48,7 @@ whitespace = {
 Match = namedtuple("Match", ["key", "value"])  # noqa: PYI024
 
 
-def parse(query):
+def parse(query) -> MultiDict:
     """
     Parse a free text, Lucene-like, query string into a MultiDict.
 


### PR DESCRIPTION
Tests using hypothesis (the property testing library) started failing CI after a recent update ([Slack thread](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1751626171191579)), with a performance issue that we cannot reproduce locally. Given we make limited usage of this library, it seems more expedient to replace it than debug it. As a first step, replace usage in the parser and redirect tests. After this there is one remaining set of tests that make use of hypothesis, `encryption_test.py`.

As an aside, while profiling the Hypothesis-using tests locally with py-spy I found that most of the time was spent parsing source code in order to find string constants for use as "random" strings in `@given(st.text())` tests. The rationale is that such constants are more likely to turn up bugs than randomly generated text. I understand the logic, but this does add a lot of complexity to the implementation and not surprisingly there are GitHub issues reporting performance problems due to this. I think the concept of property testing is perfectly sensible, but I would prefer a dumber implementation.