### PR TITLE
Increase image annotation text description limit

### DIFF
--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -93,7 +93,7 @@ class AnnotationSchema(JSONSchema):
                 "items": {
                     "type": "object",
                     "properties": {
-                        "description": {"type": "string", "maxLength": 250},
+                        "description": {"type": "string", "maxLength": 5000},
                         "selector": copy.deepcopy(SELECTOR_SCHEMA),
                     },
                 },

--- a/tests/unit/h/schemas/annotation_test.py
+++ b/tests/unit/h/schemas/annotation_test.py
@@ -276,7 +276,7 @@ class TestCreateUpdateAnnotationSchema:
         "target_description,expected_error_message",
         [
             (42, "42 is not of type 'string'"),
-            ("a" * 251, f"""'{"a" * 251}' is too long"""),
+            ("a" * 5001, f"""'{"a" * 5001}' is too long"""),
         ],
     )
     def test_target_description_invalid(


### PR DESCRIPTION
### Description 
This PR increases the allowed length of the **text description field for image annotations**. 

---

### Solution 
Updated the validation to accept longer inputs
This validation is used by the annotation creation and update endpoints.