### PR TITLE
Re-land "Lazily load `MarkdownView` and its dependencies in group forms views"

### DIFF
--- a/h/static/scripts/group-forms/components/AnnotationCard.tsx
+++ b/h/static/scripts/group-forms/components/AnnotationCard.tsx
@@ -3,7 +3,6 @@ import {
   AnnotationShareControl,
   AnnotationTimestamps,
   AnnotationUser,
-  MarkdownView,
   StyledText,
 } from '@hypothesis/annotation-ui';
 import {
@@ -12,6 +11,7 @@ import {
   ExternalIcon,
   Link,
   ReplyIcon,
+  lazy,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useContext, useMemo, useState } from 'preact/hooks';
@@ -37,6 +37,17 @@ type SaveState =
   | { type: 'saved' }
   | { type: 'saving' }
   | { type: 'error'; error: string };
+
+// Lazily load the MarkdownView as it has heavy dependencies such as Showdown,
+// KaTeX and DOMPurify.
+const MarkdownView = lazy(
+  'MarkdownView',
+  () => import('./MarkdownView').then(mod => mod.default),
+  {
+    fallback: ({ markdown }) => markdown,
+    errorFallback: /* istanbul ignore next */ ({ markdown }) => markdown,
+  },
+);
 
 export default function AnnotationCard({
   annotation,

--- a/h/static/scripts/group-forms/components/MarkdownView.tsx
+++ b/h/static/scripts/group-forms/components/MarkdownView.tsx
@@ -1,0 +1,5 @@
+// Entry point for MarkdownView component bundle.
+//
+// The main purpose of this wrapper is to cause Rollup to generate a bundle
+// with a meaningful name, as it uses the file name of the entry point.
+export { MarkdownView as default } from '@hypothesis/annotation-ui';

--- a/h/static/scripts/group-forms/components/test/AnnotationCard-test.js
+++ b/h/static/scripts/group-forms/components/test/AnnotationCard-test.js
@@ -46,8 +46,14 @@ describe('AnnotationCard', () => {
         AnnotationTimestamps: () => null,
         AnnotationUser: () => null,
         AnnotationGroupInfo: () => null,
-        MarkdownView: () => null,
         AnnotationShareControl: () => null,
+      },
+      '@hypothesis/frontend-shared': {
+        lazy: displayName => {
+          const DummyComponent = () => null;
+          DummyComponent.displayName = displayName;
+          return DummyComponent;
+        },
       },
       '../hooks/use-update-moderation-status': {
         useUpdateModerationStatus: fakeUseUpdateModerationStatus,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/preset-typescript": "^7.27.0",
     "@hypothesis/annotation-ui": "^0.4.1",
     "@hypothesis/frontend-build": "^4.0.0",
-    "@hypothesis/frontend-shared": "^9.6.1",
+    "@hypothesis/frontend-shared": "^9.7.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/rollup-tests.config.js
+++ b/rollup-tests.config.js
@@ -18,6 +18,9 @@ export default {
     file: 'build/scripts/tests.bundle.js',
     format: 'es',
     sourcemap: true,
+
+    // Simplify build output by putting all code in one bundle.
+    inlineDynamicImports: true,
   },
   treeshake: false,
   // Suppress a warning (https://rollupjs.org/guide/en/#error-this-is-undefined)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,15 +2009,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^9.6.1":
-  version: 9.6.1
-  resolution: "@hypothesis/frontend-shared@npm:9.6.1"
+"@hypothesis/frontend-shared@npm:^9.7.0":
+  version: 9.7.0
+  resolution: "@hypothesis/frontend-shared@npm:9.7.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: cbc67107535b0411f3262c5f10749dc9a921effc50643af81dddf8e5ea3375d858642dcf46b9a9ad1f176d074785abc222e56e9eb5ed5339bbf1f668b6fbc3dc
+  checksum: bdb31cf6181c2ca1fea9ef881ce93f4e5095476720191b7afd2bc20e5cba94dbbe63dd8d58ce6c344ed7ace059294591e9737ec49e54606f39cb2902788f7426
   languageName: node
   linkType: hard
 
@@ -6927,7 +6927,7 @@ __metadata:
     "@babel/preset-typescript": ^7.27.0
     "@hypothesis/annotation-ui": ^0.4.1
     "@hypothesis/frontend-build": ^4.0.0
-    "@hypothesis/frontend-shared": ^9.6.1
+    "@hypothesis/frontend-shared": ^9.7.0
     "@hypothesis/frontend-testing": ^1.7.1
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.3


### PR DESCRIPTION
Re-land https://github.com/hypothesis/h/pull/9705 following resolution of a CSP issue in https://github.com/hypothesis/h/pull/9737.

Reverts hypothesis/h#9735