### PR TITLE
Remove unused `hypothesis` dependency

### DIFF
--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -17,7 +17,6 @@ attrs==24.3.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-    #   hypothesis
     #   jsonschema
     #   referencing
 bcrypt==4.2.1
@@ -181,8 +180,6 @@ hupper==1.12
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pyramid
-hypothesis==6.135.20
-    # via -r requirements/tests.txt
 idna==3.10
     # via
     #   -r requirements/functests.txt
@@ -473,10 +470,6 @@ six==1.17.0
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator
-sortedcontainers==2.4.0
-    # via
-    #   -r requirements/tests.txt
-    #   hypothesis
 soupsieve==2.5
     # via
     #   -r requirements/functests.txt

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -10,5 +10,4 @@ h-matchers
 h-testkit
 httpretty
 freezegun
-hypothesis
 pytest-mock

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -13,7 +13,6 @@ amqp==5.3.1
 attrs==24.3.0
     # via
     #   -r requirements/prod.txt
-    #   hypothesis
     #   jsonschema
     #   referencing
 bcrypt==4.2.1
@@ -122,8 +121,6 @@ hupper==1.12
     # via
     #   -r requirements/prod.txt
     #   pyramid
-hypothesis==6.135.20
-    # via -r requirements/tests.in
 idna==3.10
     # via
     #   -r requirements/prod.txt
@@ -321,8 +318,6 @@ six==1.17.0
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator
-sortedcontainers==2.4.0
-    # via hypothesis
 sqlalchemy==2.0.25
     # via
     #   -r requirements/prod.txt


### PR DESCRIPTION
It is unused following https://github.com/hypothesis/h/pull/9711 and https://github.com/hypothesis/h/pull/9714.