### PR TITLE
Revert "Bump pip from 25.2 to 25.3 in /requirements"

### DIFF
--- a/requirements/checkdocs.txt
+++ b/requirements/checkdocs.txt
@@ -111,7 +111,7 @@ zipp==3.19.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==25.2
     # via pip-tools
 setuptools==78.1.1
     # via pip-tools

--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -30,7 +30,7 @@ zipp==3.19.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==25.2
     # via pip-tools
 setuptools==78.1.1
     # via pip-tools

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -30,7 +30,7 @@ zipp==3.19.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==25.2
     # via pip-tools
 setuptools==78.1.1
     # via pip-tools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,50 +5,50 @@
 #    pip-compile --allow-unsafe requirements/dev.in
 #
 alembic==1.16.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 amqp==5.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   kombu
 asttokens==2.4.1
     # via stack-data
 attrs==24.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
 bcrypt==4.3.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 billiard==4.2.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 bleach==6.2.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 build==1.0.3
     # via pip-tools
 celery==5.5.3
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 certifi==2025.7.14
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
     #   sentry-sdk
 cffi==1.17.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cryptography
 chameleon==4.6.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
 charset-normalizer==3.4.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
 click==8.1.8
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -56,171 +56,171 @@ click==8.1.8
     #   pip-tools
 click-didyoumean==0.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 colander==2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
 cryptography==44.0.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyjwt
 data-tasks==0.0.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 deform==2.0.15
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 elasticsearch==6.8.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   elasticsearch-dsl
 elasticsearch-dsl==6.4.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 executing==2.0.1
     # via stack-data
 factory-boy==3.3.3
-    # via -r dev.in
+    # via -r requirements/dev.in
 faker==22.2.0
     # via factory-boy
 gevent==25.8.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 greenlet==3.2.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   gevent
     #   sqlalchemy
 gunicorn==23.0.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-api==1.1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-assets==1.1.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-matchers==1.2.17
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-pyramid-sentry==1.2.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 hupper==1.12
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 idna==3.10
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
 importlib-metadata==7.0.1
     # via pip-sync-faster
 importlib-resources==6.5.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   h-api
 ipdb==0.13.13
-    # via -r dev.in
+    # via -r requirements/dev.in
 ipython==8.20.0
     # via
     #   ipdb
     #   pyramid-ipython
 iso8601==2.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   colander
     #   deform
 itsdangerous==2.2.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 jedi==0.19.1
     # via ipython
 jinja2==3.1.6
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   pyramid-jinja2
 jsonschema==4.24.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
 jsonschema-specifications==2024.10.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
 kombu==5.5.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 mako==1.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
 markdown==3.8.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 markupsafe==2.1.5
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jinja2
     #   mako
     #   pyramid-jinja2
 matplotlib-inline==0.1.6
     # via ipython
 newrelic==10.5.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 oauthlib==3.3.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 packaging==25.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   build
     #   gunicorn
     #   zope-sqlalchemy
 parso==0.8.3
     # via jedi
 passlib==1.7.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pastedeploy==3.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
 peppercorn==0.6
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
 pexpect==4.9.0
     # via ipython
 pip-sync-faster==0.0.5
-    # via -r dev.in
+    # via -r requirements/dev.in
 pip-tools==7.4.1
     # via
-    #   -r dev.in
+    #   -r requirements/dev.in
     #   pip-sync-faster
 plaster==1.1.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
     #   pyramid
 plaster-pastedeploy==1.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 prompt-toolkit==3.0.50
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   click-repl
     #   ipython
 psycogreen==1.0.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 psycopg2==2.9.10
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 ptyprocess==0.7.0
     # via pexpect
@@ -228,23 +228,23 @@ pure-eval==0.2.2
     # via stack-data
 pycparser==2.22
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cffi
 pycryptodomex==3.23.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pygments==2.17.2
     # via ipython
 pyjwt[crypto]==2.10.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyparsing==3.2.3
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
 pyramid==2.0.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-assets
     #   h-pyramid-sentry
     #   pyramid-exclog
@@ -256,84 +256,84 @@ pyramid==2.0.2
     #   pyramid-services
     #   pyramid-tm
 pyramid-exclog==1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-ipython==0.2
-    # via -r dev.in
+    # via -r requirements/dev.in
 pyramid-jinja2==2.10.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-mailer==0.15.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-retry==2.1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-sanity==1.0.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-services==2.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-tm==2.6
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 python-dateutil==2.9.0.post0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   elasticsearch-dsl
     #   faker
 python-slugify==8.0.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pytz==2025.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 referencing==0.36.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
 repoze-sendmail==4.4.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-mailer
 requests==2.32.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 rfc3339-validator==0.1.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 rpds-py==0.22.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
 sentry-sdk==2.40.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-pyramid-sentry
 six==1.17.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   asttokens
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator
 sqlalchemy==2.0.25
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   data-tasks
     #   zope-sqlalchemy
 sqlparse==0.5.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 stack-data==0.6.3
     # via ipython
 supervisor==4.2.5
     # via
-    #   -r dev.in
-    #   -r prod.txt
+    #   -r requirements/dev.in
+    #   -r requirements/prod.txt
 tabulate==0.9.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 text-unidecode==1.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   python-slugify
 traitlets==5.14.1
     # via
@@ -341,80 +341,80 @@ traitlets==5.14.1
     #   matplotlib-inline
 transaction==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-mailer
     #   pyramid-tm
     #   repoze-sendmail
     #   zope-sqlalchemy
 translationstring==1.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   colander
     #   deform
     #   pyramid
 typing-extensions==4.13.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   referencing
     #   sqlalchemy
 tzdata==2025.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   kombu
 urllib3==2.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   elasticsearch
     #   requests
     #   sentry-sdk
 venusian==3.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 vine==5.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.2.13
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   bleach
 webob==1.8.8
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 wheel==0.42.0
     # via pip-tools
 wired==0.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-services
 ws4py==0.6.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 wsaccel==0.6.7
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 zipp==3.19.1
     # via importlib-metadata
 zope-deprecation==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
     #   pyramid
     #   pyramid-jinja2
 zope-event==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   gevent
 zope-interface==8.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   gevent
     #   pyramid
     #   pyramid-retry
@@ -424,14 +424,14 @@ zope-interface==8.0.1
     #   wired
     #   zope-sqlalchemy
 zope-sqlalchemy==4.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==25.2
     # via pip-tools
 setuptools==78.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pip-tools
     #   pyramid
     #   repoze-sendmail

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -111,7 +111,7 @@ zipp==3.19.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==25.2
     # via pip-tools
 setuptools==78.1.1
     # via pip-tools

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -30,7 +30,7 @@ zipp==3.19.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==25.2
     # via pip-tools
 setuptools==78.1.1
     # via pip-tools

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -5,50 +5,50 @@
 #    pip-compile --allow-unsafe requirements/functests.in
 #
 alembic==1.16.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 amqp==5.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   kombu
 attrs==24.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
 bcrypt==4.3.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 beautifulsoup4==4.12.2
     # via webtest
 billiard==4.2.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 bleach==6.2.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 build==1.0.3
     # via pip-tools
 celery==5.5.3
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 certifi==2025.7.14
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
     #   sentry-sdk
 cffi==1.17.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cryptography
 chameleon==4.6.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
 charset-normalizer==3.4.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
 click==8.1.8
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -56,76 +56,76 @@ click==8.1.8
     #   pip-tools
 click-didyoumean==0.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 colander==2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
 cryptography==44.0.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyjwt
 data-tasks==0.0.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 deform==2.0.15
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 elasticsearch==6.8.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   elasticsearch-dsl
 elasticsearch-dsl==6.4.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 factory-boy==3.3.3
     # via
-    #   -r functests.in
+    #   -r requirements/functests.in
     #   pytest-factoryboy
 faker==22.2.0
     # via factory-boy
 gevent==25.8.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 greenlet==3.2.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   gevent
     #   sqlalchemy
 gunicorn==23.0.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-api==1.1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-assets==1.1.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-matchers==1.2.17
     # via
-    #   -r functests.in
-    #   -r prod.txt
+    #   -r requirements/functests.in
+    #   -r requirements/prod.txt
 h-pyramid-sentry==1.2.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-testkit==1.0.1
-    # via -r functests.in
+    # via -r requirements/functests.in
 httpretty==1.1.4
-    # via -r functests.in
+    # via -r requirements/functests.in
 hupper==1.12
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 idna==3.10
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
 importlib-metadata==7.0.1
     # via pip-sync-faster
 importlib-resources==6.5.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   h-api
 inflection==0.5.1
@@ -134,108 +134,108 @@ iniconfig==2.0.0
     # via pytest
 iso8601==2.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   colander
     #   deform
 itsdangerous==2.2.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 jinja2==3.1.6
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   pyramid-jinja2
 jsonschema==4.24.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
 jsonschema-specifications==2024.10.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
 kombu==5.5.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 mako==1.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
 markdown==3.8.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 markupsafe==2.1.5
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jinja2
     #   mako
     #   pyramid-jinja2
 newrelic==10.5.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 oauthlib==3.3.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 packaging==25.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   build
     #   gunicorn
     #   pytest
     #   pytest-factoryboy
     #   zope-sqlalchemy
 passlib==1.7.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pastedeploy==3.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
 peppercorn==0.6
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
 pip-sync-faster==0.0.5
-    # via -r functests.in
+    # via -r requirements/functests.in
 pip-tools==7.4.1
     # via
-    #   -r functests.in
+    #   -r requirements/functests.in
     #   pip-sync-faster
 plaster==1.1.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
     #   pyramid
 plaster-pastedeploy==1.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.50
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   click-repl
 psycogreen==1.0.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 psycopg2==2.9.10
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 pycparser==2.22
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cffi
 pycryptodomex==3.23.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pygments==2.19.2
     # via pytest
 pyjwt[crypto]==2.10.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyparsing==3.2.3
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
 pyramid==2.0.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-assets
     #   h-pyramid-sentry
     #   pyramid-exclog
@@ -246,64 +246,64 @@ pyramid==2.0.2
     #   pyramid-services
     #   pyramid-tm
 pyramid-exclog==1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-jinja2==2.10.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-mailer==0.15.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-retry==2.1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-sanity==1.0.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-services==2.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-tm==2.6
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pytest==8.4.1
     # via
-    #   -r functests.in
+    #   -r requirements/functests.in
     #   pytest-factoryboy
     #   pytest-reverse
 pytest-factoryboy==2.8.1
-    # via -r functests.in
+    # via -r requirements/functests.in
 pytest-reverse==1.8.0
-    # via -r functests.in
+    # via -r requirements/functests.in
 python-dateutil==2.9.0.post0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   elasticsearch-dsl
     #   faker
 python-slugify==8.0.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pytz==2025.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 referencing==0.36.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
 repoze-sendmail==4.4.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-mailer
 requests==2.32.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 rfc3339-validator==0.1.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 rpds-py==0.22.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
 sentry-sdk==2.40.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-pyramid-sentry
 six==1.17.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator
@@ -311,61 +311,61 @@ soupsieve==2.5
     # via beautifulsoup4
 sqlalchemy==2.0.25
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   data-tasks
     #   zope-sqlalchemy
 sqlparse==0.5.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 supervisor==4.2.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 tabulate==0.9.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 text-unidecode==1.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   python-slugify
 transaction==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-mailer
     #   pyramid-tm
     #   repoze-sendmail
     #   zope-sqlalchemy
 translationstring==1.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   colander
     #   deform
     #   pyramid
 typing-extensions==4.13.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   pytest-factoryboy
     #   referencing
     #   sqlalchemy
 tzdata==2025.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   kombu
 urllib3==2.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   elasticsearch
     #   requests
     #   sentry-sdk
 venusian==3.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 vine==5.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   amqp
     #   celery
     #   kombu
@@ -373,44 +373,44 @@ waitress==3.0.2
     # via webtest
 wcwidth==0.2.13
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   bleach
 webob==1.8.8
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
     #   webtest
 webtest==3.0.6
-    # via -r functests.in
+    # via -r requirements/functests.in
 wheel==0.42.0
     # via pip-tools
 wired==0.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-services
 ws4py==0.6.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 wsaccel==0.6.7
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 zipp==3.19.1
     # via importlib-metadata
 zope-deprecation==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
     #   pyramid
     #   pyramid-jinja2
 zope-event==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   gevent
 zope-interface==8.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   gevent
     #   pyramid
     #   pyramid-retry
@@ -420,14 +420,14 @@ zope-interface==8.0.1
     #   wired
     #   zope-sqlalchemy
 zope-sqlalchemy==4.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==25.2
     # via pip-tools
 setuptools==78.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pip-tools
     #   pyramid
     #   repoze-sendmail

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -6,70 +6,70 @@
 #
 alembic==1.16.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 amqp==5.3.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   kombu
 attrs==24.3.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   jsonschema
     #   referencing
 bcrypt==4.3.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 beautifulsoup4==4.12.2
     # via
-    #   -r functests.txt
+    #   -r requirements/functests.txt
     #   webtest
 billiard==4.2.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
 bleach==6.2.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 build==1.0.3
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pip-tools
 celery==5.5.3
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 certifi==2025.7.14
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   requests
     #   sentry-sdk
 cffi==1.17.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   cryptography
 chameleon==4.6.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   deform
 charset-normalizer==3.4.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   requests
 click==8.1.8
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -77,194 +77,194 @@ click==8.1.8
     #   pip-tools
 click-didyoumean==0.3.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
 colander==2.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   deform
 coverage[toml]==7.10.7
     # via
-    #   -r tests.txt
+    #   -r requirements/tests.txt
     #   pytest-cov
 cryptography==44.0.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyjwt
 data-tasks==0.0.5
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 deform==2.0.15
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 elasticsearch==6.8.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   elasticsearch-dsl
 elasticsearch-dsl==6.4.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 execnet==2.1.1
     # via
-    #   -r tests.txt
+    #   -r requirements/tests.txt
     #   pytest-xdist
 factory-boy==3.3.3
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pytest-factoryboy
 faker==22.2.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   factory-boy
 freezegun==1.5.5
-    # via -r tests.txt
+    # via -r requirements/tests.txt
 gevent==25.8.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 greenlet==3.2.4
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   gevent
     #   sqlalchemy
 gunicorn==23.0.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 h-api==1.1.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 h-assets==1.1.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 h-matchers==1.2.17
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 h-pyramid-sentry==1.2.4
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 h-testkit==1.0.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 httpretty==1.1.4
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 hupper==1.12
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid
 idna==3.10
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   requests
 importlib-metadata==7.0.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pip-sync-faster
 importlib-resources==6.5.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   data-tasks
     #   h-api
 inflection==0.5.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pytest-factoryboy
 iniconfig==2.0.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pytest
 iso8601==2.1.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   colander
     #   deform
 itsdangerous==2.2.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 jinja2==3.1.6
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   data-tasks
     #   pyramid-jinja2
 jsonschema==4.24.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   h-api
 jsonschema-specifications==2024.10.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   jsonschema
 kombu==5.5.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
 mako==1.3.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   alembic
 markdown==3.8.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 markupsafe==2.1.5
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   jinja2
     #   mako
     #   pyramid-jinja2
 newrelic==10.5.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 oauthlib==3.3.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 packaging==25.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   build
     #   gunicorn
     #   pytest
@@ -272,96 +272,96 @@ packaging==25.0
     #   zope-sqlalchemy
 passlib==1.7.4
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pastedeploy==3.1.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   plaster-pastedeploy
 peppercorn==0.6
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   deform
 pip-sync-faster==0.0.5
     # via
-    #   -r functests.txt
-    #   -r lint.in
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/lint.in
+    #   -r requirements/tests.txt
 pip-tools==7.4.1
     # via
-    #   -r functests.txt
-    #   -r lint.in
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/lint.in
+    #   -r requirements/tests.txt
     #   pip-sync-faster
 plaster==1.1.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   plaster-pastedeploy
     #   pyramid
 plaster-pastedeploy==1.0.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid
 pluggy==1.5.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pytest
     #   pytest-cov
 prompt-toolkit==3.0.50
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   click-repl
 psutil==6.1.1
     # via
-    #   -r tests.txt
+    #   -r requirements/tests.txt
     #   pytest-xdist
 psycogreen==1.0.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 psycopg2==2.9.10
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   data-tasks
 pycparser==2.22
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   cffi
 pycryptodomex==3.23.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pygments==2.19.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pytest
 pyjwt[crypto]==2.10.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyparsing==3.2.3
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyproject-hooks==1.0.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   build
     #   pip-tools
 pyramid==2.0.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   h-assets
     #   h-pyramid-sentry
     #   pyramid-exclog
@@ -373,247 +373,247 @@ pyramid==2.0.2
     #   pyramid-tm
 pyramid-exclog==1.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyramid-jinja2==2.10.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyramid-mailer==0.15.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyramid-retry==2.1.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyramid-sanity==1.0.4
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyramid-services==2.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyramid-tm==2.6
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pytest==8.4.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pytest-cov
     #   pytest-factoryboy
     #   pytest-mock
     #   pytest-reverse
     #   pytest-xdist
 pytest-cov==7.0.0
-    # via -r tests.txt
+    # via -r requirements/tests.txt
 pytest-factoryboy==2.8.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pytest-mock==3.15.1
-    # via -r tests.txt
+    # via -r requirements/tests.txt
 pytest-reverse==1.8.0
-    # via -r functests.txt
+    # via -r requirements/functests.txt
 pytest-xdist[psutil]==3.8.0
-    # via -r tests.txt
+    # via -r requirements/tests.txt
 python-dateutil==2.9.0.post0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
     #   elasticsearch-dsl
     #   faker
     #   freezegun
 python-slugify==8.0.4
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pytz==2025.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 referencing==0.36.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
 repoze-sendmail==4.4.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid-mailer
 requests==2.32.4
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 rfc3339-validator==0.1.4
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 rpds-py==0.22.3
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   jsonschema
     #   referencing
 ruff==0.13.2
-    # via -r lint.in
+    # via -r requirements/lint.in
 sentry-sdk==2.40.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   h-pyramid-sentry
 six==1.17.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator
 soupsieve==2.5
     # via
-    #   -r functests.txt
+    #   -r requirements/functests.txt
     #   beautifulsoup4
 sqlalchemy==2.0.25
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   alembic
     #   data-tasks
     #   zope-sqlalchemy
 sqlparse==0.5.3
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   data-tasks
 supervisor==4.2.5
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 tabulate==0.9.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   data-tasks
 text-unidecode==1.3
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   python-slugify
 transaction==5.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid-mailer
     #   pyramid-tm
     #   repoze-sendmail
     #   zope-sqlalchemy
 translationstring==1.4
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   colander
     #   deform
     #   pyramid
 typing-extensions==4.13.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   alembic
     #   pytest-factoryboy
     #   referencing
     #   sqlalchemy
 tzdata==2025.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   kombu
 urllib3==2.3.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   elasticsearch
     #   requests
     #   sentry-sdk
 venusian==3.1.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid
 vine==5.1.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   amqp
     #   celery
     #   kombu
 waitress==3.0.2
     # via
-    #   -r functests.txt
+    #   -r requirements/functests.txt
     #   webtest
 wcwidth==0.2.13
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   bleach
 webob==1.8.8
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid
     #   webtest
 webtest==3.0.6
-    # via -r functests.txt
+    # via -r requirements/functests.txt
 wheel==0.42.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pip-tools
 wired==0.4
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid-services
 ws4py==0.6.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 wsaccel==0.6.7
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 zipp==3.19.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   importlib-metadata
 zope-deprecation==5.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   deform
     #   pyramid
     #   pyramid-jinja2
 zope-event==5.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   gevent
 zope-interface==8.0.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   gevent
     #   pyramid
     #   pyramid-retry
@@ -624,19 +624,19 @@ zope-interface==8.0.1
     #   zope-sqlalchemy
 zope-sqlalchemy==4.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==25.2
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pip-tools
 setuptools==78.1.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pip-tools
     #   pyramid
     #   repoze-sendmail

--- a/requirements/template.txt
+++ b/requirements/template.txt
@@ -72,7 +72,7 @@ zipp==3.21.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==25.2
     # via pip-tools
 setuptools==78.1.1
     # via pip-tools

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,48 +5,48 @@
 #    pip-compile --allow-unsafe requirements/tests.in
 #
 alembic==1.16.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 amqp==5.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   kombu
 attrs==24.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
 bcrypt==4.3.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 billiard==4.2.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 bleach==6.2.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 build==1.0.3
     # via pip-tools
 celery==5.5.3
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 certifi==2025.7.14
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
     #   sentry-sdk
 cffi==1.17.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cryptography
 chameleon==4.6.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
 charset-normalizer==3.4.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
 click==8.1.8
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -54,82 +54,82 @@ click==8.1.8
     #   pip-tools
 click-didyoumean==0.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 colander==2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
 coverage[toml]==7.10.7
     # via pytest-cov
 cryptography==44.0.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyjwt
 data-tasks==0.0.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 deform==2.0.15
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 elasticsearch==6.8.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   elasticsearch-dsl
 elasticsearch-dsl==6.4.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 execnet==2.1.1
     # via pytest-xdist
 factory-boy==3.3.3
     # via
-    #   -r tests.in
+    #   -r requirements/tests.in
     #   pytest-factoryboy
 faker==22.2.0
     # via factory-boy
 freezegun==1.5.5
-    # via -r tests.in
+    # via -r requirements/tests.in
 gevent==25.8.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 greenlet==3.2.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   gevent
     #   sqlalchemy
 gunicorn==23.0.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-api==1.1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-assets==1.1.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-matchers==1.2.17
     # via
-    #   -r prod.txt
-    #   -r tests.in
+    #   -r requirements/prod.txt
+    #   -r requirements/tests.in
 h-pyramid-sentry==1.2.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-testkit==1.0.1
-    # via -r tests.in
+    # via -r requirements/tests.in
 httpretty==1.1.4
-    # via -r tests.in
+    # via -r requirements/tests.in
 hupper==1.12
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 idna==3.10
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
 importlib-metadata==7.0.1
     # via pip-sync-faster
 importlib-resources==6.5.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   h-api
 inflection==0.5.1
@@ -138,76 +138,76 @@ iniconfig==2.0.0
     # via pytest
 iso8601==2.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   colander
     #   deform
 itsdangerous==2.2.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 jinja2==3.1.6
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   pyramid-jinja2
 jsonschema==4.24.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
 jsonschema-specifications==2024.10.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
 kombu==5.5.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 mako==1.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
 markdown==3.8.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 markupsafe==2.1.5
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jinja2
     #   mako
     #   pyramid-jinja2
 newrelic==10.5.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 oauthlib==3.3.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 packaging==25.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   build
     #   gunicorn
     #   pytest
     #   pytest-factoryboy
     #   zope-sqlalchemy
 passlib==1.7.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pastedeploy==3.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
 peppercorn==0.6
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
 pip-sync-faster==0.0.5
-    # via -r tests.in
+    # via -r requirements/tests.in
 pip-tools==7.4.1
     # via
-    #   -r tests.in
+    #   -r requirements/tests.in
     #   pip-sync-faster
 plaster==1.1.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
     #   pyramid
 plaster-pastedeploy==1.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 pluggy==1.5.0
     # via
@@ -215,35 +215,35 @@ pluggy==1.5.0
     #   pytest-cov
 prompt-toolkit==3.0.50
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   click-repl
 psutil==6.1.1
     # via pytest-xdist
 psycogreen==1.0.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 psycopg2==2.9.10
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 pycparser==2.22
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cffi
 pycryptodomex==3.23.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pygments==2.19.2
     # via pytest
 pyjwt[crypto]==2.10.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyparsing==3.2.3
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
 pyramid==2.0.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-assets
     #   h-pyramid-sentry
     #   pyramid-exclog
@@ -254,171 +254,171 @@ pyramid==2.0.2
     #   pyramid-services
     #   pyramid-tm
 pyramid-exclog==1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-jinja2==2.10.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-mailer==0.15.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-retry==2.1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-sanity==1.0.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-services==2.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-tm==2.6
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pytest==8.4.1
     # via
-    #   -r tests.in
+    #   -r requirements/tests.in
     #   pytest-cov
     #   pytest-factoryboy
     #   pytest-mock
     #   pytest-xdist
 pytest-cov==7.0.0
-    # via -r tests.in
+    # via -r requirements/tests.in
 pytest-factoryboy==2.8.1
-    # via -r tests.in
+    # via -r requirements/tests.in
 pytest-mock==3.15.1
-    # via -r tests.in
+    # via -r requirements/tests.in
 pytest-xdist[psutil]==3.8.0
-    # via -r tests.in
+    # via -r requirements/tests.in
 python-dateutil==2.9.0.post0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   elasticsearch-dsl
     #   faker
     #   freezegun
 python-slugify==8.0.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pytz==2025.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 referencing==0.36.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
 repoze-sendmail==4.4.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-mailer
 requests==2.32.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 rfc3339-validator==0.1.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 rpds-py==0.22.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
 sentry-sdk==2.40.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-pyramid-sentry
 six==1.17.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator
 sqlalchemy==2.0.25
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   data-tasks
     #   zope-sqlalchemy
 sqlparse==0.5.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 supervisor==4.2.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 tabulate==0.9.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 text-unidecode==1.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   python-slugify
 transaction==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-mailer
     #   pyramid-tm
     #   repoze-sendmail
     #   zope-sqlalchemy
 translationstring==1.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   colander
     #   deform
     #   pyramid
 typing-extensions==4.13.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   pytest-factoryboy
     #   referencing
     #   sqlalchemy
 tzdata==2025.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   kombu
 urllib3==2.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   elasticsearch
     #   requests
     #   sentry-sdk
 venusian==3.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 vine==5.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.2.13
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   bleach
 webob==1.8.8
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 wheel==0.42.0
     # via pip-tools
 wired==0.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-services
 ws4py==0.6.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 wsaccel==0.6.7
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 zipp==3.19.1
     # via importlib-metadata
 zope-deprecation==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
     #   pyramid
     #   pyramid-jinja2
 zope-event==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   gevent
 zope-interface==8.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   gevent
     #   pyramid
     #   pyramid-retry
@@ -428,14 +428,14 @@ zope-interface==8.0.1
     #   wired
     #   zope-sqlalchemy
 zope-sqlalchemy==4.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==25.2
     # via pip-tools
 setuptools==78.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pip-tools
     #   pyramid
     #   repoze-sendmail

--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -5,48 +5,48 @@
 #    pip-compile --allow-unsafe requirements/typecheck.in
 #
 alembic==1.16.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 amqp==5.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   kombu
 attrs==24.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
 bcrypt==4.3.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 billiard==4.2.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 bleach==6.2.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 build==1.2.2.post1
     # via pip-tools
 celery==5.5.3
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 certifi==2025.7.14
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
     #   sentry-sdk
 cffi==1.17.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cryptography
 chameleon==4.6.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
 charset-normalizer==3.4.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
 click==8.1.8
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -54,170 +54,170 @@ click==8.1.8
     #   pip-tools
 click-didyoumean==0.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 colander==2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
 cryptography==44.0.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyjwt
 data-tasks==0.0.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 deform==2.0.15
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 elasticsearch==6.8.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   elasticsearch-dsl
 elasticsearch-dsl==6.4.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 gevent==25.8.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 greenlet==3.2.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   gevent
     #   sqlalchemy
 gunicorn==23.0.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-api==1.1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-assets==1.1.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-matchers==1.2.17
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-pyramid-sentry==1.2.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 hupper==1.12
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 idna==3.10
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
 importlib-metadata==8.6.1
     # via pip-sync-faster
 importlib-resources==6.5.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   h-api
 iso8601==2.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   colander
     #   deform
 itsdangerous==2.2.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 jinja2==3.1.6
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   pyramid-jinja2
 jsonschema==4.24.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
 jsonschema-specifications==2024.10.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
 kombu==5.5.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 mako==1.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
 markdown==3.8.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 markupsafe==2.1.5
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jinja2
     #   mako
     #   pyramid-jinja2
 mypy==1.18.2
-    # via -r typecheck.in
+    # via -r requirements/typecheck.in
 mypy-extensions==1.0.0
     # via mypy
 newrelic==10.5.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 oauthlib==3.3.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 packaging==25.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   build
     #   gunicorn
     #   zope-sqlalchemy
 passlib==1.7.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pastedeploy==3.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
 pathspec==0.12.1
     # via mypy
 peppercorn==0.6
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
 pip-sync-faster==0.0.5
-    # via -r typecheck.in
+    # via -r requirements/typecheck.in
 pip-tools==7.4.1
     # via
-    #   -r typecheck.in
+    #   -r requirements/typecheck.in
     #   pip-sync-faster
 plaster==1.1.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
     #   pyramid
 plaster-pastedeploy==1.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 prompt-toolkit==3.0.50
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   click-repl
 psycogreen==1.0.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 psycopg2==2.9.10
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 pycparser==2.22
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cffi
 pycryptodomex==3.23.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyjwt[crypto]==2.10.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyparsing==3.2.3
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
 pyramid==2.0.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-assets
     #   h-pyramid-sentry
     #   pyramid-exclog
@@ -228,154 +228,154 @@ pyramid==2.0.2
     #   pyramid-services
     #   pyramid-tm
 pyramid-exclog==1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-jinja2==2.10.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-mailer==0.15.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-retry==2.1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-sanity==1.0.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-services==2.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-tm==2.6
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 python-dateutil==2.9.0.post0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   elasticsearch-dsl
 python-slugify==8.0.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pytz==2025.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 referencing==0.36.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
 repoze-sendmail==4.4.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-mailer
 requests==2.32.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 rfc3339-validator==0.1.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 rpds-py==0.22.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
 sentry-sdk==2.40.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-pyramid-sentry
 six==1.17.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   elasticsearch-dsl
     #   python-dateutil
     #   rfc3339-validator
 sqlalchemy==2.0.25
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   data-tasks
     #   zope-sqlalchemy
 sqlparse==0.5.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 supervisor==4.2.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 tabulate==0.9.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 text-unidecode==1.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   python-slugify
 transaction==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-mailer
     #   pyramid-tm
     #   repoze-sendmail
     #   zope-sqlalchemy
 translationstring==1.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   colander
     #   deform
     #   pyramid
 typing-extensions==4.13.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   mypy
     #   referencing
     #   sqlalchemy
 tzdata==2025.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   kombu
 urllib3==2.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   elasticsearch
     #   requests
     #   sentry-sdk
 venusian==3.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 vine==5.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.2.13
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   bleach
 webob==1.8.8
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 wheel==0.45.1
     # via pip-tools
 wired==0.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-services
 ws4py==0.6.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 wsaccel==0.6.7
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 zipp==3.21.0
     # via importlib-metadata
 zope-deprecation==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   deform
     #   pyramid
     #   pyramid-jinja2
 zope-event==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   gevent
 zope-interface==8.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   gevent
     #   pyramid
     #   pyramid-retry
@@ -385,14 +385,14 @@ zope-interface==8.0.1
     #   wired
     #   zope-sqlalchemy
 zope-sqlalchemy==4.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==25.2
     # via pip-tools
 setuptools==78.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pip-tools
     #   pyramid
     #   repoze-sendmail


### PR DESCRIPTION
Reverts hypothesis/h#9961

Creating this in case we need to merge https://github.com/hypothesis/h/pull/9976, since CI is currently failing in this project due to the incompatibility between pip-tools and pip 25.3