### PR TITLE
Send current_moderation_status when moderating annotations

### DIFF
--- a/h/static/scripts/group-forms/hooks/test/use-update-moderation-status-test.js
+++ b/h/static/scripts/group-forms/hooks/test/use-update-moderation-status-test.js
@@ -17,6 +17,7 @@ describe('useUpdateModerationStatus', () => {
     fakeAnnotation = {
       id: '1',
       updated: '2025-06-24T08:43:50.914807+00:00',
+      moderation_status: 'PENDING',
     };
 
     fakeCallAPI = sinon.stub();
@@ -64,6 +65,7 @@ describe('useUpdateModerationStatus', () => {
         sinon.match({
           json: {
             annotation_updated: fakeAnnotation.updated,
+            current_moderation_status: fakeAnnotation.moderation_status,
             moderation_status: moderationStatus,
           },
         }),

--- a/h/static/scripts/group-forms/hooks/use-update-moderation-status.ts
+++ b/h/static/scripts/group-forms/hooks/use-update-moderation-status.ts
@@ -35,11 +35,17 @@ export function useUpdateModerationStatus(annotation: APIAnnotationData) {
           signal: abortCtrlRef.current.signal,
           json: {
             annotation_updated: annotation.updated,
+            current_moderation_status: annotation.moderation_status,
             moderation_status: moderationStatus,
           },
         },
       );
     },
-    [annotation.id, annotation.updated, config?.api.annotationModeration],
+    [
+      annotation.id,
+      annotation.moderation_status,
+      annotation.updated,
+      config?.api.annotationModeration,
+    ],
   );
 }


### PR DESCRIPTION
Part of https://github.com/hypothesis/h/issues/9743

Take advantage of the changes introduced in https://github.com/hypothesis/h/pull/9799, by sending the `current_moderation_status` when trying to moderate an annotation, ensuring a conflict error is returned if it has changed since the annotation was loaded.

### Test steps

1. Open the annotation moderation queue in two different browsers.
2. Change the moderation status for one annotation in one of them.
3. Try to change the status in the same annotation in the other one. You should see a warning message indicating the annotation was changed, and the annotation should be reloaded reflecting its new moderation status.
4. If you retry afterwards, it should now be possible to change the status.

### Considerations

The message we display when the conflict is due to the annotation's author editing the annotation, or the annotation being moderated by someone else, is currently the same.

We could adjust the message to more clearly indicate the possible cases in which a conflict can happen, but since the annotation is immediately reloaded, those changes will probably be obvious to the moderator.

Alternatively, we could display different messages depending on the reason for the conflict, but since the BE does not currently return machine error codes, we would have to implement this based on the human-friendly error message, which is more brittle.

We could perhaps put this in front of users/other team members, and refine it based on feedback.

### Out of scope

If the moderation queue is filtered by one moderation status, when the annotation is reloaded with a different status, the experience might be confusing to end-users, but solving this is tricky, so it needs more discussion.