### PR TITLE
Fix permissions for hidden annotations

### DIFF
--- a/h/security/permission_map.py
+++ b/h/security/permission_map.py
@@ -80,11 +80,20 @@ PERMISSION_MAP = {
         # of the annotation. We bend the predicate system here a little and
         # put a raw permission in which will cause us to look up that
         # permission.
-        [p.annotation_shared, Permission.Group.READ],
+        [p.annotation_shared, p.annotation_not_hidden, Permission.Group.READ],
+        [p.annotation_hidden, p.annotation_created_by_user],
+        [p.annotation_hidden, Permission.Annotation.MODERATE],
     ],
     Permission.Annotation.READ: [
         [p.annotation_live, p.annotation_not_shared, p.annotation_created_by_user],
-        [p.annotation_live, p.annotation_shared, Permission.Group.READ],
+        [
+            p.annotation_live,
+            p.annotation_shared,
+            p.annotation_not_hidden,
+            Permission.Group.READ,
+        ],
+        [p.annotation_hidden, p.annotation_created_by_user],
+        [p.annotation_hidden, Permission.Annotation.MODERATE],
     ],
     Permission.Annotation.FLAG: [
         [p.annotation_live, p.annotation_not_shared, p.annotation_created_by_user],

--- a/h/security/predicates.py
+++ b/h/security/predicates.py
@@ -102,6 +102,16 @@ def annotation_not_shared(_identity, context):
 
 
 @requires(annotation_found)
+def annotation_hidden(_identity, context):
+    return context.annotation.is_hidden
+
+
+@requires(annotation_found)
+def annotation_not_hidden(_identity, context):
+    return not context.annotation.is_hidden
+
+
+@requires(annotation_found)
 def annotation_live(_identity, context):
     return not context.annotation.deleted
 
@@ -215,9 +225,9 @@ def group_member_remove(identity, context: GroupMembershipContext):
 
 @requires(authenticated_user, group_found)
 def group_member_edit(identity, context: EditGroupMembershipContext):  # noqa: PLR0911
-    assert context.new_roles is not None, (  # noqa: S101
-        "new_roles must be set before checking permissions"
-    )
+    assert (  # noqa: S101
+        context.new_roles is not None
+    ), "new_roles must be set before checking permissions"
 
     old_roles = context.membership.roles
     new_roles = context.new_roles

--- a/tests/unit/h/security/predicates_test.py
+++ b/tests/unit/h/security/predicates_test.py
@@ -2,6 +2,7 @@ from unittest.mock import sentinel
 
 import pytest
 
+from h.models import ModerationStatus
 from h.models.group import (
     GroupMembership,
     GroupMembershipRoles,
@@ -108,6 +109,42 @@ class TestAnnotationPredicates:
         result = predicates.annotation_not_shared(sentinel.identity, annotation_context)
 
         assert result is not is_shared
+
+    @pytest.mark.parametrize(
+        "moderation_status,expected_result",
+        [
+            [ModerationStatus.PENDING, True],
+            [ModerationStatus.APPROVED, False],
+            [ModerationStatus.DENIED, True],
+            [ModerationStatus.SPAM, True],
+        ],
+    )
+    def test_annotation_hidden(
+        self, annotation_context, moderation_status, expected_result
+    ):
+        annotation_context.annotation.moderation_status = moderation_status
+
+        result = predicates.annotation_hidden(sentinel.identity, annotation_context)
+
+        assert result == expected_result
+
+    @pytest.mark.parametrize(
+        "moderation_status,expected_result",
+        [
+            [ModerationStatus.PENDING, False],
+            [ModerationStatus.APPROVED, True],
+            [ModerationStatus.DENIED, False],
+            [ModerationStatus.SPAM, False],
+        ],
+    )
+    def test_annotation_not_hidden(
+        self, annotation_context, moderation_status, expected_result
+    ):
+        annotation_context.annotation.moderation_status = moderation_status
+
+        result = predicates.annotation_not_hidden(sentinel.identity, annotation_context)
+
+        assert result == expected_result
 
     @pytest.mark.parametrize("is_deleted", (True, False))
     def test_annotation_live(self, annotation_context, is_deleted):


### PR DESCRIPTION
Fixes https://github.com/hypothesis/h/issues/9884

Annotations hidden by moderation were still being returned by the single-annotation fetch API and by the WebSocket. Fix both by making h's security system aware of annotation moderation statuses.

## Testing WebSocket

1. Log in as devdata_admin
2. Go to http://localhost:5000/admin/features and enable the pre_moderation feature
3. Go to http://localhost:5000/groups/new and create a new group with pre-moderation enabled.
4. Log in as devdata_user and join the group by visiting its invite URL.
5. Open http://localhost:3000/ in two separate browsers, one logged in as devdata_admin and one logged in as devdata_user. Focus the new group in both browsers.
6. As devdata_admin create a new annotation. The annotation will be pending initially. On main devdata_user's open tab would receive a realtime notification of the new annotation and they would be able to see the pending annotation. On this branch no notification will be receivbed.
7. If you change the annotation's state to declined, spam or pending or edit the annotation while it's in any of these states then no notification will be recieved.
8. But if you _approve_ the annotation then devdata_user will see a notification
  9. If you edit the annotation while it's approved then it will revert to pending and devdata_user will not see a notification
10. You can also test the other way round: have devdata_user create and edit a pending annotation. devdata_admin is a moderator so _will_ see live updates about the annotation.

## Testing single-annotation fetch API

Create a hidden annotation, e.g. a pending one, then make API requests for it:

```
$ httpx 'http://localhost:5000/api/annotations/ANNOTATION_ID' --headers Authorization 'Bearer DEVELOPER_TOKEN'
```

The annotation's author and group moderators will be able to read a pending, denied or spam annotation. But other group members, non-group members, and unauthenticated requests shouuld not be able to read the annotation unless it is approved.