### PR TITLE
Change server-rendered SVG icon display back to `inline`

### DIFF
--- a/h/static/styles/core/_icons.scss
+++ b/h/static/styles/core/_icons.scss
@@ -32,6 +32,10 @@
 // ----------------------------------------------------------------------------
 
 .svg-icon {
+  // Tailwind sets SVG display to block level by default. This undoes that.
+  // See https://tailwindcss.com/docs/preflight#images-are-block-level.
+  display: inline;
+
   // This apparently no-op transform triggers snapping of the <svg> element to
   // the nearest pixel, resulting in sharper rendering of icons, assuming that
   // the icon itself has been pixel-fitted.


### PR DESCRIPTION
Fix a regression from 57f30591fe2d9d19509a72873ca332e0bd4649c9 where applying Tailwind base styles to the whole page changed `<svg>`s rendered by `svg_icon` from inline to block display. This made the clickable area of the Hypothesis logo on the signup page span the whole width of the page. This made it too easy to accidentally click on the logo and get taken to web.hypothes.is.