### PR TITLE
Bump @hypothesis/frontend-shared to v9.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/preset-typescript": "^7.27.0",
     "@hypothesis/annotation-ui": "^0.8.1",
     "@hypothesis/frontend-build": "^4.0.0",
-    "@hypothesis/frontend-shared": "^9.9.2",
+    "@hypothesis/frontend-shared": "^9.9.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,15 +2009,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^9.9.2":
-  version: 9.9.2
-  resolution: "@hypothesis/frontend-shared@npm:9.9.2"
+"@hypothesis/frontend-shared@npm:^9.9.3":
+  version: 9.9.3
+  resolution: "@hypothesis/frontend-shared@npm:9.9.3"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: 7d1d0c0778ec8e83e11847e1806a9e9a732737c87ceb216140a206f663aab09dc8935263f245fdcc5bd65cf6b70841e6ccf142a3f730f170f426b5b963f64642
+  checksum: 498b8a96005296a6551e13580a94ce28e08507477ea5766b27d0404bf656df168ec536e22c068c4eca738c13e3147c2872cc8a2adeffdb30dcb6c355020654a7
   languageName: node
   linkType: hard
 
@@ -6948,7 +6948,7 @@ __metadata:
     "@babel/preset-typescript": ^7.27.0
     "@hypothesis/annotation-ui": ^0.8.1
     "@hypothesis/frontend-build": ^4.0.0
-    "@hypothesis/frontend-shared": ^9.9.2
+    "@hypothesis/frontend-shared": ^9.9.3
     "@hypothesis/frontend-testing": ^1.7.1
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.3


### PR DESCRIPTION
This is a partial fix for an issue where annotation card heights change slightly after the first render. See https://github.com/hypothesis/frontend-shared/pull/2074.