### PR TITLE
Turn `JWTService` into a proper service

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -21,6 +21,7 @@ from h.services.openid_client import OpenIDClientService
 from h.services.orcid_client import ORCIDClientService
 from h.services.subscription import SubscriptionService
 from h.services.task_done import TaskDoneService
+from h.services.user import UserService
 
 
 def includeme(config):  # pragma: no cover  # noqa: PLR0915
@@ -132,6 +133,7 @@ def includeme(config):  # pragma: no cover  # noqa: PLR0915
     config.register_service_factory(
         "h.services.job_queue.factory", iface=JobQueueService, name="queue_service"
     )
+    config.register_service_factory("h.services.jwt.factory", name="jwt")
 
     config.register_service_factory("h.services.nipsa.nipsa_factory", name="nipsa")
     config.register_service_factory(

--- a/h/services/jwt.py
+++ b/h/services/jwt.py
@@ -58,3 +58,9 @@ class JWTService:
         We want to keep the clients around with `lru_cache` to reuse that internal cache.
         """
         return PyJWKClient(jwk_url, cache_keys=True, timeout=JWK_CLIENT_TIMEOUT)
+
+
+def factory(context, request):
+    del context, request
+
+    return JWTService()

--- a/tests/unit/h/conftest.py
+++ b/tests/unit/h/conftest.py
@@ -49,6 +49,7 @@ from h.services.group_list import GroupListService
 from h.services.group_members import GroupMembersService
 from h.services.group_update import GroupUpdateService
 from h.services.job_queue import JobQueueService
+from h.services.jwt import JWTService
 from h.services.links import LinksService
 from h.services.list_organizations import ListOrganizationsService
 from h.services.nipsa import NipsaService
@@ -416,6 +417,11 @@ def search_index(mock_service):
 @pytest.fixture
 def queue_service(mock_service):
     return mock_service(JobQueueService, name="queue_service")
+
+
+@pytest.fixture
+def jwt_service(mock_service):
+    return mock_service(JWTService, name="jwt")
 
 
 @pytest.fixture

--- a/tests/unit/h/services/jwt_test.py
+++ b/tests/unit/h/services/jwt_test.py
@@ -3,15 +3,15 @@ from unittest.mock import sentinel
 import pytest
 from jwt.exceptions import InvalidTokenError
 
-from h.services.jwt import JWK_CLIENT_TIMEOUT, JWTService, TokenValidationError
+from h.services.jwt import JWK_CLIENT_TIMEOUT, JWTService, TokenValidationError, factory
 
 
 class TestJWTService:
-    def test_decode_token(self, jwt, PyJWKClient):
+    def test_decode_token(self, service, jwt, PyJWKClient):
         jwt.decode.return_value = {"aud": "AUD", "iss": "ISS"}
         jwt.get_unverified_header.return_value = {"kid": "KID"}
 
-        payload = JWTService.decode_token(
+        payload = service.decode_token(
             sentinel.token, sentinel.key_set_url, sentinel.algorithms
         )
 
@@ -24,33 +24,33 @@ class TestJWTService:
             key=PyJWKClient.return_value.get_signing_key_from_jwt.return_value.key,
             audience="AUD",
             algorithms=sentinel.algorithms,
-            leeway=JWTService.LEEWAY,
+            leeway=service.LEEWAY,
         )
         assert payload == jwt.decode.return_value
 
-    def test_decode_token_with_no_kid(self, jwt):
+    def test_decode_token_with_no_kid(self, service, jwt):
         jwt.get_unverified_header.return_value = {}
 
         with pytest.raises(
             TokenValidationError, match="Missing 'kid' value in JWT header"
         ):
-            JWTService.decode_token(
+            service.decode_token(
                 sentinel.token, sentinel.key_set_url, sentinel.algorithms
             )
 
-    def test_decode_token_with_invalid_jwt_header(self, jwt):
+    def test_decode_token_with_invalid_jwt_header(self, service, jwt):
         jwt.get_unverified_header.side_effect = InvalidTokenError()
 
         with pytest.raises(TokenValidationError, match="Invalid JWT"):
-            JWTService.decode_token(
+            service.decode_token(
                 sentinel.token, sentinel.key_set_url, sentinel.algorithms
             )
 
-    def test_decode_token_with_invalid_jwt(self, jwt):
+    def test_decode_token_with_invalid_jwt(self, service, jwt):
         jwt.decode.side_effect = [{"aud": "AUD", "iss": "ISS"}, InvalidTokenError()]
 
         with pytest.raises(TokenValidationError, match="Invalid JWT"):
-            JWTService.decode_token(
+            service.decode_token(
                 sentinel.token, sentinel.key_set_url, sentinel.algorightms
             )
 
@@ -63,5 +63,21 @@ class TestJWTService:
         return patch("h.services.jwt.PyJWKClient")
 
     @pytest.fixture(autouse=True)
-    def clear_jwk_cache(self):
-        JWTService._get_jwk_client.cache_clear()  # noqa: SLF001
+    def clear_jwk_cache(self, service):
+        service._get_jwk_client.cache_clear()  # noqa: SLF001
+
+    @pytest.fixture
+    def service(self):
+        return JWTService()
+
+
+class TestFactory:
+    def test_it(self, JWTService):
+        service = factory(sentinel.context, sentinel.request)
+
+        JWTService.assert_called_once_with()
+        assert service == JWTService.return_value
+
+    @pytest.fixture(autouse=True)
+    def JWTService(self, patch):
+        return patch("h.services.jwt.JWTService")


### PR DESCRIPTION
Turn `JWTService` into a `pyramid_services`-based service rather than just a class. This has several advantages:

1. It's consistent with the rest of our services.

2. It hides instantiation of `JWTService` from the other classes that use it, allowing `JWTService`'s `factory()` method to inject dependencies (e.g. config settings from `request.registry.settings`, other services from `request.find_service()`, etc) without any of `JWTService`'s users having to worry about these dependencies or pass them in.

   Currently `JWTService` doesn't have any `__init__()` method arguments but in a future PR I need to add some, and I'll now be able to do that without changing any of `JWTService`'s users or requiring them to pass the dependencies in.

3. It allows unittests for users of `JWTService` to take advantage of our centralised registry of mock services in `conftest.py`.
