### PR TITLE
Update email moderation copy for Approved, Denied and Pending

### DIFF
--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -212,7 +212,7 @@ class AnnotationModerationService:
                 "You'll receive another email when your comment's moderation status changes."
             )
         if new_status == ModerationStatus.APPROVED:
-            return f"The following comment has been approved by the {group_name} moderation team and is now visible to other users.\n"
+            return f"The following comment has been approved by the {group_name} moderation team and is now visible to other users."
 
         msg = f"Unexpected moderation status change description for {new_status}"
         raise ValueError(msg)

--- a/tests/unit/h/services/annotation_moderation_test.py
+++ b/tests/unit/h/services/annotation_moderation_test.py
@@ -277,7 +277,7 @@ class TestAnnotationModerationService:
                 "unsubscribe",
                 token=subscription_service.get_unsubscribe_token.return_value,
             ),
-            "status_change_description": "The following comment has been approved by the GROUP NAME moderation team and is now visible to other users.\n",
+            "status_change_description": "The following comment has been approved by the GROUP NAME moderation team and is now visible to other users.",
         }
         html_renderer.assert_(**expected_context)  # noqa: PT009
         text_renderer.assert_(**expected_context)  # noqa: PT009
@@ -324,7 +324,7 @@ class TestAnnotationModerationService:
         [
             (
                 ModerationStatus.APPROVED,
-                "The following comment has been approved by the GROUP NAME moderation team and is now visible to other users.\n",
+                "The following comment has been approved by the GROUP NAME moderation team and is now visible to other users.",
             ),
             (
                 ModerationStatus.PENDING,

--- a/tests/unit/h/views/admin/email_test.py
+++ b/tests/unit/h/views/admin/email_test.py
@@ -101,7 +101,7 @@ class TestPreviewModeratedAnnotationNotification:
 
         assert result == {
             "user_display_name": "Jane Doe",
-            "status_change_description": "The following comment has been approved by the GROUP NAME moderation team and is now visible to other users.\n",
+            "status_change_description": "The following comment has been approved by the GROUP NAME moderation team and is now visible to other users.",
             "annotation_url": "https://example.com/bouncer",
             "annotation": {
                 "text_rendered": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla tincidunt malesuada ex, id dictum risus posuere sed. Curabitur risus lectus, aliquam vel tempus ut, tempus non risus. Duis ac nibh lacinia, lacinia leo sit amet, lacinia tortor. Vestibulum dictum maximus lorem, nec lobortis augue ullamcorper nec. Ut ac viverra nisi. Nam congue neque eu mi viverra ultricies. Integer pretium odio nulla, at semper dolor tincidunt quis. Pellentesque suscipit magna nec nunc mollis, a interdum purus aliquam.",


### PR DESCRIPTION
[#1689](https://github.com/hypothesis/product-backlog/issues/1689)

This pull request updates the wording of moderation status change notification emails to make them clearer and more consistent. The changes affect both the email content generation logic and the corresponding unit tests.

**Email content improvements:**

* Updated the phrasing in `email_status_change_description` in `annotation_moderation.py` to clarify the role of the moderation team and make the messages more user-friendly. For example, messages now refer to "the {group_name} moderation team" and clarify visibility to "other users" instead of "everyone viewing that group."

**Test updates for new email phrasing:**

* Updated expected strings in `test_queue_moderation_change_email_sent`, `test_email_subject_raises_value_error_for_unexpected_status`, and `test_returns_dummy_data` to match the revised email descriptions. [[1]](diffhunk://#diff-9cd810f06913fbca9a2bbcb00b18b12cbce676da2acd6397151479c9b21d6b03L280-R280) [[2]](diffhunk://#diff-9cd810f06913fbca9a2bbcb00b18b12cbce676da2acd6397151479c9b21d6b03L327-R336) [[3]](diffhunk://#diff-b3004d5a0698ea3e4a2e15346e6356e844dcb296d56017f2549327382bd73fb1L104-R104)