### PR TITLE
Pin to pip==25.2 in tox file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,7 @@ passenv =
     {tests,functests}: DATABASE_URL
     functests: BROKER_URL
 deps =
+    pip==25.2
     pip-tools
     pip-sync-faster
 depends =


### PR DESCRIPTION
Pin to pip 25.2 directly in tox file to get CI back to green

See https://github.com/jazzband/pip-tools/issues/2252