### PR TITLE
Change BulkGroupService.group_search to use AnnotationSlim

### DIFF
--- a/h/services/bulk_api/group.py
+++ b/h/services/bulk_api/group.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
-from h.models import Annotation, Group
+from h.models import AnnotationSlim, Group
 from h.services.bulk_api._helpers import date_match
 
 
@@ -35,10 +35,10 @@ class BulkGroupService:
             Group.authority_provided_id.in_(groups),
             sa.exists(
                 sa.select(1)
-                .select_from(Annotation)
+                .select_from(AnnotationSlim)
                 .where(
-                    Annotation.groupid == Group.pubid,
-                    date_match(Annotation.created, annotations_created),
+                    AnnotationSlim.group_id == Group.id,
+                    date_match(AnnotationSlim.created, annotations_created),
                 )
             ),
         )

--- a/tests/unit/h/services/bulk_api/group_test.py
+++ b/tests/unit/h/services/bulk_api/group_test.py
@@ -13,8 +13,8 @@ class TestBulkGroupService:
         group_without_annos = factories.Group()
         group_with_annos_in_other_dates = factories.Group()
         another_group = factories.Group()
-        factories.Annotation(group=group, created=since + timedelta(days=1))
-        factories.Annotation(
+        factories.AnnotationSlim(group=group, created=since + timedelta(days=1))
+        factories.AnnotationSlim(
             group=group_with_annos_in_other_dates, created=since - timedelta(days=1)
         )
 


### PR DESCRIPTION
All the fields required by this query are present on AnnotationSlim, and querying AnnotationSlim should be more efficient than querying Annotation because it is a much smaller table (`annotation` is about 6.5x larger than `annotation_slim`) with integer keys to other tables.

The downside of this change is that the query will no longer be able to surface results based on annotations that haven't been back-filled into `annotation_slim` yet. The table was added two years ago, so we should be able to back at least that far. _Update: According to estimates in `pg_class`, both tables have almost the same number of rows, so I think this was actually completed_

Part of https://github.com/hypothesis/product-backlog/issues/1679