### PR TITLE
Enable `log_in_with_facebook` via query param

### DIFF
--- a/h/services/feature.py
+++ b/h/services/feature.py
@@ -55,10 +55,13 @@ class FeatureService:
         session,
         overrides: dict[str, bool] | None = None,
         default_authority=None,
+        *,
+        facebook_enabled_by_query_param=False,
     ):
         self.default_authority = default_authority
         self.session = session
         self.overrides = overrides
+        self.facebook_enabled_by_query_param = facebook_enabled_by_query_param
 
         self._cached_load = lru_cache_in_transaction(self.session)(self._load)
 
@@ -86,6 +89,15 @@ class FeatureService:
         return models.Feature.all(self.session)
 
     def _state(self, feature, user=None):  # noqa: PLR0911
+        # This is a temporary hack to allow log-in-with-Facebook to be tested
+        # on production without exposing all users to it.  This should be
+        # removed after log-in-with-Facebook has been released.
+        if (
+            feature.name == "log_in_with_facebook"
+            and self.facebook_enabled_by_query_param
+        ):  # pragma: no cover
+            return True
+
         # Handle explicit overrides
         if self.overrides is not None and feature.name in self.overrides:
             return self.overrides[feature.name]
@@ -114,6 +126,7 @@ def feature_service_factory(_context, request):
         session=request.db,
         overrides=_feature_overrides(request),
         default_authority=request.default_authority,
+        facebook_enabled_by_query_param="facebook" in request.GET,
     )
 
 


### PR DESCRIPTION
Enable the `log_in_with_facebook` feature on the `/login`, `/signup` and `/account/settings` pages if the URL contains a `facebook` query param.

This is a temporary hack to enable testing of the `log_in_with_facebook` feature on production without yet exposing all users to the feature.

This commit should be reverted once the `log_in_with_facebook` feature flag has been enabled for all users.

# Testing

Disable the `log_in_with_facebook` feature flag and visit http://localhost:5000/login?facebook, http://localhost:5000/signup?facebook or http://localhost:5000/account/settings?facebook.