### PR TITLE
Return conflict error when annotation moderation has changed

### DIFF
--- a/docs/_extra/api-reference/hypothesis-v1.yaml
+++ b/docs/_extra/api-reference/hypothesis-v1.yaml
@@ -761,6 +761,15 @@ paths:
             description: The new moderation status for the annotation.
             type: string
             enum: [APPROVED, PENDING, DENIED, SPAM]
+        - name: current_moderation_status
+          in: query
+          schema:
+            description: |
+              The annotation's `moderation_status` as returned by the API when fetching this annotation.
+              If this optional parameter is included then the moderation request will fail if the annotation's 
+              `moderation_status` does not match the given `current_moderation_status`.
+            type: string
+            enum: [APPROVED, PENDING, DENIED, SPAM]
         - name: annotation_updated
           in: query
           description: |

--- a/docs/_extra/api-reference/hypothesis-v2.yaml
+++ b/docs/_extra/api-reference/hypothesis-v2.yaml
@@ -759,6 +759,15 @@ paths:
             description: The new moderation status for the annotation.
             type: string
             enum: [APPROVED, PENDING, DENIED, SPAM]
+        - name: current_moderation_status
+          in: query
+          schema:
+            description: |
+              The annotation's `moderation_status` as returned by the API when fetching this annotation.
+              If this optional parameter is included then the moderation request will fail if the annotation's 
+              `moderation_status` does not match the given `current_moderation_status`.
+            type: string
+            enum: [APPROVED, PENDING, DENIED, SPAM]
         - name: annotation_updated
           in: query
           description: |

--- a/h/schemas/api/moderation.py
+++ b/h/schemas/api/moderation.py
@@ -3,6 +3,8 @@ from datetime import UTC
 import colander
 from pyramid import httpexceptions
 
+from h.models import Annotation
+
 
 class ModerationStatusNode(colander.SchemaNode):
     schema_type = colander.String
@@ -12,18 +14,33 @@ class ModerationStatusNode(colander.SchemaNode):
 class ChangeAnnotationModerationStatusSchema(colander.Schema):
     """Schema for validating change-annotation-moderation-status API data."""
 
-    moderation_status = ModerationStatusNode(missing=colander.required)
+    moderation_status = ModerationStatusNode(
+        missing=colander.required, description="New moderation status to be set"
+    )
+    current_moderation_status = ModerationStatusNode(
+        missing=None,
+        description="Sentinel value to avoid conflicting updates. If provided, it should match the current value of annotation.moderation_status",
+    )
     annotation_updated = colander.SchemaNode(
         colander.DateTime(),
         description="Sentinel value to avoid conflicting updates. It should match the current value of annotation.updated",
     )
 
-    def __init__(self, annotation):
+    def __init__(self, annotation: Annotation):
         super().__init__()
 
         self._annotation = annotation
 
     def validator(self, _node, cstruct):
+        if (
+            cstruct["current_moderation_status"]
+            and cstruct["current_moderation_status"]
+            != self._annotation.moderation_status.value
+        ):
+            raise httpexceptions.HTTPConflict(
+                detail="The annotation has been moderated since it was loaded."
+            )
+
         # Annotations are updated in the DB without timezone but they are implicitly UTC
         annotation_updated = self._annotation.updated.replace(tzinfo=UTC).timestamp()
         if annotation_updated != cstruct["annotation_updated"].timestamp():


### PR DESCRIPTION
Part of #9743 

This PR adds a new optional `current_moderation_status` to the `/api/annotations/{id}/moderation` endpoint, which when provided, will cause its value to be checked against the annotation's current status. If they don't match, we return a 409 conflict error, but with a different error message.

This will allow us to provide detailed feedback when there are more than one moderator working in parallel, and one of them tries to moderate an annotation that has already been moderated by someone else.

### Considerations

- The new `current_moderation_status` prop is optional, and the check is skipped if not provided. This is to avoid a breaking change, although, since the moderation feature is not fully shipped, we could choose to make it mandatory to avoid a scenario where a moderator could override what someone else did.
- ~I choose the name `previous_moderation_status` to differentiate from `moderation_status`, but I'm open to suggestions. Perhaps `current_moderation_status` would also be an option.~ We finally chose to name it `current_moderation_status`.
- The API does not currently return machine error codes, so the only way to differentiate the two possible 409 conflict errors is introspecting the detail message. However, I think we can make the UI treat both the same way, showing a more generic error in the lines of "The annotation has been edited by its author or moderated by someone else".
  We could of course add an error code to these particular errors if we want to show different feedback.

