### PR TITLE
Extract a component for the form footer and submit button

### DIFF
--- a/h/static/scripts/components/AccountSettingsForms.tsx
+++ b/h/static/scripts/components/AccountSettingsForms.tsx
@@ -9,6 +9,7 @@ import type { FormValue } from '../util/form-value';
 import FacebookIcon from './FacebookIcon';
 import Form from './Form';
 import FormContainer from './FormContainer';
+import FormFooter from './FormFooter';
 import GoogleIcon from './GoogleIcon';
 import ORCIDIcon from './ORCIDIcon';
 import TextField from './TextField';
@@ -22,17 +23,6 @@ const textFieldProps = (field: FormValue<string>) => ({
 
 function Heading({ text }: { text: string }) {
   return <h1 class="text-lg mb-4">{text}</h1>;
-}
-
-function FormSubmitButton() {
-  return (
-    <div className="mb-8 pt-2 flex items-center gap-x-4">
-      <div className="grow" />
-      <Button type="submit" variant="primary" data-testid="submit-button">
-        Save
-      </Button>
-    </div>
-  );
 }
 
 function ChangeEmailForm({ config }: { config: AccountSettingsConfigObject }) {
@@ -73,7 +63,7 @@ function ChangeEmailForm({ config }: { config: AccountSettingsConfigObject }) {
             {...textFieldProps(password)}
           />
         )}
-        <FormSubmitButton />
+        <FormFooter />
       </Form>
     </FormContainer>
   );
@@ -126,7 +116,7 @@ function ChangePasswordForm({
           required={true}
           {...textFieldProps(newPasswordConfirm)}
         />
-        <FormSubmitButton />
+        <FormFooter />
       </Form>
     </FormContainer>
   );

--- a/h/static/scripts/components/FormFooter.tsx
+++ b/h/static/scripts/components/FormFooter.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@hypothesis/frontend-shared';
+import type { ComponentChildren } from 'preact';
+
+export type FormFooterProps = {
+  /** Whether to disable the submit button. */
+  disableSubmit?: boolean;
+
+  /** Label for the submit button. */
+  submitLabel?: ComponentChildren;
+};
+
+/**
+ * Form footer containing a submit button.
+ */
+export default function FormFooter({
+  disableSubmit = false,
+  submitLabel = 'Save',
+}: FormFooterProps) {
+  return (
+    <div className="mb-4 pt-2 flex items-center gap-x-4">
+      <div className="grow" />
+      <Button
+        type="submit"
+        variant="primary"
+        data-testid="submit-button"
+        disabled={disableSubmit}
+      >
+        {submitLabel}
+      </Button>
+    </div>
+  );
+}

--- a/h/static/scripts/components/ProfileForm.tsx
+++ b/h/static/scripts/components/ProfileForm.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@hypothesis/frontend-shared';
 import { useContext } from 'preact/hooks';
 
 import { LoginFormsConfig } from '../config';
@@ -7,6 +6,7 @@ import { useFormValue } from '../util/form-value';
 import type { FormValue } from '../util/form-value';
 import Form from './Form';
 import FormContainer from './FormContainer';
+import FormFooter from './FormFooter';
 import TextField from './TextField';
 
 export default function ProfileForm() {
@@ -53,12 +53,7 @@ export default function ProfileForm() {
           label="ORCID Identifier"
           {...textFieldProps(orcid)}
         />
-        <div className="mb-8 pt-2 flex items-center gap-x-4">
-          <div className="grow" />
-          <Button type="submit" variant="primary" data-testid="submit-button">
-            Save
-          </Button>
-        </div>
+        <FormFooter />
       </Form>
     </FormContainer>
   );

--- a/h/static/scripts/components/SignupForm.tsx
+++ b/h/static/scripts/components/SignupForm.tsx
@@ -1,4 +1,4 @@
-import { Button, CheckIcon } from '@hypothesis/frontend-shared';
+import { CheckIcon } from '@hypothesis/frontend-shared';
 import { useContext, useLayoutEffect, useState } from 'preact/hooks';
 
 import { LoginFormsConfig } from '../config';
@@ -8,6 +8,7 @@ import Checkbox from './Checkbox';
 import FacebookIcon from './FacebookIcon';
 import Form from './Form';
 import FormContainer from './FormContainer';
+import FormFooter from './FormFooter';
 import FormHeader from './FormHeader';
 import GoogleIcon from './GoogleIcon';
 import ORCIDIcon from './ORCIDIcon';
@@ -217,19 +218,12 @@ export default function SignupForm({
           >
             I would like to receive news about annotation and Hypothesis.
           </Checkbox>
-          <div className="pt-2 flex items-center gap-x-4">
-            <div className="grow" />
-            <Button
-              type="submit"
-              variant="primary"
-              data-testid="submit-button"
-              // Prevent duplicate signup attempts.
-              // See https://github.com/hypothesis/h/pull/3851
-              disabled={submitted}
-            >
-              Sign up
-            </Button>
-          </div>
+          <FormFooter
+            // Prevent duplicate signup attempts.
+            // See https://github.com/hypothesis/h/pull/3851
+            disableSubmit={submitted}
+            submitLabel="Sign up"
+          />
         </Form>
       </FormContainer>
       <SignupFooter action="login" />


### PR DESCRIPTION
Extract the footer that was duplicated across several forms. This excludes the one in the group creation form as that has extra features needed for forms that use an API call rather than doing a regular form submission.