### PR TITLE
Wrap annotations in `<article>` and `<section>` elements

### DIFF
--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -14,7 +14,8 @@
 
 {% macro annotation_card(presented_annotation, request, tag_link) -%}
 <li class="annotation-card">
-  <div class="annotation-card__header">
+  <article>
+  <header class="annotation-card__header">
     <div class="annotation-card__username-timestamp">
       <a title="username" href="{{ request.route_url('activity.user_search', username=presented_annotation.annotation.username) }}"
         class="annotation-card__username">
@@ -45,15 +46,15 @@
         </span>
       {% endif %}
     </div>
-  </div>
+  </header>
   {% if presented_annotation.annotation.quote %}
     <blockquote title="Annotation quote" class="annotation-card__quote">
       {{ presented_annotation.annotation.quote }}
     </blockquote>
   {% endif %}
-  <div class="annotation-card__text">
+  <section class="annotation-card__text">
     {{ presented_annotation.annotation.text_rendered }}
-  </div>
+  </section>
   <div title="Tags" class="annotation-card__tags">
     {% for tag in presented_annotation.annotation.tags%}
       <a class="annotation-card__tag" href="{{ tag_link(tag) }}">
@@ -80,5 +81,6 @@
       </a>
     {% endif %}
   </footer>
+  </article>
 </li>
 {%- endmacro %}


### PR DESCRIPTION
Fix an issue on activity pages where annotation bodies containing lone `<li>` elements (without a parent `<ul>`) could break the page layout. This is because when parsing an `<li>` element in this context, the browser will search up the tree to find any open `<li>`, then close it and insert the new element after that [^1]. Wrapping the annotation body in a _special_ element such as `<section>` stops the traversal at that point. Wrapping the whole annotation in an `<article>` and using `<section>` for the content is approximately consistent with the client.

This is a stop-gap solution for https://github.com/hypothesis/h/issues/9828 until we replace activity pages with a client-rendered approach which works more like the new moderation UI. That doesn't encounter the problem because the sanitized annotation body is assigned to the `innerHTML` of a specific node.

Fixes https://github.com/hypothesis/h/issues/9828 (see my comments there for steps to reproduce)

[^1]: https://dev.w3.org/html5/spec-LC/tree-construction.html#parsing-main-inbody