### PR TITLE
Rename RegisterSchema to SignupSchema

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -153,7 +153,7 @@ def _privacy_accepted_message():
     return privacy_msg
 
 
-class RegisterSchema(CSRFSchema):
+class SignupSchema(CSRFSchema):
     username = colander.SchemaNode(
         colander.String(),
         validator=colander.All(

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -7,7 +7,7 @@ from pyramid.csrf import get_csrf_token
 from pyramid.view import view_config, view_defaults
 
 from h import i18n
-from h.accounts.schemas import RegisterSchema
+from h.accounts.schemas import SignupSchema
 from h.services.exceptions import ConflictError
 
 _ = i18n.TranslationString
@@ -34,7 +34,7 @@ class SignupViews:
         """Handle submission of the new user registration form."""
         self.redirect_if_logged_in()
 
-        form = self.request.create_form(RegisterSchema().bind(request=self.request))
+        form = self.request.create_form(SignupSchema().bind(request=self.request))
 
         try:
             appstruct = form.validate(self.request.POST.items())

--- a/tests/unit/h/accounts/schemas_test.py
+++ b/tests/unit/h/accounts/schemas_test.py
@@ -74,30 +74,30 @@ class TestUniqueEmail:
         schemas.unique_email(dummy_node, "elliot@bar.com")
 
 
-class TestRegisterSchema:
+class TestSignupSchema:
     def test_it_is_invalid_when_password_too_short(self, pyramid_request):
-        schema = schemas.RegisterSchema().bind(request=pyramid_request)
+        schema = schemas.SignupSchema().bind(request=pyramid_request)
 
         with pytest.raises(colander.Invalid) as exc:
             schema.deserialize({"password": "a"})
         assert exc.value.asdict()["password"] == ("Must be 8 characters or more.")  # noqa: S105
 
     def test_it_is_invalid_when_username_too_short(self, pyramid_request):
-        schema = schemas.RegisterSchema().bind(request=pyramid_request)
+        schema = schemas.SignupSchema().bind(request=pyramid_request)
 
         with pytest.raises(colander.Invalid) as exc:
             schema.deserialize({"username": "ab"})
         assert "Must be 3 characters or more." in exc.value.asdict()["username"]
 
     def test_it_is_invalid_when_username_too_long(self, pyramid_request):
-        schema = schemas.RegisterSchema().bind(request=pyramid_request)
+        schema = schemas.SignupSchema().bind(request=pyramid_request)
 
         with pytest.raises(colander.Invalid) as exc:
             schema.deserialize({"username": "a" * 500})
         assert exc.value.asdict()["username"] == ("Must be 30 characters or less.")
 
     def test_it_is_invalid_with_invalid_characters_in_username(self, pyramid_request):
-        schema = schemas.RegisterSchema().bind(request=pyramid_request)
+        schema = schemas.SignupSchema().bind(request=pyramid_request)
 
         with pytest.raises(colander.Invalid) as exc:
             schema.deserialize({"username": "Fred Flintstone"})
@@ -106,7 +106,7 @@ class TestRegisterSchema:
         )
 
     def test_it_is_invalid_with_false_privacy_accepted(self, pyramid_request):
-        schema = schemas.RegisterSchema().bind(request=pyramid_request)
+        schema = schemas.SignupSchema().bind(request=pyramid_request)
 
         with pytest.raises(colander.Invalid) as exc:
             schema.deserialize({"privacy_accepted": "false"})
@@ -117,7 +117,7 @@ class TestRegisterSchema:
         )
 
     def test_it_is_invalid_when_privacy_accepted_missing(self, pyramid_request):
-        schema = schemas.RegisterSchema().bind(request=pyramid_request)
+        schema = schemas.SignupSchema().bind(request=pyramid_request)
 
         with pytest.raises(colander.Invalid) as exc:
             schema.deserialize({})
@@ -128,7 +128,7 @@ class TestRegisterSchema:
         self, factories, pyramid_request, valid_params
     ):
         """If an account with the same username was recently deleted it should be invalid."""
-        schema = schemas.RegisterSchema().bind(request=pyramid_request)
+        schema = schemas.SignupSchema().bind(request=pyramid_request)
         factories.UserDeletion(
             userid=format_userid(
                 username=valid_params["username"],
@@ -144,7 +144,7 @@ class TestRegisterSchema:
     def test_it_validates_with_valid_payload(
         self, pyramid_csrf_request, valid_params, factories
     ):
-        schema = schemas.RegisterSchema().bind(request=pyramid_csrf_request)
+        schema = schemas.SignupSchema().bind(request=pyramid_csrf_request)
         # A user with the same username was deleted over a month ago.
         # This should not prevent registration.
         factories.UserDeletion(

--- a/tests/unit/h/views/account_signup_test.py
+++ b/tests/unit/h/views/account_signup_test.py
@@ -35,7 +35,7 @@ class TestSignupViews:
     def test_post(
         self,
         views,
-        RegisterSchema,
+        SignupSchema,
         pyramid_request,
         user_signup_service,
         frozen_time,
@@ -43,12 +43,10 @@ class TestSignupViews:
     ):
         response = views.post()
 
-        RegisterSchema.assert_called_once_with()
-        RegisterSchema.return_value.bind.assert_called_once_with(
-            request=pyramid_request
-        )
+        SignupSchema.assert_called_once_with()
+        SignupSchema.return_value.bind.assert_called_once_with(request=pyramid_request)
         pyramid_request.create_form.assert_called_once_with(
-            RegisterSchema.return_value.bind.return_value
+            SignupSchema.return_value.bind.return_value
         )
         pyramid_request.create_form.return_value.validate.assert_called_once_with(ANY)
         assert list(
@@ -213,5 +211,5 @@ def get_csrf_token(patch):
 
 
 @pytest.fixture(autouse=True)
-def RegisterSchema(patch):
-    return patch("h.views.account_signup.RegisterSchema")
+def SignupSchema(patch):
+    return patch("h.views.account_signup.SignupSchema")


### PR DESCRIPTION
We mostly use "signup" rather than "register" (e.g. in the services,
views). Rename the schema for consistency.
