### PR TITLE
Support sign up with Facebook in the frontend

### DIFF
--- a/h/static/scripts/login-forms/components/AppRoot.tsx
+++ b/h/static/scripts/login-forms/components/AppRoot.tsx
@@ -29,7 +29,9 @@ export default function AppRoot({ config }: AppRootProps) {
     useToastMessages(initialToasts);
 
   const enableSocialLogin =
-    config.features.log_in_with_orcid || config.features.log_in_with_google;
+    config.features.log_in_with_orcid ||
+    config.features.log_in_with_google ||
+    config.features.log_in_with_facebook;
 
   return (
     <div>
@@ -49,6 +51,9 @@ export default function AppRoot({ config }: AppRootProps) {
             </Route>
             <Route path={routes.signupWithEmail}>
               <SignupForm />
+            </Route>
+            <Route path={routes.signupWithFacebook}>
+              <SignupForm idProvider="facebook" />
             </Route>
             <Route path={routes.signupWithGoogle}>
               <SignupForm idProvider="google" />

--- a/h/static/scripts/login-forms/components/FacebookIcon.tsx
+++ b/h/static/scripts/login-forms/components/FacebookIcon.tsx
@@ -1,0 +1,46 @@
+import type { JSX } from 'preact';
+
+export default function FacebookIcon({
+  ...props
+}: JSX.SVGAttributes<SVGSVGElement>) {
+  return (
+    <svg
+      version="1.1"
+      id="svg9"
+      width="24"
+      height="24"
+      viewBox="0 0 666.66668 666.66717"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <defs id="defs13">
+        <clipPath clipPathUnits="userSpaceOnUse" id="clipPath25">
+          <path d="M 0,700 H 700 V 0 H 0 Z" id="path23" />
+        </clipPath>
+      </defs>
+      <g
+        id="g17"
+        transform="matrix(1.3333333,0,0,-1.3333333,-133.33333,799.99999)"
+      >
+        <g id="g19">
+          <g id="g21" clip-path="url(#clipPath25)">
+            <g id="g27" transform="translate(600,350)">
+              <path
+                d="m 0,0 c 0,138.071 -111.929,250 -250,250 -138.071,0 -250,-111.929 -250,-250 0,-117.245 80.715,-215.622 189.606,-242.638 v 166.242 h -51.552 V 0 h 51.552 v 32.919 c 0,85.092 38.508,124.532 122.048,124.532 15.838,0 43.167,-3.105 54.347,-6.211 V 81.986 c -5.901,0.621 -16.149,0.932 -28.882,0.932 -40.993,0 -56.832,-15.528 -56.832,-55.9 V 0 h 81.659 l -14.028,-76.396 h -67.631 V -248.169 C -95.927,-233.218 0,-127.818 0,0"
+                style="fill:#0866ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                id="path29"
+              />
+            </g>
+            <g id="g31" transform="translate(447.9175,273.6036)">
+              <path
+                d="M 0,0 14.029,76.396 H -67.63 v 27.019 c 0,40.372 15.838,55.899 56.831,55.899 12.733,0 22.981,-0.31 28.882,-0.931 v 69.253 c -11.18,3.106 -38.509,6.212 -54.347,6.212 -83.539,0 -122.048,-39.441 -122.048,-124.533 V 76.396 h -51.552 V 0 h 51.552 v -166.242 c 19.343,-4.798 39.568,-7.362 60.394,-7.362 10.254,0 20.358,0.632 30.288,1.831 L -67.63,0 Z"
+                style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                id="path33"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/h/static/scripts/login-forms/components/SignupForm.tsx
+++ b/h/static/scripts/login-forms/components/SignupForm.tsx
@@ -9,11 +9,12 @@ import TextField from '../../forms-common/components/TextField';
 import { useFormValue } from '../../forms-common/form-value';
 import { Config } from '../config';
 import type { SignupConfigObject } from '../config';
+import FacebookIcon from './FacebookIcon';
 import GoogleIcon from './GoogleIcon';
 import ORCIDIcon from './ORCIDIcon';
 
 type IdProviderBadgeProps = {
-  provider: 'google' | 'orcid';
+  provider: IdProvider;
   identity: string;
 };
 
@@ -24,6 +25,9 @@ type IdProviderBadgeProps = {
 function IdProviderBadge({ provider, identity }: IdProviderBadgeProps) {
   return (
     <div data-testid="id-badge">
+      {provider === 'facebook' && (
+        <FacebookIcon className="inline" aria-label="Facebook icon" />
+      )}
       {provider === 'google' && (
         <GoogleIcon className="inline" aria-label="Google icon" />
       )}
@@ -37,6 +41,9 @@ function IdProviderBadge({ provider, identity }: IdProviderBadgeProps) {
   );
 }
 
+/** Supported ID providers for OIDC-based login. */
+export type IdProvider = 'facebook' | 'google' | 'orcid';
+
 export type SignupFormProps = {
   /**
    * Identity provider if using OIDC / social login.
@@ -46,7 +53,7 @@ export type SignupFormProps = {
    *  - An `identity` field in the config for the page
    *  - An `idinfo` query parameter
    */
-  idProvider?: 'google' | 'orcid';
+  idProvider?: IdProvider;
 
   // Test seams
   location_?: Location;

--- a/h/static/scripts/login-forms/components/SignupSelectForm.tsx
+++ b/h/static/scripts/login-forms/components/SignupSelectForm.tsx
@@ -10,6 +10,7 @@ import { Link as RouterLink } from 'wouter-preact';
 import FormHeader from '../../forms-common/components/FormHeader';
 import { Config } from '../config';
 import { routes } from '../routes';
+import FacebookIcon from './FacebookIcon';
 import GoogleIcon from './GoogleIcon';
 import ORCIDIcon from './ORCIDIcon';
 
@@ -55,6 +56,8 @@ function SignupLink({
 export default function SignupSelectForm() {
   const config = useContext(Config)!;
 
+  // nb. Options for social login are listed in descending order of expected
+  // usage rather than alphabetically.
   return (
     <div className="flex flex-col text-md">
       <FormHeader>Sign up for Hypothesis</FormHeader>
@@ -80,6 +83,14 @@ export default function SignupSelectForm() {
             providerIcon={<GoogleIcon className="inline" />}
           >
             Continue with <b>Google</b>
+          </SignupLink>
+        )}
+        {config.features.log_in_with_facebook && (
+          <SignupLink
+            href={routes.loginWithFacebook}
+            providerIcon={<FacebookIcon className="inline" />}
+          >
+            Continue with <b>Facebook</b>
           </SignupLink>
         )}
         {config.features.log_in_with_orcid && (

--- a/h/static/scripts/login-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/login-forms/components/test/AppRoot-test.js
@@ -154,6 +154,13 @@ describe('AppRoot', () => {
       selector: 'SignupSelectForm',
     },
     {
+      path: '/signup',
+      features: {
+        log_in_with_facebook: true,
+      },
+      selector: 'SignupSelectForm',
+    },
+    {
       path: '/signup/email',
       selector: 'SignupForm',
     },
@@ -169,6 +176,13 @@ describe('AppRoot', () => {
       selector: 'SignupForm',
       props: {
         idProvider: 'google',
+      },
+    },
+    {
+      path: '/signup/facebook',
+      selector: 'SignupForm',
+      props: {
+        idProvider: 'facebook',
       },
     },
   ].forEach(({ path, selector, features = {}, props = {} }) => {

--- a/h/static/scripts/login-forms/components/test/SignupForm-test.js
+++ b/h/static/scripts/login-forms/components/test/SignupForm-test.js
@@ -293,6 +293,19 @@ describe('SignupForm', () => {
       assert.equal(connectedId.text(), '0000-0000-0000-0001');
     });
 
+    it('displays Facebook identity when using Facebook provider', () => {
+      const { wrapper } = createSignupFormWithIdProvider({
+        idProvider: 'facebook',
+      });
+
+      const idBadge = wrapper.find('[data-testid="id-badge"]');
+      assert.isTrue(idBadge.exists());
+      assert.isTrue(idBadge.find('FacebookIcon').exists());
+
+      const connectedId = wrapper.find('[data-testid="connected-id"]');
+      assert.equal(connectedId.text(), '0000-0000-0000-0001');
+    });
+
     it('renders "idinfo" hidden input field', () => {
       const { wrapper } = createSignupFormWithIdProvider({
         idInfo: 'test-jwt-token',

--- a/h/static/scripts/login-forms/components/test/SignupSelectForm-test.js
+++ b/h/static/scripts/login-forms/components/test/SignupSelectForm-test.js
@@ -18,6 +18,7 @@ describe('SignupSelectForm', () => {
   beforeEach(() => {
     fakeConfig = {
       features: {
+        log_in_with_facebook: false,
         log_in_with_google: false,
         log_in_with_orcid: false,
       },
@@ -36,6 +37,14 @@ describe('SignupSelectForm', () => {
       text: 'Continue with Google',
       features: {
         log_in_with_google: true,
+      },
+    },
+    {
+      provider: 'Facebook',
+      link: routes.loginWithFacebook,
+      text: 'Continue with Facebook',
+      features: {
+        log_in_with_facebook: true,
       },
     },
     {

--- a/h/static/scripts/login-forms/config.ts
+++ b/h/static/scripts/login-forms/config.ts
@@ -9,6 +9,7 @@ export type ConfigBase = {
   csrfToken: string;
   flashMessages?: FlashMessage[];
   features: {
+    log_in_with_facebook: boolean;
     log_in_with_google: boolean;
     log_in_with_orcid: boolean;
   };
@@ -25,11 +26,6 @@ export type LoginConfigObject = ConfigBase & {
     password?: string;
   };
   forOAuth?: boolean;
-  features: {
-    log_in_with_orcid: boolean;
-    log_in_with_google: boolean;
-    log_in_with_facebook: boolean;
-  };
 };
 
 /** Identity information if signing up with an identity provider such as Google. */


### PR DESCRIPTION
Add Facebook to the supported options on the `/signup` page and support the `/signup/facebook` route.

The non-alphabetical ordering of options here is intentional. It is in descending order of expected usage. This also happens to align with how I think we would rate the providers based on our experience of implementing OIDC with them.

<img width="572" height="544" alt="Facebook sign up" src="https://github.com/user-attachments/assets/27ba961e-b369-4f86-97f6-51c7743954fc" />
