### PR TITLE
Tidy up `account_signup.py`

### DIFF
--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -76,9 +76,7 @@ class SignupViews:
 
     @property
     def js_config(self) -> dict[str, Any]:
-        csrf_token = get_csrf_token(self.request)
-
-        return {"csrfToken": csrf_token}
+        return {"csrfToken": get_csrf_token(self.request)}
 
     def redirect_if_logged_in(self):
         if self.request.authenticated_userid is not None:

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -68,11 +68,7 @@ class SignupViews:
             heading = _("Account already registered")
             message = _(f"{exc.args[0]}")  # noqa: INT001
 
-        return {
-            "js_config": js_config,
-            "heading": heading,
-            "message": message,
-        }
+        return {"js_config": js_config, "heading": heading, "message": message}
 
     @property
     def js_config(self) -> dict[str, Any]:

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -53,7 +53,6 @@ class SignupViews:
 
         signup_service = self.request.find_service(name="user_signup")
 
-        js_config = self.js_config
         heading = _("Account registration successful")
         message = None
         try:
@@ -68,7 +67,7 @@ class SignupViews:
             heading = _("Account already registered")
             message = _(f"{exc.args[0]}")  # noqa: INT001
 
-        return {"js_config": js_config, "heading": heading, "message": message}
+        return {"js_config": self.js_config, "heading": heading, "message": message}
 
     @property
     def js_config(self) -> dict[str, Any]:

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -27,9 +27,7 @@ class SignupViews:
         """Render the empty registration form."""
         self._redirect_if_logged_in()
 
-        return {
-            "js_config": self._js_config(),
-        }
+        return {"js_config": self._js_config()}
 
     def _js_config(self) -> dict[str, Any]:
         csrf_token = get_csrf_token(self.request)

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -14,7 +14,7 @@ _ = i18n.TranslationString
 
 
 @view_defaults(route_name="signup")
-class SignupController:
+class SignupViews:
     def __init__(self, request):
         self.request = request
         self.schema = schemas.RegisterSchema().bind(request=self.request)

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -13,10 +13,6 @@ from h.services.exceptions import ConflictError
 _ = i18n.TranslationString
 
 
-def _login_redirect_url(request):
-    return request.route_url("activity.user_search", username=request.user.username)
-
-
 @view_defaults(route_name="signup")
 class SignupController:
     def __init__(self, request):
@@ -89,4 +85,8 @@ class SignupController:
 
     def _redirect_if_logged_in(self):
         if self.request.authenticated_userid is not None:
-            raise httpexceptions.HTTPFound(_login_redirect_url(self.request))
+            raise httpexceptions.HTTPFound(
+                self.request.route_url(
+                    "activity.user_search", username=self.request.user.username
+                )
+            )

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -49,9 +49,7 @@ class SignupViews:
                 == "true",
                 "comms_opt_in": self.request.POST.get("comms_opt_in", "") == "true",
             }
-            return {
-                "js_config": js_config,
-            }
+            return {"js_config": js_config}
 
         signup_service = self.request.find_service(name="user_signup")
 

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -25,7 +25,7 @@ class SignupViews:
     )
     def get(self):
         """Render the empty registration form."""
-        self._redirect_if_logged_in()
+        self.redirect_if_logged_in()
 
         return {"js_config": self._js_config()}
 
@@ -39,7 +39,7 @@ class SignupViews:
     )
     def post(self):
         """Handle submission of the new user registration form."""
-        self._redirect_if_logged_in()
+        self.redirect_if_logged_in()
 
         try:
             appstruct = self.form.validate(self.request.POST.items())
@@ -81,7 +81,7 @@ class SignupViews:
             "message": message,
         }
 
-    def _redirect_if_logged_in(self):
+    def redirect_if_logged_in(self):
         if self.request.authenticated_userid is not None:
             raise httpexceptions.HTTPFound(
                 self.request.route_url(

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -27,12 +27,7 @@ class SignupViews:
         """Render the empty registration form."""
         self.redirect_if_logged_in()
 
-        return {"js_config": self._js_config()}
-
-    def _js_config(self) -> dict[str, Any]:
-        csrf_token = get_csrf_token(self.request)
-
-        return {"csrfToken": csrf_token}
+        return {"js_config": self.js_config}
 
     @view_config(
         request_method="POST", renderer="h:templates/accounts/signup-post.html.jinja2"
@@ -44,7 +39,7 @@ class SignupViews:
         try:
             appstruct = self.form.validate(self.request.POST.items())
         except ValidationFailure as e:
-            js_config = self._js_config()
+            js_config = self.js_config
             js_config["formErrors"] = e.error.asdict()
             js_config["formData"] = {
                 "username": self.request.POST.get("username", ""),
@@ -60,7 +55,7 @@ class SignupViews:
 
         signup_service = self.request.find_service(name="user_signup")
 
-        js_config = self._js_config()
+        js_config = self.js_config
         heading = _("Account registration successful")
         message = None
         try:
@@ -80,6 +75,12 @@ class SignupViews:
             "heading": heading,
             "message": message,
         }
+
+    @property
+    def js_config(self) -> dict[str, Any]:
+        csrf_token = get_csrf_token(self.request)
+
+        return {"csrfToken": csrf_token}
 
     def redirect_if_logged_in(self):
         if self.request.authenticated_userid is not None:

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -38,10 +38,7 @@ class SignupController:
     def _js_config(self) -> dict[str, Any]:
         csrf_token = get_csrf_token(self.request)
 
-        return {
-            "styles": self.request.registry["assets_env"].urls("forms_css"),
-            "csrfToken": csrf_token,
-        }
+        return {"csrfToken": csrf_token}
 
     @view_config(
         request_method="POST", renderer="h:templates/accounts/signup-post.html.jinja2"

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Any
 
-import deform
+from deform import ValidationFailure
 from pyramid import httpexceptions
 from pyramid.csrf import get_csrf_token
 from pyramid.view import view_config, view_defaults
@@ -45,7 +45,7 @@ class SignupController:
 
         try:
             appstruct = self.form.validate(self.request.POST.items())
-        except deform.ValidationFailure as e:
+        except ValidationFailure as e:
             js_config = self._js_config()
             js_config["formErrors"] = e.error.asdict()
             js_config["formData"] = {

--- a/tests/unit/h/views/account_signup_test.py
+++ b/tests/unit/h/views/account_signup_test.py
@@ -7,7 +7,7 @@ from h.services.exceptions import ConflictError
 from h.views import account_signup as views
 
 
-@pytest.mark.usefixtures("pyramid_config", "routes", "user_signup_service")
+@pytest.mark.usefixtures("pyramid_config", "user_signup_service")
 class TestSignupController:
     def test_post_returns_errors_when_validation_fails(
         self, invalid_form, pyramid_request, get_csrf_token
@@ -125,16 +125,15 @@ class TestSignupController:
 
         return controller
 
+    @pytest.fixture(autouse=True)
+    def routes(self, pyramid_config):
+        pyramid_config.add_route("activity.user_search", "/users/{username}")
+        pyramid_config.add_route("index", "/index")
+
 
 @pytest.fixture(autouse=True)
 def get_csrf_token(patch):
     return patch("h.views.account_signup.get_csrf_token")
-
-
-@pytest.fixture
-def routes(pyramid_config):
-    pyramid_config.add_route("activity.user_search", "/users/{username}")
-    pyramid_config.add_route("index", "/index")
 
 
 @pytest.fixture

--- a/tests/unit/h/views/account_signup_test.py
+++ b/tests/unit/h/views/account_signup_test.py
@@ -4,7 +4,6 @@ import pytest
 from pyramid import httpexceptions
 
 from h.services.exceptions import ConflictError
-from h.services.user_signup import UserSignupService
 from h.views import account_signup as views
 
 
@@ -133,13 +132,6 @@ class TestSignupController:
 def routes(pyramid_config):
     pyramid_config.add_route("activity.user_search", "/users/{username}")
     pyramid_config.add_route("index", "/index")
-
-
-@pytest.fixture
-def user_signup_service(pyramid_config):
-    service = mock.create_autospec(UserSignupService, spec_set=True, instance=True)
-    pyramid_config.register_service(service, name="user_signup")
-    return service
 
 
 @pytest.fixture

--- a/tests/unit/h/views/account_signup_test.py
+++ b/tests/unit/h/views/account_signup_test.py
@@ -1,8 +1,6 @@
 from unittest import mock
-from unittest.mock import create_autospec
 
 import pytest
-from h_assets import Environment
 from pyramid import httpexceptions
 
 from h.services.exceptions import ConflictError
@@ -13,7 +11,7 @@ from h.views import account_signup as views
 @pytest.mark.usefixtures("pyramid_config", "routes", "user_signup_service")
 class TestSignupController:
     def test_post_returns_errors_when_validation_fails(
-        self, invalid_form, pyramid_request, mocker, assets_env
+        self, invalid_form, pyramid_request, mocker
     ):
         pyramid_request.POST = {
             "username": "jane",
@@ -33,7 +31,6 @@ class TestSignupController:
 
         assert result == {
             "js_config": {
-                "styles": assets_env.urls.return_value,
                 "csrfToken": views.get_csrf_token.spy_return,
                 "formErrors": form_errors,
                 "formData": {
@@ -100,18 +97,13 @@ class TestSignupController:
             "The account bob@example.com is already registered."
         )
 
-    def test_get_renders_form_when_not_logged_in(
-        self, pyramid_request, mocker, assets_env
-    ):
+    def test_get_renders_form_when_not_logged_in(self, pyramid_request, mocker):
         mocker.spy(views, "get_csrf_token")
         controller = views.SignupController(pyramid_request)
         controller.form.render = mock.Mock()
 
         assert controller.get() == {
-            "js_config": {
-                "styles": assets_env.urls.return_value,
-                "csrfToken": views.get_csrf_token.spy_return,
-            }
+            "js_config": {"csrfToken": views.get_csrf_token.spy_return}
         }
 
     def test_get_redirects_when_logged_in(self, pyramid_config, pyramid_request):
@@ -135,15 +127,6 @@ class TestSignupController:
         )
 
         return controller
-
-    @pytest.fixture
-    def assets_env(self):
-        return create_autospec(Environment, instance=True, spec_set=True)
-
-    @pytest.fixture(autouse=True)
-    def pyramid_config(self, pyramid_config, assets_env):
-        pyramid_config.registry["assets_env"] = assets_env
-        return pyramid_config
 
 
 @pytest.fixture


### PR DESCRIPTION
The backend code for the new SSO interstitial/signup page is going to go in `account_signup.py` alongside the code for the existing signup page. Do some refactoring and tidy up of `account_signup.py` to make the code easier to work with in future PRs.