### PR TITLE
Add `matchers.InstanceOf`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,13 @@ from sqlalchemy.orm import sessionmaker
 from h import search
 
 
+@pytest.fixture
+def matchers():
+    from tests import matchers
+
+    return matchers
+
+
 @pytest.fixture(scope="session")
 def db_engine():
     return create_engine(environ["DATABASE_URL"])

--- a/tests/functional/client_login_test.py
+++ b/tests/functional/client_login_test.py
@@ -22,19 +22,21 @@ class TestLoginFlow:
         assert next_url == "http://localhost/oauth/authorize"
         assert query == params
 
-    def test_authorisation_presents_form_if_logged_in(self, app, user, params):
+    def test_authorisation_presents_form_if_logged_in(
+        self, app, user, params, matchers
+    ):
         self.login(app, user)
         response = app.get("/oauth/authorize", params=params, status=200)
 
         js_settings = self._approve_authorize_request(response)
 
         assert js_settings == {
-            "code": Any.string(),
+            "code": matchers.InstanceOf(str),
             "origin": "http://localhost:5000",
             "state": params["state"],
         }
 
-    def test_the_code_from_auth_can_be_exchanged(self, app, user, params):
+    def test_the_code_from_auth_can_be_exchanged(self, app, user, params, matchers):
         self.login(app, user)
         response = app.get("/oauth/authorize", params=params, status=200)
         js_settings = self._approve_authorize_request(response)
@@ -56,8 +58,8 @@ class TestLoginFlow:
         assert response.json == Any.dict.containing(
             {
                 "token_type": "Bearer",
-                "access_token": Any.string(),
-                "refresh_token": Any.string(),
+                "access_token": matchers.InstanceOf(str),
+                "refresh_token": matchers.InstanceOf(str),
             }
         )
 

--- a/tests/matchers.py
+++ b/tests/matchers.py
@@ -44,6 +44,39 @@ class Matcher:
         return repr_(self, self.repr_attrs)
 
 
+class InstanceOf(Matcher):
+    """Matches any instance of the given class with the given attrs.
+
+    As with Python's builtin isinstance() `class_` can be either a single class
+    or a tuple of classes (in which case the matcher will match instances of
+    *any* of the classes in the tuple).
+
+    If no kwargs are given then the matcher will match instances of the given
+    class(es) without checking any of the instance's attributes.
+    """
+
+    def __init__(self, class_, **kwargs):
+        self.class_ = class_
+        self.with_attrs = kwargs
+
+    @property
+    def repr_attrs(self):
+        if self.with_attrs:
+            return ("class_", "with_attrs")
+
+        return ("class_",)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.class_):
+            return False
+
+        for name, value in self.with_attrs.items():
+            if not getattr(other, name) == value:
+                return False
+
+        return True
+
+
 class Redirect302To(Matcher):
     """Matches any HTTPFound redirect to the given URL."""
 

--- a/tests/unit/h/conftest.py
+++ b/tests/unit/h/conftest.py
@@ -156,13 +156,6 @@ def invalid_form():
 
 
 @pytest.fixture
-def matchers():
-    from tests import matchers
-
-    return matchers
-
-
-@pytest.fixture
 def notify(pyramid_config, request):
     patcher = mock.patch.object(pyramid_config.registry, "notify", autospec=True)
     request.addfinalizer(patcher.stop)  # noqa: PT021

--- a/tests/unit/h/emails/test_test.py
+++ b/tests/unit/h/emails/test_test.py
@@ -1,5 +1,4 @@
 import pytest
-from h_matchers import Any
 
 from h import __version__
 from h.emails.test import generate
@@ -8,14 +7,14 @@ from h.services.email import EmailData, EmailTag
 
 class TestGenerate:
     def test_calls_renderers_with_appropriate_context(
-        self, pyramid_request, html_renderer, text_renderer
+        self, pyramid_request, html_renderer, text_renderer, matchers
     ):
         generate(pyramid_request, "meerkat@example.com")
 
         expected_context = {
-            "time": Any.string(),
-            "hostname": Any.string(),
-            "python_version": Any.string(),
+            "time": matchers.InstanceOf(str),
+            "hostname": matchers.InstanceOf(str),
+            "python_version": matchers.InstanceOf(str),
             "version": __version__,
         }
         html_renderer.assert_(**expected_context)  # noqa: PT009

--- a/tests/unit/h/form_test.py
+++ b/tests/unit/h/form_test.py
@@ -77,13 +77,15 @@ class TestCreateForm:
 
         assert result == Form.return_value
 
-    def test_passes_args_including_renderer_to_form_ctor(self, Form, pyramid_request):
+    def test_passes_args_including_renderer_to_form_ctor(
+        self, Form, pyramid_request, matchers
+    ):
         form.create_form(pyramid_request, mock.sentinel.schema, foo="bar")
 
         Form.assert_called_once_with(
             mock.sentinel.schema,
             foo="bar",
-            renderer=Any.instance_of(form.Jinja2Renderer),
+            renderer=matchers.InstanceOf(form.Jinja2Renderer),
         )
 
     def test_adds_feature_client_to_system_context(self, patch, pyramid_request):

--- a/tests/unit/h/jinja2_extensions/navbar_data_test.py
+++ b/tests/unit/h/jinja2_extensions/navbar_data_test.py
@@ -8,7 +8,7 @@ from h.models import GroupMembership
 
 
 class TestNavbarData:
-    def test_it(self, pyramid_request, user):
+    def test_it(self, pyramid_request, user, matchers):
         pyramid_request.matched_route = None
         pyramid_request.params["q"] = "tag:question"
         pyramid_request.user = user
@@ -36,7 +36,7 @@ class TestNavbarData:
                 for group in user.groups
             ],
             "q": "tag:question",
-            "search_url": Any.string(),
+            "search_url": matchers.InstanceOf(str),
             "settings_menu_items": [
                 {"link": "http://example.com/account", "title": "Account details"},
                 {"link": "http://example.com/account/profile", "title": "Edit profile"},

--- a/tests/unit/h/models/document/_meta_test.py
+++ b/tests/unit/h/models/document/_meta_test.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock
 
 import pytest
 import sqlalchemy as sa
-from h_matchers import Any
 
 from h.models import Document, DocumentMeta
 from h.models.document import ConcurrentUpdateError, create_or_update_document_meta
@@ -21,7 +20,7 @@ class TestDocumentMeta:
 
 class TestCreateOrUpdateDocumentMeta:
     def test_it_creates_a_new_DocumentMeta_if_there_is_no_existing_one(
-        self, db_session, meta_attrs
+        self, db_session, meta_attrs, matchers
     ):
         # Add one non-matching DocumentMeta to the database to be ignored.
         db_session.add(DocumentMeta(**dict(meta_attrs, type="noise")))
@@ -29,7 +28,7 @@ class TestCreateOrUpdateDocumentMeta:
         create_or_update_document_meta(session=db_session, **meta_attrs)
 
         document_meta = db_session.query(DocumentMeta).all()[-1]
-        assert document_meta == Any.object.with_attrs(meta_attrs)
+        assert document_meta == matchers.InstanceOf(object, **meta_attrs)
 
     @pytest.mark.parametrize("correct_document", (True, False))
     def test_it_updates_an_existing_DocumentMeta_if_there_is_one(

--- a/tests/unit/h/models/document/_uri_test.py
+++ b/tests/unit/h/models/document/_uri_test.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock
 
 import pytest
 import sqlalchemy as sa
-from h_matchers import Any
 
 from h.models.document import ConcurrentUpdateError, create_or_update_document_uri
 from h.models.document._document import Document
@@ -103,7 +102,7 @@ class TestCreateOrUpdateDocumentURI:
         )
 
     def test_it_creates_a_new_DocumentURI_if_there_is_no_existing_one(
-        self, db_session, doc_uri_attrs
+        self, db_session, doc_uri_attrs, matchers
     ):
         original_attrs = doc_uri_attrs
         updated_attrs = dict(
@@ -119,7 +118,7 @@ class TestCreateOrUpdateDocumentURI:
         document_uri = (
             db_session.query(DocumentURI).order_by(DocumentURI.created.desc()).first()
         )
-        assert document_uri == Any.object.with_attrs(updated_attrs)
+        assert document_uri == matchers.InstanceOf(object, **updated_attrs)
 
     def test_it_skips_denormalizing_http_uris_to_document(
         self, db_session, doc_uri_attrs

--- a/tests/unit/h/presenters/annotation_jsonld_test.py
+++ b/tests/unit/h/presenters/annotation_jsonld_test.py
@@ -1,13 +1,12 @@
 import datetime
 
 import pytest
-from h_matchers import Any
 
 from h.presenters.annotation_jsonld import AnnotationJSONLDPresenter
 
 
 class TestAnnotationJSONLDPresenter:
-    def test_it(self, presenter, annotation, links_service):
+    def test_it(self, presenter, annotation, links_service, matchers):
         annotation.created = datetime.datetime(2016, 2, 24, 18, 3, 25, 768)  # noqa: DTZ001
         annotation.updated = datetime.datetime(2016, 2, 29, 10, 24, 5, 564)  # noqa: DTZ001
 
@@ -18,11 +17,11 @@ class TestAnnotationJSONLDPresenter:
             "created": "2016-02-24T18:03:25.000768+00:00",
             "modified": "2016-02-29T10:24:05.000564+00:00",
             "creator": annotation.userid,
-            "body": Any.list(),
+            "body": matchers.InstanceOf(list),
             "target": [
                 {
                     "source": annotation.target_uri,
-                    "selector": Any.list(),
+                    "selector": matchers.InstanceOf(list),
                 }
             ],
         }

--- a/tests/unit/h/realtime_test.py
+++ b/tests/unit/h/realtime_test.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import kombu
 import pytest
-from h_matchers import Any
 from kombu.exceptions import LimitExceeded, OperationalError
 
 from h import realtime
@@ -168,11 +167,11 @@ class TestGetConnection:
         realtime.get_connection({"broker_url": broker_url})
         Connection.assert_called_once_with(broker_url)
 
-    def test_it_adds_timeout_options_for_failfast(self, Connection):
+    def test_it_adds_timeout_options_for_failfast(self, Connection, matchers):
         realtime.get_connection({}, fail_fast=True)
 
         Connection.assert_called_once_with(
-            Any.string(), transport_options=RETRY_POLICY_QUICK
+            matchers.InstanceOf(str), transport_options=RETRY_POLICY_QUICK
         )
 
     @pytest.fixture

--- a/tests/unit/h/security/identity_test.py
+++ b/tests/unit/h/security/identity_test.py
@@ -1,7 +1,6 @@
 from unittest.mock import call, sentinel
 
 import pytest
-from h_matchers import Any
 
 from h.models import GroupMembership, GroupMembershipRoles
 from h.security.identity import (
@@ -14,13 +13,13 @@ from h.security.identity import (
 
 
 class TestLongLivedGroup:
-    def test_from_models(self, factories):
+    def test_from_models(self, factories, matchers):
         group = factories.Group.build()
 
         model = LongLivedGroup.from_model(group)
 
-        assert model == Any.instance_of(LongLivedGroup).with_attrs(
-            {"id": group.id, "pubid": group.pubid}
+        assert model == matchers.InstanceOf(
+            LongLivedGroup, id=group.id, pubid=group.pubid
         )
 
 
@@ -72,40 +71,39 @@ class TestLongLivedUser:
 
 
 class TestLongLivedAuthClient:
-    def test_from_models(self, factories):
+    def test_from_models(self, factories, matchers):
         auth_client = factories.AuthClient.build()
 
         model = LongLivedAuthClient.from_model(auth_client)
 
-        assert model == Any.instance_of(LongLivedAuthClient).with_attrs(
-            {"id": auth_client.id, "authority": auth_client.authority}
+        assert model == matchers.InstanceOf(
+            LongLivedAuthClient,
+            id=auth_client.id,
+            authority=auth_client.authority,
         )
 
 
 class TestIdentity:
-    def test_from_models(self, LongLivedUser, LongLivedAuthClient):
+    def test_from_models(self, LongLivedUser, LongLivedAuthClient, matchers):
         identity = Identity.from_models(
             user=sentinel.user, auth_client=sentinel.auth_client
         )
 
         LongLivedUser.from_model.assert_called_once_with(sentinel.user)
         LongLivedAuthClient.from_model.assert_called_once_with(sentinel.auth_client)
-        assert identity == Any.instance_of(Identity).with_attrs(
-            {
-                "user": LongLivedUser.from_model.return_value,
-                "auth_client": LongLivedAuthClient.from_model.return_value,
-            }
+        assert identity == matchers.InstanceOf(
+            Identity,
+            user=LongLivedUser.from_model.return_value,
+            auth_client=LongLivedAuthClient.from_model.return_value,
         )
 
-    def test_from_models_with_None(self, LongLivedUser, LongLivedAuthClient):
+    def test_from_models_with_None(self, LongLivedUser, LongLivedAuthClient, matchers):
         identity = Identity.from_models()
 
         LongLivedUser.from_model.assert_not_called()
         LongLivedAuthClient.from_model.assert_not_called()
 
-        assert identity == Any.instance_of(Identity).with_attrs(
-            {"user": None, "auth_client": None}
-        )
+        assert identity == matchers.InstanceOf(Identity, user=None, auth_client=None)
 
     @pytest.mark.parametrize(
         "identity,authenticated_userid",

--- a/tests/unit/h/services/annotation_json_test.py
+++ b/tests/unit/h/services/annotation_json_test.py
@@ -158,7 +158,7 @@ class TestAnnotationJSONService:
         )
 
     def test_present_for_user_only_shows_moderation_to_moderators(
-        self, service, annotation, user, identity_permits, Identity
+        self, service, annotation, user, identity_permits, Identity, matchers
     ):
         identity_permits.return_value = False
 
@@ -167,9 +167,7 @@ class TestAnnotationJSONService:
         Identity.from_models.assert_called_once_with(user=user)
         identity_permits.assert_called_once_with(
             identity=Identity.from_models.return_value,
-            context=Any.instance_of(AnnotationContext).with_attrs(
-                {"annotation": annotation}
-            ),
+            context=matchers.InstanceOf(AnnotationContext, annotation=annotation),
             permission=Permission.Annotation.MODERATE,
         )
 

--- a/tests/unit/h/services/annotation_write_test.py
+++ b/tests/unit/h/services/annotation_write_test.py
@@ -24,6 +24,7 @@ class TestAnnotationWriteService:
         _validate_group,  # noqa: PT019
         db_session,
         moderation_service,
+        matchers,
     ):
         root_annotation = factories.Annotation()
         annotation_read_service.get_annotation_by_id.return_value = root_annotation
@@ -46,14 +47,13 @@ class TestAnnotationWriteService:
         mention_service.update_mentions.assert_called_once_with(anno)
         moderation_service.update_status.assert_called_once_with("create", anno)
 
-        assert anno == Any.instance_of(Annotation).with_attrs(
-            {
-                "userid": create_data["userid"],
-                "groupid": root_annotation.groupid,
-                "target_uri": create_data["target_uri"],
-                "references": create_data["references"],
-                "document": update_document_metadata.return_value,
-            }
+        assert anno == matchers.InstanceOf(
+            Annotation,
+            userid=create_data["userid"],
+            groupid=root_annotation.groupid,
+            target_uri=create_data["target_uri"],
+            references=create_data["references"],
+            document=update_document_metadata.return_value,
         )
         self.assert_annotation_slim(db_session, anno)
 

--- a/tests/unit/h/services/bulk_executor/_actions_test.py
+++ b/tests/unit/h/services/bulk_executor/_actions_test.py
@@ -38,14 +38,16 @@ class UserMatcher(AnyObject):
 
 
 class TestBulkUserUpsert:
-    def test_it_can_insert_new_records(self, db_session, commands):
+    def test_it_can_insert_new_records(self, db_session, commands, matchers):
         reports = UserUpsertAction(db_session).execute(commands)
 
-        assert reports == Any.iterable.comprised_of(Any.instance_of(Report)).of_size(3)
+        assert reports == Any.iterable.comprised_of(
+            matchers.InstanceOf(Report)
+        ).of_size(3)
 
         self.assert_users_match_commands(db_session, commands)
 
-    def test_it_can_update_records(self, db_session, commands):
+    def test_it_can_update_records(self, db_session, commands, matchers):
         update_commands = [
             upsert_user_command(i, display_name=f"changed_{i}") for i in range(3)
         ]
@@ -54,7 +56,9 @@ class TestBulkUserUpsert:
         action.execute(commands)
         reports = action.execute(update_commands)
 
-        assert reports == Any.iterable.comprised_of(Any.instance_of(Report)).of_size(3)
+        assert reports == Any.iterable.comprised_of(
+            matchers.InstanceOf(Report)
+        ).of_size(3)
 
         self.assert_users_match_commands(db_session, update_commands)
 
@@ -126,17 +130,19 @@ class TestBulkUserUpsert:
 
 
 class TestBulkGroupUpsert:
-    def test_it_can_insert_new_records(self, db_session, commands, user):
+    def test_it_can_insert_new_records(self, db_session, commands, user, matchers):
         reports = GroupUpsertAction(db_session).execute(
             commands, effective_user_id=user.id
         )
 
-        assert reports == Any.iterable.comprised_of(Any.instance_of(Report)).of_size(3)
+        assert reports == Any.iterable.comprised_of(
+            matchers.InstanceOf(Report)
+        ).of_size(3)
 
         self.assert_groups_match_commands(db_session, commands)
         self.assert_groups_are_private_and_owned_by_user(db_session, user)
 
-    def test_it_can_update_records(self, db_session, commands, user):
+    def test_it_can_update_records(self, db_session, commands, user, matchers):
         update_commands = [
             group_upsert_command(i, name=f"changed_{i}") for i in range(3)
         ]
@@ -146,7 +152,9 @@ class TestBulkGroupUpsert:
             update_commands, effective_user_id=user.id
         )
 
-        assert reports == Any.iterable.comprised_of(Any.instance_of(Report)).of_size(3)
+        assert reports == Any.iterable.comprised_of(
+            matchers.InstanceOf(Report)
+        ).of_size(3)
 
         self.assert_groups_match_commands(db_session, update_commands)
         self.assert_groups_are_private_and_owned_by_user(db_session, user)
@@ -242,20 +250,26 @@ class TestBulkGroupUpsert:
 
 
 class TestBulkGroupMembershipCreate:
-    def test_it_can_insert_new_records(self, db_session, commands):
+    def test_it_can_insert_new_records(self, db_session, commands, matchers):
         reports = GroupMembershipCreateAction(db_session).execute(commands)
 
-        assert reports == Any.iterable.comprised_of(Any.instance_of(Report)).of_size(3)
+        assert reports == Any.iterable.comprised_of(
+            matchers.InstanceOf(Report)
+        ).of_size(3)
 
         self.assert_membership_matches_commands(db_session, commands)
 
-    def test_it_can_continue_with_existing_records(self, db_session, commands):
+    def test_it_can_continue_with_existing_records(
+        self, db_session, commands, matchers
+    ):
         GroupMembershipCreateAction(db_session).execute(commands)
         reports = GroupMembershipCreateAction(db_session).execute(
             commands, on_duplicate="continue"
         )
 
-        assert reports == Any.iterable.comprised_of(Any.instance_of(Report)).of_size(3)
+        assert reports == Any.iterable.comprised_of(
+            matchers.InstanceOf(Report)
+        ).of_size(3)
 
         self.assert_membership_matches_commands(db_session, commands)
 

--- a/tests/unit/h/services/developer_token_test.py
+++ b/tests/unit/h/services/developer_token_test.py
@@ -1,5 +1,4 @@
 import pytest
-from h_matchers import Any
 
 from h import models
 from h.services.developer_token import (
@@ -31,7 +30,7 @@ class TestDeveloperTokenService:
         user_service.fetch.assert_called_once_with(user.userid)
 
     def test_create_creates_new_developer_token_for_userid(
-        self, svc, db_session, user, user_service
+        self, svc, db_session, user, user_service, matchers
     ):
         assert not db_session.query(models.Token).count()
         user_service.fetch.return_value = user
@@ -40,7 +39,7 @@ class TestDeveloperTokenService:
 
         user_service.fetch.assert_called_once_with(user.userid)
         assert db_session.query(models.Token).all() == [
-            Any.instance_of(models.Token).with_attrs({"user": user})
+            matchers.InstanceOf(models.Token, user=user)
         ]
 
     def test_create_returns_new_developer_token_for_userid(

--- a/tests/unit/h/services/group_test.py
+++ b/tests/unit/h/services/group_test.py
@@ -2,7 +2,6 @@ import datetime
 from unittest import mock
 
 import pytest
-from h_matchers import Any
 
 from h.models import Group, GroupMembership
 from h.models.group import ReadableBy
@@ -60,13 +59,11 @@ class TestGroupServiceFetchByGroupid:
 
 @pytest.mark.usefixtures("groups")
 class TestFilterByName:
-    def test_it_filters_by_name(self, svc):
+    def test_it_filters_by_name(self, svc, matchers):
         filtered_groups = svc.filter_by_name(name="Hello")
 
         assert len(filtered_groups.all()) == 1
-        assert filtered_groups.all() == [
-            Any.instance_of(Group).with_attrs({"name": "Hello"})
-        ]
+        assert filtered_groups.all() == [matchers.InstanceOf(Group, name="Hello")]
 
     def test_it_returns_all_groups_if_name_is_None(self, svc, groups):
         filtered_groups = svc.filter_by_name()
@@ -84,12 +81,12 @@ class TestFilterByName:
 
         assert len(filtered_groups.all()) == 2
 
-    def test_results_sorted_by_created_desc(self, svc):
+    def test_results_sorted_by_created_desc(self, svc, matchers):
         filtered_groups = svc.filter_by_name("Finger")
 
         assert filtered_groups.all() == [
-            Any.instance_of(Group).with_attrs({"name": "Fingers"}),
-            Any.instance_of(Group).with_attrs({"name": "Finger"}),
+            matchers.InstanceOf(Group, name="Fingers"),
+            matchers.InstanceOf(Group, name="Finger"),
         ]
 
     @pytest.fixture

--- a/tests/unit/h/services/subscription_test.py
+++ b/tests/unit/h/services/subscription_test.py
@@ -1,7 +1,6 @@
 from unittest.mock import call, patch, sentinel
 
 import pytest
-from h_matchers import Any
 
 from h.models import Subscriptions
 from h.services import SubscriptionService
@@ -29,17 +28,16 @@ class TestSubscriptionService:
         assert result == reply_subscription
         assert result.active == reply_subscription.active
 
-    def test_get_subscription_with_a_missing_subscription(self, svc):
+    def test_get_subscription_with_a_missing_subscription(self, svc, matchers):
         result = svc.get_subscription(
             user_id="acct:new_user@example.com", type_=Subscriptions.Type.REPLY
         )
 
-        assert result == Any.instance_of(Subscriptions).with_attrs(
-            {
-                "uri": "acct:new_user@example.com",
-                "type": Subscriptions.Type.REPLY.value,
-                "active": True,
-            }
+        assert result == matchers.InstanceOf(
+            Subscriptions,
+            uri="acct:new_user@example.com",
+            type=Subscriptions.Type.REPLY.value,
+            active=True,
         )
 
     def test_get_all_subscriptions(self, svc):

--- a/tests/unit/h/streamer/messages_test.py
+++ b/tests/unit/h/streamer/messages_test.py
@@ -64,7 +64,7 @@ class TestProcessMessages:
 
 
 class TestHandleMessage:
-    def test_calls_handler_with_list_of_sockets(self, websocket, registry):
+    def test_calls_handler_with_list_of_sockets(self, websocket, registry, matchers):
         handler = Mock(return_value=None)
         session = sentinel.db_session
         message = messages.Message(topic="foo", payload={"foo": "bar"})
@@ -77,7 +77,7 @@ class TestHandleMessage:
         handler.assert_called_once_with(
             message.payload,
             websocket.instances,
-            Any.object.of_type(Request).with_attrs({"registry": registry}),
+            matchers.InstanceOf(Request, registry=registry),
             session,
         )
 

--- a/tests/unit/h/tweens_test.py
+++ b/tests/unit/h/tweens_test.py
@@ -9,14 +9,14 @@ from h.util.redirects import Redirect
 
 
 class TestRedirectTween:
-    def test_it_loads_redirects(self, patch):
+    def test_it_loads_redirects(self, patch, matchers):
         parse_redirects = patch("h.tweens.parse_redirects")
 
         tweens.redirect_tween_factory(handler=None, registry=None)
 
         parse_redirects.assert_called_once_with(
             # Check parse_redirects is called with a file like object
-            Any.object.with_attrs({"readlines": Any.callable()})
+            matchers.InstanceOf(object, readlines=Any.callable())
         )
 
     def test_it_loads_successfully(self):

--- a/tests/unit/h/views/accounts_test.py
+++ b/tests/unit/h/views/accounts_test.py
@@ -960,7 +960,13 @@ class TestDeveloperController:
 
 class TestDeleteController:
     def test_get(
-        self, authenticated_user, controller, factories, pyramid_request, schemas
+        self,
+        authenticated_user,
+        controller,
+        factories,
+        pyramid_request,
+        schemas,
+        matchers,
     ):
         oldest_annotation = factories.Annotation(
             userid=authenticated_user.userid,
@@ -987,11 +993,11 @@ class TestDeleteController:
         )
         pyramid_request.create_form.assert_called_once_with(
             schemas.DeleteAccountSchema.return_value.bind.return_value,
-            buttons=Any.iterable.comprised_of(Any.instance_of(deform.Button)),
+            buttons=Any.iterable.comprised_of(matchers.InstanceOf(deform.Button)),
             formid="delete",
             back_link={
                 "href": "http://example.com/account/settings",
-                "text": Any.string(),
+                "text": matchers.InstanceOf(str),
             },
         )
         pyramid_request.create_form.return_value.render.assert_called_once_with()
@@ -1013,7 +1019,7 @@ class TestDeleteController:
             "form": pyramid_request.create_form.return_value.render.return_value,
         }
 
-    def test_post(self, controller, form, pyramid_request, schemas):
+    def test_post(self, controller, form, pyramid_request, schemas, matchers):
         result = controller.post()
 
         schemas.DeleteAccountSchema.assert_called_once_with()
@@ -1022,11 +1028,11 @@ class TestDeleteController:
         )
         pyramid_request.create_form.assert_called_once_with(
             schemas.DeleteAccountSchema.return_value.bind.return_value,
-            buttons=Any.iterable.comprised_of(Any.instance_of(deform.Button)),
+            buttons=Any.iterable.comprised_of(matchers.InstanceOf(deform.Button)),
             formid="delete",
             back_link={
                 "href": "http://example.com/account/settings",
-                "text": Any.string(),
+                "text": matchers.InstanceOf(str),
             },
         )
         form.handle_form_submission.assert_called_once_with(
@@ -1039,7 +1045,12 @@ class TestDeleteController:
         assert result == form.handle_form_submission.return_value
 
     def test_delete_user(
-        self, authenticated_user, controller, pyramid_request, user_delete_service
+        self,
+        authenticated_user,
+        controller,
+        pyramid_request,
+        user_delete_service,
+        matchers,
     ):
         response = controller.delete_user(mock.sentinel.appstruct)
 
@@ -1048,8 +1059,9 @@ class TestDeleteController:
             requested_by=authenticated_user,
             tag=pyramid_request.matched_route.name,
         )
-        assert response == Any.instance_of(httpexceptions.HTTPFound).with_attrs(
-            {"location": "http://example.com/account/deleted"}
+        assert response == matchers.InstanceOf(
+            httpexceptions.HTTPFound,
+            location="http://example.com/account/deleted",
         )
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
This replaces h-matchers's `Any.instance_of()` with a new `matchers.InstanceOf()`:

```python
# h-matchers:
Any.instance_of(Foo)
# InstanceOf matcher:
matchers.InstanceOf(Foo)

# h-matchers:
Any.instance_of(Foo).with_attrs({"bar": "BAR", "gar": "GAR"})
# InstanceOf matcher:
matchers.InstanceOf(Foo, bar="BAR", gar="GAR")
```

A handful of other `h-matchers` usages can also be replaced with this: `Any.string()` becomes `matchers.InstanceOf(str)`, `Any.list` becomes `matchers.InstanceOf(list)`, `Any.object` becomes `matchers.InstanceOf(object)`, `Any.object.of_type(Foo)` becomes `matchers.InstanceOf(Foo)`, `Any.object.with_attrs({...})` becomes `matchers.InstanceOf(object, ...)`.

Also replaces [the pre-h-matchers `InstanceOf` matcher](https://github.com/hypothesis/h/blob/029a6c7a6aefd0388014dc9e6a9e349e3e8589e9/tests/common/matchers.py#L50-L60).

Other stylistic tweaks we could make to this in future:

* Rename the `matchers` fixture to `any`
* Change the naming style of matcher classes like `InstanceOf` to
  `instance_of` even though technically they're classes

So we could have:

```python
any.instance_of(Foo, bar="BAR", gar="GAR")
```