### PR TITLE
Disable new signup form on submit

### DIFF
--- a/h/static/scripts/login-forms/components/SignupForm.tsx
+++ b/h/static/scripts/login-forms/components/SignupForm.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@hypothesis/frontend-shared';
-import { useContext } from 'preact/hooks';
+import { useContext, useState } from 'preact/hooks';
 
 import Checkbox from '../../forms-common/components/Checkbox';
 import Form from '../../forms-common/components/Form';
@@ -12,6 +12,7 @@ import type { SignupConfigObject } from '../config';
 
 export default function SignupForm() {
   const config = useContext(Config) as SignupConfigObject;
+  const [submitted, setSubmitted] = useState(false);
 
   const username = useFormValue(config.formData?.username ?? '', {
     initialError: config.formErrors?.username,
@@ -43,7 +44,7 @@ export default function SignupForm() {
     <>
       <FormHeader>Sign up for Hypothesis</FormHeader>
       <FormContainer>
-        <Form csrfToken={config.csrfToken}>
+        <Form csrfToken={config.csrfToken} onSubmit={() => setSubmitted(true)}>
           <TextField
             type="input"
             name="username"
@@ -128,7 +129,14 @@ export default function SignupForm() {
           </Checkbox>
           <div className="pt-2 flex items-center gap-x-4">
             <div className="grow" />
-            <Button type="submit" variant="primary" data-testid="submit-button">
+            <Button
+              type="submit"
+              variant="primary"
+              data-testid="submit-button"
+              // Prevent duplicate signup attempts.
+              // See https://github.com/hypothesis/h/pull/3851
+              disabled={submitted}
+            >
               Sign up
             </Button>
           </div>

--- a/h/static/scripts/login-forms/components/test/SignupForm-test.js
+++ b/h/static/scripts/login-forms/components/test/SignupForm-test.js
@@ -225,6 +225,22 @@ describe('SignupForm', () => {
     assert.isTrue(updatedElements.commsCheckbox.prop('checked'));
   });
 
+  it('disables submit button when form is submitted', () => {
+    const { wrapper, elements } = createWrapper();
+    const { form, submitButton } = elements;
+
+    assert.isFalse(submitButton.getDOMNode().disabled);
+
+    // Simulate submitting the form.
+    //
+    // To really submit the form we would have to populate all fields with
+    // valid values and then use `HTMLFormElement.requestSubmit`.
+    form.getDOMNode().dispatchEvent(new Event('submit'));
+    wrapper.update();
+
+    assert.isTrue(submitButton.getDOMNode().disabled);
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({ content: () => createWrapper().wrapper }),


### PR DESCRIPTION
The old signup form was disabled on submit to prevent conflicting DB operations. See https://github.com/hypothesis/h/pull/3851. This behavior was not applied in the new Preact-based signup form. Re-introduce the logic there.

See also Slack thread: https://hypothes-is.slack.com/archives/C1M8NH76X/p1753270136340759