### PR TITLE
Test per-group custom `Reply-To` header

### DIFF
--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -167,7 +167,13 @@ class AnnotationModerationService:
             html=render(f"{template_base}.html.jinja2", context, request=request),
             tag=EmailTag.MODERATION,
             subaccount=self._email_subaccount,
+            reply_to=(
+                "marc-cola-reunite-spilling@mailinator.com"
+                if group.pubid == "yxJdKrLg"
+                else None
+            ),
         )
+
         task_data = TaskData(
             tag=email_data.tag,
             sender_id=author.id,

--- a/h/services/email.py
+++ b/h/services/email.py
@@ -28,13 +28,20 @@ class EmailData:
     tag: EmailTag
     html: str | None = None
     subaccount: str | None = None
+    reply_to: str | None = None
 
     @property
     def message(self) -> pyramid_mailer.message.Message:
         extra_headers: dict[str, str] = {"X-MC-Tags": self.tag}
+
         if self.subaccount:
             extra_headers["X-MC-Subaccount"] = self.subaccount
+
+        if self.reply_to:  # pragma: nocover
+            extra_headers["Reply-To"] = self.reply_to
+
         subject = " ".join(self.subject.splitlines())
+
         return pyramid_mailer.message.Message(
             subject=subject,
             recipients=self.recipients,

--- a/tests/unit/h/services/annotation_moderation_test.py
+++ b/tests/unit/h/services/annotation_moderation_test.py
@@ -289,6 +289,7 @@ class TestAnnotationModerationService:
                 "tag": EmailTag.MODERATION,
                 "html": "",
                 "subaccount": sentinel.email_subaccount,
+                "reply_to": None,
             },
             {
                 "tag": EmailTag.MODERATION,

--- a/tests/unit/h/views/api/flags_test.py
+++ b/tests/unit/h/views/api/flags_test.py
@@ -50,6 +50,7 @@ class TestCreate:
                     "tag": EmailTag.FLAG_NOTIFICATION,
                     "html": sentinel.html1,
                     "subaccount": None,
+                    "reply_to": None,
                 },
                 {
                     "sender_id": pyramid_request.user.id,
@@ -66,6 +67,7 @@ class TestCreate:
                     "tag": EmailTag.FLAG_NOTIFICATION,
                     "html": sentinel.html2,
                     "subaccount": None,
+                    "reply_to": None,
                 },
                 {
                     "sender_id": pyramid_request.user.id,


### PR DESCRIPTION
This is intended to be reverted once I've quickly tested it on production.