### PR TITLE
Fix error about missing login/signup URLs on `/signup/{provider}` page

### DIFF
--- a/h/static/scripts/login-forms/components/LoginForm.tsx
+++ b/h/static/scripts/login-forms/components/LoginForm.tsx
@@ -93,7 +93,7 @@ export default function LoginForm({ enableSocialLogin }: LoginFormProps) {
             </Button>
           </div>
         </Form>
-        {enableSocialLogin && (
+        {enableSocialLogin && config.urls?.login && (
           <>
             <div className="self-center uppercase">or</div>
             {config.urls.login.google && (

--- a/h/static/scripts/login-forms/components/SignupFooter.tsx
+++ b/h/static/scripts/login-forms/components/SignupFooter.tsx
@@ -18,6 +18,9 @@ export type SignupFooterProps = {
  */
 export default function SignupFooter({ action }: SignupFooterProps) {
   const config = useContext(Config) as SignupConfigObject;
+  if (!config.urls?.login) {
+    return null;
+  }
 
   return (
     <footer

--- a/h/static/scripts/login-forms/components/SignupSelectForm.tsx
+++ b/h/static/scripts/login-forms/components/SignupSelectForm.tsx
@@ -16,6 +16,8 @@ import SocialLoginLink from './SocialLoginLink';
 export default function SignupSelectForm() {
   const config = useContext(Config) as SignupConfigObject;
 
+  const loginURLs = config.urls?.login;
+
   // nb. Options for social login are listed in descending order of expected
   // usage rather than alphabetically.
   return (
@@ -37,21 +39,22 @@ export default function SignupSelectForm() {
           >
             Sign up with <b>email</b>
           </LoginLink>
-          <div className="self-center uppercase">or</div>
-          {config.urls.login.google && (
-            <SocialLoginLink
-              provider="google"
-              href={config.urls.login.google}
-            />
-          )}
-          {config.urls.login.facebook && (
-            <SocialLoginLink
-              provider="facebook"
-              href={config.urls.login.facebook}
-            />
-          )}
-          {config.urls.login.orcid && (
-            <SocialLoginLink provider="orcid" href={config.urls.login.orcid} />
+          {loginURLs && (
+            <>
+              <div className="self-center uppercase">or</div>
+              {loginURLs.google && (
+                <SocialLoginLink provider="google" href={loginURLs.google} />
+              )}
+              {loginURLs.facebook && (
+                <SocialLoginLink
+                  provider="facebook"
+                  href={loginURLs.facebook}
+                />
+              )}
+              {loginURLs.orcid && (
+                <SocialLoginLink provider="orcid" href={loginURLs.orcid} />
+              )}
+            </>
           )}
         </div>
       </div>

--- a/h/static/scripts/login-forms/components/test/SignupFooter-test.js
+++ b/h/static/scripts/login-forms/components/test/SignupFooter-test.js
@@ -26,6 +26,17 @@ describe('SignupFooter', () => {
     };
   });
 
+  it('renders footer if login URL is present', () => {
+    const wrapper = createComponent({ action: 'login' });
+    assert.isTrue(wrapper.exists('footer'));
+  });
+
+  it('renders nothing if login URL is missing', () => {
+    delete fakeConfig.urls;
+    const wrapper = createComponent({ action: 'login' });
+    assert.isFalse(wrapper.exists('footer'));
+  });
+
   describe('when action is "login"', () => {
     it('renders login link with correct href', () => {
       const wrapper = createComponent({ action: 'login' });

--- a/h/static/scripts/login-forms/config.ts
+++ b/h/static/scripts/login-forms/config.ts
@@ -15,9 +15,12 @@ export type ConfigBase = {
     log_in_with_google: boolean;
     log_in_with_orcid: boolean;
   };
-  urls: {
+
+  // URLs for social login. These are present on the login and initial signup
+  // page but missing on the `/signup/{provider}` page.
+  urls?: {
     signup?: string;
-    login: {
+    login?: {
       username_or_email?: string;
       facebook?: string;
       google?: string;


### PR DESCRIPTION
Fix a frontend error when rendering the footer after redirecting back to Hypothesis during signup with social login.

 - Update the types for the JS configuration to reflect that the URLs are not always present.
 - Handle the possibility for these to be missing in each form.