### PR TITLE
Add provider select screen to sign up flow

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -310,5 +310,6 @@ def includeme(config):  # noqa: PLR0915
     config.add_route("oidc.login.google", "/oidc/login/google")
     config.add_route("oidc.redirect.orcid", "/oidc/redirect/orcid")
     config.add_route("oidc.redirect.google", "/oidc/redirect/google")
+    config.add_route("signup.email", "/signup/email")
     config.add_route("signup.orcid", "/signup/orcid")
     config.add_route("signup.google", "/signup/google")

--- a/h/static/scripts/login-forms/components/AppRoot.tsx
+++ b/h/static/scripts/login-forms/components/AppRoot.tsx
@@ -9,6 +9,7 @@ import { Config } from '../config';
 import { routes } from '../routes';
 import LoginForm from './LoginForm';
 import SignupForm from './SignupForm';
+import SignupSelectForm from './SignupSelectForm';
 
 function toastMessagesFromConfig(config: ConfigObject): ToastMessageData[] {
   const flashMessages = config.flashMessages ?? [];
@@ -27,6 +28,9 @@ export default function AppRoot({ config }: AppRootProps) {
   const { toastMessages, dismissToastMessage } =
     useToastMessages(initialToasts);
 
+  const enableSocialLogin =
+    config.features.log_in_with_orcid || config.features.log_in_with_google;
+
   return (
     <div>
       <ToastMessages
@@ -40,6 +44,10 @@ export default function AppRoot({ config }: AppRootProps) {
               <LoginForm />
             </Route>
             <Route path={routes.signup}>
+              {enableSocialLogin && <SignupSelectForm />}
+              {!enableSocialLogin && <SignupForm />}
+            </Route>
+            <Route path={routes.signupWithEmail}>
               <SignupForm />
             </Route>
             <Route path={routes.signupWithGoogle}>

--- a/h/static/scripts/login-forms/components/SignupSelectForm.tsx
+++ b/h/static/scripts/login-forms/components/SignupSelectForm.tsx
@@ -1,0 +1,96 @@
+import {
+  ArrowRightIcon,
+  EmailFilledIcon,
+  ExternalIcon,
+} from '@hypothesis/frontend-shared';
+import type { ComponentChildren } from 'preact';
+import { useContext } from 'preact/hooks';
+import { Link as RouterLink } from 'wouter-preact';
+
+import FormHeader from '../../forms-common/components/FormHeader';
+import { Config } from '../config';
+import { routes } from '../routes';
+import GoogleIcon from './GoogleIcon';
+import ORCIDIcon from './ORCIDIcon';
+
+type SocialSignupLinkProps = {
+  /** True if this navigation is handled client-side. */
+  routerLink?: boolean;
+
+  /** Target URL for the link. */
+  href: string;
+
+  /** Icon for the identity provider. */
+  providerIcon: ComponentChildren;
+
+  /** Text for the link. */
+  children: ComponentChildren;
+};
+
+function SignupLink({
+  routerLink,
+  href,
+  providerIcon,
+  children,
+}: SocialSignupLinkProps) {
+  const LinkType = routerLink ? RouterLink : 'a';
+  const NavigateIcon = routerLink ? ArrowRightIcon : ExternalIcon;
+
+  return (
+    <LinkType
+      href={href}
+      className="border rounded-md p-3 flex flex-row items-center gap-x-3"
+    >
+      {providerIcon}
+      <span className="grow">{children}</span>
+      <NavigateIcon className="w-[20px] h-[20px]" />
+    </LinkType>
+  );
+}
+
+/**
+ * Form for the first page of the signup flow which gives users a list of
+ * identity providers to choose from.
+ */
+export default function SignupSelectForm() {
+  const config = useContext(Config)!;
+
+  return (
+    <div className="flex flex-col text-md">
+      <FormHeader>Sign up for Hypothesis</FormHeader>
+      <div
+        // Top margin intended to give roughly even spacing above and below the
+        // provider list.
+        className="mt-[40px] self-center flex flex-col gap-y-3 text-grey-7 w-[400px]"
+      >
+        <SignupLink
+          routerLink={true}
+          href={routes.signupWithEmail}
+          providerIcon={
+            // Expand icon size to 24px to match other provider icons.
+            <EmailFilledIcon className="inline w-[24px] h-[24px]" />
+          }
+        >
+          Sign up with <b>email</b>
+        </SignupLink>
+        <div className="self-center uppercase">or</div>
+        {config.features.log_in_with_google && (
+          <SignupLink
+            href={routes.loginWithGoogle}
+            providerIcon={<GoogleIcon className="inline" />}
+          >
+            Continue with <b>Google</b>
+          </SignupLink>
+        )}
+        {config.features.log_in_with_orcid && (
+          <SignupLink
+            href={routes.loginWithORCID}
+            providerIcon={<ORCIDIcon className="inline" />}
+          >
+            Continue with <b>ORCID</b>
+          </SignupLink>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/h/static/scripts/login-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/login-forms/components/test/AppRoot-test.js
@@ -5,9 +5,8 @@ import { Config } from '../../config';
 import { $imports, default as AppRoot } from '../AppRoot';
 
 describe('AppRoot', () => {
+  let config;
   let configContext;
-
-  const config = { csrfToken: 'fake-csrf-token' };
 
   beforeEach(() => {
     const mockComponent = name => {
@@ -21,9 +20,12 @@ describe('AppRoot', () => {
 
     configContext = null;
 
+    config = { csrfToken: 'fake-csrf-token', features: {} };
+
     $imports.$mock({
       './LoginForm': mockComponent('LoginForm'),
       './SignupForm': mockComponent('SignupForm'),
+      './SignupSelectForm': mockComponent('SignupSelectForm'),
     });
   });
 
@@ -131,8 +133,28 @@ describe('AppRoot', () => {
       path: '/Login',
       selector: 'LoginForm',
     },
+    // "/signup" shows email signup form if all social logins are disabled
     {
       path: '/signup',
+      selector: 'SignupForm',
+    },
+    // "/signup" shows signup provider form if any social logins are enabled
+    {
+      path: '/signup',
+      features: {
+        log_in_with_orcid: true,
+      },
+      selector: 'SignupSelectForm',
+    },
+    {
+      path: '/signup',
+      features: {
+        log_in_with_google: true,
+      },
+      selector: 'SignupSelectForm',
+    },
+    {
+      path: '/signup/email',
       selector: 'SignupForm',
     },
     {
@@ -149,8 +171,10 @@ describe('AppRoot', () => {
         idProvider: 'google',
       },
     },
-  ].forEach(({ path, selector, props = {} }) => {
+  ].forEach(({ path, selector, features = {}, props = {} }) => {
     it(`renders expected component for URL (${path})`, () => {
+      config.features = features;
+
       navigate(path, () => {
         const wrapper = createComponent();
         const component = wrapper.find(selector);

--- a/h/static/scripts/login-forms/components/test/SignupSelectForm-test.js
+++ b/h/static/scripts/login-forms/components/test/SignupSelectForm-test.js
@@ -1,0 +1,60 @@
+import { mount } from '@hypothesis/frontend-testing';
+
+import { Config } from '../../config';
+import { routes } from '../../routes';
+import SignupSelectForm from '../SignupSelectForm';
+
+describe('SignupSelectForm', () => {
+  let fakeConfig;
+
+  function createComponent() {
+    return mount(
+      <Config.Provider value={fakeConfig}>
+        <SignupSelectForm />
+      </Config.Provider>,
+    );
+  }
+
+  beforeEach(() => {
+    fakeConfig = {
+      features: {
+        log_in_with_google: false,
+        log_in_with_orcid: false,
+      },
+    };
+  });
+
+  [
+    {
+      provider: 'email',
+      link: routes.signupWithEmail,
+      text: 'Sign up with email',
+    },
+    {
+      provider: 'Google',
+      link: routes.loginWithGoogle,
+      text: 'Continue with Google',
+      features: {
+        log_in_with_google: true,
+      },
+    },
+    {
+      provider: 'ORCID',
+      link: routes.loginWithORCID,
+      text: 'Continue with ORCID',
+      features: {
+        log_in_with_orcid: true,
+      },
+    },
+  ].forEach(({ provider, link, text, features = {} }) => {
+    it(`renders ${provider} signup link with correct href`, () => {
+      fakeConfig.features = features;
+
+      const wrapper = createComponent();
+
+      const emailLink = wrapper.find(`a[href="${link}"]`);
+      assert.isTrue(emailLink.exists());
+      assert.include(emailLink.text(), text);
+    });
+  });
+});

--- a/h/static/scripts/login-forms/config.ts
+++ b/h/static/scripts/login-forms/config.ts
@@ -8,6 +8,10 @@ export type FlashMessage = {
 export type ConfigBase = {
   csrfToken: string;
   flashMessages?: FlashMessage[];
+  features: {
+    log_in_with_google: boolean;
+    log_in_with_orcid: boolean;
+  };
 };
 
 /** Data passed to frontend for login form. */
@@ -21,10 +25,6 @@ export type LoginConfigObject = ConfigBase & {
     password?: string;
   };
   forOAuth?: boolean;
-  features: {
-    log_in_with_orcid: boolean;
-    log_in_with_google: boolean;
-  };
 };
 
 /** Identity information if signing up with an identity provider such as Google. */

--- a/h/static/scripts/login-forms/routes.ts
+++ b/h/static/scripts/login-forms/routes.ts
@@ -10,6 +10,7 @@ export const routes = {
   loginWithORCID: '/oidc/login/orcid',
   loginWithGoogle: '/oidc/login/google',
   signup: '/signup',
+  signupWithEmail: '/signup/email',
   signupWithGoogle: '/signup/google',
   signupWithORCID: '/signup/orcid',
 };

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -19,21 +19,37 @@ from h.views.helpers import login
 _ = i18n.TranslationString
 
 
-@view_defaults(route_name="signup", is_authenticated=False)
+@view_defaults(is_authenticated=False)
 class SignupViews:
     def __init__(self, context, request):
         self.context = context
         self.request = request
 
     @view_config(
-        request_method="GET", renderer="h:templates/accounts/signup.html.jinja2"
+        route_name="signup",
+        request_method="GET",
+        renderer="h:templates/accounts/signup.html.jinja2",
+    )
+    @view_config(
+        route_name="signup.email",
+        request_method="GET",
+        renderer="h:templates/accounts/signup.html.jinja2",
     )
     def get(self):
         """Render the empty registration form."""
         return {"js_config": self.js_config}
 
+    # "signup" route needed here in case social sign up flags are disabled.
+    # This can be removed once the `log_in_with_orcid` flag is removed.
     @view_config(
-        request_method="POST", renderer="h:templates/accounts/signup-post.html.jinja2"
+        route_name="signup",
+        request_method="POST",
+        renderer="h:templates/accounts/signup-post.html.jinja2",
+    )
+    @view_config(
+        route_name="signup.email",
+        request_method="POST",
+        renderer="h:templates/accounts/signup-post.html.jinja2",
     )
     def post(self):
         """Handle submission of the new user registration form."""
@@ -59,8 +75,16 @@ class SignupViews:
 
         return {"js_config": self.js_config, "heading": heading, "message": message}
 
+    # For "signup" route, see note in `post` method.
     @exception_view_config(
         ValidationFailure,
+        route_name="signup",
+        request_method="POST",
+        renderer="h:templates/accounts/signup-post.html.jinja2",
+    )
+    @exception_view_config(
+        ValidationFailure,
+        route_name="signup.email",
         request_method="POST",
         renderer="h:templates/accounts/signup-post.html.jinja2",
     )

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -279,6 +279,7 @@ def test_includeme():
         call("oidc.login.google", "/oidc/login/google"),
         call("oidc.redirect.orcid", "/oidc/redirect/orcid"),
         call("oidc.redirect.google", "/oidc/redirect/google"),
+        call("signup.email", "/signup/email"),
         call("signup.orcid", "/signup/orcid"),
         call("signup.google", "/signup/google"),
     ]


### PR DESCRIPTION
Add an initial screen to the signup flow which allows the user to select an identity provider, or continue with email as before. This screen is shown at `/signup` if the `log_in_with_google` or `log_in_with_orcid` features are enabled. Otherwise `/signup` shows the email signup form. Clicking the email option in the new screen performs a client-side navigation to `/signup/email` where it shows the email signup form. On the backend, the `/signup/email` route serves the same HTML as the `/signup` route.

<img width="580" height="488" alt="Sign up picker form v2" src="https://github.com/user-attachments/assets/6b173ca5-0071-4e7e-8b06-ee912938a775" />

**Testing:**

1. Go to http://localhost:5000/signup with the `log_in_*` features all disabled. You should see the existing signup form.
2. Go to http://localhost:5000/signup with any combination of the `log_in_*` features enabled. You should see the new form.
3. On the new form, click the email sign up link and you should be taken to the email signup form
4. On the new form, click either the ORCID or Google sign up link and you should be taken through the same flow as if clicking the "Continue with {provider}" link on the login form.