### PR TITLE
Port developer token form to Preact

### DIFF
--- a/h/static/scripts/components/CopyButton.tsx
+++ b/h/static/scripts/components/CopyButton.tsx
@@ -1,0 +1,41 @@
+import { IconButton, CopyIcon, CheckIcon } from '@hypothesis/frontend-shared';
+import { useState, useEffect } from 'preact/hooks';
+
+export type CopyButtonProps = {
+  /** Tooltip for the copy button. */
+  title: string;
+
+  /** Text to be copied. */
+  value: string;
+};
+
+/**
+ * Button for copying text to the clipboard.
+ *
+ * When text is copied, the icon briefly changes to indicate success.
+ */
+export default function CopyButton({ title, value }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copyValue = async () => {
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+  };
+
+  useEffect(() => {
+    if (!copied) {
+      return () => {};
+    }
+    const timeout = setTimeout(() => setCopied(false), 1000);
+    return () => clearTimeout(timeout);
+  }, [copied]);
+
+  return (
+    <IconButton
+      icon={copied ? CheckIcon : CopyIcon}
+      title={title}
+      onClick={copyValue}
+      variant="dark"
+    />
+  );
+}

--- a/h/static/scripts/components/DeveloperForm.tsx
+++ b/h/static/scripts/components/DeveloperForm.tsx
@@ -1,0 +1,58 @@
+import { Callout, Link, InputGroup, Input } from '@hypothesis/frontend-shared';
+import { useContext, useId } from 'preact/hooks';
+
+import { LoginFormsConfig } from '../config';
+import type { DeveloperConfigObject } from '../config';
+import CopyButton from './CopyButton';
+import Form from './Form';
+import FormFooter from './FormFooter';
+import Label from './Label';
+import Text from './Text';
+
+export default function DeveloperForm() {
+  const config = useContext(LoginFormsConfig) as DeveloperConfigObject;
+  const token = config.token;
+
+  const inputId = useId();
+
+  return (
+    <>
+      <Text>
+        API tokens can be used to access your data via the{' '}
+        <Link
+          target="_blank"
+          href="https://h.readthedocs.io/en/latest/api/"
+          underline="always"
+        >
+          Hypothesis API
+        </Link>
+        .
+      </Text>
+      <Callout status="notice" classes="my-4">
+        <b>Keep your API tokens safe</b> as they can be used to access all data
+        in your account.
+      </Callout>
+      <Form classes="mt-8" csrfToken={config.csrfToken}>
+        {token && (
+          <>
+            <Label htmlFor={inputId} text="Current API token" />
+            <InputGroup>
+              <Input
+                id={inputId}
+                name="token"
+                readonly
+                value={token}
+                // Use monospace font for better legibility.
+                classes="font-mono"
+              />
+              <CopyButton title="Copy token" value={token} />
+            </InputGroup>
+          </>
+        )}
+        <FormFooter
+          submitLabel={token ? 'Recreate API token' : 'Create API token'}
+        />
+      </Form>
+    </>
+  );
+}

--- a/h/static/scripts/components/Form.tsx
+++ b/h/static/scripts/components/Form.tsx
@@ -16,6 +16,9 @@ export type FormProps = JSX.FormHTMLAttributes & {
   /** Center form in parent container. Defaults to true. */
   center?: boolean;
 
+  /** Additional CSS classes for the form element. */
+  classes?: string;
+
   children: ComponentChildren;
 };
 
@@ -24,6 +27,7 @@ export type FormProps = JSX.FormHTMLAttributes & {
  */
 export default function Form({
   center = true,
+  classes,
   children,
   csrfToken,
   ...formAttrs
@@ -35,6 +39,7 @@ export default function Form({
       className={classnames(
         'max-w-[530px] flex flex-col gap-y-4',
         center && 'mx-auto',
+        classes,
       )}
       {...formAttrs}
     >

--- a/h/static/scripts/components/LoginAppRoot.tsx
+++ b/h/static/scripts/components/LoginAppRoot.tsx
@@ -8,6 +8,7 @@ import { LoginFormsConfig } from '../config';
 import { routes } from '../routes';
 import AccountSettingsForms from './AccountSettingsForms';
 import AppContainer from './AppContainer';
+import DeveloperForm from './DeveloperForm';
 import LoginForm from './LoginForm';
 import ProfileForm from './ProfileForm';
 import Router from './Router';
@@ -72,6 +73,9 @@ export default function LoginAppRoot({ config }: AppRootProps) {
             </Route>
             <Route path={routes.profile}>
               <ProfileForm />
+            </Route>
+            <Route path={routes.accountDeveloper}>
+              <DeveloperForm />
             </Route>
             <Route>
               <h1 data-testid="unknown-route">Page not found</h1>

--- a/h/static/scripts/components/Text.tsx
+++ b/h/static/scripts/components/Text.tsx
@@ -1,0 +1,12 @@
+import type { JSX } from 'preact';
+
+export default function Text({
+  children,
+  ...rest
+}: JSX.HTMLAttributes<HTMLParagraphElement>) {
+  return (
+    <p className="my-2" {...rest}>
+      {children}
+    </p>
+  );
+}

--- a/h/static/scripts/components/test/CopyButton-test.js
+++ b/h/static/scripts/components/test/CopyButton-test.js
@@ -1,0 +1,141 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+
+import CopyButton from '../CopyButton';
+
+describe('CopyButton', () => {
+  let clock;
+  let fakeClipboard;
+
+  beforeEach(() => {
+    fakeClipboard = {
+      writeText: sinon.stub().resolves(),
+    };
+    sinon.stub(navigator, 'clipboard').value(fakeClipboard);
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+    sinon.restore();
+  });
+
+  function createComponent(props = {}) {
+    return mount(
+      <CopyButton title="Copy text" value="text to copy" {...props} />,
+    );
+  }
+
+  it('renders copy icon initially', () => {
+    const wrapper = createComponent();
+    const button = wrapper.find('IconButton');
+
+    assert.equal(button.prop('title'), 'Copy text');
+    assert.equal(button.prop('icon').name, 'CopyIcon');
+  });
+
+  it('copies text to clipboard when clicked', async () => {
+    const wrapper = createComponent({ value: 'test text' });
+
+    await act(async () => {
+      wrapper.find('IconButton').prop('onClick')();
+    });
+
+    assert.calledWith(fakeClipboard.writeText, 'test text');
+  });
+
+  it('shows check icon after copying', async () => {
+    const wrapper = createComponent();
+
+    await act(async () => {
+      wrapper.find('IconButton').prop('onClick')();
+    });
+
+    wrapper.update();
+    assert.equal(wrapper.find('IconButton').prop('icon').name, 'CheckIcon');
+  });
+
+  it('reverts to copy icon after timeout', async () => {
+    const wrapper = createComponent();
+
+    await act(async () => {
+      wrapper.find('IconButton').prop('onClick')();
+    });
+
+    wrapper.update();
+    assert.equal(wrapper.find('IconButton').prop('icon').name, 'CheckIcon');
+
+    act(() => {
+      clock.tick(1000);
+    });
+
+    wrapper.update();
+    assert.equal(wrapper.find('IconButton').prop('icon').name, 'CopyIcon');
+  });
+
+  it('does not revert to copy icon if timeout is cleared', async () => {
+    const wrapper = createComponent();
+
+    await act(async () => {
+      wrapper.find('IconButton').prop('onClick')();
+    });
+
+    wrapper.update();
+    assert.equal(wrapper.find('IconButton').prop('icon').name, 'CheckIcon');
+
+    // Unmount component to trigger cleanup
+    wrapper.unmount();
+
+    act(() => {
+      clock.tick(1000);
+    });
+
+    // No assertion needed - this test ensures no errors occur when
+    // timeout cleanup happens after component unmount
+  });
+
+  it('handles multiple clicks correctly', async () => {
+    const wrapper = createComponent({ value: 'test' });
+
+    // First click
+    await act(async () => {
+      wrapper.find('IconButton').prop('onClick')();
+    });
+
+    wrapper.update();
+    assert.equal(wrapper.find('IconButton').prop('icon').name, 'CheckIcon');
+    assert.calledWith(fakeClipboard.writeText, 'test');
+
+    // Second click before timeout
+    act(() => {
+      clock.tick(500);
+    });
+
+    await act(async () => {
+      wrapper.find('IconButton').prop('onClick')();
+    });
+
+    assert.calledTwice(fakeClipboard.writeText);
+
+    // Icon should still be CheckIcon and timeout should reset
+    wrapper.update();
+    assert.equal(wrapper.find('IconButton').prop('icon').name, 'CheckIcon');
+
+    act(() => {
+      clock.tick(1000);
+    });
+
+    wrapper.update();
+    assert.equal(wrapper.find('IconButton').prop('icon').name, 'CopyIcon');
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => {
+        clock.restore();
+        return createComponent();
+      },
+    }),
+  );
+});

--- a/h/static/scripts/components/test/DeveloperForm-test.js
+++ b/h/static/scripts/components/test/DeveloperForm-test.js
@@ -1,0 +1,61 @@
+import { mount } from '@hypothesis/frontend-testing';
+
+import { LoginFormsConfig } from '../../config';
+import DeveloperForm from '../DeveloperForm';
+
+describe('DeveloperForm', () => {
+  function createComponent(configOverrides = {}) {
+    const config = {
+      csrfToken: 'test-csrf',
+      token: null,
+      ...configOverrides,
+    };
+
+    return mount(
+      <LoginFormsConfig.Provider value={config}>
+        <DeveloperForm />
+      </LoginFormsConfig.Provider>,
+    );
+  }
+
+  it('shows "Create API token" button when no token exists', () => {
+    const wrapper = createComponent({ token: null });
+
+    const formFooter = wrapper.find('FormFooter');
+    assert.equal(formFooter.prop('submitLabel'), 'Create API token');
+  });
+
+  it('shows "Recreate API token" button when token exists', () => {
+    const wrapper = createComponent({ token: 'existing-token' });
+
+    const formFooter = wrapper.find('FormFooter');
+    assert.equal(formFooter.prop('submitLabel'), 'Recreate API token');
+  });
+
+  it('does not show token input when no token exists', () => {
+    const wrapper = createComponent({ token: null });
+
+    assert.isFalse(wrapper.exists('Input[name="token"]'));
+    assert.isFalse(wrapper.exists('CopyButton'));
+  });
+
+  it('shows token input and copy button when token exists', () => {
+    const wrapper = createComponent({ token: 'my-secret-token' });
+
+    const tokenInput = wrapper.find('Input[name="token"]');
+    assert.isTrue(tokenInput.exists());
+    assert.equal(tokenInput.prop('value'), 'my-secret-token');
+
+    const copyButton = wrapper.find('CopyButton');
+    assert.isTrue(copyButton.exists());
+    assert.equal(copyButton.prop('value'), 'my-secret-token');
+    assert.equal(copyButton.prop('title'), 'Copy token');
+  });
+
+  it('passes csrfToken to Form', () => {
+    const wrapper = createComponent({ csrfToken: 'custom-csrf-token' });
+
+    const form = wrapper.find('Form');
+    assert.equal(form.prop('csrfToken'), 'custom-csrf-token');
+  });
+});

--- a/h/static/scripts/components/test/LoginAppRoot-test.js
+++ b/h/static/scripts/components/test/LoginAppRoot-test.js
@@ -24,6 +24,7 @@ describe('LoginAppRoot', () => {
 
     $imports.$mock({
       './AccountSettingsForms': mockComponent('AccountSettingsForms'),
+      './DeveloperForm': mockComponent('DeveloperForm'),
       './LoginForm': mockComponent('LoginForm'),
       './ProfileForm': mockComponent('ProfileForm'),
       './SignupForm': mockComponent('SignupForm'),
@@ -132,6 +133,14 @@ describe('LoginAppRoot', () => {
 
   [
     {
+      path: '/account/developer',
+      selector: 'DeveloperForm',
+    },
+    {
+      path: '/account/profile',
+      selector: 'ProfileForm',
+    },
+    {
       path: '/account/settings',
       selector: 'AccountSettingsForms',
       props: {},
@@ -152,10 +161,6 @@ describe('LoginAppRoot', () => {
       props: {
         enableSocialLogin: true,
       },
-    },
-    {
-      path: '/account/profile',
-      selector: 'ProfileForm',
     },
     // "/signup" shows email signup form if all social logins are disabled
     {

--- a/h/static/scripts/config.ts
+++ b/h/static/scripts/config.ts
@@ -165,11 +165,16 @@ export type ProfileConfigObject = LoginFormsConfigBase & {
   }>;
 };
 
+export type DeveloperConfigObject = LoginFormsConfigBase & {
+  token?: string;
+};
+
 export type LoginFormsConfigObject =
   | LoginConfigObject
   | SignupConfigObject
   | AccountSettingsConfigObject
-  | ProfileConfigObject;
+  | ProfileConfigObject
+  | DeveloperConfigObject;
 
 export const LoginFormsConfig = createContext<LoginFormsConfigObject | null>(
   null,

--- a/h/static/scripts/routes.ts
+++ b/h/static/scripts/routes.ts
@@ -5,6 +5,7 @@
  * These must be synchronized with h/routes.py.
  */
 export const routes = {
+  accountDeveloper: '/account/developer',
   accountSettings: '/account/settings',
   forgotPassword: '/forgot-password',
   groups: {

--- a/h/templates/accounts/developer.html.jinja2
+++ b/h/templates/accounts/developer.html.jinja2
@@ -3,40 +3,23 @@
 {% set page_route = 'account_developer' %}
 {% set page_title = 'Developer' %}
 
-{% block page_content %}
-  <div class="form-vertical">
-    {% if token %}
-      <p class="form-help-text">
-      <label for="token">{% trans %}Your API token is:{% endtrans %}</label>
-      </p>
-      <input id="token"
-             type="text"
-             value="{{ token }}"
-             readonly="readonly"
-             class="api-token">
-      <p class="form-help-text">
-        Please keep your API token safe as it can be used to access your account.
-      </p>
-    {% endif %}
+{% block styles %}
+  {{ super() }}
 
-      <form method="post" class="js-disable-on-submit">
-        {% if token %}
-          <button type="submit" class="btn"
-                  title="{% trans %}Delete your API token and generate a new one{% endtrans%}">
-            Regenerate your API token
-          </button>
-        {% else %}
-          <button type="submit" class="btn btn-primary">
-            {% trans %}Generate your API token{% endtrans %}
-          </button>
-        {% endif %}
-      </form>
-  </div>
+  {% for url in asset_urls('forms_css') %}
+    <link rel="stylesheet" href="{{ url }}">
+  {% endfor %}
+{% endblock %}
+
+{% block page_content %}
+  <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
+  <div id="login-form"></div>
 {% endblock page_content %}
 
-{% block form_footer_left %}
-  <p>
-    You can learn more about the Hypothesis API at
-    <a class="link--footer" href="https://h.readthedocs.io/en/latest/api.html">h.readthedocs.io/en/latest/api.html</a>
-  </p>
+{% block scripts %}
+  {{ super() }}
+
+  {% for url in asset_urls('login_forms_js') %}
+    <script type="module" src="{{ url }}"></script>
+  {% endfor %}
 {% endblock %}

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -764,11 +764,7 @@ class DeveloperController:
     def get(self):
         """Render the developer page, including the form."""
         token = self.svc.fetch(self.userid)
-
-        if token:
-            return {"token": token.value}
-
-        return {}
+        return {"js_config": self._js_config(token)}
 
     @view_config(request_method="POST")
     def post(self):
@@ -782,7 +778,13 @@ class DeveloperController:
             # The user doesn't have an API token yet, generate one for them.
             token = self.svc.create(self.userid)
 
-        return {"token": token.value}
+        return {"js_config": self._js_config(token)}
+
+    def _js_config(self, token):
+        config = {"features": {}}
+        if token:
+            config["token"] = token.value
+        return config
 
 
 @view_defaults(

--- a/tests/unit/h/views/accounts_test.py
+++ b/tests/unit/h/views/accounts_test.py
@@ -1307,7 +1307,10 @@ class TestDeveloperController:
         self, controller, developer_token_service
     ):
         assert controller.get() == {
-            "token": developer_token_service.fetch.return_value.value
+            "js_config": {
+                "features": {},
+                "token": developer_token_service.fetch.return_value.value,
+            }
         }
 
     def test_get_returns_empty_context_for_missing_token(
@@ -1315,7 +1318,7 @@ class TestDeveloperController:
     ):
         developer_token_service.fetch.return_value = None
 
-        assert controller.get() == {}
+        assert controller.get() == {"js_config": {"features": {}}}
 
     def test_post_fetches_token(
         self, controller, developer_token_service, authenticated_userid
@@ -1339,7 +1342,10 @@ class TestDeveloperController:
         result = controller.post()
 
         assert result == {
-            "token": developer_token_service.regenerate.return_value.value
+            "js_config": {
+                "features": {},
+                "token": developer_token_service.regenerate.return_value.value,
+            }
         }
 
     def test_post_creates_new_token_when_not_found(
@@ -1358,7 +1364,12 @@ class TestDeveloperController:
 
         result = controller.post()
 
-        assert result == {"token": developer_token_service.create.return_value.value}
+        assert result == {
+            "js_config": {
+                "features": {},
+                "token": developer_token_service.create.return_value.value,
+            }
+        }
 
     @pytest.fixture
     def controller(self, pyramid_request):


### PR DESCRIPTION
Port the developer token page to Preact. In the process improve the UI by:

 - Use a `Callout` to make the warning about safe handling of tokens more visible.
 - Adding a copy-to-clipboard button for the API token

**When there is no existing token:**

<img width="554" height="291" alt="No token" src="https://github.com/user-attachments/assets/3f8912a1-6587-4132-896d-e09a9605cc9a" />

**When there is an existing token:**

<img width="553" height="388" alt="Recreate token" src="https://github.com/user-attachments/assets/49c1db41-3897-473b-a0a4-48a925e2a197" />


