### PR TITLE
Convert "Edit profile" form to Preact

### DIFF
--- a/h/form.py
+++ b/h/form.py
@@ -145,8 +145,8 @@ def handle_form_submission(
 
     try:
         appstruct = get_form().validate(request.POST.items())
-    except deform.ValidationFailure:
-        result = on_failure()
+    except deform.ValidationFailure as e:
+        result = on_failure(errors=e.error.asdict(), items=request.POST)
         request.response.status_int = 400
     else:
         result = on_success(appstruct)

--- a/h/schemas/forms/accounts/edit_profile.py
+++ b/h/schemas/forms/accounts/edit_profile.py
@@ -1,5 +1,4 @@
 import colander
-import deform
 
 from h import i18n
 from h.accounts import util
@@ -29,29 +28,24 @@ class EditProfileSchema(CSRFSchema):
         colander.String(),
         missing=None,
         validator=validators.Length(max=DISPLAY_NAME_MAX_LENGTH),
-        title=_("Display name"),
     )
 
     description = colander.SchemaNode(
         colander.String(),
         missing=None,
         validator=validators.Length(max=250),
-        widget=deform.widget.TextAreaWidget(max_length=250, rows=4),
-        title=_("Description"),
     )
 
     location = colander.SchemaNode(
         colander.String(),
         missing=None,
         validator=validators.Length(max=100),
-        title=_("Location"),
     )
 
     link = colander.SchemaNode(
         colander.String(),
         missing=None,
         validator=colander.All(validators.Length(max=250), validate_url),
-        title=_("Link"),
     )
 
     orcid = colander.SchemaNode(

--- a/h/static/scripts/forms-common/form-value.ts
+++ b/h/static/scripts/forms-common/form-value.ts
@@ -21,6 +21,12 @@ export type FormValueOptions<T> = {
   validate?: (value: T, committed: boolean) => string | undefined;
 };
 
+/**
+ * State for a form field value.
+ *
+ * This tracks the current value, the validation error (if any), whether the
+ * value has been committed and whether it has changed since the last submission.
+ */
 export type FormValue<T> = {
   /** Current form field value. */
   value: T;

--- a/h/static/scripts/login-forms/components/AppRoot.tsx
+++ b/h/static/scripts/login-forms/components/AppRoot.tsx
@@ -9,6 +9,7 @@ import { Config } from '../config';
 import { routes } from '../routes';
 import AccountSettingsForms from './AccountSettingsForms';
 import LoginForm from './LoginForm';
+import ProfileForm from './ProfileForm';
 import SignupForm from './SignupForm';
 import SignupSelectForm from './SignupSelectForm';
 
@@ -65,6 +66,9 @@ export default function AppRoot({ config }: AppRootProps) {
             </Route>
             <Route path={routes.accountSettings}>
               <AccountSettingsForms />
+            </Route>
+            <Route path={routes.profile}>
+              <ProfileForm />
             </Route>
             <Route>
               <h1 data-testid="unknown-route">Page not found</h1>

--- a/h/static/scripts/login-forms/components/ProfileForm.tsx
+++ b/h/static/scripts/login-forms/components/ProfileForm.tsx
@@ -1,0 +1,65 @@
+import { Button } from '@hypothesis/frontend-shared';
+import { useContext } from 'preact/hooks';
+
+import Form from '../../forms-common/components/Form';
+import FormContainer from '../../forms-common/components/FormContainer';
+import TextField from '../../forms-common/components/TextField';
+import { useFormValue } from '../../forms-common/form-value';
+import type { FormValue } from '../../forms-common/form-value';
+import { Config } from '../config';
+import type { ProfileConfigObject } from '../config';
+
+export default function ProfileForm() {
+  const config = useContext(Config) as ProfileConfigObject;
+  const form = config.form;
+
+  const displayName = useFormValue(form, 'display_name', '');
+  const description = useFormValue(form, 'description', '');
+  const location = useFormValue(form, 'location', '');
+  const link = useFormValue(form, 'link', '');
+  const orcid = useFormValue(form, 'orcid', '');
+
+  const textFieldProps = (field: FormValue<string>) => ({
+    value: field.value,
+    fieldError: field.error,
+    onChangeValue: field.update,
+    onCommitValue: field.commit,
+  });
+
+  return (
+    <FormContainer>
+      <Form csrfToken={config.csrfToken}>
+        <TextField
+          name="display_name"
+          label="Display name"
+          maxLength={30}
+          {...textFieldProps(displayName)}
+        />
+        <TextField
+          name="description"
+          type="textarea"
+          label="Description"
+          maxLength={250}
+          {...textFieldProps(description)}
+        />
+        <TextField
+          name="location"
+          label="Location"
+          {...textFieldProps(location)}
+        />
+        <TextField name="link" label="Link" {...textFieldProps(link)} />
+        <TextField
+          name="orcid"
+          label="ORCID Identifier"
+          {...textFieldProps(orcid)}
+        />
+        <div className="mb-8 pt-2 flex items-center gap-x-4">
+          <div className="grow" />
+          <Button type="submit" variant="primary" data-testid="submit-button">
+            Save
+          </Button>
+        </div>
+      </Form>
+    </FormContainer>
+  );
+}

--- a/h/static/scripts/login-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/login-forms/components/test/AppRoot-test.js
@@ -25,6 +25,7 @@ describe('AppRoot', () => {
     $imports.$mock({
       './AccountSettingsForms': mockComponent('AccountSettingsForms'),
       './LoginForm': mockComponent('LoginForm'),
+      './ProfileForm': mockComponent('ProfileForm'),
       './SignupForm': mockComponent('SignupForm'),
       './SignupSelectForm': mockComponent('SignupSelectForm'),
     });
@@ -151,6 +152,10 @@ describe('AppRoot', () => {
       props: {
         enableSocialLogin: true,
       },
+    },
+    {
+      path: '/account/profile',
+      selector: 'ProfileForm',
     },
     // "/signup" shows email signup form if all social logins are disabled
     {

--- a/h/static/scripts/login-forms/components/test/ProfileForm-test.js
+++ b/h/static/scripts/login-forms/components/test/ProfileForm-test.js
@@ -1,0 +1,139 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+
+import { Config } from '../../config';
+import ProfileForm from '../ProfileForm';
+
+describe('ProfileForm', () => {
+  let fakeConfig;
+
+  beforeEach(() => {
+    fakeConfig = {
+      csrfToken: 'fake-csrf-token',
+      features: {},
+      form: {
+        data: {
+          display_name: '',
+          description: '',
+          location: '',
+          link: '',
+          orcid: '',
+        },
+        errors: {},
+      },
+    };
+  });
+
+  const getElements = wrapper => {
+    return {
+      form: wrapper.find('form[data-testid="form"]'),
+      csrfInput: wrapper.find('input[name="csrf_token"]'),
+      displayNameField: wrapper.find('TextField[name="display_name"]'),
+      descriptionField: wrapper.find('TextField[name="description"]'),
+      locationField: wrapper.find('TextField[name="location"]'),
+      linkField: wrapper.find('TextField[name="link"]'),
+      orcidField: wrapper.find('TextField[name="orcid"]'),
+      submitButton: wrapper.find('Button[data-testid="submit-button"]'),
+    };
+  };
+
+  const createWrapper = () => {
+    const wrapper = mount(
+      <Config.Provider value={fakeConfig}>
+        <ProfileForm />
+      </Config.Provider>,
+    );
+    const elements = getElements(wrapper);
+    return { wrapper, elements };
+  };
+
+  it('pre-fills form fields from form data', () => {
+    fakeConfig.form.data = {
+      display_name: 'John Doe',
+      description: 'Software Developer',
+      location: 'San Francisco, CA',
+      link: 'https://johndoe.com',
+      orcid: '0000-0000-0000-0001',
+    };
+
+    const { elements } = createWrapper();
+    const {
+      displayNameField,
+      descriptionField,
+      locationField,
+      linkField,
+      orcidField,
+    } = elements;
+
+    assert.equal(
+      displayNameField.prop('value'),
+      fakeConfig.form.data.display_name,
+    );
+    assert.equal(
+      descriptionField.prop('value'),
+      fakeConfig.form.data.description,
+    );
+    assert.equal(locationField.prop('value'), fakeConfig.form.data.location);
+    assert.equal(linkField.prop('value'), fakeConfig.form.data.link);
+    assert.equal(orcidField.prop('value'), fakeConfig.form.data.orcid);
+  });
+
+  it('displays form errors', () => {
+    fakeConfig.form.errors = {
+      display_name: 'Display name is too long',
+      description: 'Description is required',
+      location: 'Invalid location',
+      link: 'Must be a valid URL',
+      orcid: 'Invalid ORCID format',
+    };
+
+    const { elements } = createWrapper();
+    const {
+      displayNameField,
+      descriptionField,
+      locationField,
+      linkField,
+      orcidField,
+    } = elements;
+
+    assert.equal(
+      displayNameField.prop('fieldError'),
+      fakeConfig.form.errors.display_name,
+    );
+    assert.equal(
+      descriptionField.prop('fieldError'),
+      fakeConfig.form.errors.description,
+    );
+    assert.equal(
+      locationField.prop('fieldError'),
+      fakeConfig.form.errors.location,
+    );
+    assert.equal(linkField.prop('fieldError'), fakeConfig.form.errors.link);
+    assert.equal(orcidField.prop('fieldError'), fakeConfig.form.errors.orcid);
+  });
+
+  [
+    { field: 'displayNameField', value: 'Jane Smith' },
+    { field: 'descriptionField', value: 'Product Manager' },
+    { field: 'locationField', value: 'New York, NY' },
+    { field: 'linkField', value: 'https://janesmith.dev' },
+    { field: 'orcidField', value: '0000-0000-0000-0002' },
+  ].forEach(({ field, value }) => {
+    it(`updates ${field} when input changes`, () => {
+      const { wrapper, elements } = createWrapper();
+
+      act(() => {
+        elements[field].prop('onChangeValue')(value);
+      });
+      wrapper.update();
+      const updatedElements = getElements(wrapper);
+
+      assert.equal(updatedElements[field].prop('value'), value);
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({ content: () => createWrapper().wrapper }),
+  );
+});

--- a/h/static/scripts/login-forms/config.ts
+++ b/h/static/scripts/login-forms/config.ts
@@ -90,9 +90,21 @@ export type AccountSettingsConfigObject = ConfigBase & {
   };
 };
 
+/** Configuration for Edit Profile form. */
+export type ProfileConfigObject = ConfigBase & {
+  form: FormFields<{
+    display_name: string;
+    description: string;
+    link: string;
+    location: string;
+    orcid: string;
+  }>;
+};
+
 export type ConfigObject =
   | LoginConfigObject
   | SignupConfigObject
-  | AccountSettingsConfigObject;
+  | AccountSettingsConfigObject
+  | ProfileConfigObject;
 
 export const Config = createContext<ConfigObject | null>(null);

--- a/h/static/scripts/login-forms/routes.ts
+++ b/h/static/scripts/login-forms/routes.ts
@@ -7,6 +7,7 @@
 export const routes = {
   forgotPassword: '/forgot-password',
   login: '/login',
+  profile: '/account/profile',
   signup: '/signup',
   signupWithEmail: '/signup/email',
   signupWithGoogle: '/signup/google',

--- a/h/templates/accounts/profile.html.jinja2
+++ b/h/templates/accounts/profile.html.jinja2
@@ -3,6 +3,23 @@
 {% set page_route = 'account_profile' %}
 {% set page_title = 'Edit profile' %}
 
+{% block styles %}
+  {{ super() }}
+
+  {% for url in asset_urls('forms_css') %}
+    <link rel="stylesheet" href="{{ url }}">
+  {% endfor %}
+{% endblock %}
+
 {% block page_content %}
-  {{ form }}
+  <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
+  <div id="login-form"></div>
 {% endblock page_content %}
+
+{% block scripts %}
+  {{ super() }}
+
+  {% for url in asset_urls('login_forms_js') %}
+    <script type="module" src="{{ url }}"></script>
+  {% endfor %}
+{% endblock %}

--- a/tests/unit/h/form_test.py
+++ b/tests/unit/h/form_test.py
@@ -178,7 +178,7 @@ class TestHandleFormSubmission:
             pyramid_request, invalid_form(), mock.sentinel.on_success, on_failure
         )
 
-        on_failure.assert_called_once_with()
+        on_failure.assert_called_once_with(errors={}, items=pyramid_request.POST)
 
     def test_if_validation_fails_it_calls_to_xhr_response(
         self, invalid_form, pyramid_request, to_xhr_response
@@ -358,7 +358,7 @@ class TestHandleFormSubmission:
         def form_callable_spec():
             """Spec for the callable_form mock."""
 
-        def on_failure_spec():
+        def on_failure_spec(errors, items):
             """Spec for the on_failure mock."""
 
         form1 = mock.create_autospec(Form, instance=True, spec_set=True)
@@ -369,15 +369,18 @@ class TestHandleFormSubmission:
         )
 
         on_failure = mock.create_autospec(on_failure_spec, spec_set=True)
+        errors = mock.Mock()
         form1.validate.side_effect = ValidationFailure(
-            mock.sentinel.field, mock.sentinel.cstruct, mock.sentinel.error
+            mock.sentinel.field, mock.sentinel.cstruct, errors
         )
 
         result = form.handle_form_submission(
             pyramid_request, form_callable, mock.sentinel.on_success, on_failure
         )
 
-        on_failure.assert_called_once_with()
+        on_failure.assert_called_once_with(
+            errors=errors.asdict.return_value, items=pyramid_request.POST
+        )
         to_xhr_response.assert_called_once_with(
             pyramid_request, on_failure.return_value, mock.sentinel.form2
         )


### PR DESCRIPTION
This converts the Edit Profile form to use the same tech stack (Preact, Tailwind etc.) as the new group and login forms. Like the new login forms, it still uses a regular form submission, just the rendering is handled client-side.

The upside for users is that it makes the look and behavior of the form more consistent with other recently-added forms. The upside for us is that it would be a step towards having all forms work the same way, so it becomes extend/modify them.

**Preview:**

(Note the tabs are still part of the Jinja template, only the body is new)

<img width="572" height="576" alt="Edit profile form" src="https://github.com/user-attachments/assets/5e1ace27-d04d-4294-87fe-2c53380d6f14" />

**Implementation notes:**

There is an open issue about how best to split the bundles. In this draft I put it in the `login-forms` bundle but this isn't really a login-form related thing, although it does share many of the components. I'm doing a bit of exploration to figure out what works best here.

**Testing:**

1. Go to http://localhost:5000/account/profile. Fill in all the fields, click Save. Reload the page and all the data should be preserved.
2. Enter invalid input in one of the fields (easiest is ORCID iD) and click Save. You should see a validation error appear underneath the form.