### PR TITLE
Add form field name to `FormValue`

### DIFF
--- a/h/static/scripts/components/AccountSettingsForms.tsx
+++ b/h/static/scripts/components/AccountSettingsForms.tsx
@@ -15,6 +15,7 @@ import ORCIDIcon from './ORCIDIcon';
 import TextField from './TextField';
 
 const textFieldProps = (field: FormValue<string>) => ({
+  name: field.name,
   value: field.value,
   fieldError: field.error,
   onChangeValue: field.update,
@@ -46,7 +47,6 @@ function ChangeEmailForm({ config }: { config: AccountSettingsConfigObject }) {
           </p>
         )}
         <TextField
-          name="email"
           inputType="email"
           label={
             config.context.user.email ? 'New email address' : 'Email address'
@@ -56,7 +56,6 @@ function ChangeEmailForm({ config }: { config: AccountSettingsConfigObject }) {
         />
         {config.context.user.has_password && (
           <TextField
-            name="password"
             label="Confirm password"
             inputType="password"
             required={true}
@@ -94,7 +93,6 @@ function ChangePasswordForm({
         <input type="hidden" name="__formid__" value="password" />
         {config.context.user.has_password && (
           <TextField
-            name="password"
             label="Current password"
             inputType="password"
             required={true}
@@ -102,7 +100,6 @@ function ChangePasswordForm({
           />
         )}
         <TextField
-          name="new_password"
           label="New password"
           inputType="password"
           required={true}
@@ -110,7 +107,6 @@ function ChangePasswordForm({
           {...textFieldProps(newPassword)}
         />
         <TextField
-          name="new_password_confirm"
           label="Confirm new password"
           inputType="password"
           required={true}

--- a/h/static/scripts/components/ProfileForm.tsx
+++ b/h/static/scripts/components/ProfileForm.tsx
@@ -20,6 +20,7 @@ export default function ProfileForm() {
   const orcid = useFormValue(form, 'orcid', '');
 
   const textFieldProps = (field: FormValue<string>) => ({
+    name: field.name,
     value: field.value,
     fieldError: field.error,
     onChangeValue: field.update,
@@ -30,29 +31,19 @@ export default function ProfileForm() {
     <FormContainer>
       <Form csrfToken={config.csrfToken}>
         <TextField
-          name="display_name"
           label="Display name"
           maxLength={30}
           {...textFieldProps(displayName)}
         />
         <TextField
-          name="description"
           type="textarea"
           label="Description"
           maxLength={250}
           {...textFieldProps(description)}
         />
-        <TextField
-          name="location"
-          label="Location"
-          {...textFieldProps(location)}
-        />
-        <TextField name="link" label="Link" {...textFieldProps(link)} />
-        <TextField
-          name="orcid"
-          label="ORCID Identifier"
-          {...textFieldProps(orcid)}
-        />
+        <TextField label="Location" {...textFieldProps(location)} />
+        <TextField label="Link" {...textFieldProps(link)} />
+        <TextField label="ORCID Identifier" {...textFieldProps(orcid)} />
         <FormFooter />
       </Form>
     </FormContainer>

--- a/h/static/scripts/util/form-value.ts
+++ b/h/static/scripts/util/form-value.ts
@@ -28,6 +28,9 @@ export type FormValueOptions<T> = {
  * value has been committed and whether it has changed since the last submission.
  */
 export type FormValue<T> = {
+  /** Name of the form field. */
+  name: string;
+
   /** Current form field value. */
   value: T;
 
@@ -80,7 +83,7 @@ export type FormValue<T> = {
  * @param field - Name of form field
  * @param defaultValue - Default value if no initial value is present in `fields`
  */
-export function useFormValue<Fields, F extends keyof Fields>(
+export function useFormValue<Fields, F extends keyof Fields & string>(
   fields: FormFields<Fields>,
   field: F,
   defaultValue: Fields[F],
@@ -110,5 +113,5 @@ export function useFormValue<Fields, F extends keyof Fields>(
     error = fields.errors?.[field];
   }
 
-  return { value, update, commit, changed, committed, error };
+  return { name: field, value, update, commit, changed, committed, error };
 }


### PR DESCRIPTION
This is a small refactoring to avoid the need to specify the `name` attribute for form fields in multiple places (`useFormValue` and the `TextField` or `Checkbox` component).