### PR TITLE
Fix JS error due to obsolete `window.envFlags` reference in admin site

### DIFF
--- a/h/static/scripts/admin-site.js
+++ b/h/static/scripts/admin-site.js
@@ -19,4 +19,3 @@ const controllers = Object.assign(
   sharedControllers,
 );
 upgradeElements(document.body, controllers);
-window.envFlags.ready();


### PR DESCRIPTION
This should have been removed in 135b7084ff0059d597d14b5632a67522d1bbf0f9.

Fixes https://hypothesis.sentry.io/issues/6810864109.