### PR TITLE
Add JS import map to `<head>` tag on all pages

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -105,9 +105,12 @@ def includeme(config):  # pragma: no cover
 
 
 def _configure_jinja2_assets(config):
+    assets_env = config.registry["assets_env"]
+
     jinja2_env = config.get_jinja2_environment()
-    jinja2_env.globals["asset_url"] = config.registry["assets_env"].url
-    jinja2_env.globals["asset_urls"] = config.registry["assets_env"].urls
+    jinja2_env.globals["asset_url"] = assets_env.url
+    jinja2_env.globals["asset_urls"] = assets_env.urls
+    jinja2_env.globals["asset_import_map"] = assets_env.import_map
 
 
 def _configure_sentry(config):

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -57,6 +57,12 @@
 
     {% include 'h:templates/includes/settings.html.jinja2' %}
 
+    {# Import map must be placed before any module script tags. Firefox will
+       fail to load it otherwise. #}
+    {% block importmap %}
+    <script type="importmap">{{ asset_import_map() | tojson }}</script>
+    {% endblock %}
+
     {% for url in asset_urls("header_js") %}
     <script type="module" src="{{ url }}"></script>
     {% endfor %}

--- a/requirements/checkdocs.txt
+++ b/requirements/checkdocs.txt
@@ -47,10 +47,10 @@ packaging==25.0
     #   build
     #   sphinx
 pip-sync-faster==0.0.5
-    # via -r checkdocs.in
+    # via -r requirements/checkdocs.in
 pip-tools==7.4.1
     # via
-    #   -r checkdocs.in
+    #   -r requirements/checkdocs.in
     #   pip-sync-faster
 pygments==2.17.2
     # via sphinx
@@ -68,7 +68,7 @@ snowballstemmer==2.2.0
     # via sphinx
 sphinx==8.2.3
     # via
-    #   -r checkdocs.in
+    #   -r requirements/checkdocs.in
     #   sphinx-autobuild
     #   sphinx-rtd-theme
     #   sphinxcontrib-applehelp
@@ -76,9 +76,9 @@ sphinx==8.2.3
     #   sphinxcontrib-qthelp
     #   sphinxcontrib-serializinghtml
 sphinx-autobuild==2024.10.3
-    # via -r checkdocs.in
+    # via -r requirements/checkdocs.in
 sphinx-rtd-theme==3.0.2
-    # via -r checkdocs.in
+    # via -r requirements/checkdocs.in
 sphinxcontrib-applehelp==1.0.7
     # via sphinx
 sphinxcontrib-devhelp==2.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -100,12 +100,11 @@ greenlet==3.1.1
     # via
     #   -r requirements/prod.txt
     #   gevent
-    #   sqlalchemy
 gunicorn==23.0.0
     # via -r requirements/prod.txt
 h-api==1.1.1
     # via -r requirements/prod.txt
-h-assets==1.0.7
+h-assets==1.1.0
     # via -r requirements/prod.txt
 h-matchers==1.2.17
     # via -r requirements/prod.txt
@@ -325,8 +324,8 @@ stack-data==0.6.3
     # via ipython
 supervisor==4.2.5
     # via
-    #   -r requirements/dev.in
     #   -r requirements/prod.txt
+    #   -r requirements/dev.in
 tabulate==0.9.0
     # via
     #   -r requirements/prod.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -47,10 +47,10 @@ packaging==25.0
     #   build
     #   sphinx
 pip-sync-faster==0.0.5
-    # via -r docs.in
+    # via -r requirements/docs.in
 pip-tools==7.4.1
     # via
-    #   -r docs.in
+    #   -r requirements/docs.in
     #   pip-sync-faster
 pygments==2.17.2
     # via sphinx
@@ -68,7 +68,7 @@ snowballstemmer==2.2.0
     # via sphinx
 sphinx==8.2.3
     # via
-    #   -r docs.in
+    #   -r requirements/docs.in
     #   sphinx-autobuild
     #   sphinx-rtd-theme
     #   sphinxcontrib-applehelp
@@ -76,9 +76,9 @@ sphinx==8.2.3
     #   sphinxcontrib-qthelp
     #   sphinxcontrib-serializinghtml
 sphinx-autobuild==2024.10.3
-    # via -r docs.in
+    # via -r requirements/docs.in
 sphinx-rtd-theme==3.0.2
-    # via -r docs.in
+    # via -r requirements/docs.in
 sphinxcontrib-applehelp==1.0.7
     # via sphinx
 sphinxcontrib-devhelp==2.0.0

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -96,17 +96,16 @@ greenlet==3.1.1
     # via
     #   -r requirements/prod.txt
     #   gevent
-    #   sqlalchemy
 gunicorn==23.0.0
     # via -r requirements/prod.txt
 h-api==1.1.1
     # via -r requirements/prod.txt
-h-assets==1.0.7
+h-assets==1.1.0
     # via -r requirements/prod.txt
 h-matchers==1.2.17
     # via
-    #   -r requirements/functests.in
     #   -r requirements/prod.txt
+    #   -r requirements/functests.in
 h-pyramid-sentry==1.2.4
     # via -r requirements/prod.txt
 h-testkit==1.0.1

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -146,7 +146,6 @@ greenlet==3.1.1
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   gevent
-    #   sqlalchemy
 gunicorn==23.0.0
     # via
     #   -r requirements/functests.txt
@@ -155,7 +154,7 @@ h-api==1.1.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-h-assets==1.0.7
+h-assets==1.1.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -287,13 +286,13 @@ peppercorn==0.6
 pip-sync-faster==0.0.5
     # via
     #   -r requirements/functests.txt
-    #   -r requirements/lint.in
     #   -r requirements/tests.txt
+    #   -r requirements/lint.in
 pip-tools==7.4.1
     # via
     #   -r requirements/functests.txt
-    #   -r requirements/lint.in
     #   -r requirements/tests.txt
+    #   -r requirements/lint.in
     #   pip-sync-faster
 plaster==1.1.2
     # via

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -63,14 +63,12 @@ elasticsearch-dsl==6.4.0
 gevent==24.11.1
     # via -r requirements/prod.in
 greenlet==3.1.1
-    # via
-    #   gevent
-    #   sqlalchemy
+    # via gevent
 gunicorn==23.0.0
     # via -r requirements/prod.in
 h-api==1.1.1
     # via -r requirements/prod.in
-h-assets==1.0.7
+h-assets==1.1.0
     # via -r requirements/prod.in
 h-matchers==1.2.17
     # via -r requirements/prod.in

--- a/requirements/template.txt
+++ b/requirements/template.txt
@@ -21,7 +21,7 @@ click==8.1.8
     #   cookiecutter
     #   pip-tools
 cookiecutter==2.6.0
-    # via -r template.in
+    # via -r requirements/template.in
 idna==3.10
     # via requests
 importlib-metadata==8.6.1
@@ -37,10 +37,10 @@ mdurl==0.1.2
 packaging==25.0
     # via build
 pip-sync-faster==0.0.5
-    # via -r template.in
+    # via -r requirements/template.in
 pip-tools==7.4.1
     # via
-    #   -r template.in
+    #   -r requirements/template.in
     #   pip-sync-faster
 pygments==2.19.1
     # via rich

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -100,12 +100,11 @@ greenlet==3.1.1
     # via
     #   -r requirements/prod.txt
     #   gevent
-    #   sqlalchemy
 gunicorn==23.0.0
     # via -r requirements/prod.txt
 h-api==1.1.1
     # via -r requirements/prod.txt
-h-assets==1.0.7
+h-assets==1.1.0
     # via -r requirements/prod.txt
 h-matchers==1.2.17
     # via

--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -88,12 +88,11 @@ greenlet==3.1.1
     # via
     #   -r requirements/prod.txt
     #   gevent
-    #   sqlalchemy
 gunicorn==23.0.0
     # via -r requirements/prod.txt
 h-api==1.1.1
     # via -r requirements/prod.txt
-h-assets==1.0.7
+h-assets==1.1.0
     # via -r requirements/prod.txt
 h-matchers==1.2.17
     # via -r requirements/prod.txt


### PR DESCRIPTION
Add a `<script type="importmap">` tag to the `<head>` of all pages. This will allow JS bundles to dynamically load other bundles in future. See https://github.com/hypothesis/h/pull/9705 for an example usage and https://github.com/hypothesis/h-assets/pull/55 for more background.

The import map currently includes mappings for all bundles that exist. We could slim this down in future by filtering the map depending on the page, but this didn't seem worthwhile to do at present.

**Testing:**

On this branch, the `<head>` tag should now contain a new `importmap` script:

<img width="782" alt="importmap" src="https://github.com/user-attachments/assets/8a2b39d6-bc88-46f3-a78e-47712dd1155b" />

