### PR TITLE
Change account forms navigation to match group forms

### DIFF
--- a/h/static/scripts/components/AccountFormHeader.tsx
+++ b/h/static/scripts/components/AccountFormHeader.tsx
@@ -1,0 +1,36 @@
+import { routes } from '../routes';
+import TabLinks from './TabLinks';
+
+/** Navigation tabs for the account forms. */
+export default function AccountFormHeader() {
+  return (
+    <div className="mt-2 mb-6 border-b border-b-text-grey-6 py-2 flex flex-row items-center">
+      <TabLinks>
+        <TabLinks.Link
+          testId="settings-link"
+          href={routes.accountSettings}
+          server
+        >
+          Account
+        </TabLinks.Link>
+        <TabLinks.Link testId="profile-link" href={routes.profile} server>
+          Profile
+        </TabLinks.Link>
+        <TabLinks.Link
+          testId="notifications-link"
+          href={routes.accountNotifications}
+          server
+        >
+          Notifications
+        </TabLinks.Link>
+        <TabLinks.Link
+          testId="developer-link"
+          href={routes.accountDeveloper}
+          server
+        >
+          Developer
+        </TabLinks.Link>
+      </TabLinks>
+    </div>
+  );
+}

--- a/h/static/scripts/components/AccountSettingsForms.tsx
+++ b/h/static/scripts/components/AccountSettingsForms.tsx
@@ -6,6 +6,7 @@ import { LoginFormsConfig } from '../config';
 import type { AccountSettingsConfigObject } from '../config';
 import { useFormValue } from '../util/form-value';
 import type { FormValue } from '../util/form-value';
+import AccountFormHeader from './AccountFormHeader';
 import FacebookIcon from './FacebookIcon';
 import Form from './Form';
 import FormFooter from './FormFooter';
@@ -248,6 +249,7 @@ export default function AccountSettingsForms() {
 
   return (
     <>
+      <AccountFormHeader />
       <ChangeEmailForm config={config} />
       <ChangePasswordForm config={config} />
       <ConnectAccountButtons config={config} />

--- a/h/static/scripts/components/DeveloperForm.tsx
+++ b/h/static/scripts/components/DeveloperForm.tsx
@@ -3,6 +3,7 @@ import { useContext, useId } from 'preact/hooks';
 
 import { LoginFormsConfig } from '../config';
 import type { DeveloperConfigObject } from '../config';
+import AccountFormHeader from './AccountFormHeader';
 import CopyButton from './CopyButton';
 import Form from './Form';
 import FormFooter from './FormFooter';
@@ -17,6 +18,7 @@ export default function DeveloperForm() {
 
   return (
     <>
+      <AccountFormHeader />
       <Text>
         API tokens can be used to access your data via the{' '}
         <Link

--- a/h/static/scripts/components/NotificationsForm.tsx
+++ b/h/static/scripts/components/NotificationsForm.tsx
@@ -6,6 +6,7 @@ import type { NotificationsConfigObject } from '../config';
 import { routes } from '../routes';
 import { useFormValue } from '../util/form-value';
 import type { FormValue } from '../util/form-value';
+import AccountFormHeader from './AccountFormHeader';
 import Checkbox from './Checkbox';
 import Form from './Form';
 import FormFooter from './FormFooter';
@@ -45,21 +46,24 @@ export default function NotificationsForm() {
   }
 
   return (
-    <Form csrfToken={config.csrfToken}>
-      <p>Email me when someone:</p>
-      <Checkbox data-testid="reply-checkbox" {...checkboxProps(reply)}>
-        Replies to my annotations
-      </Checkbox>
-      <Checkbox data-testid="mention-checkbox" {...checkboxProps(mention)}>
-        Mentions me in an annotation
-      </Checkbox>
-      <Checkbox
-        data-testid="moderation-checkbox"
-        {...checkboxProps(moderation)}
-      >
-        Moderates my annotations
-      </Checkbox>
-      <FormFooter />
-    </Form>
+    <>
+      <AccountFormHeader />
+      <Form csrfToken={config.csrfToken}>
+        <p>Email me when someone:</p>
+        <Checkbox data-testid="reply-checkbox" {...checkboxProps(reply)}>
+          Replies to my annotations
+        </Checkbox>
+        <Checkbox data-testid="mention-checkbox" {...checkboxProps(mention)}>
+          Mentions me in an annotation
+        </Checkbox>
+        <Checkbox
+          data-testid="moderation-checkbox"
+          {...checkboxProps(moderation)}
+        >
+          Moderates my annotations
+        </Checkbox>
+        <FormFooter />
+      </Form>
+    </>
   );
 }

--- a/h/static/scripts/components/ProfileForm.tsx
+++ b/h/static/scripts/components/ProfileForm.tsx
@@ -4,6 +4,7 @@ import { LoginFormsConfig } from '../config';
 import type { ProfileConfigObject } from '../config';
 import { useFormValue } from '../util/form-value';
 import type { FormValue } from '../util/form-value';
+import AccountFormHeader from './AccountFormHeader';
 import Form from './Form';
 import FormFooter from './FormFooter';
 import TextField from './TextField';
@@ -28,6 +29,7 @@ export default function ProfileForm() {
 
   return (
     <>
+      <AccountFormHeader />
       <Form csrfToken={config.csrfToken}>
         <TextField
           label="Display name"

--- a/h/static/scripts/components/TabLinks.tsx
+++ b/h/static/scripts/components/TabLinks.tsx
@@ -6,12 +6,21 @@ export type TabLinkProps = {
   href: string;
   children: ComponentChildren;
   testId?: string;
+
+  /**
+   * If true, use a server-side navigation for this link.
+   *
+   * Defaults to false.
+   */
+  server?: boolean;
 };
 
-function TabLink({ children, href, testId }: TabLinkProps) {
+function TabLink({ children, href, testId, server = false }: TabLinkProps) {
   const [selected] = useRoute(href);
+  const Component = server ? 'a' : RouterLink;
+
   return (
-    <RouterLink
+    <Component
       href={href}
       className={classnames({
         'focus-visible-ring whitespace-nowrap flex items-center font-semibold rounded px-2 py-1 gap-x-2':
@@ -23,7 +32,7 @@ function TabLink({ children, href, testId }: TabLinkProps) {
       role="listitem"
     >
       {children}
-    </RouterLink>
+    </Component>
   );
 }
 

--- a/h/static/scripts/components/TabLinks.tsx
+++ b/h/static/scripts/components/TabLinks.tsx
@@ -26,6 +26,7 @@ function TabLink({ children, href, testId, server = false }: TabLinkProps) {
         'focus-visible-ring whitespace-nowrap flex items-center font-semibold rounded px-2 py-1 gap-x-2':
           true,
         'text-grey-1 bg-grey-7': selected,
+        'hover:bg-grey-2': !selected,
       })}
       data-testid={testId}
       aria-current={selected}

--- a/h/static/scripts/components/test/TabLinks-test.js
+++ b/h/static/scripts/components/test/TabLinks-test.js
@@ -1,0 +1,85 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+import { Router } from 'wouter-preact';
+
+import TabLinks from '../TabLinks';
+
+describe('TabLinks', () => {
+  const createWrapper = (initialLocation = '/') => {
+    // Set initial location. We currently modify the real URL, but could mock
+    // `useRoute` if that becomes problematic.
+    history.pushState({}, '', initialLocation);
+
+    return mount(
+      <Router>
+        <TabLinks>
+          <TabLinks.Link href="/profile" testId="profile-tab">
+            Profile
+          </TabLinks.Link>
+          <TabLinks.Link href="/notifications" testId="notifications-tab">
+            Notifications
+          </TabLinks.Link>
+        </TabLinks>
+      </Router>,
+    );
+  };
+
+  const getTab = (wrapper, testId) => {
+    // We use `first()` here to get the outermost component of the link.
+    return wrapper.find(`[data-testid="${testId}"]`).first();
+  };
+
+  afterEach(() => {
+    // Reset to initial location
+    history.pushState({}, '', '/');
+  });
+
+  it('displays tab for current route as selected', () => {
+    const wrapper = createWrapper('/profile');
+
+    let profileTab = getTab(wrapper, 'profile-tab');
+    let notificationsTab = getTab(wrapper, 'notifications-tab');
+
+    assert.isTrue(profileTab.prop('aria-current'));
+    assert.isFalse(notificationsTab.prop('aria-current'));
+
+    act(() => {
+      history.pushState({}, '', '/notifications');
+    });
+    wrapper.update();
+
+    profileTab = getTab(wrapper, 'profile-tab');
+    notificationsTab = getTab(wrapper, 'notifications-tab');
+
+    assert.isTrue(notificationsTab.prop('aria-current'));
+    assert.isFalse(profileTab.prop('aria-current'));
+  });
+
+  it('renders client-side router links by default', () => {
+    const wrapper = createWrapper();
+    const profileTab = getTab(wrapper, 'profile-tab');
+
+    // Should render as a router Link component (not a plain 'a' tag)
+    assert.notEqual(profileTab.name(), 'a');
+  });
+
+  it('renders server-side links when `server` prop is true', () => {
+    const wrapper = mount(
+      <Router>
+        <TabLinks>
+          <TabLinks.Link href="/external" server testId="external-tab">
+            External Link
+          </TabLinks.Link>
+        </TabLinks>
+      </Router>,
+    );
+
+    const externalTab = getTab(wrapper, 'external-tab');
+    assert.equal(externalTab.name(), 'a');
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({ content: () => createWrapper() }),
+  );
+});

--- a/h/templates/accounts/delete.html.jinja2
+++ b/h/templates/accounts/delete.html.jinja2
@@ -3,8 +3,6 @@
 {% set page_route = 'account_delete' %}
 {% set page_title = 'Delete your account' %}
 
-{% block tabs %}{% endblock tabs %}
-
 {% block page_content %}
   <h1 class="form-header">{% trans %}Delete your account{% endtrans %}</h1>
 

--- a/h/templates/layouts/account.html.jinja2
+++ b/h/templates/layouts/account.html.jinja2
@@ -17,20 +17,6 @@
 {% block content %}
   <div class="content paper">
     <div class="form-container">
-      {% block tabs %}
-      <nav class="tabs">
-        <ul>
-          {% for route, title in nav_pages %}
-            <li class="tabs__item">
-                <a href="{{ request.route_url(route) }}"
-                   class="tabs__link{% if route == page_route %} is-active{% endif %}">
-                  {{ title }}
-                </a>
-            </li>
-          {% endfor %}
-        </ul>
-      </nav>
-      {% endblock tabs %}
       {% include "h:templates/includes/flash-messages.html.jinja2" %}
       {{ self.page_content() }}
 


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/h/pull/9842 and https://github.com/hypothesis/h/pull/9848.**~~

This PR changes the navigation tabs in the account forms to be rendered client-side using the same style as used for navigation in the group forms. Unlike the group forms, the links still result in server-side navigations.

One problem with the new navigation headers is that they have exactly the same style as primary buttons. This issue is more obvious with the account forms since we have more regular buttons on the page. Before landing this I think I want to look at some alternative styles that don't have this issue. (_Update: I've experimented with some alternatives, but decided to keep the style as-is for the moment_)

**Before:**

<img width="751" height="491" alt="Old account navigation style v2" src="https://github.com/user-attachments/assets/4a2fe5a8-871c-40b8-9c52-87b28b7b0178" />

**After:**

<img width="803" height="457" alt="New account navigation style" src="https://github.com/user-attachments/assets/d0294a04-05d5-4936-b3c8-985a4198dbf8" />
