### PR TITLE
Leave one JSON-serialization method in AnnotationJSONService

### DIFF
--- a/h/services/annotation_authority_queue.py
+++ b/h/services/annotation_authority_queue.py
@@ -51,7 +51,7 @@ class AnnotationAuthorityQueueService:
             )
             return
 
-        annotation_dict = self._annotation_json_service.present_for_user(
+        annotation_dict = self._annotation_json_service.present(
             annotation=annotation, user=annotation.slim.user, with_metadata=True
         )
         # We already done the work to sanitize the text, send that value to the queue

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -27,7 +27,7 @@ class FlagService:
 
         self._session.add(Flag(user=user, annotation=annotation))
 
-    def flagged(self, user: User, annotation: Annotation):
+    def flagged(self, user: User | None, annotation: Annotation):
         """
         Check if a given user has flagged a given annotation.
 

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -86,7 +86,7 @@ def create(request):
 
     _publish_annotation_event(request, annotation, "create")
 
-    return request.find_service(name="annotation_json").present_for_user(
+    return request.find_service(name="annotation_json").present(
         annotation=annotation, user=request.user
     )
 
@@ -101,7 +101,7 @@ def create(request):
 )
 def read(context, request):
     """Return the annotation (simply how it was stored in the database)."""
-    return request.find_service(name="annotation_json").present_for_user(
+    return request.find_service(name="annotation_json").present(
         annotation=context.annotation, user=request.user
     )
 
@@ -145,7 +145,7 @@ def update(context, request):
 
     _publish_annotation_event(request, annotation, "update")
 
-    return request.find_service(name="annotation_json").present_for_user(
+    return request.find_service(name="annotation_json").present(
         annotation=annotation, user=request.user
     )
 

--- a/h/views/api/group_annotations.py
+++ b/h/views/api/group_annotations.py
@@ -45,7 +45,7 @@ def list_annotations(context: GroupContext, request):
     annotations = request.db.scalars(query)
 
     annotations_dicts = [
-        annotation_json_service.present_for_user(annotation, request.user)
+        annotation_json_service.present(annotation, request.user)
         for annotation in annotations
     ]
 

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -60,7 +60,7 @@ def change_annotation_moderation_status(context, request):
 
     _notify_moderation_change(request, context.annotation.id, moderation_log)
 
-    return request.find_service(name="annotation_json").present_for_user(
+    return request.find_service(name="annotation_json").present(
         annotation=context.annotation, user=request.user
     )
 

--- a/tests/unit/h/services/annotation_authority_queue_test.py
+++ b/tests/unit/h/services/annotation_authority_queue_test.py
@@ -45,7 +45,7 @@ class TestAnnotationAuthorityQueueService:
         Connection,
     ):
         annotation_presented = {"id": annotation.id}
-        annotation_json_service.present_for_user.return_value = annotation_presented
+        annotation_json_service.present.return_value = annotation_presented
         annotation_read_service.get_annotation_by_id.return_value = annotation
 
         svc.publish("create", sentinel.annotation_id)
@@ -53,7 +53,7 @@ class TestAnnotationAuthorityQueueService:
         annotation_read_service.get_annotation_by_id.assert_called_once_with(
             sentinel.annotation_id
         )
-        annotation_json_service.present_for_user.assert_called_once_with(
+        annotation_json_service.present.assert_called_once_with(
             annotation=annotation_read_service.get_annotation_by_id.return_value,
             user=annotation_read_service.get_annotation_by_id.return_value.slim.user,
             with_metadata=True,

--- a/tests/unit/h/views/api/annotations_test.py
+++ b/tests/unit/h/views/api/annotations_test.py
@@ -113,10 +113,10 @@ class TestCreate:
             AnnotationEvent.return_value
         )
         # Check we present
-        annotation_json_service.present_for_user.assert_called_once_with(
+        annotation_json_service.present.assert_called_once_with(
             annotation=annotation, user=pyramid_request.user
         )
-        assert result == annotation_json_service.present_for_user.return_value
+        assert result == annotation_json_service.present.return_value
 
     @pytest.mark.usefixtures("with_invalid_json_body")
     def test_it_raises_for_invalid_json(self, pyramid_request):
@@ -141,10 +141,10 @@ class TestRead:
     ):
         result = views.read(annotation_context, pyramid_request)
 
-        annotation_json_service.present_for_user.assert_called_once_with(
+        annotation_json_service.present.assert_called_once_with(
             annotation=annotation_context.annotation, user=pyramid_request.user
         )
-        assert result == annotation_json_service.present_for_user.return_value
+        assert result == annotation_json_service.present.return_value
 
 
 @pytest.mark.usefixtures("AnnotationJSONLDPresenter", "links_service")
@@ -222,11 +222,11 @@ class TestUpdate:
             AnnotationEvent.return_value
         )
         # Check it presents the annotation
-        annotation_json_service.present_for_user.assert_called_once_with(
+        annotation_json_service.present.assert_called_once_with(
             annotation=annotation_write_service.update_annotation.return_value,
             user=pyramid_request.user,
         )
-        assert returned == annotation_json_service.present_for_user.return_value
+        assert returned == annotation_json_service.present.return_value
 
     @pytest.mark.usefixtures("with_invalid_json_body")
     def test_it_raises_for_invalid_json(self, pyramid_request, annotation_context):

--- a/tests/unit/h/views/api/group_annotations_test.py
+++ b/tests/unit/h/views/api/group_annotations_test.py
@@ -41,13 +41,13 @@ class TestListAnnotations:
         sorted_annotations = sorted(
             annotations, key=attrgetter("created"), reverse=True
         )
-        assert annotation_json_service.present_for_user.call_args_list == [
+        assert annotation_json_service.present.call_args_list == [
             call(annotation, pyramid_request.user) for annotation in sorted_annotations
         ]
         assert response == {
             "data": [
                 # It returns the JSON presentation (the result of calling
-                # AnnotationJSONService.present_for_user()) of each annotation.
+                # AnnotationJSONService.present()) of each annotation.
                 getattr(sentinel, f"annotation_json_{annotation.id}")
                 for annotation in sorted_annotations
             ],
@@ -166,7 +166,7 @@ class TestListAnnotations:
 
     @pytest.fixture
     def annotation_json_service(self, annotation_json_service):
-        annotation_json_service.present_for_user.side_effect = (
+        annotation_json_service.present.side_effect = (
             lambda annotation, *_args, **_kwargs: getattr(
                 sentinel, f"annotation_json_{annotation.id}"
             )

--- a/tests/unit/h/views/api/moderation_test.py
+++ b/tests/unit/h/views/api/moderation_test.py
@@ -120,10 +120,10 @@ class TestChangeAnnotationModerationStatus:
                 mock.call(events.ModeratedAnnotationEvent.return_value),
             ]
         )
-        annotation_json_service.present_for_user.assert_called_once_with(
+        annotation_json_service.present.assert_called_once_with(
             annotation=annotation, user=pyramid_request.user
         )
-        assert response == annotation_json_service.present_for_user.return_value
+        assert response == annotation_json_service.present.return_value
 
     @pytest.mark.parametrize(
         "annotation_updated,message",


### PR DESCRIPTION
> This is an alternative to https://github.com/hypothesis/h/pull/9874
> This refactoring was suggested in https://github.com/hypothesis/h/pull/9874#issuecomment-3245437246

Part of https://github.com/hypothesis/h/issues/9802

Refactor `AnnotationJSONService` to combine `present` and `present_for_user` methods into a single `present` method.

Previously `present` was documented as a method to serialize annotations in a user-agnostic way, but the reality is that we had added a few changes as part of recent feature that  broke this rule, causing the service to have two methods producing slightly different JSON structures.

This ensures there's only one JSON representation of individual annotations.

Additionally, we deduplicate the logic to check if current user is a moderator, which was being done in both `present`, and `present_for_user` (which internally called `present`).