### PR TITLE
Allow editing group type from admin pages

### DIFF
--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -21,7 +21,11 @@ from h.util import group_scope
 
 _ = i18n.TranslationString
 
-VALID_GROUP_TYPES = (("restricted", _("Restricted")), ("open", _("Open")))
+VALID_GROUP_TYPES = (
+    ("private", _("Private")),
+    ("restricted", _("Restricted")),
+    ("open", _("Open")),
+)
 
 
 def username_validator(form, value):
@@ -111,18 +115,8 @@ def url_with_origin_validator(node, val):
 
 
 @colander.deferred
-def group_type_validator(_node, kwargs):
-    group = kwargs.get("group")
-    if not group:
-        return colander.OneOf([key for key, title in VALID_GROUP_TYPES])
-
-    def validate(node, value):
-        if group.type != value:
-            raise colander.Invalid(
-                node, _("Changing group type is currently not supported")
-            )
-
-    return validate
+def group_type_validator(_node, _kwargs):
+    return colander.OneOf([key for key, title in VALID_GROUP_TYPES])
 
 
 @colander.deferred

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -27,13 +27,8 @@
         {% for group in results %}
           <tr>
             <td>
-              {% if group.type in ('open', 'restricted') %}
               {% set edit_url = request.route_url('admin.groups_edit', id=group.pubid) %}
               <a href="{{ edit_url }}">{{ group.name }}</a>
-              {% else %}
-              {# The group edit view does not currently support editing private groups. #}
-              {{ group.name }}
-              {% endif %}
             </td>
             <td>
               {% set group_url = request.route_url('group_read', pubid=group.pubid, slug=group.slug) %}

--- a/h/views/admin/groups.py
+++ b/h/views/admin/groups.py
@@ -197,6 +197,7 @@ class GroupEditViews:
                 enforce_scope=appstruct["enforce_scope"],
                 reply_to=appstruct["reply_to"] or None,
                 email_from_name=appstruct["email_from_name"] or None,
+                type=appstruct["group_type"],
             )
 
             memberids = []

--- a/tests/unit/h/schemas/forms/admin/group_test.py
+++ b/tests/unit/h/schemas/forms/admin/group_test.py
@@ -87,21 +87,6 @@ class TestAdminGroupSchema:
 
         bound_schema.deserialize(group_data)
 
-    def test_it_raises_if_group_type_changed(
-        self, group_data, pyramid_csrf_request, org, user_service
-    ):
-        group = mock.Mock(type="open")
-        group_data["group_type"] = "restricted"
-        schema = AdminGroupSchema().bind(
-            request=pyramid_csrf_request,
-            group=group,
-            user_svc=user_service,
-            organizations={org.pubid: org},
-        )
-
-        with pytest.raises(colander.Invalid, match="Changing group type"):
-            schema.deserialize(group_data)
-
     def test_it_does_not_raise_if_group_type_is_same(
         self, group_data, pyramid_csrf_request, org, user_service
     ):

--- a/tests/unit/h/views/admin/groups_test.py
+++ b/tests/unit/h/views/admin/groups_test.py
@@ -342,6 +342,7 @@ class TestGroupEditViews:
             enforce_scope=False,
             reply_to=None,
             email_from_name=None,
+            type="open",
         )
         assert response["form"] == self._expected_form(group)
 


### PR DESCRIPTION
In order to be able to set spammy groups as private, this PR updates the groups section in admin pages to:

- Allow editing private groups. Right now, private groups cannot be edited from the admin pages.
- Allow selecting "private" from the group type dropdown. Right now, the dropdown includes only "open" and "restricted", due to the point above.
- Allow changing the type of a group. Right now, changing the value throws a validation error, and the value is ignored anyway.