### PR TITLE
Filter out all access logs and re-enable Sentry logs

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -130,7 +130,7 @@ def _configure_sentry(config):
             # For the full list of options that sentry_sdk.init() supports see:
             # https://docs.sentry.io/platforms/python/configuration/options/
             "h_pyramid_sentry.init.release": get_version(),
-            "h_pyramid_sentry.init.enable_logs": False,
+            "h_pyramid_sentry.init.enable_logs": True,
             "h_pyramid_sentry.init.before_send_log": sentry_before_send_log,
         }
     )

--- a/h/sentry_filters.py
+++ b/h/sentry_filters.py
@@ -7,29 +7,7 @@ from sentry_sdk.types import Hint, Log
 def sentry_before_send_log(log: Log, _hint: Hint) -> Log | None:
     """Filter out log messages that we don't want to send to Sentry Logs."""
 
-    attributes = log["attributes"]
-    logger_name = attributes.get("logger.name")
-    path = attributes.get("sentry.message.parameter.{path_info}e")
-    request_method = attributes.get("sentry.message.parameter.{request_method}e")
-    response_status = attributes.get("sentry.message.parameter.s")
-
-    try:
-        response_status_int = int(response_status)  # type: ignore[arg-type]
-    except TypeError:
-        response_status_int = None
-
-    # Filter out badge endpoint access logs.
-    if logger_name == "gunicorn.access" and path == "/api/badge":
-        return None
-
-    # Filter out all successful GET request access logs.
-    if (
-        logger_name == "gunicorn.access"
-        and request_method == "GET"
-        and response_status is not None
-        and response_status_int >= 200  # type: ignore[operator]
-        and response_status_int < 400  # type: ignore[operator]
-    ):
+    if log.get("attributes", {}).get("logger.name") == "gunicorn.access":
         return None
 
     return log

--- a/tests/unit/h/sentry_filters_test.py
+++ b/tests/unit/h/sentry_filters_test.py
@@ -15,56 +15,9 @@ class TestSentryBeforeSendLog:
     @pytest.mark.parametrize(
         "log,should_be_filtered_out",
         [
-            (
-                {
-                    "attributes": {
-                        "logger.name": "gunicorn.access",
-                        "sentry.message.parameter.{path_info}e": "/api/badge",
-                    }
-                },
-                True,
-            ),
-            (
-                {
-                    "attributes": {
-                        "logger.name": "gunicorn.access",
-                        "sentry.message.parameter.{request_method}e": "GET",
-                        "sentry.message.parameter.s": "200",
-                    }
-                },
-                True,
-            ),
-            (
-                {
-                    "attributes": {
-                        "logger.name": "gunicorn.access",
-                        "sentry.message.parameter.{request_method}e": "GET",
-                        "sentry.message.parameter.s": "301",
-                    }
-                },
-                True,
-            ),
-            (
-                {
-                    "attributes": {
-                        "logger.name": "gunicorn.access",
-                        "sentry.message.parameter.{request_method}e": "GET",
-                        "sentry.message.parameter.s": "400",
-                    }
-                },
-                False,
-            ),
-            (
-                {
-                    "attributes": {
-                        "logger.name": "gunicorn.access",
-                        "sentry.message.parameter.{request_method}e": "GET",
-                        "sentry.message.parameter.s": "500",
-                    }
-                },
-                False,
-            ),
-            ({"attributes": {}}, False),
+            ({"attributes": {"logger.name": "gunicorn.access"}}, True),
+            ({"attributes": {"logger.name": "foo"}}, False),
+            ({}, False),
         ],
     )
     def test_it(self, log, should_be_filtered_out):


### PR DESCRIPTION
For now completely filter out all Gunicorn access logs. Want to run this for a while and find out how much log data we send to Sentry for the non-access logs only. Later I might try re-enabling some or all of the access logs but perhaps with additional attributes that're sent to Sentry stripped to save data.
