### PR TITLE
Allow long texts to be collapsed in the moderation queue

### DIFF
--- a/h/static/scripts/group-forms/components/AnnotationCard.tsx
+++ b/h/static/scripts/group-forms/components/AnnotationCard.tsx
@@ -3,6 +3,7 @@ import {
   AnnotationShareControl,
   AnnotationTimestamps,
   AnnotationUser,
+  Excerpt,
   ModerationStatusSelect,
   StyledText,
 } from '@hypothesis/annotation-ui';
@@ -126,6 +127,8 @@ export default function AnnotationCard({
     ? config.routes['activity.user_search'].replace(':username', username)
     : undefined;
 
+  const annoQuote = quote(annotation);
+
   return useMemo(
     () => (
       <article>
@@ -166,19 +169,25 @@ export default function AnnotationCard({
               </div>
             </header>
 
-            <StyledText>
-              <blockquote className="hover:border-l-blue-quote">
-                {quote(annotation)}
-              </blockquote>
-            </StyledText>
+            {annoQuote && (
+              <Excerpt collapsedHeight={40} overflowThreshold={20}>
+                <StyledText>
+                  <blockquote className="hover:border-l-blue-quote">
+                    {annoQuote}
+                  </blockquote>
+                </StyledText>
+              </Excerpt>
+            )}
 
-            <MarkdownView
-              markdown={annotation.text}
-              mentions={annotation.mentions}
-              mentionMode="username"
-              mentionsEnabled
-              classes="text-color-text"
-            />
+            <Excerpt collapsedHeight={194} overflowThreshold={20}>
+              <MarkdownView
+                markdown={annotation.text}
+                mentions={annotation.mentions}
+                mentionMode="username"
+                mentionsEnabled
+                classes="text-color-text"
+              />
+            </Excerpt>
 
             {annotation.tags.length > 0 && (
               <ul
@@ -249,6 +258,7 @@ export default function AnnotationCard({
       </article>
     ),
     [
+      annoQuote,
       annotation,
       group,
       isReply,

--- a/h/static/scripts/group-forms/components/test/AnnotationCard-test.js
+++ b/h/static/scripts/group-forms/components/test/AnnotationCard-test.js
@@ -191,9 +191,16 @@ describe('AnnotationCard', () => {
     );
   });
 
-  it('extract the annotation quote', () => {
+  it('extracts the annotation quote', () => {
     const wrapper = createComponent();
     assert.equal(wrapper.find('blockquote').text(), 'The quote');
+  });
+
+  it('does not render quote elements for quoteless annotations', () => {
+    fakeAnnotation.target[0].selector = [];
+    const wrapper = createComponent();
+
+    assert.isFalse(wrapper.exists('blockquote'));
   });
 
   ['PENDING', 'APPROVED', 'DENIED', 'SPAM'].forEach(status => {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@babel/preset-env": "^7.27.1",
     "@babel/preset-react": "^7.26.3",
     "@babel/preset-typescript": "^7.27.0",
-    "@hypothesis/annotation-ui": "^0.5.0",
+    "@hypothesis/annotation-ui": "^0.6.0",
     "@hypothesis/frontend-build": "^4.0.0",
     "@hypothesis/frontend-shared": "^9.8.0",
     "@rollup/plugin-babel": "^6.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,16 +1969,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/annotation-ui@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@hypothesis/annotation-ui@npm:0.5.0"
+"@hypothesis/annotation-ui@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@hypothesis/annotation-ui@npm:0.6.0"
   peerDependencies:
     "@hypothesis/frontend-shared": ^9.4.0
     dompurify: ^3.0.0
     escape-html: ^1.0.3
     katex: ^0.16.0
     showdown: ^2.0.0
-  checksum: e35e8ddfa5e5393b6d4cd43614abfb7ca5cd12da498016fc17807cfeac701227d0f1c46b595e7700ae447673146847c9d91319d6aecb9b7b92c39554dc8eb01f
+  checksum: 95ed0dcd56524273d4184d81b7ebd7ee58b5f6489f06713053966cfc8c03bab48cc8a72240c42b196a31e7b615de6c91de85f38df8661b506fd61baf5c5e235a
   languageName: node
   linkType: hard
 
@@ -6946,7 +6946,7 @@ __metadata:
     "@babel/preset-env": ^7.27.1
     "@babel/preset-react": ^7.26.3
     "@babel/preset-typescript": ^7.27.0
-    "@hypothesis/annotation-ui": ^0.5.0
+    "@hypothesis/annotation-ui": ^0.6.0
     "@hypothesis/frontend-build": ^4.0.0
     "@hypothesis/frontend-shared": ^9.8.0
     "@hypothesis/frontend-testing": ^1.7.1


### PR DESCRIPTION
Part of https://github.com/hypothesis/h/issues/9808
Depends on https://github.com/hypothesis/annotation-ui/pull/66

Add initial support to collapse annotation bodies and quotes when they are too long, providing an experience similar to the one in the client.

This PR just uses the default "More"/"Less" controls to expand/collapse the content, but we'll be improving that afterwards.

[Grabación de pantalla desde 2025-08-11 10-50-08.webm](https://github.com/user-attachments/assets/f350bc19-3642-4cef-bdcd-99b7dfc6d624)
