### PR TITLE
Fix WebSocket crash when no authenticated user

### DIFF
--- a/tests/unit/h/streamer/messages_test.py
+++ b/tests/unit/h/streamer/messages_test.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from unittest.mock import Mock, sentinel
+from unittest.mock import ANY, Mock, sentinel
 
 import pytest
 from gevent.queue import Queue
@@ -226,6 +226,26 @@ class TestHandleAnnotationEvent:
         )
 
         assert bool(socket.send_json.call_count) == can_see
+
+    def test_with_no_identity(
+        self, handle_annotation_event, socket, user_service, annotation_json_service
+    ):
+        socket.identity = None
+
+        handle_annotation_event(sockets=[socket])
+
+        user_service.fetch.assert_not_called()
+        annotation_json_service.present.assert_called_once_with(ANY, user=None)
+
+    def test_with_no_user(
+        self, handle_annotation_event, socket, user_service, annotation_json_service
+    ):
+        socket.identity.user = None
+
+        handle_annotation_event(sockets=[socket])
+
+        user_service.fetch.assert_not_called()
+        annotation_json_service.present.assert_called_once_with(ANY, user=None)
 
     @pytest.fixture
     def handle_annotation_event(self, message, socket, pyramid_request, session):


### PR DESCRIPTION
Sentry doesn't seem to be working for the WebSocket currently (a separate issue) so we don't have a crash report, but in the WebSocket's logs (which are only available in AWS, not in New Relic) I'm seeing this repeatedly:

    AttributeError: 'NoneType' object has no attribute 'user'
    2025-09-18 12:45:40,652 [12] [h.streamer.db:WARNING] Caught exception during streamer transaction:
    Traceback (most recent call last):
      File "/var/lib/hypothesis/h/streamer/db.py", line 24, in read_only_transaction
        yield
      File "/var/lib/hypothesis/h/streamer/streamer.py", line 80, in process_work_queue
        messages.handle_message(msg, registry, session, TOPIC_HANDLERS)
      File "/var/lib/hypothesis/h/streamer/messages.py", line 77, in handle_message
        handler(message.payload, sockets, request, session)
      File "/var/lib/hypothesis/h/streamer/messages.py", line 127, in handle_annotation_event
        request, message, annotation, user=socket.identity.user

Fix the WebSocket's `handle_annotation_event()` function to work if `socket.identity` is `None` or if `socket.identity.user` is `None`. This should fix the crash.