### PR TITLE
Refresh login page if user logs in on another tab

### DIFF
--- a/h/static/scripts/header.js
+++ b/h/static/scripts/header.js
@@ -3,6 +3,7 @@
 // This should be a small script which does things like setting up flags to
 // indicate that scripting is active, send analytics events etc.
 import { EnvironmentFlags } from './base/environment-flags';
+import { notifyAuthStatus } from './util/login-status';
 
 window.envFlags = new EnvironmentFlags(document.documentElement);
 window.envFlags.init();
@@ -21,3 +22,12 @@ if (gaMeasurementId) {
   gtag('config', gaMeasurementId);
   /* eslint-enable */
 }
+
+// Notify other tabs about whether the user is logged in.
+//
+// The main use for this is to streamline the flow where a user signs up from a
+// login window opened by the client. If the user signs up via email, we require
+// them to verify their address before they can log in. After they activate
+// their account and log in, we want to notify the original auth popup window so
+// it can continue and log in the user into the client.
+notifyAuthStatus();

--- a/h/static/scripts/login-forms/components/LoginForm.tsx
+++ b/h/static/scripts/login-forms/components/LoginForm.tsx
@@ -1,11 +1,12 @@
 import { Button, Link, LogoIcon } from '@hypothesis/frontend-shared';
-import { useContext } from 'preact/hooks';
+import { useContext, useEffect } from 'preact/hooks';
 
 import Form from '../../forms-common/components/Form';
 import FormContainer from '../../forms-common/components/FormContainer';
 import FormHeader from '../../forms-common/components/FormHeader';
 import TextField from '../../forms-common/components/TextField';
 import { useFormValue } from '../../forms-common/form-value';
+import { listenForAuthStatusChange } from '../../util/login-status';
 import { Config } from '../config';
 import type { LoginConfigObject } from '../config';
 import { routes } from '../routes';
@@ -38,6 +39,17 @@ export default function LoginForm({ enableSocialLogin }: LoginFormProps) {
   // following an activation link).
   const autofocusUsername =
     Boolean(username.error) || username.value.length === 0;
+
+  // Reload the page if user logs in, in another tab.
+  useEffect(() => {
+    const ctrl = new AbortController();
+    listenForAuthStatusChange(status => {
+      if (status === 'logged-in') {
+        location.reload();
+      }
+    }, ctrl.signal);
+    return () => ctrl.abort();
+  }, []);
 
   return (
     <>

--- a/h/static/scripts/util/login-status.ts
+++ b/h/static/scripts/util/login-status.ts
@@ -1,0 +1,54 @@
+type AuthStatus = 'logged-in' | 'logged-out';
+
+type AuthStatusMessage = {
+  type: 'auth-status';
+  status: AuthStatus;
+};
+
+/**
+ * Send a message to other tabs in the same browser to report whether the
+ * user is logged in.
+ */
+export function notifyAuthStatus() {
+  const channel = createChannel();
+  if (!channel) {
+    return;
+  }
+  const userid = document.querySelector('meta[name=userid]') as
+    | HTMLMetaElement
+    | undefined;
+
+  const msg: AuthStatusMessage = {
+    type: 'auth-status',
+    status: userid?.content ? 'logged-in' : 'logged-out',
+  };
+  channel.postMessage(msg);
+  channel.close();
+}
+
+/**
+ * Register a listener for changes to the logged-in/logged-out status in other tabs.
+ */
+export function listenForAuthStatusChange(
+  cb: (status: AuthStatus) => void,
+  signal: AbortSignal,
+) {
+  const channel = createChannel();
+  if (!channel) {
+    return;
+  }
+  signal.addEventListener('abort', () => channel.close());
+  channel.onmessage = e => {
+    const data = e.data as AuthStatusMessage;
+    if (data.type === 'auth-status') {
+      cb(data.status);
+    }
+  };
+}
+
+function createChannel() {
+  if (typeof BroadcastChannel !== 'function') {
+    return undefined;
+  }
+  return new BroadcastChannel('account-events');
+}

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -63,6 +63,10 @@
     <script type="importmap" nonce="{{ request.csp_nonce }}">{{ asset_import_map() | tojson }}</script>
     {% endblock %}
 
+    {% if request.user %}
+    <meta name="userid" content="{{ request.user.userid }}">
+    {% endif %}
+
     {% for url in asset_urls("header_js") %}
     <script type="module" src="{{ url }}"></script>
     {% endfor %}


### PR DESCRIPTION
Add a BroadcastChannel-based mechanism for JS to observe when the user logs into Hypothesis in another tab. This will be used to streamline the process where the user signs up from an auth popup window opened by the Hypothesis client.

It works as follows:

 - In every HTML page, the backend renders a `<meta name="userid" ...>` tag if the user is logged in.
 - On the frontend, the header script that is included on every page reads this and sends out a notification of the current status via a `BroadcastChannel`
 - Interested observers in other tabs can listen for events on this channel.

In this proof of concept, the login form auto-refreshes via `location.reload()` when this happens.

Part of https://github.com/hypothesis/client/issues/7216.