### PR TITLE
Generate per-request CSP nonce value and add `nonce` attribute to importmap script

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -150,9 +150,17 @@ def _configure_csp(config):
     # Define the global default Content Security Policy
     client_url = settings.get("h.client_url", DEFAULT_CLIENT_URL)
     client_host = urlparse(client_url).netloc
+
+    # References to `NONCE_VALUE` are replaced with a per-request value when
+    # the Content-Security-Policy header is generated.
     settings["csp"] = {
         "font-src": ["'self'", "fonts.gstatic.com", client_host],
-        "script-src": ["'self'", client_host, "www.googletagmanager.com"],
+        "script-src": [
+            "'self'",
+            client_host,
+            "www.googletagmanager.com",
+            "'nonce-NONCE_VALUE'",
+        ],
         # Allow inline styles until https://github.com/hypothesis/client/issues/293
         # is resolved as otherwise our own tool would break on the site,
         # including on /docs/help.

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -60,7 +60,7 @@
     {# Import map must be placed before any module script tags. Firefox will
        fail to load it otherwise. #}
     {% block importmap %}
-    <script type="importmap">{{ asset_import_map() | tojson }}</script>
+    <script type="importmap" nonce="{{ request.csp_nonce }}">{{ asset_import_map() | tojson }}</script>
     {% endblock %}
 
     {% for url in asset_urls("header_js") %}

--- a/h/viewderivers.py
+++ b/h/viewderivers.py
@@ -1,3 +1,6 @@
+from secrets import token_hex
+
+
 def csp_protected_view(view, info):
     """
     Add Content-Security-Policy headers to responses.
@@ -28,8 +31,14 @@ def csp_protected_view(view, info):
         header_name = "Content-Security-Policy"
 
     def wrapper_view(context, request):
+        # Spec recommends nonce should be 128 bits (16 bytes) before encoding:
+        # https://www.w3.org/TR/CSP3/#security-nonces.
+        request.csp_nonce = token_hex(16)
+
         resp = view(context, request)
-        resp.headers[header_name] = header_value
+        resp.headers[header_name] = header_value.replace(
+            "NONCE_VALUE", request.csp_nonce
+        )
         return resp
 
     return wrapper_view


### PR DESCRIPTION
Fix an issue where browsers reject the `importmap` script when Content-Security-Policy is enabled by using CSP [nonces](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/nonce). This works by:

- Generating a random 16 byte (32 hex chars) value per request and adding it to the `Content-Security-Policy` header's `script-src` field
- Adding the value to the `<script type="importmap">` element as a `nonce` attribute. Note that this attribute is not readable from JavaScript and shows up as an attribute with no value in developer tools. (Correction: The nonce is not readable _as an attribute_, it is readable as a property. See [MDN note](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/nonce#accessing_nonces_and_nonce_hiding)).

**Testing:**

1. On `main` (after https://github.com/hypothesis/h/pull/9736 is merged), go to any HTML page in h and observe an error in the browser dev tools about a script being rejected due to CSP
2. On this branch, load the same page and observe the error is gone. Additionally the HTTP response for the page will contain a `Content-Security-Policy` header with a `'nonce-{32-hex-chars}'` value and the `importmap` tag will contain a `nonce` attribute, which will appear blank in dev tools.