### PR TITLE
Fix cropped words in anno body when they are longer than the card

### DIFF
--- a/h/static/scripts/group-forms/components/AnnotationCard.tsx
+++ b/h/static/scripts/group-forms/components/AnnotationCard.tsx
@@ -185,7 +185,7 @@ export default function AnnotationCard({
                 mentions={annotation.mentions}
                 mentionMode="username"
                 mentionsEnabled
-                classes="text-color-text"
+                classes="text-color-text hyp-wrap-anywhere"
               />
             </Excerpt>
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/preset-typescript": "^7.27.0",
     "@hypothesis/annotation-ui": "^0.6.0",
     "@hypothesis/frontend-build": "^4.0.0",
-    "@hypothesis/frontend-shared": "^9.8.0",
+    "@hypothesis/frontend-shared": "^9.9.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,15 +2009,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^9.8.0":
-  version: 9.8.0
-  resolution: "@hypothesis/frontend-shared@npm:9.8.0"
+"@hypothesis/frontend-shared@npm:^9.9.0":
+  version: 9.9.0
+  resolution: "@hypothesis/frontend-shared@npm:9.9.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: 053fbea7b5235a15dd7a9ddf4352ec47fbbaff6f967f4d05d3e8897cbac5b9bc873454cba982b22ddeab22022e1e5150133082b9526e7d7af0abb55ef1b125b7
+  checksum: 7101630bf111e448deb28571daab98cd700bdafaa747012073634f5927368ac42961ca32180fe0e1cfd24e3bd31475dbcd7ecddb4e5fb030d8bf73d3f2488bef
   languageName: node
   linkType: hard
 
@@ -6948,7 +6948,7 @@ __metadata:
     "@babel/preset-typescript": ^7.27.0
     "@hypothesis/annotation-ui": ^0.6.0
     "@hypothesis/frontend-build": ^4.0.0
-    "@hypothesis/frontend-shared": ^9.8.0
+    "@hypothesis/frontend-shared": ^9.9.0
     "@hypothesis/frontend-testing": ^1.7.1
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.3


### PR DESCRIPTION
Fix an issue in the moderation queue, where individual words that are longer than an annotation card would get cropped instead of wrapping multiple lines.

This is done by taking advantage of the utility introduced in https://github.com/hypothesis/frontend-shared/pull/2056

This utility will be implicitly used in `@hypothesis/annotation-ui`'s `MarkdownView` eventually, but for now this solves the problem here without having to release another version of the library.

This is how an annotation with a very long word looked before:
<img width="713" height="230" alt="Captura desde 2025-08-11 15-35-41" src="https://github.com/user-attachments/assets/50b72a90-0627-4b01-a078-8fc19879fa6e" />

Vs how it looks now:
<img width="713" height="274" alt="Captura desde 2025-08-11 15-36-28" src="https://github.com/user-attachments/assets/1c261ea8-fb2c-48cf-9fb5-fd755a2fe18d" />
