### PR TITLE
Persist moderation status filter in query

### DIFF
--- a/h/static/scripts/group-forms/components/test/GroupModeration-test.js
+++ b/h/static/scripts/group-forms/components/test/GroupModeration-test.js
@@ -45,12 +45,31 @@ describe('GroupModeration', () => {
   });
 
   describe('moderation status filter', () => {
-    it('shows pending status initially', () => {
-      const wrapper = createComponent();
-      assert.equal(
-        wrapper.find('ModerationStatusSelect').prop('selected'),
-        'PENDING',
-      );
+    [
+      { queryParamStatus: undefined, expectedSelectedStatus: 'PENDING' },
+      { queryParamStatus: 'invalid', expectedSelectedStatus: 'PENDING' },
+      { queryParamStatus: 'ALL', expectedSelectedStatus: undefined },
+      { queryParamStatus: 'APPROVED', expectedSelectedStatus: 'APPROVED' },
+      { queryParamStatus: 'DENIED', expectedSelectedStatus: 'DENIED' },
+      { queryParamStatus: 'SPAM', expectedSelectedStatus: 'SPAM' },
+      { queryParamStatus: 'PENDING', expectedSelectedStatus: 'PENDING' },
+    ].forEach(({ queryParamStatus, expectedSelectedStatus }) => {
+      it('shows expected initial status', () => {
+        if (queryParamStatus) {
+          history.replaceState(
+            null,
+            '',
+            `?moderation_status=${queryParamStatus}`,
+          );
+        }
+
+        const wrapper = createComponent();
+
+        assert.equal(
+          wrapper.find('ModerationStatusSelect').prop('selected'),
+          expectedSelectedStatus,
+        );
+      });
     });
 
     ['APPROVED', 'DENIED', 'SPAM'].forEach(newStatus => {
@@ -64,6 +83,7 @@ describe('GroupModeration', () => {
           wrapper.find('ModerationStatusSelect').prop('selected'),
           newStatus,
         );
+        assert.equal(location.search, `?moderation_status=${newStatus}`);
       });
     });
   });

--- a/h/static/scripts/group-forms/utils/moderation-status.ts
+++ b/h/static/scripts/group-forms/utils/moderation-status.ts
@@ -8,3 +8,9 @@ export const moderationStatusToLabel: Record<ModerationStatus, string> = {
 } as const;
 
 Object.freeze(moderationStatusToLabel);
+
+const moderationStatuses = Object.keys(moderationStatusToLabel);
+
+export const isModerationStatus = (
+  status: string,
+): status is ModerationStatus => moderationStatuses.includes(status);


### PR DESCRIPTION
Closes #9752 

This PR ensures every time the moderation status filter is changed, we persist the new value in the query. Then, if the page is reloaded, the value is read from there to determine the initial filter.

This avoids current behavior, where reloading the page after changing the moderation status filter causes it to be reset back to `PENDING`.

https://github.com/user-attachments/assets/dc3dd49e-7f4c-456f-9b79-95675a090310

### Test steps

1. Go to http://localhost:5000/search, and select a group from the groups dropdown
2. Click on "Edit group", then go to the "Moderation" tab.
3. Using the dropdown in the upper-right corner, change the status filter. Selected value should be set in the URL's query string.
4. Reload the page. The previously selected filter value should be set in the filter.
5. The same should happen if other values are selected.