### PR TITLE
Add some margin at the bottom of the group form

### DIFF
--- a/h/static/scripts/components/CreateEditGroupForm.tsx
+++ b/h/static/scripts/components/CreateEditGroupForm.tsx
@@ -318,7 +318,7 @@ export default function CreateEditGroupForm({
           </fieldset>
         )}
 
-        <div className="pt-2 border-t border-t-text-grey-6 flex items-center gap-x-4">
+        <div className="pt-2 mt-3 border-t border-t-text-grey-6 flex items-center gap-x-4">
           <span>
             {/* These are in a child span to avoid a gap between them. */}
             <Star />


### PR DESCRIPTION
Closes https://github.com/hypothesis/h/issues/9958

Add some top margin to the group form footer, so that there's a bit of space when neither `pre_moderation` or `group_type` feature flags are enabled.

The extra margin when either of them is enabled is negligible, so I'm not adding logic to conditionally add the margin, and instead the margin is added in all cases. 