### PR TITLE
Add shortcuts_preferences column to user

### DIFF
--- a/h/migrations/versions/7c1a3e2b9f20_add_user_shortcuts_preferences_column.py
+++ b/h/migrations/versions/7c1a3e2b9f20_add_user_shortcuts_preferences_column.py
@@ -1,0 +1,16 @@
+"""Add user.shortcuts_preferences column."""
+
+from alembic import op
+from sqlalchemy import Column
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "7c1a3e2b9f20"
+down_revision = "d4dd768e1439"
+
+
+def upgrade():
+    op.add_column("user", Column("shortcuts_preferences", JSONB, nullable=True))
+
+
+def downgrade():
+    op.drop_column("user", "shortcuts_preferences")


### PR DESCRIPTION
This pull request introduces a new database migration to add support for storing user shortcut preferences. The migration adds a new column to the `user` table and ensures it can be reverted if needed.

Database schema changes:

* Added a new `shortcuts_preferences` column of type `JSONB` to the `user` table to store user shortcut preferences. (`h/migrations/versions/7c1a3e2b9f20_add_user_shortcuts_preferences_column.py.py`)
* Provided a downgrade path to remove the `shortcuts_preferences` column if the migration is rolled back. (`h/migrations/versions/7c1a3e2b9f20_add_user_shortcuts_preferences_column.py.py`)