### PR TITLE
Convert notification settings form to Preact + Tailwind

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -309,30 +309,10 @@ class DeleteAccountSchemaNoPassword(CSRFSchema):
             raise exc
 
 
-@colander.deferred
-def deferred_notification_widget(node, kw):  # noqa: ARG001
-    types = [("reply", _("Email me when someone replies to one of my annotations."))]
-
-    request = node.bindings["request"]
-    feature_service = request.find_service(name="feature")
-    if feature_service.enabled("at_mentions", request.user):  # pragma: no cover
-        types.append(
-            ("mention", _("Email me when someone mentions me in an annotation."))
-        )
-
-    if feature_service.enabled("pre_moderation", request.user):  # pragma: no cover
-        types.append(
-            ("moderation", _("Email me when someone moderates one of my annotations."))
-        )
-
-    return deform.widget.CheckboxChoiceWidget(omit_label=True, values=types)
-
-
 class NotificationsSchema(CSRFSchema):
-    notifications = colander.SchemaNode(
-        colander.Set(),
-        widget=deferred_notification_widget,
-    )
+    reply = colander.SchemaNode(colander.Boolean())
+    mention = colander.SchemaNode(colander.Boolean())
+    moderation = colander.SchemaNode(colander.Boolean())
 
 
 def includeme(_config):  # pragma: no cover

--- a/h/static/scripts/components/LoginAppRoot.tsx
+++ b/h/static/scripts/components/LoginAppRoot.tsx
@@ -10,6 +10,7 @@ import AccountSettingsForms from './AccountSettingsForms';
 import AppContainer from './AppContainer';
 import DeveloperForm from './DeveloperForm';
 import LoginForm from './LoginForm';
+import NotificationsForm from './NotificationsForm';
 import ProfileForm from './ProfileForm';
 import Router from './Router';
 import SignupForm from './SignupForm';
@@ -76,6 +77,9 @@ export default function LoginAppRoot({ config }: AppRootProps) {
             </Route>
             <Route path={routes.accountDeveloper}>
               <DeveloperForm />
+            </Route>
+            <Route path={routes.accountNotifications}>
+              <NotificationsForm />
             </Route>
             <Route>
               <h1 data-testid="unknown-route">Page not found</h1>

--- a/h/static/scripts/components/NotificationsForm.tsx
+++ b/h/static/scripts/components/NotificationsForm.tsx
@@ -1,0 +1,65 @@
+import { Callout, Link } from '@hypothesis/frontend-shared';
+import { useContext } from 'preact/hooks';
+
+import { LoginFormsConfig } from '../config';
+import type { NotificationsConfigObject } from '../config';
+import { routes } from '../routes';
+import { useFormValue } from '../util/form-value';
+import type { FormValue } from '../util/form-value';
+import Checkbox from './Checkbox';
+import Form from './Form';
+import FormFooter from './FormFooter';
+
+export default function NotificationsForm() {
+  const config = useContext(LoginFormsConfig) as NotificationsConfigObject;
+
+  const form = config.form;
+  const reply = useFormValue(form, 'reply', true);
+  const mention = useFormValue(form, 'mention', true);
+  const moderation = useFormValue(form, 'moderation', true);
+
+  const checkboxProps = (field: FormValue<boolean>) => {
+    return {
+      name: field.name,
+      checked: field.value,
+      // Backend form validation expects the string "true" rather than the
+      // HTML form default of "on".
+      value: 'true',
+      onChange: (e: Event) => {
+        field.update((e.target as HTMLInputElement).checked);
+      },
+    };
+  };
+
+  if (!config.hasEmail) {
+    return (
+      <Callout>
+        Notifications will not be sent because your account does not have an
+        email address. You can add an email address in{' '}
+        <Link underline="always" href={routes.accountSettings}>
+          account settings
+        </Link>
+        .
+      </Callout>
+    );
+  }
+
+  return (
+    <Form csrfToken={config.csrfToken}>
+      <p>Email me when someone:</p>
+      <Checkbox data-testid="reply-checkbox" {...checkboxProps(reply)}>
+        Replies to my annotations
+      </Checkbox>
+      <Checkbox data-testid="mention-checkbox" {...checkboxProps(mention)}>
+        Mentions me in an annotation
+      </Checkbox>
+      <Checkbox
+        data-testid="moderation-checkbox"
+        {...checkboxProps(moderation)}
+      >
+        Moderates my annotations
+      </Checkbox>
+      <FormFooter />
+    </Form>
+  );
+}

--- a/h/static/scripts/components/test/NotificationsForm-test.js
+++ b/h/static/scripts/components/test/NotificationsForm-test.js
@@ -1,0 +1,130 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+
+import { LoginFormsConfig } from '../../config';
+import NotificationsForm from '../NotificationsForm';
+
+describe('NotificationsForm', () => {
+  let fakeConfig;
+
+  beforeEach(() => {
+    fakeConfig = {
+      csrfToken: 'fake-csrf-token',
+      features: {},
+      hasEmail: true,
+      form: {
+        data: {
+          reply: true,
+          mention: true,
+          moderation: true,
+        },
+        errors: {},
+      },
+    };
+  });
+
+  const getElements = wrapper => {
+    return {
+      form: wrapper.find('form[data-testid="form"]'),
+      csrfInput: wrapper.find('input[name="csrf_token"]'),
+      replyCheckbox: wrapper.find('Checkbox[data-testid="reply-checkbox"]'),
+      mentionCheckbox: wrapper.find('Checkbox[data-testid="mention-checkbox"]'),
+      moderationCheckbox: wrapper.find(
+        'Checkbox[data-testid="moderation-checkbox"]',
+      ),
+      submitButton: wrapper.find('Button[data-testid="submit-button"]'),
+      callout: wrapper.find('Callout'),
+    };
+  };
+
+  const createWrapper = () => {
+    const wrapper = mount(
+      <LoginFormsConfig.Provider value={fakeConfig}>
+        <NotificationsForm />
+      </LoginFormsConfig.Provider>,
+    );
+    const elements = getElements(wrapper);
+    return { wrapper, elements };
+  };
+
+  describe('when user has email', () => {
+    it('renders the notification settings form', () => {
+      const { elements } = createWrapper();
+      const { form, replyCheckbox, mentionCheckbox, moderationCheckbox } =
+        elements;
+
+      assert.isTrue(form.exists());
+      assert.isTrue(replyCheckbox.exists());
+      assert.isTrue(mentionCheckbox.exists());
+      assert.isTrue(moderationCheckbox.exists());
+      assert.isFalse(elements.callout.exists());
+    });
+
+    it('pre-fills checkboxes from form data', () => {
+      fakeConfig.form.data = {
+        reply: false,
+        mention: true,
+        moderation: false,
+      };
+
+      const { elements } = createWrapper();
+      const { replyCheckbox, mentionCheckbox, moderationCheckbox } = elements;
+
+      assert.equal(replyCheckbox.prop('checked'), false);
+      assert.equal(mentionCheckbox.prop('checked'), true);
+      assert.equal(moderationCheckbox.prop('checked'), false);
+    });
+
+    it('sets correct checkbox names and values', () => {
+      const { elements } = createWrapper();
+      const { replyCheckbox, mentionCheckbox, moderationCheckbox } = elements;
+
+      assert.equal(replyCheckbox.prop('name'), 'reply');
+      assert.equal(replyCheckbox.prop('value'), 'true');
+      assert.equal(mentionCheckbox.prop('name'), 'mention');
+      assert.equal(mentionCheckbox.prop('value'), 'true');
+      assert.equal(moderationCheckbox.prop('name'), 'moderation');
+      assert.equal(moderationCheckbox.prop('value'), 'true');
+    });
+
+    [
+      { field: 'replyCheckbox', name: 'reply' },
+      { field: 'mentionCheckbox', name: 'mention' },
+      { field: 'moderationCheckbox', name: 'moderation' },
+    ].forEach(({ field, name }) => {
+      it(`updates ${name} checkbox when clicked`, () => {
+        const { wrapper, elements } = createWrapper();
+
+        act(() => {
+          const event = {
+            target: { checked: false },
+          };
+          elements[field].prop('onChange')(event);
+        });
+        wrapper.update();
+        const updatedElements = getElements(wrapper);
+
+        assert.equal(updatedElements[field].prop('checked'), false);
+      });
+    });
+  });
+
+  describe('when user has no email', () => {
+    beforeEach(() => {
+      fakeConfig.hasEmail = false;
+    });
+
+    it('displays callout message instead of form', () => {
+      const { elements } = createWrapper();
+      const { form, callout } = elements;
+
+      assert.isFalse(form.exists());
+      assert.isTrue(callout.exists());
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({ content: () => createWrapper().wrapper }),
+  );
+});

--- a/h/static/scripts/config.ts
+++ b/h/static/scripts/config.ts
@@ -165,16 +165,28 @@ export type ProfileConfigObject = LoginFormsConfigBase & {
   }>;
 };
 
+/** Configuration for developer settings form. */
 export type DeveloperConfigObject = LoginFormsConfigBase & {
   token?: string;
+};
+
+/** Configuration for notification settings form. */
+export type NotificationsConfigObject = LoginFormsConfigBase & {
+  hasEmail: boolean;
+  form: FormFields<{
+    reply: boolean;
+    mention: boolean;
+    moderation: boolean;
+  }>;
 };
 
 export type LoginFormsConfigObject =
   | LoginConfigObject
   | SignupConfigObject
   | AccountSettingsConfigObject
-  | ProfileConfigObject
-  | DeveloperConfigObject;
+  | DeveloperConfigObject
+  | NotificationsConfigObject
+  | ProfileConfigObject;
 
 export const LoginFormsConfig = createContext<LoginFormsConfigObject | null>(
   null,

--- a/h/static/scripts/routes.ts
+++ b/h/static/scripts/routes.ts
@@ -6,6 +6,7 @@
  */
 export const routes = {
   accountDeveloper: '/account/developer',
+  accountNotifications: '/account/settings/notifications',
   accountSettings: '/account/settings',
   forgotPassword: '/forgot-password',
   groups: {

--- a/h/templates/accounts/notifications.html.jinja2
+++ b/h/templates/accounts/notifications.html.jinja2
@@ -3,11 +3,23 @@
 {% set page_route = 'account_notifications' %}
 {% set page_title = 'Notifications' %}
 
+{% block styles %}
+  {{ super() }}
+
+  {% for url in asset_urls('forms_css') %}
+    <link rel="stylesheet" href="{{ url }}">
+  {% endfor %}
+{% endblock %}
+
 {% block page_content %}
-  {% if user_has_email_address %}
-    {{ form }}
-  {% else %}
-    Want notifications? We'll need your email address for that. You can add an email address in your
-    <a href="{{ request.route_path('account') }}">Account Settings</a>.
-  {% endif %}
+  <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
+  <div id="login-form"></div>
 {% endblock page_content %}
+
+{% block scripts %}
+  {{ super() }}
+
+  {% for url in asset_urls('login_forms_js') %}
+    <script type="module" src="{{ url }}"></script>
+  {% endfor %}
+{% endblock %}

--- a/tests/unit/h/accounts/schemas_test.py
+++ b/tests/unit/h/accounts/schemas_test.py
@@ -611,13 +611,15 @@ class TestDeleteAccountSchemaNoPassword:
         )
 
 
-@pytest.mark.usefixtures("feature_service")
 class TestNotificationSchema:
-    def test_it(self, schema, user, feature_service):
-        schema.deserialize({"notifications": ["reply", "mention"]})
+    def test_it(self, schema):
+        result = schema.deserialize(
+            {"reply": True, "mention": True, "moderation": False}
+        )
 
-        feature_service.enabled.assert_any_call("at_mentions", user)
-        feature_service.enabled.assert_any_call("pre_moderation", user)
+        assert result["reply"] is True
+        assert result["mention"] is True
+        assert result["moderation"] is False
 
     @pytest.fixture
     def user(self, factories):


### PR DESCRIPTION
Convert the notification settings form to the new UI stack. As part of this, the feature flag checks for at-mentions and pre-moderation have been removed and all checkboxes are always rendered. See [Slack thread](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1755848277154129).

**Before, with no email set:**

<img width="557" height="160" alt="old-notifications-no-email" src="https://github.com/user-attachments/assets/5ab11f94-5869-4447-99cf-2726123e083b" />

**Before, with email set:**

<img width="557" height="260" alt="old-notifications" src="https://github.com/user-attachments/assets/21440332-0ccb-4d47-a522-f3cfaf35d09d" />

**After, with no email set:**

<img width="544" height="173" alt="notifications-no-email-2" src="https://github.com/user-attachments/assets/cf2a3e31-6680-4174-a0eb-1f2cdb92d8db" />

I have rephrased the first sentence here to make it more explicit what the current behavior is (the user will _not_ receive emails).

**After, with email set:**

<img width="557" height="295" alt="notifications-frontend-v2" src="https://github.com/user-attachments/assets/2fa4e6b0-7a4b-45ab-844c-a61ca349840c" />

**After, toast notification when clicking "Save":**

<img width="565" height="355" alt="Notifications save toast" src="https://github.com/user-attachments/assets/4ded27da-3cbf-492c-85d6-c1a4b7238c0e" />

The new labels are intentionally more succinct to make it easier to see what is unique about each one.