### PR TITLE
Test Sentry error reporting from WebSocket

### DIFF
--- a/h/views/status.py
+++ b/h/views/status.py
@@ -11,6 +11,9 @@ log = logging.getLogger(__name__)
 
 @json_view(route_name="status", http_cache=0)
 def status(request):
+    if "crash" in request.params:  # pragma: no cover
+        raise RuntimeError("This is a test crash")  # noqa: EM101,TRY003
+
     try:
         request.db.execute(text("SELECT 1"))
     except Exception as err:


### PR DESCRIPTION
Sentry logging doesn't seem to be working from the WebSocket app and I can't figure out why. Adding some temporary code to test whether _error reporting_ is also broken (I suspect it is‚.
