### PR TITLE
Add per-group custom email Reply-To and From-names

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -159,6 +159,27 @@ class Group(Base, mixins.Timestamps):
 
     pre_moderated: Mapped[bool | None] = mapped_column()
 
+    #: A custom Reply-To email address to be used for emails sent from this
+    #: group, for example: 'My Group Moderators <mygroup@example.com>'.
+    #:
+    #: This is used for example as the Reply-To address when the group's
+    #: moderators approve or decline an annotation in the group and we send
+    #: a notification email to the annotation's author.
+    reply_to = sa.Column(sa.UnicodeText(), nullable=True)
+
+    #: A custom name component to be used in the `From` headers of emails sent
+    #: from this group, for example: "My Group".
+    #:
+    #: This does not affect the `From` email address of the group, only the
+    #: name part. The email `From` header will be:
+    #: `My Group <default_sender@example.com>`
+    #: (where default_sender@example.com is the app's default sender address).
+    #:
+    #: This is used for example in the From address when the group's
+    #: moderators approve or decline an annotation in the group and we send
+    #: a notification email to the annotation's author.
+    email_from_name = sa.Column(sa.UnicodeText(), nullable=True)
+
     @property
     def groupid(self):
         if self.authority_provided_id is None:

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -167,6 +167,8 @@ class AnnotationModerationService:
             html=render(f"{template_base}.html.jinja2", context, request=request),
             tag=EmailTag.MODERATION,
             subaccount=self._email_subaccount,
+            reply_to=group.reply_to,
+            from_name=group.email_from_name,
         )
         task_data = TaskData(
             tag=email_data.tag,

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -195,6 +195,8 @@ class GroupEditViews:
                 name=appstruct["name"],
                 scopes=scopes,
                 enforce_scope=appstruct["enforce_scope"],
+                reply_to=appstruct["reply_to"] or None,
+                email_from_name=appstruct["email_from_name"] or None,
             )
 
             memberids = []
@@ -231,10 +233,14 @@ class GroupEditViews:
                 ),
                 "scopes": [s.scope for s in group.scopes],
                 "enforce_scope": group.enforce_scope,
+                "reply_to": group.reply_to or "",
+                "email_from_name": group.email_from_name or "",
             }
         )
 
-    def _template_context(self):
+    def _template_context(self, errors=None, items=None):
+        del errors, items
+
         num_annotations = (
             self.request.db.query(Annotation)
             .filter_by(groupid=self.group.pubid)

--- a/tests/unit/h/schemas/forms/admin/group_test.py
+++ b/tests/unit/h/schemas/forms/admin/group_test.py
@@ -182,6 +182,48 @@ class TestAdminGroupSchema:
             ),
         ]
 
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {"reply_to": "email_address@example.com"},
+            {"reply_to": "Real Name <email_address@example.com>"},
+        ],
+    )
+    def test_valid_reply_to(self, bound_schema, data, group_data):
+        group_data.update(data)
+
+        result = bound_schema.deserialize(group_data)
+
+        assert result["reply_to"] == data["reply_to"]
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {"reply_to": "@@"},
+        ],
+    )
+    def test_invalid_reply_to(self, bound_schema, data, group_data):
+        group_data.update(data)
+
+        with pytest.raises(
+            colander.Invalid, match=r"^{'reply_to': 'Invalid email address'}$"
+        ):
+            bound_schema.deserialize(group_data)
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {"email_from_name": "Real Name"},
+            {"email_from_name": None},
+        ],
+    )
+    def test_valid_email_from_name(self, bound_schema, data, group_data):
+        group_data.update(data)
+
+        result = bound_schema.deserialize(group_data)
+
+        assert result["email_from_name"] == data["email_from_name"]
+
 
 @pytest.fixture
 def group_data(org):

--- a/tests/unit/h/services/annotation_moderation_test.py
+++ b/tests/unit/h/services/annotation_moderation_test.py
@@ -289,6 +289,8 @@ class TestAnnotationModerationService:
                 "tag": EmailTag.MODERATION,
                 "html": "",
                 "subaccount": sentinel.email_subaccount,
+                "reply_to": group.reply_to,
+                "from_name": group.email_from_name,
             },
             {
                 "tag": EmailTag.MODERATION,

--- a/tests/unit/h/views/admin/groups_test.py
+++ b/tests/unit/h/views/admin/groups_test.py
@@ -319,6 +319,8 @@ class TestGroupEditViews:
                     "scopes": ["http://somewhereelse.com", "http://www.gladiolus.org"],
                     "members": [],
                     "enforce_scope": False,
+                    "reply_to": None,
+                    "email_from_name": None,
                 }
             )
 
@@ -338,6 +340,8 @@ class TestGroupEditViews:
                 for scope in ["http://somewhereelse.com", "http://www.gladiolus.org"]
             ],
             enforce_scope=False,
+            reply_to=None,
+            email_from_name=None,
         )
         assert response["form"] == self._expected_form(group)
 
@@ -359,6 +363,8 @@ class TestGroupEditViews:
                     "scopes": [],
                     "members": [],
                     "enforce_scope": False,
+                    "reply_to": None,
+                    "email_from_name": None,
                 }
             )
 
@@ -398,6 +404,8 @@ class TestGroupEditViews:
                     "organization": group.organization.pubid,
                     "scopes": ["http://www.example.com"],
                     "enforce_scope": group.enforce_scope,
+                    "reply_to": None,
+                    "email_from_name": None,
                 }
             )
 
@@ -427,6 +435,8 @@ class TestGroupEditViews:
             "organization": group.organization.pubid,
             "scopes": [s.scope for s in group.scopes],
             "enforce_scope": group.enforce_scope,
+            "reply_to": "",
+            "email_from_name": "",
         }
 
     @pytest.fixture

--- a/tests/unit/h/views/api/flags_test.py
+++ b/tests/unit/h/views/api/flags_test.py
@@ -50,6 +50,8 @@ class TestCreate:
                     "tag": EmailTag.FLAG_NOTIFICATION,
                     "html": sentinel.html1,
                     "subaccount": None,
+                    "reply_to": None,
+                    "from_name": None,
                 },
                 {
                     "sender_id": pyramid_request.user.id,
@@ -66,6 +68,8 @@ class TestCreate:
                     "tag": EmailTag.FLAG_NOTIFICATION,
                     "html": sentinel.html2,
                     "subaccount": None,
+                    "reply_to": None,
+                    "from_name": None,
                 },
                 {
                     "sender_id": pyramid_request.user.id,


### PR DESCRIPTION
Fixes <https://github.com/hypothesis/h/issues/9878>.

This commit adds a new feature whereby a group can have a custom Reply-To email address and From-name. These can be added to a group on the admin pages and then moderation notification emails from that group will use them in the email Reply-To and From headers.

Testing:

1. [Log in](http://localhost:5000/login) as `devdata_admin`. You only need one user who is a group moderator to test this: you can create and moderate your own annotations and see the email notifications to yourself.
2. Go to <http://localhost:5000/admin/features> and enable the **group_type** and **pre_moderation** features
3. Go to <http://localhost:5000/groups/new> and create a new **Restricted** or **Open** group with **pre-moderation enabled**
4. Go to <http://localhost:5000/admin/groups>, find the new group, and set the group's **Email reply-to** and **Email from-name** fields. Here you can also test what happens if you try to enter an invalid reply-to email address (e.g. `@@`). You can also clear the group's reply-to and from by setting the fields to empty strings and saving.
5. Go to <http://localhost:3000/>, log in to the client, switch to the new group, and create an annotation. It will be **Pending**.  Change the annotation to **Approved**, **Declined** or **Spam** and a notification email will be sent. Look at the email in the `mail/` folder and you'll see that the group's custom settings were used in the `Reply-To` and `From` headers. You can also test that if the group does not have a custom reply-to or from then the system defaults are used.