### PR TITLE
Open ORCID profile URLs in new tabs

### DIFF
--- a/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
+++ b/h/static/scripts/login-forms/components/AccountSettingsForms.tsx
@@ -178,6 +178,8 @@ function ConnectAccountButton({
           <span className="grow">
             Connected:{' '}
             <a
+              target="_blank"
+              rel="noreferrer"
               class="font-bold"
               href={providerURL}
               data-testid={`connect-account-link-${provider}`}


### PR DESCRIPTION
This feels right to me since they're external URLs.
