### PR TITLE
Enable users without passwords to delete their accounts

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -293,6 +293,22 @@ class DeleteAccountSchema(CSRFSchema):
             raise exc
 
 
+class DeleteAccountSchemaNoPassword(CSRFSchema):
+    username = colander.SchemaNode(
+        colander.String(), title=_("Confirm your username to delete your account")
+    )
+
+    def validator(self, node, value):
+        super().validator(node, value)
+
+        request = node.bindings["request"]
+
+        if value.get("username") != request.user.username:
+            exc = colander.Invalid(node)
+            exc["username"] = _("Wrong username.")
+            raise exc
+
+
 @colander.deferred
 def deferred_notification_widget(node, kw):  # noqa: ARG001
     types = [("reply", _("Email me when someone replies to one of my annotations."))]


### PR DESCRIPTION
Testing:

* Sign up with a provider, go to <http://localhost:5000/account/delete>, and you'll be able to delete your account by confirming your username rather than your password. If you enter the wrong username you'll get a validation error. If you enter the right username your account will be deleted.
* Log in as a user with a password (e.g. `devdata_user`), go to http://localhost:5000/account/delete, and you'll have to confirm your password to delete your account.