### PR TITLE
Fix JS error if "keydown" event is missing `key` property

### DIFF
--- a/h/static/scripts/controllers/input-autofocus-controller.js
+++ b/h/static/scripts/controllers/input-autofocus-controller.js
@@ -1,8 +1,13 @@
 import { Controller } from '../base/controller';
 
 function isWordChar(event) {
+  // `event.key` should always be a string, but we've seen users (bots?) trigger
+  // the global "keydown" handler with an an event where `key` is undefined.
   return (
-    event.key.match(/^\w$/) && !event.ctrlKey && !event.altKey && !event.metaKey
+    event.key?.match(/^\w$/) &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.metaKey
   );
 }
 

--- a/h/static/scripts/tests/controllers/input-autofocus-controller-test.js
+++ b/h/static/scripts/tests/controllers/input-autofocus-controller-test.js
@@ -66,6 +66,13 @@ describe('InputAutofocusController', () => {
       sendKey('c', { metaKey: true });
       assert.notEqual(document.activeElement, ctrl.element);
     });
+
+    it('should not focus if "keydown" event does not have a `key`', () => {
+      document.activeElement.dispatchEvent(
+        new Event('keydown', { bubbles: true }),
+      );
+      assert.notEqual(document.activeElement, ctrl.element);
+    });
   });
 
   context('when another element has focus', () => {


### PR DESCRIPTION
The "keydown" event argument should always be a `KeyboardEvent` with a `key` property that is a string. In production however we are seeing that there are users (or bots?) that trigger the event with objects that don't have a `key` property. Ignore such events if they happen.

We're not going to try handling this in every "keydown" event handler, just the global "keydown" event handler in h that causes the search field to be focused on activity pages when typing if nothing else is focused.

Fixes https://hypothesis.sentry.io/issues/5592288454