### PR TITLE
Add social login options to login form

### DIFF
--- a/h/static/scripts/forms-common/components/Form.tsx
+++ b/h/static/scripts/forms-common/components/Form.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 import type { JSX } from 'preact';
 
@@ -12,18 +13,29 @@ export type FormProps = JSX.FormHTMLAttributes & {
    */
   csrfToken: string | null;
 
+  /** Center form in parent container. Defaults to true. */
+  center?: boolean;
+
   children: ComponentChildren;
 };
 
 /**
  * Wrapper around an HTML form which adds standard styling, CSRF token etc.
  */
-export default function Form({ children, csrfToken, ...formAttrs }: FormProps) {
+export default function Form({
+  center = true,
+  children,
+  csrfToken,
+  ...formAttrs
+}: FormProps) {
   return (
     <form
       method="POST"
       data-testid="form"
-      className="max-w-[530px] mx-auto flex flex-col gap-y-4"
+      className={classnames(
+        'max-w-[530px] flex flex-col gap-y-4',
+        center && 'mx-auto',
+      )}
       {...formAttrs}
     >
       {csrfToken && <input type="hidden" name="csrf_token" value={csrfToken} />}

--- a/h/static/scripts/forms-common/components/FormContainer.tsx
+++ b/h/static/scripts/forms-common/components/FormContainer.tsx
@@ -6,7 +6,9 @@ export type FormContainerProps = {
   classes?: string;
 };
 
-/** A container for a form with a title. */
+/**
+ * Container that sets default styles for a form.
+ */
 export default function FormContainer({
   children,
   classes,

--- a/h/static/scripts/login-forms/components/AppRoot.tsx
+++ b/h/static/scripts/login-forms/components/AppRoot.tsx
@@ -28,10 +28,11 @@ export default function AppRoot({ config }: AppRootProps) {
   const { toastMessages, dismissToastMessage } =
     useToastMessages(initialToasts);
 
-  const enableSocialLogin =
+  const enableSocialLogin = Boolean(
     config.features.log_in_with_orcid ||
-    config.features.log_in_with_google ||
-    config.features.log_in_with_facebook;
+      config.features.log_in_with_google ||
+      config.features.log_in_with_facebook,
+  );
 
   return (
     <div>
@@ -43,7 +44,7 @@ export default function AppRoot({ config }: AppRootProps) {
         <Router>
           <Switch>
             <Route path={routes.login}>
-              <LoginForm />
+              <LoginForm enableSocialLogin={enableSocialLogin} />
             </Route>
             <Route path={routes.signup}>
               {enableSocialLogin && <SignupSelectForm />}

--- a/h/static/scripts/login-forms/components/LoginForm.tsx
+++ b/h/static/scripts/login-forms/components/LoginForm.tsx
@@ -9,8 +9,13 @@ import { useFormValue } from '../../forms-common/form-value';
 import { Config } from '../config';
 import type { LoginConfigObject } from '../config';
 import { routes } from '../routes';
+import SocialLoginLink from './SocialLoginLink';
 
-export default function LoginForm() {
+export type LoginFormProps = {
+  enableSocialLogin: boolean;
+};
+
+export default function LoginForm({ enableSocialLogin }: LoginFormProps) {
   const config = useContext(Config) as LoginConfigObject;
 
   const username = useFormValue(config.formData?.username ?? '', {
@@ -25,7 +30,7 @@ export default function LoginForm() {
   // when visiting the website directly.
   const title = config.forOAuth ? (
     <>
-      Log in with Hypothesis{' '}
+      Log in to Hypothesis{' '}
       <LogoIcon className="inline ml-1 w-[28px] h-[28px]" />
     </>
   ) : (
@@ -42,15 +47,25 @@ export default function LoginForm() {
       <FormHeader classes={config.forOAuth ? 'text-center' : undefined}>
         {title}
       </FormHeader>
-      <FormContainer>
-        <Form csrfToken={config.csrfToken}>
+      <FormContainer
+        // The max width here and item gap should match SignupSelectForm.
+        //
+        // This keeps the positioning of items consistent if the user navigates
+        // from the login page to the signup page.
+        classes="mx-auto max-w-[400px] flex flex-col gap-y-3 items-stretch"
+      >
+        <Form
+          csrfToken={config.csrfToken}
+          // Remove `mx-auto` from this form since it is applied to the parent.
+          center={false}
+        >
           <TextField
             type="input"
             name="username"
             value={username.value}
             fieldError={username.error}
             onChangeValue={username.update}
-            label="Username / email"
+            label="Username or email"
             autofocus={autofocusUsername}
             required
             showRequired={false}
@@ -67,7 +82,7 @@ export default function LoginForm() {
             required
             showRequired={false}
           />
-          <div className="text-right">
+          <div className="pt-2 flex flex-row items-center">
             <Link
               href={routes.forgotPassword}
               underline="always"
@@ -76,38 +91,25 @@ export default function LoginForm() {
             >
               Forgot your password?
             </Link>
-          </div>
-          <div className="mb-8 pt-2 flex items-center gap-x-4">
-            {config.forOAuth && (
-              <Button
-                type="button"
-                variant="secondary"
-                data-testid="cancel-button"
-                onClick={() => window.close()}
-              >
-                Cancel
-              </Button>
-            )}
             <div className="grow" />
             <Button type="submit" variant="primary" data-testid="submit-button">
               Log in
             </Button>
           </div>
         </Form>
-        {config.features.log_in_with_orcid && (
-          <p>
-            <a href={routes.loginWithORCID}>Continue with ORCID</a>
-          </p>
-        )}
-        {config.features.log_in_with_google && (
-          <p>
-            <a href={routes.loginWithGoogle}>Continue with Google</a>
-          </p>
-        )}
-        {config.features.log_in_with_facebook && (
-          <p>
-            <a href={routes.loginWithFacebook}>Continue with Facebook</a>
-          </p>
+        {enableSocialLogin && (
+          <>
+            <div className="self-center uppercase">or</div>
+            {config.features.log_in_with_google && (
+              <SocialLoginLink provider="google" />
+            )}
+            {config.features.log_in_with_facebook && (
+              <SocialLoginLink provider="facebook" />
+            )}
+            {config.features.log_in_with_orcid && (
+              <SocialLoginLink provider="orcid" />
+            )}
+          </>
         )}
       </FormContainer>
     </>

--- a/h/static/scripts/login-forms/components/LoginLink.tsx
+++ b/h/static/scripts/login-forms/components/LoginLink.tsx
@@ -1,0 +1,41 @@
+import { ArrowRightIcon, ExternalIcon } from '@hypothesis/frontend-shared';
+import type { ComponentChildren } from 'preact';
+import { Link as RouterLink } from 'wouter-preact';
+
+export type LoginLinkProps = {
+  /** True if this navigation is handled client-side. */
+  routerLink?: boolean;
+
+  /** Target URL for the link. */
+  href: string;
+
+  /** Icon for the identity provider. */
+  providerIcon: ComponentChildren;
+
+  /** Text for the link (eg. "Continue with Google"). */
+  children: ComponentChildren;
+};
+
+/**
+ * Base component for login / sign-up provider buttons.
+ */
+export default function LoginLink({
+  routerLink,
+  href,
+  providerIcon,
+  children,
+}: LoginLinkProps) {
+  const LinkType = routerLink ? RouterLink : 'a';
+  const NavigateIcon = routerLink ? ArrowRightIcon : ExternalIcon;
+
+  return (
+    <LinkType
+      href={href}
+      className="border rounded-md p-3 flex flex-row items-center gap-x-3"
+    >
+      {providerIcon}
+      <span className="grow">{children}</span>
+      <NavigateIcon className="w-[20px] h-[20px]" />
+    </LinkType>
+  );
+}

--- a/h/static/scripts/login-forms/components/SignupSelectForm.tsx
+++ b/h/static/scripts/login-forms/components/SignupSelectForm.tsx
@@ -1,53 +1,11 @@
-import {
-  ArrowRightIcon,
-  EmailFilledIcon,
-  ExternalIcon,
-} from '@hypothesis/frontend-shared';
-import type { ComponentChildren } from 'preact';
+import { EmailFilledIcon } from '@hypothesis/frontend-shared';
 import { useContext } from 'preact/hooks';
-import { Link as RouterLink } from 'wouter-preact';
 
 import FormHeader from '../../forms-common/components/FormHeader';
 import { Config } from '../config';
 import { routes } from '../routes';
-import FacebookIcon from './FacebookIcon';
-import GoogleIcon from './GoogleIcon';
-import ORCIDIcon from './ORCIDIcon';
-
-type SocialSignupLinkProps = {
-  /** True if this navigation is handled client-side. */
-  routerLink?: boolean;
-
-  /** Target URL for the link. */
-  href: string;
-
-  /** Icon for the identity provider. */
-  providerIcon: ComponentChildren;
-
-  /** Text for the link. */
-  children: ComponentChildren;
-};
-
-function SignupLink({
-  routerLink,
-  href,
-  providerIcon,
-  children,
-}: SocialSignupLinkProps) {
-  const LinkType = routerLink ? RouterLink : 'a';
-  const NavigateIcon = routerLink ? ArrowRightIcon : ExternalIcon;
-
-  return (
-    <LinkType
-      href={href}
-      className="border rounded-md p-3 flex flex-row items-center gap-x-3"
-    >
-      {providerIcon}
-      <span className="grow">{children}</span>
-      <NavigateIcon className="w-[20px] h-[20px]" />
-    </LinkType>
-  );
-}
+import LoginLink from './LoginLink';
+import SocialLoginLink from './SocialLoginLink';
 
 /**
  * Form for the first page of the signup flow which gives users a list of
@@ -66,7 +24,7 @@ export default function SignupSelectForm() {
         // provider list.
         className="mt-[40px] self-center flex flex-col gap-y-3 text-grey-7 w-[400px]"
       >
-        <SignupLink
+        <LoginLink
           routerLink={true}
           href={routes.signupWithEmail}
           providerIcon={
@@ -75,31 +33,16 @@ export default function SignupSelectForm() {
           }
         >
           Sign up with <b>email</b>
-        </SignupLink>
+        </LoginLink>
         <div className="self-center uppercase">or</div>
         {config.features.log_in_with_google && (
-          <SignupLink
-            href={routes.loginWithGoogle}
-            providerIcon={<GoogleIcon className="inline" />}
-          >
-            Continue with <b>Google</b>
-          </SignupLink>
+          <SocialLoginLink provider="google" />
         )}
         {config.features.log_in_with_facebook && (
-          <SignupLink
-            href={routes.loginWithFacebook}
-            providerIcon={<FacebookIcon className="inline" />}
-          >
-            Continue with <b>Facebook</b>
-          </SignupLink>
+          <SocialLoginLink provider="facebook" />
         )}
         {config.features.log_in_with_orcid && (
-          <SignupLink
-            href={routes.loginWithORCID}
-            providerIcon={<ORCIDIcon className="inline" />}
-          >
-            Continue with <b>ORCID</b>
-          </SignupLink>
+          <SocialLoginLink provider="orcid" />
         )}
       </div>
     </div>

--- a/h/static/scripts/login-forms/components/SocialLoginLink.tsx
+++ b/h/static/scripts/login-forms/components/SocialLoginLink.tsx
@@ -1,0 +1,49 @@
+import { routes } from '../routes';
+import FacebookIcon from './FacebookIcon';
+import GoogleIcon from './GoogleIcon';
+import LoginLink from './LoginLink';
+import ORCIDIcon from './ORCIDIcon';
+
+const providerInfo = {
+  google: {
+    href: routes.loginWithGoogle,
+    text: (
+      <>
+        Continue with <b>Google</b>
+      </>
+    ),
+    Icon: GoogleIcon,
+  },
+  facebook: {
+    href: routes.loginWithFacebook,
+    text: (
+      <>
+        Continue with <b>Facebook</b>
+      </>
+    ),
+    Icon: FacebookIcon,
+  },
+  orcid: {
+    href: routes.loginWithORCID,
+    text: (
+      <>
+        Continue with <b>ORCID</b>
+      </>
+    ),
+    Icon: ORCIDIcon,
+  },
+};
+
+export type SocialLoginLinkProps = {
+  provider: 'google' | 'facebook' | 'orcid';
+};
+
+/** Sign-up / login link for an external identity provider. */
+export default function SocialLoginLink({ provider }: SocialLoginLinkProps) {
+  const info = providerInfo[provider];
+  return (
+    <LoginLink href={info.href} providerIcon={<info.Icon className="inline" />}>
+      {info.text}
+    </LoginLink>
+  );
+}

--- a/h/static/scripts/login-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/login-forms/components/test/AppRoot-test.js
@@ -132,6 +132,19 @@ describe('AppRoot', () => {
     {
       path: '/Login',
       selector: 'LoginForm',
+      props: {
+        enableSocialLogin: false,
+      },
+    },
+    {
+      path: '/Login',
+      selector: 'LoginForm',
+      features: {
+        log_in_with_google: true,
+      },
+      props: {
+        enableSocialLogin: true,
+      },
     },
     // "/signup" shows email signup form if all social logins are disabled
     {

--- a/h/static/scripts/login-forms/components/test/SignupSelectForm-test.js
+++ b/h/static/scripts/login-forms/components/test/SignupSelectForm-test.js
@@ -25,45 +25,41 @@ describe('SignupSelectForm', () => {
     };
   });
 
+  it('renders email signup link', () => {
+    const wrapper = createComponent();
+    const emailLink = wrapper.find(`a[href="${routes.signupWithEmail}"]`);
+    assert.isTrue(emailLink.exists());
+    assert.include(emailLink.text(), 'Sign up with email');
+  });
+
   [
     {
-      provider: 'email',
-      link: routes.signupWithEmail,
-      text: 'Sign up with email',
-    },
-    {
-      provider: 'Google',
-      link: routes.loginWithGoogle,
-      text: 'Continue with Google',
+      provider: 'google',
       features: {
         log_in_with_google: true,
       },
     },
     {
-      provider: 'Facebook',
-      link: routes.loginWithFacebook,
-      text: 'Continue with Facebook',
+      provider: 'facebook',
       features: {
         log_in_with_facebook: true,
       },
     },
     {
-      provider: 'ORCID',
-      link: routes.loginWithORCID,
-      text: 'Continue with ORCID',
+      provider: 'orcid',
       features: {
         log_in_with_orcid: true,
       },
     },
-  ].forEach(({ provider, link, text, features = {} }) => {
-    it(`renders ${provider} signup link with correct href`, () => {
+  ].forEach(({ provider, features = {} }) => {
+    it(`renders ${provider} signup link if feature enabled`, () => {
       fakeConfig.features = features;
 
       const wrapper = createComponent();
 
-      const emailLink = wrapper.find(`a[href="${link}"]`);
-      assert.isTrue(emailLink.exists());
-      assert.include(emailLink.text(), text);
+      const link = wrapper.find('SocialLoginLink');
+      assert.isTrue(link.exists());
+      assert.equal(link.prop('provider'), provider);
     });
   });
 });


### PR DESCRIPTION
Revise the layout of the login form to include enabled social login options. This increases the required height of the form, so depends on https://github.com/hypothesis/client/pull/7234.

**Summary of changes:**

 - Extract shared components for social login links from SignupSelectForm and reuse them in LoginForm
 - Remove the Cancel button from the login popup and move the "Forgotten your password?" link into the space. The "Cancel" button is redundant as the user can just close the window, and moving the forgot-password link frees up some vertical space.
 - Change the heading from "Log in _with_ Hypothesis" to "Log in _to_ Hypothesis", as the user may now be logging in with non-Hypothesis credentials
 - Show social login links below username/password form if any of the social login features are enabled
 - Adjust the width of the login form so that social login links have a consistent width across the login and sign-up forms.

**Revised login popup:**

<img width="490" height="705" alt="login-popup-with-social-options" src="https://github.com/user-attachments/assets/eb212c4c-dc10-4537-bd7c-2d34840deceb" />

**Revised login page:**

<img width="571" height="633" alt="login-page-with-social-options" src="https://github.com/user-attachments/assets/375dadd1-580b-4102-b180-cb225b61e514" />

**Testing:**

- Visit form with all social login features disabled in h. The login form should look similar before except for the removal of the "Cancel" button, adjusted width and title.
- Enable one or more social login features in h. The login form should disable "OR" followed by the corresponding links