### PR TITLE
Enable Content-Security-Policy in development

### DIFF
--- a/h/viewderivers.py
+++ b/h/viewderivers.py
@@ -7,7 +7,7 @@ def csp_protected_view(view, info):
     Individual views can opt out of CSP altogether by specifying a view option
     ``csp_insecure_optout=True``. This is not recommended.
     """
-    if not info.registry.settings.get("csp.enabled", False):
+    if not info.registry.settings.get("csp.enabled", True):
         return view
 
     # Views can set ``csp_insecure_optout=True`` in their view options to

--- a/tests/unit/h/viewderivers_test.py
+++ b/tests/unit/h/viewderivers_test.py
@@ -4,7 +4,15 @@ from h.viewderivers import csp_protected_view
 
 
 class TestCSPProtectedView:
-    def test_noop_by_default(self, pyramid_request, derive_view):
+    def test_enabled_by_default(self, pyramid_request, derive_view):
+        view = derive_view(_dummy_view)
+
+        response = view(None, pyramid_request)
+
+        assert "Content-Security-Policy" in response.headers
+
+    def test_disable_csp(self, pyramid_request, derive_view):
+        pyramid_request.registry.settings.update({"csp.enabled": False})
         view = derive_view(_dummy_view)
 
         response = view(None, pyramid_request)


### PR DESCRIPTION
Content-Security-Policy has been enabled on staging and production for many years. However it it was off by default and enabled via the `CSP_ENABLED` env var in prod. This could lead to problems where code worked locally but failed in production due to CSP being applied ([example](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1752666555255959)).

Align dev/prod by enabling CSP by default. It can still be disabled with `CSP_ENABLED=false` if needed.

**Testing:**

Visit any h page on this branch, except those that serve the client's HTML. There should be a `Content-Security-Policy` header in the response.