### PR TITLE
Show fallback message after moderating all annotations

### DIFF
--- a/h/static/scripts/components/GroupModeration.tsx
+++ b/h/static/scripts/components/GroupModeration.tsx
@@ -48,6 +48,7 @@ function AnnotationList({ filterStatus, classes }: AnnotationListProps) {
     removedAnnotations,
     updateAnnotationStatus,
     updateAnnotation,
+    visibleAnnotations,
   } = useGroupAnnotations({ filterStatus });
 
   const lastScrollPosition = useRef(0);
@@ -82,6 +83,7 @@ function AnnotationList({ filterStatus, classes }: AnnotationListProps) {
         loading={loading}
         annotations={annotations}
         removedAnnotations={removedAnnotations}
+        visibleAnnotations={visibleAnnotations}
         onAnnotationStatusChange={updateAnnotationStatus}
         onAnnotationReloaded={updateAnnotation}
       />
@@ -94,6 +96,7 @@ type AnnotationListContentProps = {
   loading: boolean;
   annotations?: APIAnnotationData[];
   removedAnnotations: Set<string>;
+  visibleAnnotations: number;
   onAnnotationStatusChange: (
     annotationId: string,
     moderationStatus: ModerationStatus,
@@ -108,6 +111,7 @@ function AnnotationListContent({
   loading,
   annotations,
   removedAnnotations,
+  visibleAnnotations,
   filterStatus,
   onAnnotationStatusChange,
   onAnnotationReloaded,
@@ -141,30 +145,33 @@ function AnnotationListContent({
       onAnnotationReloaded,
     ],
   );
-
-  if (annotations && annotations.length === 0) {
-    return (
-      <div
-        className="border rounded p-2 text-center"
-        data-testid="annotations-fallback-message"
-      >
-        {!filterStatus && 'There are no annotations in this group.'}
-        {filterStatus && (
-          <>
-            There are no{' '}
-            <span className="lowercase">
-              {moderationStatusInfo[filterStatus].label}
-            </span>{' '}
-            annotations in this group.
-          </>
-        )}
-      </div>
-    );
-  }
+  const fallbackMessage = useMemo(
+    () =>
+      annotations &&
+      visibleAnnotations === 0 && (
+        <div
+          className="border rounded p-2 text-center"
+          data-testid="annotations-fallback-message"
+        >
+          {!filterStatus && 'There are no annotations in this group.'}
+          {filterStatus && (
+            <>
+              There are no{' '}
+              <span className="lowercase">
+                {moderationStatusInfo[filterStatus].label}
+              </span>{' '}
+              annotations in this group.
+            </>
+          )}
+        </div>
+      ),
+    [annotations, filterStatus, visibleAnnotations],
+  );
 
   return (
     <>
       {cards}
+      {fallbackMessage}
       {loading && (
         <div className="mx-auto mt-3">
           <Spinner size="md" />

--- a/h/static/scripts/components/test/GroupModeration-test.js
+++ b/h/static/scripts/components/test/GroupModeration-test.js
@@ -123,8 +123,12 @@ describe('GroupModeration', () => {
         expectedFallbackMessage: 'There are no Spam annotations in this group.',
       },
     ].forEach(({ status, expectedFallbackMessage }) => {
-      it('shows fallback message when no annotations exist', () => {
-        fakeUseGroupAnnotations.returns({ loading: false, annotations: [] });
+      it('shows fallback message when no visible annotations exist', () => {
+        fakeUseGroupAnnotations.returns({
+          loading: false,
+          annotations: [],
+          visibleAnnotations: 0,
+        });
         const wrapper = createComponent();
 
         wrapper.find('ModerationStatusSelect').props().onChange(status);


### PR DESCRIPTION
Closes https://github.com/hypothesis/h/issues/9843
Depends on https://github.com/hypothesis/h/pull/9838

Make sure the moderation fallback message is shown when the moderation queue initially has annotations, but they all get moderated, emptying the queue.

Before the changes on this PR:

https://github.com/user-attachments/assets/fb8d3e45-5193-4bb6-9056-86800bf7fb8a

With the changes here:

https://github.com/user-attachments/assets/ee77cc9d-0df4-4d83-8011-45bc1667b160