### PR TITLE
Remove unused `styles` property

### DIFF
--- a/h/static/scripts/group-forms/config.ts
+++ b/h/static/scripts/group-forms/config.ts
@@ -19,8 +19,6 @@ export type Group = {
 };
 
 export type ConfigObject = {
-  /** The URLs of the app's CSS stylesheets. */
-  styles: string[];
   api: {
     createGroup: APIConfig;
     updateGroup?: APIConfig;


### PR DESCRIPTION
Usage of this was removed in 02bb2b50fbac4e4e08af49d32433ba9a3ff91bd0.