### PR TITLE
Rewrite account settings forms in Preact

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -203,13 +203,15 @@ class SocialLoginSignupSchema(colander.Schema):
     comms_opt_in = comms_opt_in_node()
 
 
-class EmailChangeSchema(CSRFSchema):
-    email = email_node(title=_("Email address"))
-    # No validators: all validation is done on the email field
-    password = password_node(title=_("Confirm password"), hide_until_form_active=True)
+class EmailAddSchema(colander.Schema):
+    email = email_node()
+
+
+class EmailChangeSchema(colander.Schema):
+    email = email_node()
+    password = password_node()
 
     def validator(self, node, value):
-        super().validator(node, value)
         exc = colander.Invalid(node)
         request = node.bindings["request"]
         svc = request.find_service(name="user_password")
@@ -241,13 +243,11 @@ def new_password_confirm_node():
     )
 
 
-class PasswordAddSchema(CSRFSchema):
-    new_password = new_password_node(title=_("Add password"))
+class PasswordAddSchema(colander.Schema):
+    new_password = new_password_node()
     new_password_confirm = new_password_confirm_node()
 
     def validator(self, node, value):
-        super().validator(node, value)
-
         exc = colander.Invalid(node)
 
         if value.get("new_password") != value.get("new_password_confirm"):
@@ -257,15 +257,12 @@ class PasswordAddSchema(CSRFSchema):
             raise exc
 
 
-class PasswordChangeSchema(CSRFSchema):
-    password = password_node(title=_("Current password"), inactive_label=_("Password"))
-    new_password = new_password_node(
-        title=_("New password"), hide_until_form_active=True
-    )
+class PasswordChangeSchema(colander.Schema):
+    password = password_node()
+    new_password = new_password_node()
     new_password_confirm = new_password_confirm_node()
 
-    def validator(self, node, value):  # pragma: no cover
-        super().validator(node, value)
+    def validator(self, node, value):
         exc = colander.Invalid(node)
         request = node.bindings["request"]
         svc = request.find_service(name="user_password")

--- a/h/static/scripts/forms-common/components/TextField.tsx
+++ b/h/static/scripts/forms-common/components/TextField.tsx
@@ -40,6 +40,9 @@ export type TextFieldProps = {
   /** Current value of the input. */
   value: string;
 
+  /** Placeholder text for the input. */
+  placeholder?: string;
+
   /** Callback invoked when the field's value is changed. */
   onChangeValue: (newValue: string) => void;
 
@@ -96,6 +99,7 @@ export default function TextField({
   type = 'input',
   inputType,
   value,
+  placeholder,
   onChangeValue,
   onCommitValue,
   minLength = 0,
@@ -135,6 +139,7 @@ export default function TextField({
         }}
         error={error}
         value={value}
+        placeholder={placeholder}
         classes={classes}
         autofocus={autofocus}
         autocomplete="off"

--- a/h/static/scripts/forms-common/components/TextField.tsx
+++ b/h/static/scripts/forms-common/components/TextField.tsx
@@ -32,7 +32,7 @@ export type TextFieldProps = {
   type?: 'input' | 'textarea';
 
   /** The type of input element, e.g., "text", "password", etc. */
-  inputType?: 'text' | 'password';
+  inputType?: 'text' | 'password' | 'email';
 
   /** Name of the input field. */
   name?: string;

--- a/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
+++ b/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
@@ -51,6 +51,7 @@ function ChangeEmailForm({ config }: { config: AccountSettingsConfigObject }) {
         <input type="hidden" name="__formid__" value="email" />
         <TextField
           name="email"
+          inputType="email"
           label="Email address"
           placeholder={config.context.user?.email}
           required={true}

--- a/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
+++ b/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
@@ -124,6 +124,9 @@ function ChangePasswordForm({
   );
 }
 
+// <ConnectAccountButton/> is similar to <SocialLoginLink/> but with some
+// differences: it has two modes and can either indicate an already-connected
+// account or can act as a button for connecting an account.
 function ConnectAccountButton({
   config,
   provider,

--- a/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
+++ b/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
@@ -1,0 +1,240 @@
+import { Button } from '@hypothesis/frontend-shared';
+import { ExternalIcon, CheckIcon } from '@hypothesis/frontend-shared';
+import { useContext } from 'preact/hooks';
+
+import Form from '../../forms-common/components/Form';
+import FormContainer from '../../forms-common/components/FormContainer';
+import TextField from '../../forms-common/components/TextField';
+import { useFormValue } from '../../forms-common/form-value';
+import type { FormValue } from '../../forms-common/form-value';
+import { Config } from '../config';
+import type { AccountSettingsConfigObject } from '../config';
+import FacebookIcon from './FacebookIcon';
+import GoogleIcon from './GoogleIcon';
+import ORCIDIcon from './ORCIDIcon';
+
+const textFieldProps = (field: FormValue<string>) => ({
+  value: field.value,
+  fieldError: field.error,
+  onChangeValue: field.update,
+  onCommitValue: field.commit,
+});
+
+function Heading({ text }: { text: string }) {
+  return <h1 class="text-lg mb-4">{text}</h1>;
+}
+
+function FormSubmitButton() {
+  return (
+    <div className="mb-8 pt-2 flex items-center gap-x-4">
+      <div className="grow" />
+      <Button type="submit" variant="primary" data-testid="submit-button">
+        Save
+      </Button>
+    </div>
+  );
+}
+
+function ChangeEmailForm({ config }: { config: AccountSettingsConfigObject }) {
+  const email = useFormValue(config.forms.email, 'email', '');
+  const password = useFormValue(config.forms.email, 'password', '');
+
+  return (
+    <FormContainer>
+      {config.context.user.email ? (
+        <Heading text="Change your email address" />
+      ) : (
+        <Heading text="Add an email address" />
+      )}
+
+      <Form csrfToken={config.csrfToken} data-testid="email-form">
+        <input type="hidden" name="__formid__" value="email" />
+        <TextField
+          name="email"
+          label="Email address"
+          placeholder={config.context.user?.email}
+          required={true}
+          {...textFieldProps(email)}
+        />
+        {config.context.user.has_password && (
+          <TextField
+            name="password"
+            label="Confirm password"
+            inputType="password"
+            required={true}
+            {...textFieldProps(password)}
+          />
+        )}
+        <FormSubmitButton />
+      </Form>
+    </FormContainer>
+  );
+}
+
+function ChangePasswordForm({
+  config,
+}: {
+  config: AccountSettingsConfigObject;
+}) {
+  const password = useFormValue(config.forms.password, 'password', '');
+  const newPassword = useFormValue(config.forms.password, 'new_password', '');
+  const newPasswordConfirm = useFormValue(
+    config.forms.password,
+    'new_password_confirm',
+    '',
+  );
+
+  return (
+    <FormContainer>
+      {config.context.user.has_password ? (
+        <Heading text="Change your password" />
+      ) : (
+        <Heading text="Add a password" />
+      )}
+
+      <Form csrfToken={config.csrfToken} data-testid="password-form">
+        <input type="hidden" name="__formid__" value="password" />
+        {config.context.user.has_password && (
+          <TextField
+            name="password"
+            label="Current password"
+            inputType="password"
+            required={true}
+            {...textFieldProps(password)}
+          />
+        )}
+        <TextField
+          name="new_password"
+          label="New password"
+          inputType="password"
+          required={true}
+          minLength={8}
+          {...textFieldProps(newPassword)}
+        />
+        <TextField
+          name="new_password_confirm"
+          label="Confirm new password"
+          inputType="password"
+          required={true}
+          {...textFieldProps(newPasswordConfirm)}
+        />
+        <FormSubmitButton />
+      </Form>
+    </FormContainer>
+  );
+}
+
+function ConnectAccountButton({
+  config,
+  provider,
+}: {
+  config: AccountSettingsConfigObject;
+  provider: 'facebook' | 'google' | 'orcid';
+}) {
+  const providerConfig = config.context.identities?.[provider];
+  const connected = providerConfig?.connected;
+  const providerUniqueID = providerConfig?.provider_unique_id;
+  const providerURL = providerConfig?.url;
+  const connectURL = config.routes?.[`oidc.connect.${provider}`];
+  const Icon = {
+    google: GoogleIcon,
+    facebook: FacebookIcon,
+    orcid: ORCIDIcon,
+  }[provider];
+  const label = {
+    google: (
+      <>
+        Connect <b>Google</b>
+      </>
+    ),
+    facebook: (
+      <>
+        Connect <b>Facebook</b>
+      </>
+    ),
+    orcid: (
+      <>
+        Connect <b>ORCID</b>
+      </>
+    ),
+  }[provider];
+
+  return (
+    <>
+      {connected ? (
+        <a
+          href={providerURL}
+          className="border rounded-md p-3 flex flex-row items-center gap-x-3"
+          data-testid={`connect-account-link-${provider}`}
+        >
+          <Icon />
+          <span className="grow">
+            Connected: <b>{providerUniqueID}</b>
+          </span>
+          <CheckIcon className="w-[20px] h-[20px]" />
+        </a>
+      ) : (
+        <a
+          href={connectURL}
+          className="border rounded-md p-3 flex flex-row items-center gap-x-3"
+          data-testid={`connect-account-link-${provider}`}
+        >
+          <Icon />
+          <span className="grow">{label}</span>
+          <ExternalIcon className="w-[20px] h-[20px]" />
+        </a>
+      )}
+    </>
+  );
+}
+
+function ConnectAccountButtons({
+  config,
+}: {
+  config: AccountSettingsConfigObject;
+}) {
+  if (
+    !(
+      config.features.log_in_with_google ||
+      config.features.log_in_with_facebook ||
+      config.features.log_in_with_orcid
+    )
+  ) {
+    return null;
+  }
+
+  return (
+    <div class="text-grey-6 text-sm/relaxed" data-testid="connect-your-account">
+      <Heading text="Connect your account" />
+
+      <p className="mb-9">
+        Connecting an account enables you to log in to Hypothesis without your
+        Hypothesis password.
+      </p>
+
+      <div class="mx-auto max-w-[400px] flex flex-col gap-y-3">
+        {config.features.log_in_with_google && (
+          <ConnectAccountButton config={config} provider="google" />
+        )}
+        {config.features.log_in_with_facebook && (
+          <ConnectAccountButton config={config} provider="facebook" />
+        )}
+        {config.features.log_in_with_orcid && (
+          <ConnectAccountButton config={config} provider="orcid" />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function AccountSettingsForms() {
+  const config = useContext(Config) as AccountSettingsConfigObject;
+
+  return (
+    <>
+      <ChangeEmailForm config={config} />
+      <ChangePasswordForm config={config} />
+      <ConnectAccountButtons config={config} />
+    </>
+  );
+}

--- a/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
+++ b/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
@@ -48,11 +48,19 @@ function ChangeEmailForm({ config }: { config: AccountSettingsConfigObject }) {
 
       <Form csrfToken={config.csrfToken} data-testid="email-form">
         <input type="hidden" name="__formid__" value="email" />
+
+        {config.context.user.email && (
+          <p>
+            Current email address:{' '}
+            <b data-testid="current-email">{config.context.user.email}</b>
+          </p>
+        )}
         <TextField
           name="email"
           inputType="email"
-          label="Email address"
-          placeholder={config.context.user?.email}
+          label={
+            config.context.user.email ? 'New email address' : 'Email address'
+          }
           required={true}
           {...textFieldProps(email)}
         />

--- a/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
+++ b/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
@@ -204,7 +204,7 @@ function ConnectAccountButtons({
   }
 
   return (
-    <div class="text-grey-6 text-sm/relaxed" data-testid="connect-your-account">
+    <FormContainer>
       <Heading text="Connect your account" />
 
       <p className="mb-9">
@@ -223,7 +223,7 @@ function ConnectAccountButtons({
           <ConnectAccountButton config={config} provider="orcid" />
         )}
       </div>
-    </div>
+    </FormContainer>
   );
 }
 

--- a/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
+++ b/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
@@ -38,14 +38,13 @@ function FormSubmitButton() {
 function ChangeEmailForm({ config }: { config: AccountSettingsConfigObject }) {
   const email = useFormValue(config.forms.email, 'email', '');
   const password = useFormValue(config.forms.email, 'password', '');
+  const heading = config.context.user.email
+    ? 'Change your email address'
+    : 'Add an email address';
 
   return (
     <FormContainer>
-      {config.context.user.email ? (
-        <Heading text="Change your email address" />
-      ) : (
-        <Heading text="Add an email address" />
-      )}
+      <Heading text={heading} />
 
       <Form csrfToken={config.csrfToken} data-testid="email-form">
         <input type="hidden" name="__formid__" value="email" />

--- a/h/static/scripts/login-forms/components/AppRoot.tsx
+++ b/h/static/scripts/login-forms/components/AppRoot.tsx
@@ -7,6 +7,7 @@ import Router from '../../forms-common/components/Router';
 import type { ConfigObject } from '../config';
 import { Config } from '../config';
 import { routes } from '../routes';
+import AccountSettingsForms from './AccountSettingsForms';
 import LoginForm from './LoginForm';
 import SignupForm from './SignupForm';
 import SignupSelectForm from './SignupSelectForm';
@@ -61,6 +62,9 @@ export default function AppRoot({ config }: AppRootProps) {
             </Route>
             <Route path={routes.signupWithORCID}>
               <SignupForm idProvider="orcid" />
+            </Route>
+            <Route path={routes.accountSettings}>
+              <AccountSettingsForms />
             </Route>
             <Route>
               <h1 data-testid="unknown-route">Page not found</h1>

--- a/h/static/scripts/login-forms/components/test/AccountSettingsForms-test.js
+++ b/h/static/scripts/login-forms/components/test/AccountSettingsForms-test.js
@@ -1,0 +1,293 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+
+import { Config } from '../../config';
+import AccountSettingsForms from '../AccountSettingsForms';
+
+describe('AccountSettingsForms', () => {
+  let fakeConfig;
+
+  beforeEach(() => {
+    fakeConfig = {
+      csrfToken: 'fakeCsrfToken',
+      features: {
+        log_in_with_google: true,
+        log_in_with_facebook: true,
+        log_in_with_orcid: true,
+      },
+      forms: {
+        email: {
+          data: {},
+        },
+        password: {
+          data: {},
+        },
+      },
+      context: {
+        user: { has_password: true },
+        identities: {
+          google: { connected: false },
+          facebook: { connected: false },
+          orcid: { connected: false },
+        },
+      },
+      routes: {
+        'oidc.connect.google': 'https://example.com/oidc/connect/google',
+        'oidc.connect.facebook': 'https://example.com/oidc/connect/facebook',
+        'oidc.connect.orcid': 'https://example.com/oidc/connect/orcid',
+      },
+    };
+  });
+
+  const getElements = wrapper => {
+    const emailFormSelector = '[data-testid="email-form"]';
+    const passwordFormSelector = '[data-testid="password-form"]';
+
+    return {
+      emailForm: {
+        form: wrapper.find(emailFormSelector),
+        csrfInput: wrapper.find(
+          `${emailFormSelector} input[name="csrf_token"]`,
+        ),
+        formIdInput: wrapper.find(
+          `${emailFormSelector} input[name="__formid__"]`,
+        ),
+        emailField: wrapper.find(
+          `${emailFormSelector} TextField[name="email"]`,
+        ),
+        passwordField: wrapper.find(
+          `${emailFormSelector} TextField[name="password"]`,
+        ),
+        submitButton: wrapper.find(
+          `${emailFormSelector} [data-testid="submit-button"]`,
+        ),
+      },
+      passwordForm: {
+        form: wrapper.find(passwordFormSelector),
+        csrfInput: wrapper.find(
+          `${passwordFormSelector} input[name="csrf_token"]`,
+        ),
+        formIdInput: wrapper.find(
+          `${passwordFormSelector} input[name="__formid__"]`,
+        ),
+        currentPasswordField: wrapper.find(
+          `${passwordFormSelector} TextField[name="password"]`,
+        ),
+        newPasswordField: wrapper.find(
+          `${passwordFormSelector} TextField[name="new_password"]`,
+        ),
+        confirmNewPasswordField: wrapper.find(
+          `${passwordFormSelector} TextField[name="new_password_confirm"]`,
+        ),
+        submitButton: wrapper.find(
+          `${passwordFormSelector} [data-testid="submit-button"]`,
+        ),
+      },
+      connectAccountEl: wrapper.find('[data-testid="connect-your-account"]'),
+      connectAccountLinks: {
+        google: wrapper.find('[data-testid="connect-account-link-google"]'),
+        facebook: wrapper.find('[data-testid="connect-account-link-facebook"]'),
+        orcid: wrapper.find('[data-testid="connect-account-link-orcid"]'),
+      },
+    };
+  };
+
+  const createWrapper = () => {
+    const wrapper = mount(
+      <Config.Provider value={fakeConfig}>
+        <AccountSettingsForms />
+      </Config.Provider>,
+    );
+    const elements = getElements(wrapper);
+    return { wrapper, elements };
+  };
+
+  it('includes the CSRF token in the forms', () => {
+    const { elements } = createWrapper();
+
+    assert.equal(elements.emailForm.csrfInput.prop('value'), 'fakeCsrfToken');
+    assert.equal(
+      elements.passwordForm.csrfInput.prop('value'),
+      'fakeCsrfToken',
+    );
+  });
+
+  it('includes the right __formid__ elements in the forms', () => {
+    const { elements } = createWrapper();
+
+    assert.equal(elements.emailForm.formIdInput.prop('value'), 'email');
+    assert.equal(elements.passwordForm.formIdInput.prop('value'), 'password');
+  });
+
+  it('renders the forms with empty fields', () => {
+    const { elements } = createWrapper();
+
+    assert.equal(elements.emailForm.emailField.prop('value'), '');
+    assert.equal(elements.emailForm.emailField.prop('placeholder'), undefined);
+    assert.equal(elements.emailForm.emailField.prop('fieldError'), undefined);
+    assert.equal(elements.emailForm.passwordField.prop('value'), '');
+    assert.equal(
+      elements.emailForm.passwordField.prop('fieldError'),
+      undefined,
+    );
+    assert.equal(elements.passwordForm.currentPasswordField.prop('value'), '');
+    assert.equal(
+      elements.passwordForm.currentPasswordField.prop('fieldError'),
+      undefined,
+    );
+    assert.equal(elements.passwordForm.newPasswordField.prop('value'), '');
+    assert.equal(
+      elements.passwordForm.newPasswordField.prop('fieldError'),
+      undefined,
+    );
+    assert.equal(
+      elements.passwordForm.confirmNewPasswordField.prop('value'),
+      '',
+    );
+    assert.equal(
+      elements.passwordForm.confirmNewPasswordField.prop('fieldError'),
+      undefined,
+    );
+  });
+
+  it('pre-fills the forms fields with data from js-config', () => {
+    fakeConfig.forms.email.data = {
+      email: 'email.prefilled.email',
+      password: 'email.prefilled.password',
+    };
+    fakeConfig.forms.password.data = {
+      password: 'password.prefilled.password',
+      new_password: 'password.prefilled.new_password',
+      new_password_confirm: 'password.prefilled.new_password_confirm',
+    };
+
+    const { elements } = createWrapper();
+
+    assert.equal(
+      elements.emailForm.emailField.prop('value'),
+      fakeConfig.forms.email.data.email,
+    );
+    assert.equal(
+      elements.emailForm.passwordField.prop('value'),
+      fakeConfig.forms.email.data.password,
+    );
+    assert.equal(
+      elements.passwordForm.currentPasswordField.prop('value'),
+      fakeConfig.forms.password.data.password,
+    );
+    assert.equal(
+      elements.passwordForm.newPasswordField.prop('value'),
+      fakeConfig.forms.password.data.new_password,
+    );
+    assert.equal(
+      elements.passwordForm.confirmNewPasswordField.prop('value'),
+      fakeConfig.forms.password.data.new_password_confirm,
+    );
+  });
+
+  it('adds placeholder text to the email field', () => {
+    fakeConfig.context.user = { email: 'current_email' };
+
+    const { elements } = createWrapper();
+
+    assert.equal(
+      elements.emailForm.emailField.prop('placeholder'),
+      'current_email',
+    );
+  });
+
+  it('omits confirm password fields if the user has no password', () => {
+    fakeConfig.context.user.has_password = false;
+
+    const { elements } = createWrapper();
+
+    assert.isTrue(elements.emailForm.passwordField.isEmpty());
+    assert.isTrue(elements.passwordForm.currentPasswordField.isEmpty());
+  });
+
+  it('renders per-field error messages from js-config', () => {
+    fakeConfig.forms.email.errors = {
+      email: 'email.error.email',
+      password: 'email.error.password',
+    };
+    fakeConfig.forms.password.errors = {
+      password: 'password.error.password',
+      new_password: 'password.error.new_password',
+      new_password_confirm: 'password.error.new_password_confirm',
+    };
+
+    const { elements } = createWrapper();
+
+    assert.equal(
+      elements.emailForm.emailField.prop('fieldError'),
+      fakeConfig.forms.email.errors.email,
+    );
+    assert.equal(
+      elements.emailForm.passwordField.prop('fieldError'),
+      fakeConfig.forms.email.errors.password,
+    );
+    assert.equal(
+      elements.passwordForm.currentPasswordField.prop('fieldError'),
+      fakeConfig.forms.password.errors.password,
+    );
+    assert.equal(
+      elements.passwordForm.newPasswordField.prop('fieldError'),
+      fakeConfig.forms.password.errors.new_password,
+    );
+    assert.equal(
+      elements.passwordForm.confirmNewPasswordField.prop('fieldError'),
+      fakeConfig.forms.password.errors.new_password_confirm,
+    );
+  });
+
+  it('includes the social connect links', () => {
+    const { elements } = createWrapper();
+
+    assert.equal(
+      elements.connectAccountLinks.google.prop('href'),
+      fakeConfig.routes['oidc.connect.google'],
+    );
+    assert.equal(
+      elements.connectAccountLinks.facebook.prop('href'),
+      fakeConfig.routes['oidc.connect.facebook'],
+    );
+    assert.equal(
+      elements.connectAccountLinks.orcid.prop('href'),
+      fakeConfig.routes['oidc.connect.orcid'],
+    );
+  });
+
+  it('indicates when social accounts are already connected', () => {
+    fakeConfig.context.identities.google.connected = true;
+    fakeConfig.context.identities.facebook.connected = true;
+    fakeConfig.context.identities.orcid.connected = true;
+    fakeConfig.context.identities.orcid.url =
+      'https://orcid.org/0000-0002-6373-1308';
+
+    const { elements } = createWrapper();
+
+    assert.equal(elements.connectAccountLinks.google.prop('href'), undefined);
+    assert.equal(elements.connectAccountLinks.facebook.prop('href'), undefined);
+    assert.equal(
+      elements.connectAccountLinks.orcid.prop('href'),
+      'https://orcid.org/0000-0002-6373-1308',
+    );
+  });
+
+  it('omits the social account links when the features are disabled', () => {
+    fakeConfig.features.log_in_with_google = false;
+    fakeConfig.features.log_in_with_facebook = false;
+    fakeConfig.features.log_in_with_orcid = false;
+
+    const { elements } = createWrapper();
+
+    assert.isTrue(elements.connectAccountEl.isEmpty());
+    assert.isTrue(elements.connectAccountLinks.google.isEmpty());
+    assert.isTrue(elements.connectAccountLinks.facebook.isEmpty());
+    assert.isTrue(elements.connectAccountLinks.orcid.isEmpty());
+  });
+
+  it(
+    'passes a11y checks',
+    checkAccessibility({ content: () => createWrapper().wrapper }),
+  );
+});

--- a/h/static/scripts/login-forms/components/test/AccountSettingsForms-test.js
+++ b/h/static/scripts/login-forms/components/test/AccountSettingsForms-test.js
@@ -51,6 +51,9 @@ describe('AccountSettingsForms', () => {
         formIdInput: wrapper.find(
           `${emailFormSelector} input[name="__formid__"]`,
         ),
+        currentEmail: wrapper.find(
+          `${emailFormSelector} [data-testid="current-email"]`,
+        ),
         emailField: wrapper.find(
           `${emailFormSelector} TextField[name="email"]`,
         ),
@@ -122,7 +125,7 @@ describe('AccountSettingsForms', () => {
     const { elements } = createWrapper();
 
     assert.equal(elements.emailForm.emailField.prop('value'), '');
-    assert.equal(elements.emailForm.emailField.prop('placeholder'), undefined);
+    assert.isTrue(elements.emailForm.currentEmail.isEmpty());
     assert.equal(elements.emailForm.emailField.prop('fieldError'), undefined);
     assert.equal(elements.emailForm.passwordField.prop('value'), '');
     assert.equal(
@@ -184,15 +187,12 @@ describe('AccountSettingsForms', () => {
     );
   });
 
-  it('adds placeholder text to the email field', () => {
+  it('shows the current email address', () => {
     fakeConfig.context.user = { email: 'current_email' };
 
     const { elements } = createWrapper();
 
-    assert.equal(
-      elements.emailForm.emailField.prop('placeholder'),
-      'current_email',
-    );
+    assert.equal(elements.emailForm.currentEmail.text(), 'current_email');
   });
 
   it('omits confirm password fields if the user has no password', () => {

--- a/h/static/scripts/login-forms/components/test/AccountSettingsForms-test.js
+++ b/h/static/scripts/login-forms/components/test/AccountSettingsForms-test.js
@@ -125,7 +125,7 @@ describe('AccountSettingsForms', () => {
     const { elements } = createWrapper();
 
     assert.equal(elements.emailForm.emailField.prop('value'), '');
-    assert.isTrue(elements.emailForm.currentEmail.isEmpty());
+    assert.isFalse(elements.emailForm.currentEmail.exists());
     assert.equal(elements.emailForm.emailField.prop('fieldError'), undefined);
     assert.equal(elements.emailForm.passwordField.prop('value'), '');
     assert.equal(
@@ -200,8 +200,8 @@ describe('AccountSettingsForms', () => {
 
     const { elements } = createWrapper();
 
-    assert.isTrue(elements.emailForm.passwordField.isEmpty());
-    assert.isTrue(elements.passwordForm.currentPasswordField.isEmpty());
+    assert.isFalse(elements.emailForm.passwordField.exists());
+    assert.isFalse(elements.passwordForm.currentPasswordField.exists());
   });
 
   it('renders per-field error messages from js-config', () => {
@@ -280,10 +280,10 @@ describe('AccountSettingsForms', () => {
 
     const { elements } = createWrapper();
 
-    assert.isTrue(elements.connectAccountEl.isEmpty());
-    assert.isTrue(elements.connectAccountLinks.google.isEmpty());
-    assert.isTrue(elements.connectAccountLinks.facebook.isEmpty());
-    assert.isTrue(elements.connectAccountLinks.orcid.isEmpty());
+    assert.isFalse(elements.connectAccountEl.exists());
+    assert.isFalse(elements.connectAccountLinks.google.exists());
+    assert.isFalse(elements.connectAccountLinks.facebook.exists());
+    assert.isFalse(elements.connectAccountLinks.orcid.exists());
   });
 
   it(

--- a/h/static/scripts/login-forms/components/test/AppRoot-test.js
+++ b/h/static/scripts/login-forms/components/test/AppRoot-test.js
@@ -23,6 +23,7 @@ describe('AppRoot', () => {
     config = { csrfToken: 'fake-csrf-token', features: {} };
 
     $imports.$mock({
+      './AccountSettingsForms': mockComponent('AccountSettingsForms'),
       './LoginForm': mockComponent('LoginForm'),
       './SignupForm': mockComponent('SignupForm'),
       './SignupSelectForm': mockComponent('SignupSelectForm'),
@@ -129,6 +130,11 @@ describe('AppRoot', () => {
   });
 
   [
+    {
+      path: '/account/settings',
+      selector: 'AccountSettingsForms',
+      props: {},
+    },
     {
       path: '/login',
       selector: 'LoginForm',

--- a/h/static/scripts/login-forms/config.ts
+++ b/h/static/scripts/login-forms/config.ts
@@ -50,6 +50,49 @@ export type SignupConfigObject = ConfigBase & {
   identity?: SocialLoginIdentity;
 };
 
-export type ConfigObject = LoginConfigObject | SignupConfigObject;
+/** Configuration for the 'Account settings' forms. */
+export type AccountSettingsConfigObject = ConfigBase & {
+  forms: {
+    email: FormFields<{
+      email: string;
+      password: string;
+    }>;
+    password: FormFields<{
+      password: string;
+      new_password: string;
+      new_password_confirm: string;
+    }>;
+  };
+  context: {
+    user: { email: string; has_password: boolean };
+    identities?: {
+      google: {
+        connected: boolean;
+        provider_unique_id?: string;
+        url?: string;
+      };
+      facebook: {
+        connected: boolean;
+        provider_unique_id?: string;
+        url?: string;
+      };
+      orcid: {
+        connected: boolean;
+        provider_unique_id?: string;
+        url?: string;
+      };
+    };
+  };
+  routes?: {
+    'oidc.connect.google'?: string;
+    'oidc.connect.facebook'?: string;
+    'oidc.connect.orcid'?: string;
+  };
+};
+
+export type ConfigObject =
+  | LoginConfigObject
+  | SignupConfigObject
+  | AccountSettingsConfigObject;
 
 export const Config = createContext<ConfigObject | null>(null);

--- a/h/static/scripts/login-forms/routes.ts
+++ b/h/static/scripts/login-forms/routes.ts
@@ -12,4 +12,5 @@ export const routes = {
   signupWithGoogle: '/signup/google',
   signupWithORCID: '/signup/orcid',
   signupWithFacebook: '/signup/facebook',
+  accountSettings: '/account/settings',
 };

--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -5,81 +5,25 @@
 
 {% block styles %}
   {{ super() }}
-  {% for url in asset_urls('sociallogin_css') %}
+
+  {% for url in asset_urls('forms_css')  %}
     <link rel="stylesheet" href="{{ url }}">
   {% endfor %}
 {% endblock %}
 
 {% block page_content %}
-  <div class="form-vertical">
-    {{ email_form }}
-    {{ password_form }}
-
-    {% if log_in_with_orcid or log_in_with_google %}
-      <div class="sociallogin-wrapper">
-        <div class="sociallogin-header">
-          <div style="position: relative;">
-            <div class="form-input__label js-tooltip"
-                 style="position: static;"
-                 aria-label="Connecting an account enables you to log in to Hypothesis without your Hypothesis password.">
-              Connect your account
-              <i class="form-input__hint-icon">{{ svg_icon('info_icon') }}</i>
-            </div>
-          </div>
-        </div>
-
-        {% if log_in_with_orcid %}
-        {% if orcid %}
-          <a href="{{ orcid_url }}" class="sociallogin-connect" target="_blank" rel="nofollow noopener">
-            {{ svg_icon('orcid') }}
-            <span>{% trans %} Connected: {% endtrans %}<strong>{{ orcid }}</strong></span>
-            {{ svg_icon('check', 'check-icon') }}
-          </a>
-        {% else %}
-          <a href="{{ request.route_path('oidc.connect.orcid') }}" class="sociallogin-connect">
-            {{ svg_icon('orcid') }}
-            <span>{% trans %} Connect {% endtrans %}<strong>ORCID iD</strong></span>
-            {{ svg_icon('external', 'external-icon') }}
-          </a>
-        {% endif %}
-        {% endif %}
-
-        {% if log_in_with_google %}
-        {% if google_id %}
-          <a class="sociallogin-connect" target="_blank" rel="nofollow noopener">
-            {{ svg_icon('google') }}
-            <span>{% trans %} Connected: {% endtrans %}<strong>{{ google_id }}</strong></span>
-            {{ svg_icon('check', 'check-icon') }}
-          </a>
-        {% else %}
-          <a href="{{ request.route_path('oidc.connect.google') }}" class="sociallogin-connect">
-            {{ svg_icon('google') }}
-            <span>{% trans %} Connect {% endtrans %}<strong>Google account</strong></span>
-            {{ svg_icon('external', 'external-icon') }}
-          </a>
-        {% endif %}
-        {% endif %}
-
-        {% if log_in_with_facebook %}
-        {% if facebook_id %}
-          <a class="sociallogin-connect" target="_blank" rel="nofollow noopener">
-            {{ svg_icon('facebook-sociallogin') }}
-            <span>{% trans %} Connected: {% endtrans %}<strong>{{ facebook_id }}</strong></span>
-            {{ svg_icon('check', 'check-icon') }}
-          </a>
-        {% else %}
-          <a href="{{ request.route_path('oidc.connect.facebook') }}" class="sociallogin-connect">
-            {{ svg_icon('facebook-sociallogin') }}
-            <span>{% trans %} Connect {% endtrans %}<strong>Facebook account</strong></span>
-            {{ svg_icon('external', 'external-icon') }}
-          </a>
-        {% endif %}
-        {% endif %}
-      </div>
-    {% endif %}
-  </div>
+  <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
+  <div id="login-form"></div>
 {% endblock page_content %}
 
 {% block form_footer_right %}
 <a class="link--footer" href="{{ request.route_path('account_delete') }}">{% trans %}Delete your account{% endtrans %}</a>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+
+  {% for url in asset_urls('login_forms_js') %}
+    <script type="module" src="{{ url }}"></script>
+  {% endfor %}
 {% endblock %}

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -510,30 +510,34 @@ class AccountController:
         )
 
     def _template_data(self, js_config=None):
-        js_config_ = {
-            "csrfToken": get_csrf_token(self.request),
-            "forms": {
-                "email": {"data": {}, "errors": {}},
-                "password": {"data": {}, "errors": {}},
-            },
-            "features": {
-                f"log_in_with_{provider.name.lower()}": self.request.feature(
-                    f"log_in_with_{provider.name.lower()}"
-                )
-                for provider in IdentityProvider
-            },
-            "context": {
-                "user": {
-                    "email": self.request.user.email or None,
-                    "has_password": bool(self.request.user.password),
-                },
-            },
-        }
+        js_config = js_config or {}
+        js_config.setdefault("csrfToken", get_csrf_token(self.request))
+        js_config.setdefault("forms", {})
+        js_config["forms"].setdefault("email", {})
+        js_config["forms"]["email"].setdefault("data", {})
+        js_config["forms"]["email"].setdefault("errors", {})
+        js_config["forms"].setdefault("password", {})
+        js_config["forms"]["password"].setdefault("data", {})
+        js_config["forms"]["password"].setdefault("errors", {})
+        js_config.setdefault("features", {})
+        for provider in IdentityProvider:
+            js_config["features"].setdefault(
+                f"log_in_with_{provider.name.lower()}",
+                self.request.feature(f"log_in_with_{provider.name.lower()}"),
+            )
+        js_config.setdefault("context", {})
+        js_config["context"].setdefault("user", {})
+        js_config["context"]["user"].setdefault(
+            "email", self.request.user.email or None
+        )
+        js_config["context"]["user"].setdefault(
+            "has_password", bool(self.request.user.password)
+        )
 
         oidc_svc = self.request.find_service(OIDCService)
 
         for provider in IdentityProvider:
-            if js_config_["features"][f"log_in_with_{provider.name.lower()}"]:
+            if js_config["features"][f"log_in_with_{provider.name.lower()}"]:
                 provider_config = {}
                 identity = oidc_svc.get_identity(self.request.user, provider)
 
@@ -543,29 +547,29 @@ class AccountController:
                 else:
                     provider_config["connected"] = False
 
-                js_config_["context"].setdefault("identities", {})
-                js_config_["context"]["identities"][provider.name.lower()] = {}
+                js_config["context"].setdefault("identities", {})
+                js_config["context"]["identities"].setdefault(provider.name.lower(), {})
                 for key, value in provider_config.items():
-                    js_config_["context"]["identities"][provider.name.lower()][key] = (
-                        value
-                    )
+                    js_config["context"]["identities"][
+                        provider.name.lower()
+                    ].setdefault(key, value)
 
                 route_name = f"oidc.connect.{provider.name.lower()}"
-                js_config_.setdefault("routes", {})
-                js_config_["routes"][route_name] = self.request.route_url(route_name)
+                js_config.setdefault("routes", {})
+                js_config["routes"].setdefault(
+                    route_name, self.request.route_url(route_name)
+                )
 
-        orcid_config = js_config_["context"].get("identities", {}).get("orcid", {})
+        orcid_config = js_config["context"].get("identities", {}).get("orcid", {})
         if orcid_id := orcid_config.get("provider_unique_id"):
             orcid_host = self.request.registry.settings["orcid_host"]
             # The URL to the user's public ORCID profile page
             # (for example: https://orcid.org/0000-0002-6373-1308).
-            orcid_config["url"] = urlunparse(
-                urlparse(orcid_host)._replace(path=orcid_id)
+            orcid_config.setdefault(
+                "url", urlunparse(urlparse(orcid_host)._replace(path=orcid_id))
             )
 
-        js_config_.update(js_config or {})
-
-        return {"js_config": js_config_}
+        return {"js_config": js_config}
 
 
 @view_defaults(

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -546,9 +546,9 @@ class AccountController:
                 js_config_["context"].setdefault("identities", {})
                 js_config_["context"]["identities"][provider.name.lower()] = {}
                 for key, value in provider_config.items():
-                    js_config_["context"]["identities"][provider.name.lower()][
-                        key
-                    ] = value
+                    js_config_["context"]["identities"][provider.name.lower()][key] = (
+                        value
+                    )
 
                 route_name = f"oidc.connect.{provider.name.lower()}"
                 js_config_.setdefault("routes", {})

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -23,6 +23,18 @@ TEST_SETTINGS = {
     "h_api_auth_cookie_secret_key": b"test_h_api_auth_cookie_secret_key",
     "h_api_auth_cookie_salt": b"test_h_api_auth_cookie_salt",
     "sqlalchemy.url": os.environ["DATABASE_URL"],
+    "oidc_clientid_orcid": "test_oidcclientid_orcid",
+    "oidc_clientsecret_orcid": "test_oidcclientid_orcid",
+    "oidc_tokenurl_orcid": "test_oidc_tokenurl_orcid",
+    "oidc_keyseturl_orcid": "test_oidc_keyseturl_orcid",
+    "oidc_clientid_google": "test_oidcclientid_google",
+    "oidc_clientsecret_google": "test_oidcclientid_google",
+    "oidc_tokenurl_google": "test_oidc_tokenurl_google",
+    "oidc_keyseturl_google": "test_oidc_keyseturl_google",
+    "oidc_clientid_facebook": "test_oidcclientid_facebook",
+    "oidc_clientsecret_facebook": "test_oidcclientid_facebook",
+    "oidc_tokenurl_facebook": "test_oidc_tokenurl_facebook",
+    "oidc_keyseturl_facebook": "test_oidc_keyseturl_facebook",
 }
 
 TEST_ENVIRONMENT = {


### PR DESCRIPTION
We need to allow user who don't have a password to add an email address to their account or change their email address without asking them to confirm their (non-existent) password, while still requiring users who _do_ have a password to confirm their. The way the existing code for the `/account/settings` page works makes this really difficult to do, see [Slack thread](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1754501925291849).

This PR replaces the main body of the `/account/settings` page (the part containing the change-email and change-password forms and the connect-account links) with a completely new version written in Preact.

The new page is functionally equivalent to the old except that it allows users with no password to add/change their email addresses. It also allows users with no password to add a password to their account, but that's already possible on `main` too.

### Todo

- [ ] Remove unused code. This includes some functionality that was added to `handle_form_submission()` and some legacy CSS for the connect-account links.

### Further work

- Indicate when a form contains unsaved values.  
  This can be either because the form has been edited but not yet submitted, or because it has been submitted but returned with validation errors.
- Related: disable the **Save** buttons when the forms don't contain any unsaved values.
- Don't show all the form fields all the time. For example for the email form just show the current email address and a <kbd>Change email address</kbd> button that, when clicked, expands into the change-email address form. And the same for the password form.
- Add frontend validation of the email address field.  
  The frontend can't validate that the email address isn't already taken by another user. But can it at least check that the email address is validly formed?
- Add frontend validation of the 'confirm new password' field: check that it's the same as what's in the 'new password' field.
- On page load if there are validation errors auto-focus the first field that has errors

### Testing the forms

- Go to <http://localhost:5000/signup> and sign up using Google or Facebook. This will log you into an account that has no password or email address.
- [x] Go to <http://localhost:5000/account/settings>. You should see forms for adding an email address and password that do not require you to confirm your current password.
- [x] Test that you can add an email address to your account without a password.
- [x] Test that you can add a password to your account. As soon as you do this both forms will change to require current password confirmation.
- [x] Test that you can change your email address and password again, confirming your current password.  
- Test the validation. For example:
  - [x] Try leaving the required form fields empty and submitting the forms
  - [x] Try entering an invalid email address
  - [x] Try entering an email address that's already taken, for example `user@example.com`
  - [x] Try entering a password that is too short
  - [x] Try entering the wrong value in the confirm-new-password field
  - [x] Try entering the wrong current password (both when changing your email address and when changing your password)

### Testing the "Connect your account" links

- [x] Load <http://localhost:5000/account/settings> with all three feature flags (`log_in_with_google`, `log_in_with_facebook` and `log_in_with_orcid`) disabled: you should see no **Connect your account** section at all.
- [x] Enable one of the feature flags and you should see the **Connect your account** section appear with just that provider
- [x] Enable the other two feature flags and the other two providers should appear
- [x] For all three providers, when your account is not connected, you should see a _Connect **PROVIDER**_ button with an upwards-right arrow
- [x] For all three providers you should be able to connect your account and then see a _Connect **ID**_ badge with a checkmark icon
  * Note that for ORCID you'll have to change to <http://hypothesis.local:5000/account/settings> in order to connect (and you may have to log in again if you get a 404)
  - [x] You should see a flash message after connecting each account
- [x] When your Google or Facebook account is connected the badge will have no `href`
- [x] When your ORCID account is connected the badge should link to your ORCID profile