### PR TITLE
Fix error when accessing anno.moderation_status without None check

### DIFF
--- a/h/schemas/api/moderation.py
+++ b/h/schemas/api/moderation.py
@@ -4,6 +4,7 @@ import colander
 from pyramid import httpexceptions
 
 from h.models import Annotation
+from h.models.annotation import ModerationStatus
 
 
 class ModerationStatusNode(colander.SchemaNode):
@@ -32,7 +33,9 @@ class ChangeAnnotationModerationStatusSchema(colander.Schema):
         self._annotation = annotation
 
     def validator(self, _node, cstruct):
-        current_anno_status = self._annotation.moderation_status.value
+        current_anno_status = (
+            self._annotation.moderation_status or ModerationStatus.APPROVED
+        ).value
         if all(
             [
                 current_status_param := cstruct["current_moderation_status"],

--- a/tests/unit/h/views/api/moderation_test.py
+++ b/tests/unit/h/views/api/moderation_test.py
@@ -187,6 +187,24 @@ class TestChangeAnnotationModerationStatus:
             == "The annotation has been moderated since it was loaded."
         )
 
+    def test_conflicting_prev_status_with_unmoderated_annotation(
+        self,
+        valid_payload_with_prev_status,
+        annotation_context,
+        pyramid_request,
+    ):
+        pyramid_request.json_body = valid_payload_with_prev_status
+
+        with pytest.raises(httpexceptions.HTTPConflict) as excinfo:
+            views.change_annotation_moderation_status(
+                annotation_context, pyramid_request
+            )
+
+        assert (
+            str(excinfo.value)
+            == "The annotation has been moderated since it was loaded."
+        )
+
     @pytest.fixture
     def valid_payload(self, annotation):
         return {
@@ -196,7 +214,7 @@ class TestChangeAnnotationModerationStatus:
 
     @pytest.fixture
     def valid_payload_with_prev_status(self, valid_payload):
-        valid_payload["current_moderation_status"] = "APPROVED"
+        valid_payload["current_moderation_status"] = "PENDING"
         return valid_payload
 
     @pytest.fixture


### PR DESCRIPTION
This fixes this sentry issue https://hypothesis.sentry.io/issues/6798522219, caused when trying to access `value` on `annotation.moderation_status`, without taking into consideration that `annotation.moderation_status` can be `None`.

A better solution would be probably to initialize `annotation.moderation_status` to `ModerationStatus.APPROVED`, but that requires a bit more investigation. This should fix the immediate issue in production.