### PR TITLE
Extract a separate `is_authenticated` view

### DIFF
--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -2,8 +2,8 @@ import datetime
 from typing import Any
 
 from deform import ValidationFailure
-from pyramid import httpexceptions
 from pyramid.csrf import get_csrf_token
+from pyramid.httpexceptions import HTTPFound
 from pyramid.view import exception_view_config, view_config, view_defaults
 
 from h import i18n
@@ -13,7 +13,7 @@ from h.services.exceptions import ConflictError
 _ = i18n.TranslationString
 
 
-@view_defaults(route_name="signup")
+@view_defaults(route_name="signup", is_authenticated=False)
 class SignupViews:
     def __init__(self, context, request):
         self.context = context
@@ -24,8 +24,6 @@ class SignupViews:
     )
     def get(self):
         """Render the empty registration form."""
-        self.redirect_if_logged_in()
-
         return {"js_config": self.js_config}
 
     @view_config(
@@ -33,8 +31,6 @@ class SignupViews:
     )
     def post(self):
         """Handle submission of the new user registration form."""
-        self.redirect_if_logged_in()
-
         form = self.request.create_form(SignupSchema().bind(request=self.request))
 
         appstruct = form.validate(self.request.POST.items())
@@ -82,10 +78,13 @@ class SignupViews:
     def js_config(self) -> dict[str, Any]:
         return {"csrfToken": get_csrf_token(self.request)}
 
-    def redirect_if_logged_in(self):
-        if self.request.authenticated_userid is not None:
-            raise httpexceptions.HTTPFound(
-                self.request.route_url(
-                    "activity.user_search", username=self.request.user.username
-                )
-            )
+
+# It's possible to try to sign up while already logged in. For example: start
+# to signup but don't submit the final form, then open a new tab and log in,
+# then return to the first tab and submit the signup form. This view is called
+# in these cases.
+@view_config(route_name="signup", is_authenticated=True)
+def is_authenticated(request):
+    return HTTPFound(
+        request.route_url("activity.user_search", username=request.user.username)
+    )

--- a/tests/unit/h/views/account_signup_test.py
+++ b/tests/unit/h/views/account_signup_test.py
@@ -5,11 +5,10 @@ import pytest
 from colander import Invalid
 from deform import ValidationFailure
 from freezegun import freeze_time
-from pyramid.httpexceptions import HTTPFound
 
 from h import i18n
 from h.services.exceptions import ConflictError
-from h.views.account_signup import SignupViews
+from h.views.account_signup import SignupViews, is_authenticated
 
 _ = i18n.TranslationString
 
@@ -21,16 +20,6 @@ class TestSignupViews:
 
         get_csrf_token.assert_called_once_with(pyramid_request)
         assert response == {"js_config": {"csrfToken": get_csrf_token.return_value}}
-
-    def test_get_redirects_if_logged_in(
-        self, pyramid_request, views, authenticated_user
-    ):
-        with pytest.raises(HTTPFound) as exc_info:
-            views.get()
-
-        assert exc_info.value.location == pyramid_request.route_url(
-            "activity.user_search", username=authenticated_user.username
-        )
 
     def test_post(
         self,
@@ -65,17 +54,6 @@ class TestSignupViews:
             "heading": _("Account registration successful"),
             "message": None,
         }
-
-    def test_post_redirects_if_logged_in(
-        self, pyramid_request, views, user_signup_service, authenticated_user
-    ):
-        with pytest.raises(HTTPFound) as exc_info:
-            views.post()
-
-        assert exc_info.value.location == pyramid_request.route_url(
-            "activity.user_search", username=authenticated_user.username
-        )
-        user_signup_service.signup.assert_not_called()
 
     def test_post_when_validation_failure(
         self, pyramid_request, views, user_signup_service
@@ -191,21 +169,33 @@ class TestSignupViews:
     def views(self, pyramid_request):
         return SignupViews(sentinel.context, pyramid_request)
 
-    @pytest.fixture(autouse=True)
-    def routes(self, pyramid_config):
-        pyramid_config.add_route("activity.user_search", "/users/{username}")
-
     @pytest.fixture
     def frozen_time(self):
         with freeze_time("2012-01-14 03:21:34") as frozen_time_factory:
             yield frozen_time_factory()
 
-    @pytest.fixture
-    def authenticated_user(self, factories, pyramid_config, pyramid_request):
-        user = factories.User()
-        pyramid_request.user = user
-        pyramid_config.testing_securitypolicy(userid=user.userid)
-        return user
+
+def test_is_authenticated(matchers, pyramid_request, authenticated_user):
+    response = is_authenticated(pyramid_request)
+
+    assert response == matchers.Redirect302To(
+        pyramid_request.route_url(
+            "activity.user_search", username=authenticated_user.username
+        )
+    )
+
+
+@pytest.fixture
+def authenticated_user(factories, pyramid_config, pyramid_request):
+    user = factories.User()
+    pyramid_request.user = user
+    pyramid_config.testing_securitypolicy(userid=user.userid)
+    return user
+
+
+@pytest.fixture(autouse=True)
+def routes(pyramid_config):
+    pyramid_config.add_route("activity.user_search", "/users/{username}")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Add `is_authenticated=False` to the `@view_defaults` of `SignupViews` then add a separate, new view with `@view_config(route_name="signup", is_authenticated=True)` that handles redirecting to the user's profile page if the user visits the `/signup` page while already logged in.

This simplifies the views: each view no longer needs to call a `redirect_if_logged_in()` helper. And it simplifies the view unittests: each view's unittests no longer need to test that it returns the right redirect if the user is logged in.

This is especially helpful when there are multiple views that need need to do the same redirect if the user is already logged in. We already have two such views and will be adding more in future.

### Testing

1. Test the `/signup` flow while _not_ already logged in: you should be able to sign up and log in as normal
2. Try to load `/signup` when already logged in, you should be redirected to your user page
3. Load `/signup` when not logged in, then log in in another tab, then go back to the first tab and attempt to submit the `/signup` form with either valid or invalid form fields (for invalid: enter a username that already exists, e.g. `devdata_user`). You should be redirected to your user page