### PR TITLE
Add Sentry logging

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -9,7 +9,7 @@ from pyramid.tweens import EXCVIEW
 
 from h._version import get_version
 from h.config import configure
-from h.sentry_filters import SENTRY_FILTERS
+from h.sentry_filters import SENTRY_ERROR_FILTERS, sentry_before_send_log
 from h.views.client import DEFAULT_CLIENT_URL
 
 log = logging.getLogger(__name__)
@@ -116,7 +116,7 @@ def _configure_jinja2_assets(config):
 def _configure_sentry(config):
     config.add_settings(
         {
-            "h_pyramid_sentry.filters": SENTRY_FILTERS,
+            "h_pyramid_sentry.filters": SENTRY_ERROR_FILTERS,
             "h_pyramid_sentry.retry_support": True,
             "h_pyramid_sentry.celery_support": True,
             "h_pyramid_sentry.sqlalchemy_support": True,
@@ -130,6 +130,8 @@ def _configure_sentry(config):
             # For the full list of options that sentry_sdk.init() supports see:
             # https://docs.sentry.io/platforms/python/configuration/options/
             "h_pyramid_sentry.init.release": get_version(),
+            "h_pyramid_sentry.init.enable_logs": True,
+            "h_pyramid_sentry.init.before_send_log": sentry_before_send_log,
         }
     )
     config.include("h_pyramid_sentry")

--- a/h/sentry_filters.py
+++ b/h/sentry_filters.py
@@ -1,10 +1,38 @@
-"""
-Functions for filtering out events we don't want to report to Sentry.
-
-These are intended to be passed to h_pyramid_sentry.EventFilter.add_filters
-"""
+"""Functions for filtering out events and log messages we don't want to report to Sentry."""
 
 import ws4py.exc
+from sentry_sdk.types import Hint, Log
+
+
+def sentry_before_send_log(log: Log, _hint: Hint) -> Log | None:
+    """Filter out log messages that we don't want to send to Sentry Logs."""
+
+    attributes = log["attributes"]
+    logger_name = attributes.get("logger.name")
+    path = attributes.get("sentry.message.parameter.{path_info}e")
+    request_method = attributes.get("sentry.message.parameter.{request_method}e")
+    response_status = attributes.get("sentry.message.parameter.s")
+
+    try:
+        response_status_int = int(response_status)  # type: ignore[arg-type]
+    except TypeError:
+        response_status_int = None
+
+    # Filter out badge endpoint access logs.
+    if logger_name == "gunicorn.access" and path == "/api/badge":
+        return None
+
+    # Filter out all successful GET request access logs.
+    if (
+        logger_name == "gunicorn.access"
+        and request_method == "GET"
+        and response_status is not None
+        and response_status_int >= 200  # type: ignore[operator]
+        and response_status_int <= 300  # type: ignore[operator]
+    ):
+        return None
+
+    return log
 
 
 def is_ws4py_error_logging(event):
@@ -24,4 +52,5 @@ def is_ws4py_handshake_error(event):
     )
 
 
-SENTRY_FILTERS = [is_ws4py_error_logging, is_ws4py_handshake_error]
+# These are intended to be passed to h_pyramid_sentry.EventFilter.add_filters
+SENTRY_ERROR_FILTERS = [is_ws4py_error_logging, is_ws4py_handshake_error]

--- a/h/streamer/app.py
+++ b/h/streamer/app.py
@@ -3,7 +3,7 @@ import pyramid
 from h._version import get_version
 from h.config import configure
 from h.security import StreamerPolicy
-from h.sentry_filters import SENTRY_FILTERS
+from h.sentry_filters import SENTRY_ERROR_FILTERS
 
 
 def create_app(_global_config, **settings):
@@ -44,7 +44,7 @@ def create_app(_global_config, **settings):
     # Configure sentry
     config.add_settings(
         {
-            "h_pyramid_sentry.filters": SENTRY_FILTERS,
+            "h_pyramid_sentry.filters": SENTRY_ERROR_FILTERS,
             "h_pyramid_sentry.celery_support": True,
             # Enable Sentry's "Releases" feature, see:
             # https://docs.sentry.io/platforms/python/configuration/options/#release

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -300,7 +300,7 @@ rpds-py==0.22.3
     #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
-sentry-sdk==2.22.0
+sentry-sdk==2.37.1
     # via
     #   -r requirements/prod.txt
     #   h-pyramid-sentry

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -297,7 +297,7 @@ rpds-py==0.22.3
     #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
-sentry-sdk==2.22.0
+sentry-sdk==2.37.1
     # via
     #   -r requirements/prod.txt
     #   h-pyramid-sentry

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -463,7 +463,7 @@ rpds-py==0.22.3
     #   referencing
 ruff==0.9.9
     # via -r requirements/lint.in
-sentry-sdk==2.22.0
+sentry-sdk==2.37.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -203,7 +203,7 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-sentry-sdk==2.22.0
+sentry-sdk==2.37.1
     # via
     #   -r requirements/prod.in
     #   h-pyramid-sentry

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -310,7 +310,7 @@ rpds-py==0.22.3
     #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
-sentry-sdk==2.22.0
+sentry-sdk==2.37.1
     # via
     #   -r requirements/prod.txt
     #   h-pyramid-sentry

--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -267,7 +267,7 @@ rpds-py==0.22.3
     #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
-sentry-sdk==2.22.0
+sentry-sdk==2.37.1
     # via
     #   -r requirements/prod.txt
     #   h-pyramid-sentry

--- a/tests/unit/h/app_test.py
+++ b/tests/unit/h/app_test.py
@@ -5,7 +5,7 @@ from pyramid_jinja2 import Environment as JinjaEnvironment
 
 from h.app import includeme
 from h.assets import Environment
-from h.sentry_filters import SENTRY_FILTERS
+from h.sentry_filters import SENTRY_ERROR_FILTERS
 
 
 class TestIncludeMe:
@@ -16,7 +16,7 @@ class TestIncludeMe:
 
         assert settings["h_pyramid_sentry.retry_support"] is True
         assert settings["h_pyramid_sentry.celery_support"] is True
-        assert settings["h_pyramid_sentry.filters"] == SENTRY_FILTERS
+        assert settings["h_pyramid_sentry.filters"] == SENTRY_ERROR_FILTERS
 
         pyramid_config.include.assert_any_call("h_pyramid_sentry")
 

--- a/tests/unit/h/streamer/app_test.py
+++ b/tests/unit/h/streamer/app_test.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 from pyramid.config import Configurator
 
-from h.sentry_filters import SENTRY_FILTERS
+from h.sentry_filters import SENTRY_ERROR_FILTERS
 from h.streamer.app import create_app
 
 
@@ -14,7 +14,7 @@ class TestIncludeMe:
 
         config.add_settings.assert_any_call(
             {
-                "h_pyramid_sentry.filters": SENTRY_FILTERS,
+                "h_pyramid_sentry.filters": SENTRY_ERROR_FILTERS,
                 "h_pyramid_sentry.celery_support": True,
                 "h_pyramid_sentry.init.release": get_version.return_value,
             }


### PR DESCRIPTION
I'm not sure this is set up completely correctly yet (e.g. is it collecting logs from the WebSocket app? And from Celery workers?) but I want to start collecting at least the logs from the main app so that I can try out the interface. I've made an attempt to filter out badge endpoint access logs and all 2xx and 3xx access logs.