### PR TITLE
Bind `idinfo` JWTs to session cookies

### DIFF
--- a/h/static/scripts/login-forms/components/SignupForm.tsx
+++ b/h/static/scripts/login-forms/components/SignupForm.tsx
@@ -1,4 +1,4 @@
-import { Button, ExternalIcon } from '@hypothesis/frontend-shared';
+import { Button, CheckIcon } from '@hypothesis/frontend-shared';
 import { useContext, useLayoutEffect, useState } from 'preact/hooks';
 
 import Checkbox from '../../forms-common/components/Checkbox';
@@ -43,7 +43,7 @@ function IdProviderBadge({ provider, identity }: IdProviderBadgeProps) {
       <span className="grow">
         Connected: <b data-testid="connected-id">{identity}</b>
       </span>
-      <ExternalIcon className="w-[20px] h-[20px]" />
+      <CheckIcon className="w-[20px] h-[20px]" />
     </div>
   );
 }

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -1,3 +1,4 @@
+import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -200,6 +201,13 @@ class IDInfo:
 
     sub: str
     """The user's unique ID from the third-party provider."""
+
+    rfp: str
+    """A Request Forgery Protection (RFP) token to protect against CSRF attacks.
+
+    The claim name "rfp" is compatible with
+    https://datatracker.ietf.org/doc/html/draft-bradley-oauth-jwt-encoded-state-09
+    """
 
     email: str | None = None
     name: str | None = None
@@ -537,10 +545,13 @@ def encode_idinfo_token(  # noqa: PLR0913
     audience: JWTAudience,
     next_url: str,
 ):
+    rfp = secrets.token_hex()
+
     return {
         "idinfo": jwt_service.encode_symmetric(
             IDInfo(
                 provider_unique_id,
+                rfp,
                 email,
                 name,
                 given_name,

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -379,6 +379,12 @@ class SocialLoginSignupViews:
         renderer="h:templates/error.html.jinja2",
     )
     def email_conflict_error(self):
+        # Decode the idinfo *before* generating the logout headers because
+        # calling logout() invalidates the session which removes the idinfo
+        # token's rfp (request forgery protection) token from the session
+        # meaning trying to decode the idinfo token will now fail.
+        idinfo = self.decode_idinfo()
+
         # Generate the logout headers *before* setting the flash message
         # because calling logout() invalidates the session which deletes any
         # flash messages.
@@ -392,9 +398,7 @@ class SocialLoginSignupViews:
         )
 
         return HTTPFound(
-            self.request.route_url(
-                "login", _query={"username": self.decode_idinfo().email}
-            ),
+            self.request.route_url("login", _query={"username": idinfo.email}),
             headers=headers,
         )
 

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -535,6 +535,9 @@ def is_authenticated(request):
     )
 
 
+IDINFO_RFP_SESSIONKEY_FMT = "idinfo.rfp.{audience}"
+
+
 def encode_idinfo_token(  # noqa: PLR0913
     jwt_service: JWTService,
     provider_unique_id: str,
@@ -547,9 +550,9 @@ def encode_idinfo_token(  # noqa: PLR0913
     next_url: str,
     session: ISession,
 ):
-    del session
-
     rfp = secrets.token_hex()
+
+    session[IDINFO_RFP_SESSIONKEY_FMT.format(audience=audience)] = rfp
 
     return {
         "idinfo": jwt_service.encode_symmetric(

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -8,6 +8,7 @@ from deform import ValidationFailure
 from h_pyramid_sentry import report_exception
 from pyramid.csrf import get_csrf_token
 from pyramid.httpexceptions import HTTPFound
+from pyramid.interfaces import ISession
 from pyramid.view import exception_view_config, view_config, view_defaults
 
 from h import i18n
@@ -544,7 +545,10 @@ def encode_idinfo_token(  # noqa: PLR0913
     issuer: JWTIssuer,
     audience: JWTAudience,
     next_url: str,
+    session: ISession,
 ):
+    del session
+
     rfp = secrets.token_hex()
 
     return {

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -518,6 +518,7 @@ class SocialLoginSignupViews:
             self.jwt_service,
             self.request.params["idinfo"],
             audience=self.settings.audience,
+            session=self.request.session,
         )
 
 
@@ -576,7 +577,10 @@ def decode_idinfo_token(
     jwt_service: JWTService,
     idinfo_token: str,
     audience: JWTAudience,
+    session: ISession,
 ):
+    del session
+
     try:
         idinfo = jwt_service.decode_symmetric(
             idinfo_token,

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -505,16 +505,11 @@ class SocialLoginSignupViews:
         }
 
     def decode_idinfo(self):
-        try:
-            idinfo = self.jwt_service.decode_symmetric(
-                self.request.params["idinfo"],
-                audience=self.settings.audience,
-                payload_class=IDInfo,
-            )
-        except JWTDecodeError as err:
-            raise IDInfoJWTDecodeError from err
-
-        return idinfo
+        return decode_idinfo_token(
+            self.jwt_service,
+            self.request.params["idinfo"],
+            audience=self.settings.audience,
+        )
 
 
 # It's possible to try to sign up while already logged in. For example: start
@@ -557,6 +552,23 @@ def encode_idinfo_token(  # noqa: PLR0913
             audience=audience,
         ),
     }
+
+
+def decode_idinfo_token(
+    jwt_service: JWTService,
+    idinfo_token: str,
+    audience: JWTAudience,
+):
+    try:
+        idinfo = jwt_service.decode_symmetric(
+            idinfo_token,
+            audience=audience,
+            payload_class=IDInfo,
+        )
+    except JWTDecodeError as err:
+        raise IDInfoJWTDecodeError from err
+
+    return idinfo
 
 
 def redirect_url(request, user, url):

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -579,7 +579,10 @@ def decode_idinfo_token(
     audience: JWTAudience,
     session: ISession,
 ):
-    del session
+    try:
+        expected_rfp = session[IDINFO_RFP_SESSIONKEY_FMT.format(audience=audience)]
+    except KeyError as err:
+        raise IDInfoJWTDecodeError from err
 
     try:
         idinfo = jwt_service.decode_symmetric(
@@ -589,6 +592,9 @@ def decode_idinfo_token(
         )
     except JWTDecodeError as err:
         raise IDInfoJWTDecodeError from err
+
+    if idinfo.rfp != expected_rfp:
+        raise IDInfoJWTDecodeError
 
     return idinfo
 

--- a/h/views/oidc.py
+++ b/h/views/oidc.py
@@ -452,6 +452,7 @@ class OIDCRedirectViews:
                         self.settings.jwt_issuer,
                         self.settings.idinfo_jwtaudience,
                         next_url,
+                        self._request.session,
                     ),
                 )
             )

--- a/tests/unit/h/views/account_signup_test.py
+++ b/tests/unit/h/views/account_signup_test.py
@@ -8,7 +8,6 @@ from pyramid.httpexceptions import HTTPFound
 
 from h import i18n
 from h.models.user_identity import IdentityProvider
-from h.services.exceptions import ConflictError
 from h.services.jwt import JWTAudience, JWTDecodeError
 from h.services.user_signup import (
     EmailConflictError,

--- a/tests/unit/h/views/account_signup_test.py
+++ b/tests/unit/h/views/account_signup_test.py
@@ -890,7 +890,9 @@ def test_encode_idinfo_token(jwt_service, matchers, pyramid_request):
 
 
 def test_decode_idinfo_token_valid(jwt_service):
-    result = decode_idinfo_token(jwt_service, sentinel.idinfo_token, sentinel.audience)
+    result = decode_idinfo_token(
+        jwt_service, sentinel.idinfo_token, sentinel.audience, sentinel.session
+    )
 
     jwt_service.decode_symmetric.assert_called_once_with(
         sentinel.idinfo_token, audience=sentinel.audience, payload_class=IDInfo
@@ -902,7 +904,9 @@ def test_decode_idinfo_token_invalid(jwt_service):
     exception = jwt_service.decode_symmetric.side_effect = JWTDecodeError()
 
     with pytest.raises(IDInfoJWTDecodeError) as exc_info:
-        decode_idinfo_token(jwt_service, sentinel.idinfo_token, sentinel.audience)
+        decode_idinfo_token(
+            jwt_service, sentinel.idinfo_token, sentinel.audience, sentinel.session
+        )
 
     assert exc_info.value.__cause__ == exception
 

--- a/tests/unit/h/views/account_signup_test.py
+++ b/tests/unit/h/views/account_signup_test.py
@@ -858,7 +858,7 @@ def test_is_authenticated(matchers, pyramid_request, authenticated_user):
     )
 
 
-def test_encode_idinfo_token(jwt_service, matchers):
+def test_encode_idinfo_token(jwt_service, matchers, pyramid_request):
     token = encode_idinfo_token(
         jwt_service,
         sentinel.provider_unique_id,
@@ -869,7 +869,7 @@ def test_encode_idinfo_token(jwt_service, matchers):
         sentinel.issuer,
         sentinel.audience,
         sentinel.next_url,
-        sentinel.session,
+        pyramid_request.session,
     )
 
     jwt_service.encode_symmetric.assert_called_once_with(

--- a/tests/unit/h/views/account_signup_test.py
+++ b/tests/unit/h/views/account_signup_test.py
@@ -869,6 +869,7 @@ def test_encode_idinfo_token(jwt_service, matchers):
         sentinel.issuer,
         sentinel.audience,
         sentinel.next_url,
+        sentinel.session,
     )
 
     jwt_service.encode_symmetric.assert_called_once_with(

--- a/tests/unit/h/views/account_signup_test.py
+++ b/tests/unit/h/views/account_signup_test.py
@@ -840,7 +840,7 @@ class TestSocialLoginSignupViews:
 
     @pytest.fixture
     def idinfo(self, orcid_id):
-        return IDInfo(orcid_id)
+        return IDInfo(orcid_id, sentinel.rfp)
 
     @pytest.fixture
     def jwt_service(self, jwt_service, idinfo):
@@ -858,7 +858,7 @@ def test_is_authenticated(matchers, pyramid_request, authenticated_user):
     )
 
 
-def test_encode_idinfo_token(jwt_service):
+def test_encode_idinfo_token(jwt_service, matchers):
     token = encode_idinfo_token(
         jwt_service,
         sentinel.provider_unique_id,
@@ -874,6 +874,7 @@ def test_encode_idinfo_token(jwt_service):
     jwt_service.encode_symmetric.assert_called_once_with(
         IDInfo(
             sentinel.provider_unique_id,
+            matchers.InstanceOf(str),
             sentinel.email,
             sentinel.name,
             sentinel.given_name,

--- a/tests/unit/h/views/account_signup_test.py
+++ b/tests/unit/h/views/account_signup_test.py
@@ -19,6 +19,7 @@ from h.views.account_signup import (
     IDInfoJWTDecodeError,
     SignupViews,
     SocialLoginSignupViews,
+    decode_idinfo_token,
     encode_idinfo_token,
     is_authenticated,
 )
@@ -884,6 +885,24 @@ def test_encode_idinfo_token(jwt_service):
         audience=sentinel.audience,
     )
     assert token == {"idinfo": jwt_service.encode_symmetric.return_value}
+
+
+def test_decode_idinfo_token_valid(jwt_service):
+    result = decode_idinfo_token(jwt_service, sentinel.idinfo_token, sentinel.audience)
+
+    jwt_service.decode_symmetric.assert_called_once_with(
+        sentinel.idinfo_token, audience=sentinel.audience, payload_class=IDInfo
+    )
+    assert result == jwt_service.decode_symmetric.return_value
+
+
+def test_decode_idinfo_token_invalid(jwt_service):
+    exception = jwt_service.decode_symmetric.side_effect = JWTDecodeError()
+
+    with pytest.raises(IDInfoJWTDecodeError) as exc_info:
+        decode_idinfo_token(jwt_service, sentinel.idinfo_token, sentinel.audience)
+
+    assert exc_info.value.__cause__ == exception
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/h/views/oidc_test.py
+++ b/tests/unit/h/views/oidc_test.py
@@ -383,6 +383,7 @@ class TestOIDCRedirectViews:
             JWTIssuer.OIDC_REDIRECT_ORCID,
             JWTAudience.SIGNUP_ORCID,
             jwt_service.decode_symmetric.return_value.next_url,
+            pyramid_request.session,
         )
         assert isinstance(response, HTTPFound)
         assert response.location == pyramid_request.route_url(


### PR DESCRIPTION
Testing:

* Test that you can sign up successfully with Google, Facebook etc.

* Test that signing up without a valid `rfp` in the session cookie fails.

  One way to do this is to break the code that puts the `rfp` in the session:

  ```diff
  diff --git a/h/views/account_signup.py b/h/views/account_signup.py
  index 3c9cedf37..c6c02d147 100644
  --- a/h/views/account_signup.py
  +++ b/h/views/account_signup.py
  @@ -366,7 +366,7 @@ def encode_idinfo_token(  # noqa: PLR0913
   ):
       rfp = secrets.token_hex()
   
  -    session[IDINFO_RFP_SESSIONKEY_FMT.format(audience=audience)] = rfp
  +    session[IDINFO_RFP_SESSIONKEY_FMT.format(audience=audience)] = "wrong"
   
       return {
           "idinfo": jwt_service.encode_symmetric(
  ```

`idinfo` tokens are only used when signing up. They're not used for logging into an existing account or for connecting an identity to an existing account, so no need to test those.