### PR TITLE
Fix test Sentry logging from WebSocket app

### DIFF
--- a/h/streamer/app.py
+++ b/h/streamer/app.py
@@ -1,13 +1,9 @@
-from logging import getLogger
-
 import pyramid
 
 from h._version import get_version
 from h.config import configure
 from h.security import StreamerPolicy
 from h.sentry_filters import SENTRY_ERROR_FILTERS
-
-log = getLogger(__name__)
 
 
 def create_app(_global_config, **settings):
@@ -65,7 +61,6 @@ def create_app(_global_config, **settings):
         }
     )
     config.include("h_pyramid_sentry")
-    log.info("WebSocket app has configured Sentry")
 
     # Add support for logging exceptions whenever they arise
     config.include("pyramid_exclog")

--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -1,3 +1,5 @@
+from logging import getLogger
+
 from pyramid.settings import asbool
 from pyramid.view import forbidden_view_config, notfound_view_config, view_config
 from ws4py.exc import HandshakeError
@@ -5,9 +7,13 @@ from ws4py.server.wsgiutils import WebSocketWSGIApplication
 
 from h.streamer import streamer, websocket
 
+log = getLogger(__name__)
+
 
 @view_config(route_name="ws")
 def websocket_view(request):
+    log.info("websocket_view()")
+
     # Provide environment which the WebSocket handler can use...
     request.environ.update(
         {


### PR DESCRIPTION
I don't think it works to log a message from the `create_app()` function
itself: Sentry hasn't been configured yet at this point. Try logging a
test message from one of the Pyramid app's views instead.
