### PR TITLE
Fix layout of checkbox children

### DIFF
--- a/h/static/scripts/components/Checkbox.tsx
+++ b/h/static/scripts/components/Checkbox.tsx
@@ -32,7 +32,8 @@ export default function Checkbox({
         {...checkboxProps}
         aria-describedby={description ? descriptionId : undefined}
       >
-        {children}
+        {/* Unstyled span needed to put children in a single flex item. */}
+        <span>{children}</span>
       </BaseCheckbox>
       {description && (
         <div


### PR DESCRIPTION
Fix a regression from 87998e982ebb384fd9b719e6165d6b707c081176. The children of `Checkbox` get placed in a flex layout. We need the `<span>` even if unstyled to place all children in one flex item.