### PR TITLE
Define annotation moderation endpoints under the right path

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -737,6 +737,10 @@ paths:
         '204':
           $ref: '#/components/responses/NoContent'
 
+  # ---------------------------------------------------------------------------
+  # Annotation Moderation Operations: Change status
+  # ---------------------------------------------------------------------------
+  /annotations/{id}/moderation:
     # ----------------------------------------------------------
     # PATCH annotations/{id}/moderation - Change the moderation_status of an annotation
     # ----------------------------------------------------------

--- a/docs/_extra/api-reference/hypothesis-v2.yaml
+++ b/docs/_extra/api-reference/hypothesis-v2.yaml
@@ -735,6 +735,10 @@ paths:
         '204':
           $ref: '#/components/responses/NoContent'
 
+  # ---------------------------------------------------------------------------
+  # Annotation Moderation Operations: Change status
+  # ---------------------------------------------------------------------------
+  /annotations/{id}/moderation:
     # ----------------------------------------------------------
     # PATCH annotations/{id}/moderation - Change the moderation_status of an annotation
     # ----------------------------------------------------------


### PR DESCRIPTION
While working on something else, I noticed the new annotation moderation endpoint was defined as a `PATCH` request under `/annotations/{id}/hide`, while it actually expects a different path. This was probably a simple overlook while copy-pasting stuff from the other endpoint.

<img width="1882" height="905" alt="image" src="https://github.com/user-attachments/assets/2e53be96-aaaf-4eda-bee9-c8aca252341d" />

This PR fixes it so that it's defined under the right path.