### PR TITLE
Simplify `lazy` usage

### DIFF
--- a/h/static/scripts/group-forms/components/AnnotationCard.tsx
+++ b/h/static/scripts/group-forms/components/AnnotationCard.tsx
@@ -49,14 +49,10 @@ type SaveState =
 
 // Lazily load the MarkdownView as it has heavy dependencies such as Showdown,
 // KaTeX and DOMPurify.
-const MarkdownView = lazy(
-  'MarkdownView',
-  () => import('./MarkdownView').then(mod => mod.default),
-  {
-    fallback: ({ markdown }) => markdown,
-    errorFallback: /* istanbul ignore next */ ({ markdown }) => markdown,
-  },
-);
+const MarkdownView = lazy('MarkdownView', () => import('./MarkdownView'), {
+  fallback: ({ markdown }) => markdown,
+  errorFallback: /* istanbul ignore next */ ({ markdown }) => markdown,
+});
 
 export default function AnnotationCard({
   annotation,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/preset-typescript": "^7.27.0",
     "@hypothesis/annotation-ui": "^0.5.0",
     "@hypothesis/frontend-build": "^4.0.0",
-    "@hypothesis/frontend-shared": "^9.7.0",
+    "@hypothesis/frontend-shared": "^9.8.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,15 +2009,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^9.7.0":
-  version: 9.7.0
-  resolution: "@hypothesis/frontend-shared@npm:9.7.0"
+"@hypothesis/frontend-shared@npm:^9.8.0":
+  version: 9.8.0
+  resolution: "@hypothesis/frontend-shared@npm:9.8.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: bdb31cf6181c2ca1fea9ef881ce93f4e5095476720191b7afd2bc20e5cba94dbbe63dd8d58ce6c344ed7ace059294591e9737ec49e54606f39cb2902788f7426
+  checksum: 053fbea7b5235a15dd7a9ddf4352ec47fbbaff6f967f4d05d3e8897cbac5b9bc873454cba982b22ddeab22022e1e5150133082b9526e7d7af0abb55ef1b125b7
   languageName: node
   linkType: hard
 
@@ -6948,7 +6948,7 @@ __metadata:
     "@babel/preset-typescript": ^7.27.0
     "@hypothesis/annotation-ui": ^0.5.0
     "@hypothesis/frontend-build": ^4.0.0
-    "@hypothesis/frontend-shared": ^9.7.0
+    "@hypothesis/frontend-shared": ^9.8.0
     "@hypothesis/frontend-testing": ^1.7.1
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.3


### PR DESCRIPTION
Use the changes from https://github.com/hypothesis/frontend-shared/pull/2050 to slightly simplify usage of `lazy`.

The minor change here would have a larger benefit if loading the root component for various routes this way in `AppRoot.tsx`. This is not something I definitely plan on doing yet, but I am looking into the possibility of consolidating the multiple `AppRoot` components.