### PR TITLE
Expose annotation detail endpoint config to groups forms

### DIFF
--- a/h/security/policy/_api_cookie.py
+++ b/h/security/policy/_api_cookie.py
@@ -16,6 +16,7 @@ COOKIE_AUTHENTICATABLE_API_REQUESTS = [
         "api.annotation_moderation",
         "PATCH",
     ),  # Change the moderation status of an annotation.
+    ("api.annotation", "GET"),  # Get the details of an annotation
 ]
 
 

--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -29,6 +29,7 @@ export type ConfigObject = {
     removeGroupMember?: APIConfig;
     groupAnnotations?: APIConfig;
     annotationModeration?: APIConfig;
+    annotationDetail?: APIConfig;
   };
   context: {
     group: Group | null;

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -121,6 +121,9 @@ class GroupCreateEditController:
                     "annotationModeration": api_config(
                         "api.annotation_moderation", "PATCH", id=":annotationId"
                     ),
+                    "annotationDetail": api_config(
+                        "api.annotation", "GET", id=":annotationId"
+                    ),
                 }
             )
 

--- a/tests/unit/h/views/groups_test.py
+++ b/tests/unit/h/views/groups_test.py
@@ -129,6 +129,13 @@ class TestGroupCreateEditController:
                         ),
                         "headers": {"X-CSRF-Token": views.get_csrf_token.spy_return},
                     },
+                    "annotationDetail": {
+                        "method": "GET",
+                        "url": pyramid_request.route_url(
+                            "api.annotation", id=":annotationId"
+                        ),
+                        "headers": {"X-CSRF-Token": views.get_csrf_token.spy_return},
+                    },
                 },
                 "context": {
                     "group": {
@@ -200,6 +207,7 @@ def routes(pyramid_config):
     pyramid_config.add_route(
         "api.annotation_moderation", "/api/annotations/{id}/moderation"
     )
+    pyramid_config.add_route("api.annotation", "/api/annotations/{id}")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Part of https://github.com/hypothesis/h/issues/9739

Expose the configuration for the annotation detail indpoint to the group forms pages, so that it's possible to re-fetch the annotation data when a conflict error occurs after trying to moderate it.