### PR TITLE
Fix casing of URL paths in router test

### DIFF
--- a/h/static/scripts/login-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/login-forms/components/test/AppRoot-test.js
@@ -130,14 +130,14 @@ describe('AppRoot', () => {
 
   [
     {
-      path: '/Login',
+      path: '/login',
       selector: 'LoginForm',
       props: {
         enableSocialLogin: false,
       },
     },
     {
-      path: '/Login',
+      path: '/login',
       selector: 'LoginForm',
       features: {
         log_in_with_google: true,


### PR DESCRIPTION
Update paths in tests to match the real paths. The tests were passing with incorrect casing because path matching is case-insensitive in wouter [^1].

[^1]: wouter turns paths into regexes using https://github.com/lukeed/regexparam which generates case-insensitive regexes following the conventions of https://github.com/pillarjs/path-to-regexp.