### PR TITLE
Expose group pre_moderated flag via API

### DIFF
--- a/docs/_extra/api-reference/schemas/group.yaml
+++ b/docs/_extra/api-reference/schemas/group.yaml
@@ -9,6 +9,7 @@ Group:
     - public
     - scoped
     - type
+    - pre_moderated
   properties:
     id:
       type: string
@@ -82,3 +83,6 @@ Group:
         - private
         - open
         - restricted
+    pre_moderated:
+      type: boolean
+      description: Whether this group is pre-moderated or not

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -22,6 +22,7 @@ class GroupJSONPresenter:
             # DEPRECATED: TODO: remove from client
             "scoped": bool(self.group.scopes),
             "type": self.group.type,
+            "pre_moderated": bool(self.group.pre_moderated),
         }
 
         if expand:

--- a/tests/unit/h/presenters/group_json_test.py
+++ b/tests/unit/h/presenters/group_json_test.py
@@ -13,12 +13,24 @@ pytestmark = [
 
 @pytest.mark.usefixtures("group_links_service")
 class TestGroupJSONPresenter:
-    def test_it(self, factories, pyramid_request, group_links_service):
+    @pytest.mark.parametrize(
+        "pre_moderated,expected_pre_moderated",
+        ((True, True), (False, False), (None, False)),
+    )
+    def test_it(
+        self,
+        factories,
+        pyramid_request,
+        group_links_service,
+        pre_moderated,
+        expected_pre_moderated,
+    ):
         group = factories.Group(
             name="My Group",
             pubid="mygroup",
             authority_provided_id="abc123",
             organization=factories.Organization(),
+            pre_moderated=pre_moderated,
         )
 
         results = GroupJSONPresenter(group, pyramid_request).asdict()
@@ -31,6 +43,7 @@ class TestGroupJSONPresenter:
                 "organization": group.organization.pubid,
                 "links": group_links_service.get_all.return_value,
                 "scoped": False,
+                "pre_moderated": expected_pre_moderated,
             }
         )
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/7049

Add a new `pre_moderated` flag in the Group API model, so that the client can know if pre-moderation is enabled for a group, and conditionally display moderation controls.