### PR TITLE
Fix log in with ORCID when already logged in

### DIFF
--- a/h/views/oidc.py
+++ b/h/views/oidc.py
@@ -116,14 +116,21 @@ class ORCIDConnectAndLoginViews:
         append_slash=True,
         route_name="oidc.connect.orcid",
     )
-    @notfound_view_config(
-        renderer="h:templates/notfound.html.jinja2",
-        append_slash=True,
-        route_name="oidc.login.orcid",
-    )
     def notfound(self):
         self._request.response.status_int = 401
         return {}
+
+    # It's possible to try to log in while already logged in. For example: open
+    # the /login or /signup page but don't click anything yet, then open a new
+    # tab and log in, then return to the first tab and try to start a login
+    # flow. This view is called in these cases.
+    @view_config(route_name="oidc.login.orcid", is_authenticated=True)
+    def login_already_authenticated(self):
+        return HTTPFound(
+            self._request.route_url(
+                "activity.user_search", username=self._request.user.username
+            )
+        )
 
 
 @view_defaults(request_method="GET", route_name="oidc.redirect.orcid")

--- a/tests/unit/h/views/oidc_test.py
+++ b/tests/unit/h/views/oidc_test.py
@@ -19,7 +19,7 @@ from h.views.oidc import (
 )
 
 
-class TestORCIDAndLoginViews:
+class TestORCIDConnectAndLoginViews:
     @pytest.mark.parametrize(
         "route_name,expected_action",
         [
@@ -69,6 +69,17 @@ class TestORCIDAndLoginViews:
 
         assert result == {}
 
+    def test_login_already_authenticated(self, pyramid_request, matchers):
+        response = ORCIDConnectAndLoginViews(
+            pyramid_request
+        ).login_already_authenticated()
+
+        assert response == matchers.Redirect302To(
+            pyramid_request.route_url(
+                "activity.user_search", username=pyramid_request.user.username
+            )
+        )
+
     @pytest.fixture
     def pyramid_request(self, pyramid_request, factories, signing_key):
         pyramid_request.user = factories.User()
@@ -86,6 +97,7 @@ class TestORCIDAndLoginViews:
     def routes(self, pyramid_config):
         pyramid_config.add_route("oidc.connect.orcid", "/oidc/connect/orcid")
         pyramid_config.add_route("oidc.redirect.orcid", "/oidc/redirect/orcid")
+        pyramid_config.add_route("activity.user_search", "/users/{username}")
 
     @pytest.fixture(autouse=True)
     def secrets(self, secrets):


### PR DESCRIPTION
1. Log in as `devdata_admin`
2. Go to http://hypothesis.local:5000/admin/features and enable the `log_in_with_orcid` feature
3. Go to http://hypothesis.local:5000/account/settings and connect an ORCID iD
4. Log out
5. Open http://hypothesis.local:5000/signup in a tab
6. Open a second tab and log in
7. Back in the first tab click **Continue with ORCID**

On `main` you'll get a 404. On this branch you'll get redirected to your `/account/settings` page, which is the same thing that happens if you try to load the `/login` or `/signup` pages or attempt to submit the non-ORCID login or signup forms when already logged in.
