### PR TITLE
Remove top_annos_placeholder feature flag

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -26,7 +26,6 @@ FEATURES = {
     "log_in_with_orcid": "Allow users to log in with ORCID",
     "log_in_with_google": "Allow users to log in with Google",
     "log_in_with_facebook": "Allow users to log in with Facebook",
-    "top_annos_placeholder": "Display a placeholder in Orphans tab, for deleted top-level annotations with replies",
 }
 
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/client/pull/7431

We have recently enabled `top_annos_placeholder` for everyone, so we can remove the FF after it's been tested for a couple weeks.

> [!WARNING]
> Wait a few days after the browser extension has been published with https://github.com/hypothesis/client/pull/7431 before merging this