### PR TITLE
Set annos as hidden in Elasticsearch based in moderation status

### DIFF
--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -32,6 +32,7 @@ class AnnotationSearchIndexPresenter:
             "target": self.annotation.target,
             "document": docpresenter.asdict(),
             "thread_ids": self.annotation.thread_ids,
+            "hidden": self.annotation.is_hidden,
         }
 
         result["target"][0]["scope"] = [self.annotation.target_uri_normalized]
@@ -39,22 +40,9 @@ class AnnotationSearchIndexPresenter:
         if self.annotation.references:
             result["references"] = self.annotation.references
 
-        self._add_hidden(result)
         self._add_nipsa(result, self.annotation.userid)
 
         return result
-
-    def _add_hidden(self, result):
-        # Mark an annotation as hidden if it and all of it's children have been
-        # moderated and hidden.
-        parents_and_replies = [self.annotation.id] + self.annotation.thread_ids  # noqa: RUF005
-
-        ann_mod_svc = self.request.find_service(name="annotation_moderation")
-        is_hidden = len(ann_mod_svc.all_hidden(parents_and_replies)) == len(
-            parents_and_replies
-        )
-
-        result["hidden"] = is_hidden
 
     def _add_nipsa(self, result, user_id):
         nipsa_service = self.request.find_service(name="nipsa")


### PR DESCRIPTION
Before the moderation system was implemented and unanchored threads were introduced, annotations would be marked as hidden only if the whole thread they belong to was also hidden. As soon as one annotation in the thread was not hidden, we would mark the whole thread as not hidden.

This no longer makes sense with the new moderation system. If a parent annotation is denied, but it has approved replies, we want only the replies to show as an unanchored thread, so this PR removes that old piece of logic, making annotations be hidden in elasticsearch only based on their own moderation status.

### TODO

- [x] Add/fix test