### PR TITLE
Use Jinja macros to de-duplicate markup for JS app container

### DIFF
--- a/h/static/scripts/group-forms.tsx
+++ b/h/static/scripts/group-forms.tsx
@@ -5,7 +5,7 @@ import type { GroupFormsConfigObject } from './config';
 import { findContainer, readConfig } from './util/config';
 
 function init() {
-  const container = findContainer('#group-form');
+  const container = findContainer('#js-app-container');
   const config = readConfig<GroupFormsConfigObject>();
   render(<GroupFormsAppRoot config={config} />, container);
 }

--- a/h/static/scripts/login-forms.tsx
+++ b/h/static/scripts/login-forms.tsx
@@ -5,7 +5,7 @@ import type { LoginFormsConfigObject } from './config';
 import { findContainer, readConfig } from './util/config';
 
 function init() {
-  const container = findContainer('#login-form');
+  const container = findContainer('#js-app-container');
   const config = readConfig<LoginFormsConfigObject>();
   render(<LoginAppRoot config={config} />, container);
 }

--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -1,22 +1,16 @@
 {% extends "h:templates/layouts/account.html.jinja2" %}
+{% from "h:templates/includes/js_app.html.jinja2" import css_bundle, js_app_container, js_bundle %}
 
 {% block styles %}
   {{ super() }}
-
-  {% for url in asset_urls('forms_css')  %}
-    <link rel="stylesheet" href="{{ url }}">
-  {% endfor %}
+  {{ css_bundle('forms_css') }}
 {% endblock %}
 
 {% block page_content %}
-  <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
-  <div id="login-form"></div>
+  {{ js_app_container(js_config) }}
 {% endblock page_content %}
 
 {% block scripts %}
   {{ super() }}
-
-  {% for url in asset_urls('login_forms_js') %}
-    <script type="module" src="{{ url }}"></script>
-  {% endfor %}
+  {{ js_bundle('login_forms_js') }}
 {% endblock %}

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -1,4 +1,5 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
+{% from "h:templates/includes/js_app.html.jinja2" import css_bundle, js_app_container, js_bundle %}
 
 {% block page_title %}Log in{% endblock %}
 
@@ -8,24 +9,16 @@
 
 {% block styles %}
   {{ super() }}
-
-  {% for url in asset_urls('forms_css') %}
-    <link rel="stylesheet" href="{{ url }}">
-  {% endfor %}
+  {{ css_bundle('forms_css') }}
 {% endblock %}
 
 {% block content %}
   <div class="form-container">
-    <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
-
-    <div id="login-form"></div>
+    {{ js_app_container(js_config) }}
   </div>
 {% endblock %}
 
 {% block scripts %}
   {{ super() }}
-
-  {% for url in asset_urls('login_forms_js') %}
-    <script type="module" src="{{ url }}"></script>
-  {% endfor %}
+  {{ js_bundle('login_forms_js') }}
 {% endblock %}

--- a/h/templates/accounts/login_oauth.html.jinja2
+++ b/h/templates/accounts/login_oauth.html.jinja2
@@ -1,27 +1,20 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
+{% from "h:templates/includes/js_app.html.jinja2" import css_bundle, js_app_container, js_bundle %}
 
 {% block page_title %}Log in{% endblock %}
 
 {% block styles %}
   {{ super() }}
-
-  {% for url in asset_urls('forms_css') %}
-    <link rel="stylesheet" href="{{ url }}">
-  {% endfor %}
+  {{ css_bundle('forms_css') }}
 {% endblock %}
 
 {% block content %}
   <div class="form-container form-container--popup content">
-    <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
-
-    <div id="login-form"></div>
+    {{ js_app_container(js_config) }}
   </div>
 {% endblock content %}
 
 {% block scripts %}
   {{ super() }}
-
-  {% for url in asset_urls('login_forms_js') %}
-    <script type="module" src="{{ url }}"></script>
-  {% endfor %}
+  {{ js_bundle('login_forms_js') }}
 {% endblock %}

--- a/h/templates/accounts/signup-post.html.jinja2
+++ b/h/templates/accounts/signup-post.html.jinja2
@@ -1,4 +1,5 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
+{% from "h:templates/includes/js_app.html.jinja2" import css_bundle, js_app_container, js_bundle %}
 
 {% block page_title %}{{ heading|default("Sign up for Hypothesis") }}{% endblock %}
 
@@ -8,16 +9,11 @@
 
 {% block styles %}
   {{ super() }}
-
-  {% for url in asset_urls('forms_css') %}
-    <link rel="stylesheet" href="{{ url }}">
-  {% endfor %}
+  {{ css_bundle('forms_css') }}
 {% endblock %}
 
 {% block content %}
   <div class="form-container">
-    <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
-
     {# An empty "form" means signup was successful. Otherwise there were errors. #}
     {% if not js_config.get("form") %}
       <h1 class="form-header">
@@ -32,7 +28,7 @@
           email to <a href="mailto:support@hypothes.is">support@hypothes.is</a></p>
       </div>
     {% else %}
-      <div id="login-form"></div>
+      {{ js_app_container(js_config) }}
     {% endif %}
     <footer class="form-footer">
       {# An empty "form" means signup was successful. Otherwise there were errors. #}
@@ -51,8 +47,6 @@
 
   {# Client-rendered frontend is only used if signup was not successful. #}
   {% if js_config.get("form") %}
-    {% for url in asset_urls('login_forms_js') %}
-    <script type="module" src="{{ url }}"></script>
-    {% endfor %}
+    {{ js_bundle('login_forms_js') }}
   {% endif %}
 {% endblock %}

--- a/h/templates/accounts/signup.html.jinja2
+++ b/h/templates/accounts/signup.html.jinja2
@@ -1,4 +1,5 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
+{% from "h:templates/includes/js_app.html.jinja2" import css_bundle, js_app_container, js_bundle %}
 
 {% block page_title %}Sign up for Hypothesis{% endblock %}
 
@@ -8,24 +9,16 @@
 
 {% block styles %}
   {{ super() }}
-
-  {% for url in asset_urls('forms_css') %}
-    <link rel="stylesheet" href="{{ url }}">
-  {% endfor %}
+  {{ css_bundle('forms_css') }}
 {% endblock %}
 
 {% block content %}
   <div class="form-container">
-    <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
-
-    <div id="login-form"></div>
+    {{ js_app_container(js_config) }}
   </div>
 {% endblock %}
 
 {% block scripts %}
   {{ super() }}
-
-  {% for url in asset_urls('login_forms_js') %}
-    <script type="module" src="{{ url }}"></script>
-  {% endfor %}
+  {{ js_bundle('login_forms_js') }}
 {% endblock %}

--- a/h/templates/groups/create_edit.html.jinja2
+++ b/h/templates/groups/create_edit.html.jinja2
@@ -1,24 +1,18 @@
 {% extends "h:templates/layouts/group.html.jinja2" %}
+{% from "h:templates/includes/js_app.html.jinja2" import css_bundle, js_app_container, js_bundle %}
 
 {% block styles %}
   {{ super() }}
-
-  {% for url in asset_urls('forms_css') %}
-    <link rel="stylesheet" href="{{ url }}">
-  {% endfor %}
+  {{ css_bundle('forms_css') }}
 {% endblock %}
 
 {% block page_content %}
 <div class="form-container form-container--wide">
-  <div id="group-form"></div>
-  <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
+  {{ js_app_container(js_config) }}
 </div>
 {% endblock %}
 
 {% block scripts %}
   {{ super() }}
-
-  {% for url in asset_urls('group_forms_js') %}
-    <script type="module" src="{{ url }}"></script>
-  {% endfor %}
+  {{ js_bundle('group_forms_js') }}
 {% endblock %}

--- a/h/templates/includes/js_app.html.jinja2
+++ b/h/templates/includes/js_app.html.jinja2
@@ -1,0 +1,24 @@
+{#
+  Render the main container element for a client-rendered application.
+
+  :param js_config:
+    JSON-serializable value containing the configuration for the JS application.
+#}
+{% macro js_app_container(js_config) %}
+<script type="application/json" class="js-config">{{ js_config|tojson }}</script>
+<div id="js-app-container"></div>
+{% endmacro %}
+
+{# Render the `<script>` tags for a JS bundle defined in h/assets.ini. #}
+{% macro js_bundle(bundle_name) %}
+{% for url in asset_urls(bundle_name) %}
+<script type="module" src="{{ url }}"></script>
+{% endfor %}
+{% endmacro %}
+
+{# Render the `<style>` tags for a CSS bundle defined in h/assets.ini. #}
+{% macro css_bundle(bundle_name) %}
+{% for url in asset_urls(bundle_name)  %}
+<link rel="stylesheet" href="{{ url }}">
+{% endfor %}
+{% endmacro %}


### PR DESCRIPTION
Add macros in h/templates/includes/js_app.html.jinja2 which reduce the boilerplate in rendering the various tags needed to display a client-rendered application in a page.