### PR TITLE
Add moderator actions on AnnotationJSONService.present_for_user

### DIFF
--- a/h/services/annotation_json.py
+++ b/h/services/annotation_json.py
@@ -99,11 +99,6 @@ class AnnotationJSONService:
         if with_metadata and annotation.slim.meta:
             model["metadata"] = annotation.slim.meta.data
 
-        if self._request.has_permission(
-            Permission.Annotation.MODERATE, context=AnnotationContext(annotation)
-        ):
-            model["actions"].append("moderate")
-
         return model
 
     def present_for_user(
@@ -129,16 +124,17 @@ class AnnotationJSONService:
         # The flagged value depends on whether this particular user has flagged
         model["flagged"] = self._flag_service.flagged(user=user, annotation=annotation)
 
-        # Only moderators see the full flag count
         user_is_moderator = identity_permits(
             identity=Identity.from_models(user=user),
             context=AnnotationContext(annotation),
             permission=Permission.Annotation.MODERATE,
         )
         if user_is_moderator:
+            # Only moderators see the full flag count
             model["moderation"] = {
                 "flagCount": self._flag_service.flag_count(annotation)
             }
+            model["actions"].append("moderate")
 
         # The hidden value depends on whether you are the author
         user_is_author = user and user.userid == annotation.userid

--- a/tests/unit/h/services/annotation_json_test.py
+++ b/tests/unit/h/services/annotation_json_test.py
@@ -49,7 +49,7 @@ class TestAnnotationJSONService:
             "user_info": {"display_name": user_service.fetch.return_value.display_name},
             "mentions": [],
             "moderation_status": None,
-            "actions": ["moderate"],
+            "actions": [],
         }
 
         DocumentJSONPresenter.assert_called_once_with(annotation.document)
@@ -164,6 +164,7 @@ class TestAnnotationJSONService:
                 "hidden": False,
                 "flagged": flag_service.flagged.return_value,
                 "moderation": {"flagCount": flag_service.flag_count.return_value},
+                "actions": ["moderate"],
             }
         )
 


### PR DESCRIPTION
As part of https://github.com/hypothesis/h/pull/9766, we added a new `actions` property to annotations JSON representation. This is an empty array for regular users, and an array with the `"moderate"` value for moderators.

However, the `AnnotationJSONService` has two main methods to serialize  a single annotation, `present` and `present_for_user`.

In that PR, the logic to determine the `actions` was implemented in `present`, which docstring indicates it's a user-agnostic representation of the annotation, while `present_for_user` internally calls `present` and "enhances" it with information specific for the user performing the request.

This PR refactors the logic so that actions are set empty in `present`, and only when calling `present_for_user` we do check if the actions should include `"moderate"`.

This PR should have no end-user changes, since `present` is currently only invoked by `present_for_user`, but I has two benefits:

1. We were checking if current user was a moderator twice, once to check the actions, and in `present_for_user` again to check if the flag count should be returned. This PR consolidates those in a single check.
2. We honor `present`'s docstring, avoiding a user-specific check.