### PR TITLE
Create top_annos_placeholder feature flag

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -26,6 +26,7 @@ FEATURES = {
     "log_in_with_orcid": "Allow users to log in with ORCID",
     "log_in_with_google": "Allow users to log in with Google",
     "log_in_with_facebook": "Allow users to log in with Facebook",
+    "top_annos_placeholder": "Display a placeholder in Orphans tab, for deleted top-level annotations with replies",
 }
 
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/1602

Add a feature flag which can be used to conditionally display a placeholder in the Orphans tab, representing deleted top-level annotations which had replies, so that those replies are displayed somewhere.