### PR TITLE
Replace Hypothesis usage in encryption tests

### DIFF
--- a/h/security/encryption.py
+++ b/h/security/encryption.py
@@ -1,5 +1,6 @@
 import base64
 import os
+from typing import cast
 
 from Cryptodome.Hash import SHA512
 from Cryptodome.Protocol.KDF import HKDF
@@ -23,27 +24,31 @@ password_context = CryptContext(
 )
 
 
-def derive_key(key_material, salt, info):
+def derive_key(key_material: str | bytes, salt: bytes, info: bytes) -> bytes:
     """
     Derive a fixed-size (64-byte) key for use in cryptographic operations.
 
     The key is derived using HKDF with the SHA-512 hash function. See
     https://tools.ietf.org/html/rfc5869.
 
-    :type key_material: str or bytes
-    :type salt: bytes
-    :type info: bytes
+    :arg key_material: High-entropy secret used to derive key
+    :arg salt: Non-secret value used to strengthen generation. Ideally as long
+         as the hash digest (64 bytes)
+    :arg info: Identifier describing what the key is for
     """
     if not isinstance(key_material, bytes):
         key_material = key_material.encode()
 
-    return HKDF(
-        master=key_material,
-        key_len=64,
-        salt=salt,
-        hashmod=SHA512,
-        num_keys=1,
-        context=info,
+    return cast(
+        bytes,
+        HKDF(
+            master=key_material,
+            key_len=64,
+            salt=salt,
+            hashmod=SHA512,
+            num_keys=1,
+            context=info,
+        ),
     )
 
 
@@ -63,7 +68,7 @@ def derive_key(key_material, salt, info):
 
 
 # Implementation modeled on `secrets.token_urlsafe`, new in Python 3.6.
-def token_urlsafe(nbytes=None):
+def token_urlsafe(nbytes=None) -> str:
     """Return a random URL-safe string composed of *nbytes* random bytes."""
     if nbytes is None:
         nbytes = DEFAULT_ENTROPY


### PR DESCRIPTION
Fix a flakey test due to long data generation times in hypothesis. See notes in a2293571d936ee6e88fc604f1c952c08914042fd.

Also add types and parameter documentation to help guard against incorrect usage.