### PR TITLE
Rename annotation_moderation link to annotation.moderate

### DIFF
--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -46,7 +46,8 @@ def unhide(context, request):
     versions=["v1", "v2"],
     route_name="api.annotation_moderation",
     request_method="PATCH",
-    link_name="annotation_moderation",
+    link_name="annotation.moderate",
+    permission=Permission.Annotation.MODERATE,
 )
 def change_annotation_moderation_status(context, request):
     params = validate_json(


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/7050

Renaming the link used for the annotation moderation endpoint, from `annotation_moderation` to `annotation.moderate`.

Using the dot notation we ensure it is exposed in the `/api/` index endpoint, under the `annotation` object, together with the rest of the annotation-related links.

Also, suing `moderate` instead of `moderation` to be in line with `create` , `delete`, `read`, etc.

Additionally, adding the requirement of the MODERATE permission to said endpoint, that was likely overlooked.