### PR TITLE
Add an API endpoint to upsert Hide and Reveal checkpoints

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -160,6 +160,8 @@ def includeme(config):  # noqa: PLR0915
         "api.bulk.lms.annotations", "/api/bulk/lms/annotations", request_method="POST"
     )
 
+    config.add_route("api.checkpoints", "/api/checkpoints", request_method="POST")
+
     config.add_route("api.groups", "/api/groups", factory="h.traversal.GroupRoot")
     config.add_route(
         "api.group",

--- a/h/schemas/api/checkpoint.py
+++ b/h/schemas/api/checkpoint.py
@@ -1,0 +1,16 @@
+from h.schemas.base import JSONSchema
+
+
+class UpsertCheckpointAPISchema(JSONSchema):
+    """Validate a Hide & Reveal checkpoint upsert request."""
+
+    schema = {  # noqa: RUF012
+        "type": "object",
+        "properties": {
+            "authority_provided_id": {"type": "string", "minLength": 1},
+            "document_url": {"type": "string", "minLength": 1},
+            # The value is parsed/validated as ISO 8601 in the view.
+            "reveal_date": {"type": ["string", "null"]},
+        },
+        "required": ["authority_provided_id", "document_url"],
+    }

--- a/h/security/permission_map.py
+++ b/h/security/permission_map.py
@@ -38,6 +38,8 @@ PERMISSION_MAP = {
     Permission.User.READ: [[p.user_authority_matches_authenticated_client]],
     # Bulk API - Currently only LMS uses this end-point
     Permission.API.BULK_ACTION: [[p.authenticated_client_is_lms]],
+    # Hide and Reveal checkpoint upsert - Currently only LMS uses this end-point
+    Permission.API.CHECKPOINT_UPSERT: [[p.authenticated_client_is_lms]],
     # A user can always update their own profile
     Permission.Profile.UPDATE: [[p.authenticated_user]],
     # --------------------------------------------------------------------- #

--- a/h/security/permissions.py
+++ b/h/security/permissions.py
@@ -111,3 +111,6 @@ class Permission:
 
         BULK_ACTION = "api:bulk_action"
         """Calling the /bulk/api end-point. Currently used by LMS."""
+
+        CHECKPOINT_UPSERT = "api:checkpoint_upsert"
+        """Creating or updating a Hide and Reveal checkpoint. Currently used by LMS."""

--- a/h/services/checkpoint.py
+++ b/h/services/checkpoint.py
@@ -8,10 +8,16 @@ from h.models import (
     Checkpoint,
     Document,
     DocumentURI,
+    Group,
     GroupMembership,
     User,
 )
+from h.models.document import merge_documents
 from h.models.group import LMSRole
+
+
+class GroupNotFoundError(LookupError):
+    """Raised when no group matches a given (authority, authority_provided_id)."""
 
 
 @dataclass
@@ -120,6 +126,55 @@ class CheckpointService:
             instructor_userids=instructor_userids,
             own_annotation_ids=list(own_annotation_ids),
         )
+
+    def upsert(
+        self,
+        authority: str,
+        authority_provided_id: str,
+        document_url: str,
+        reveal_date: datetime | None,
+    ) -> Checkpoint:
+        """
+        Create or update the checkpoint for a (group, document), overwriting reveal_date.
+
+        The write is an upsert keyed on (group, document): the most
+        recent write wins, which is what lets an edited or recreated assignment
+        override the previous reveal_date.
+
+        :raises GroupNotFoundError: if no group matches the given identifiers.
+        """
+        group = self.db.scalar(
+            select(Group)
+            .where(Group.authority == authority)
+            .where(Group.authority_provided_id == authority_provided_id)
+        )
+        if group is None:
+            raise GroupNotFoundError(authority_provided_id)
+
+        document = self._find_or_create_document(document_url)
+
+        checkpoint = self.db.scalar(
+            select(Checkpoint)
+            .where(Checkpoint.group_id == group.id)
+            .where(Checkpoint.document_id == document.id)
+            .where(Checkpoint.previous_checkpoint_id.is_(None))
+        )
+        if checkpoint is None:
+            checkpoint = Checkpoint(group_id=group.id, document_id=document.id)
+            self.db.add(checkpoint)
+
+        checkpoint.reveal_date = reveal_date
+        self.db.flush()
+
+        return checkpoint
+
+    def _find_or_create_document(self, document_url: str) -> Document:
+        documents = Document.find_or_create_by_uris(
+            self.db, document_url, [document_url]
+        )
+        if documents.count() > 1:
+            return merge_documents(self.db, documents)
+        return documents.first()
 
 
 def factory(_context, request) -> CheckpointService:

--- a/h/views/api/checkpoints.py
+++ b/h/views/api/checkpoints.py
@@ -1,0 +1,67 @@
+from datetime import UTC, datetime
+
+from pyramid.httpexceptions import HTTPNotFound
+
+from h.schemas import ValidationError
+from h.schemas.api.checkpoint import UpsertCheckpointAPISchema
+from h.security import Permission
+from h.services.checkpoint import CheckpointService, GroupNotFoundError
+from h.views.api.config import api_config
+from h.views.api.helpers.json_payload import json_payload
+
+
+@api_config(
+    versions=["v1", "v2"],
+    route_name="api.checkpoints",
+    request_method="POST",
+    link_name="checkpoint.upsert",
+    description="Create or update a Hide & Reveal checkpoint",
+    permission=Permission.API.CHECKPOINT_UPSERT,
+)
+def upsert(request):
+    """
+    Create or update the Hide & Reveal checkpoint for a (group, document).
+
+    Authorised clients (currently only the LMS) push the reveal_date for a
+    group + document on each launch. The write is an upsert keyed on
+    (group, document): the most recent write wins.
+    """
+    appstruct = UpsertCheckpointAPISchema().validate(json_payload(request))
+
+    reveal_date = _parse_reveal_date(appstruct.get("reveal_date"))
+
+    checkpoint_service = request.find_service(CheckpointService)
+    try:
+        checkpoint = checkpoint_service.upsert(
+            authority=request.identity.auth_client.authority,
+            authority_provided_id=appstruct["authority_provided_id"],
+            document_url=appstruct["document_url"],
+            reveal_date=reveal_date,
+        )
+    except GroupNotFoundError as err:
+        raise HTTPNotFound(str(err)) from err
+
+    return {
+        "id": checkpoint.id,
+        "reveal_date": (
+            checkpoint.reveal_date.isoformat() if checkpoint.reveal_date else None
+        ),
+    }
+
+
+def _parse_reveal_date(raw: str | None) -> datetime | None:
+    """Parse an ISO 8601 reveal_date into a naive UTC datetime, matching the model."""
+    if not raw:
+        return None
+
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError as err:
+        raise ValidationError(  # noqa: TRY003
+            f"reveal_date is not a valid ISO 8601 datetime: {raw!r}"  # noqa: EM102
+        ) from err
+
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(UTC).replace(tzinfo=None)
+
+    return parsed

--- a/tests/unit/h/routes_test.py
+++ b/tests/unit/h/routes_test.py
@@ -153,6 +153,7 @@ def test_includeme():
             "/api/bulk/lms/annotations",
             request_method="POST",
         ),
+        call("api.checkpoints", "/api/checkpoints", request_method="POST"),
         call("api.groups", "/api/groups", factory="h.traversal.GroupRoot"),
         call(
             "api.group",

--- a/tests/unit/h/services/checkpoint_test.py
+++ b/tests/unit/h/services/checkpoint_test.py
@@ -3,9 +3,9 @@ from unittest import mock
 
 import pytest
 
-from h.models import GroupMembership
+from h.models import Checkpoint, GroupMembership
 from h.models.group import LMSRole
-from h.services.checkpoint import CheckpointService, factory
+from h.services.checkpoint import CheckpointService, GroupNotFoundError, factory
 from h.util.uri import normalize as uri_normalize
 
 
@@ -186,6 +186,94 @@ class TestHiddenScopes:
     @pytest.fixture
     def null_role_membership(self, group, user):
         return self.membership(group, user, None)
+
+
+class TestUpsert:
+    def test_it_creates_a_checkpoint(self, svc, group):
+        checkpoint = svc.upsert(
+            authority=group.authority,
+            authority_provided_id=group.authority_provided_id,
+            document_url="http://example.com/page",
+            reveal_date=None,
+        )
+
+        assert checkpoint.group_id == group.id
+        assert checkpoint.reveal_date is None
+        assert checkpoint.previous_checkpoint_id is None
+
+    def test_it_creates_the_document_when_it_does_not_exist(self, svc, group):
+        checkpoint = svc.upsert(
+            authority=group.authority,
+            authority_provided_id=group.authority_provided_id,
+            document_url="http://example.com/brand-new",
+            reveal_date=None,
+        )
+
+        normalized = [uri.uri_normalized for uri in checkpoint.document.document_uris]
+        assert uri_normalize("http://example.com/brand-new") in normalized
+
+    def test_it_reuses_an_existing_document(self, svc, group, factories):
+        document = factories.Document()
+        factories.DocumentURI(document=document, uri="http://example.com/page")
+
+        checkpoint = svc.upsert(
+            authority=group.authority,
+            authority_provided_id=group.authority_provided_id,
+            document_url="http://example.com/page",
+            reveal_date=None,
+        )
+
+        assert checkpoint.document_id == document.id
+
+    def test_it_overrides_the_reveal_date_of_an_existing_checkpoint(
+        self, svc, group, db_session
+    ):
+        first = svc.upsert(
+            authority=group.authority,
+            authority_provided_id=group.authority_provided_id,
+            document_url="http://example.com/page",
+            reveal_date=datetime(2026, 7, 1),  # noqa: DTZ001
+        )
+        second = svc.upsert(
+            authority=group.authority,
+            authority_provided_id=group.authority_provided_id,
+            document_url="http://example.com/page",
+            reveal_date=datetime(2026, 6, 15),  # noqa: DTZ001
+        )
+
+        # Same checkpoint, newest write wins, no duplicate row.
+        assert second.id == first.id
+        assert second.reveal_date == datetime(2026, 6, 15)  # noqa: DTZ001
+        assert db_session.query(Checkpoint).count() == 1
+
+    def test_it_merges_documents_that_share_the_url(self, svc, group, factories):
+        # Two documents claiming the same URL must collapse into one.
+        for _ in range(2):
+            document = factories.Document()
+            factories.DocumentURI(document=document, uri="http://example.com/dup")
+
+        checkpoint = svc.upsert(
+            authority=group.authority,
+            authority_provided_id=group.authority_provided_id,
+            document_url="http://example.com/dup",
+            reveal_date=None,
+        )
+
+        normalized = [uri.uri_normalized for uri in checkpoint.document.document_uris]
+        assert uri_normalize("http://example.com/dup") in normalized
+
+    def test_it_raises_when_the_group_is_not_found(self, svc, group):
+        with pytest.raises(GroupNotFoundError):
+            svc.upsert(
+                authority=group.authority,
+                authority_provided_id="does-not-exist",
+                document_url="http://example.com/page",
+                reveal_date=None,
+            )
+
+    @pytest.fixture
+    def group(self, factories):
+        return factories.Group(authority_provided_id="test-authority-provided-id")
 
 
 class TestFactory:

--- a/tests/unit/h/views/api/checkpoints_test.py
+++ b/tests/unit/h/views/api/checkpoints_test.py
@@ -1,0 +1,126 @@
+from datetime import datetime
+from unittest import mock
+
+import pytest
+from pyramid.httpexceptions import HTTPNotFound
+
+from h.schemas import ValidationError
+from h.services.checkpoint import CheckpointService, GroupNotFoundError
+from h.views.api.checkpoints import upsert
+from h.views.api.exceptions import PayloadError
+
+
+@pytest.mark.usefixtures("with_auth_client")
+class TestUpsert:
+    def test_it(self, pyramid_request, checkpoint_service, auth_client):
+        pyramid_request.json_body = {
+            "authority_provided_id": "apid",
+            "document_url": "http://example.com/page",
+            "reveal_date": "2026-07-01T00:00:00",
+        }
+
+        result = upsert(pyramid_request)
+
+        checkpoint_service.upsert.assert_called_once_with(
+            authority=auth_client.authority,
+            authority_provided_id="apid",
+            document_url="http://example.com/page",
+            reveal_date=datetime(2026, 7, 1),  # noqa: DTZ001
+        )
+        # The response reflects the checkpoint the service returned.
+        assert result == {"id": 123, "reveal_date": "2026-12-25T00:00:00"}
+
+    def test_it_passes_none_when_reveal_date_is_null(
+        self, pyramid_request, checkpoint_service
+    ):
+        pyramid_request.json_body = {
+            "authority_provided_id": "apid",
+            "document_url": "http://example.com/page",
+            "reveal_date": None,
+        }
+
+        upsert(pyramid_request)
+
+        assert checkpoint_service.upsert.call_args.kwargs["reveal_date"] is None
+
+    def test_it_passes_none_when_reveal_date_is_absent(
+        self, pyramid_request, checkpoint_service
+    ):
+        pyramid_request.json_body = {
+            "authority_provided_id": "apid",
+            "document_url": "http://example.com/page",
+        }
+
+        upsert(pyramid_request)
+
+        assert checkpoint_service.upsert.call_args.kwargs["reveal_date"] is None
+
+    def test_it_converts_a_tz_aware_reveal_date_to_naive_utc(
+        self, pyramid_request, checkpoint_service
+    ):
+        pyramid_request.json_body = {
+            "authority_provided_id": "apid",
+            "document_url": "http://example.com/page",
+            "reveal_date": "2026-07-01T12:00:00+02:00",
+        }
+
+        upsert(pyramid_request)
+
+        expected = datetime(2026, 7, 1, 10, 0, 0)  # noqa: DTZ001
+        assert checkpoint_service.upsert.call_args.kwargs["reveal_date"] == expected
+
+    def test_it_returns_null_when_the_checkpoint_has_no_reveal_date(
+        self, pyramid_request, checkpoint_service
+    ):
+        checkpoint_service.upsert.return_value = mock.Mock(id=5, reveal_date=None)
+        pyramid_request.json_body = {
+            "authority_provided_id": "apid",
+            "document_url": "http://example.com/page",
+        }
+
+        result = upsert(pyramid_request)
+
+        assert result == {"id": 5, "reveal_date": None}
+
+    def test_it_raises_for_an_invalid_reveal_date(self, pyramid_request):
+        pyramid_request.json_body = {
+            "authority_provided_id": "apid",
+            "document_url": "http://example.com/page",
+            "reveal_date": "not-a-date",
+        }
+
+        with pytest.raises(ValidationError):
+            upsert(pyramid_request)
+
+    def test_it_raises_HTTPNotFound_when_the_group_is_not_found(
+        self, pyramid_request, checkpoint_service
+    ):
+        checkpoint_service.upsert.side_effect = GroupNotFoundError("apid")
+        pyramid_request.json_body = {
+            "authority_provided_id": "apid",
+            "document_url": "http://example.com/page",
+        }
+
+        with pytest.raises(HTTPNotFound):
+            upsert(pyramid_request)
+
+    def test_it_raises_when_a_required_field_is_missing(self, pyramid_request):
+        pyramid_request.json_body = {"authority_provided_id": "apid"}
+
+        with pytest.raises(ValidationError):
+            upsert(pyramid_request)
+
+    def test_it_raises_for_an_invalid_json_body(self, pyramid_request):
+        type(pyramid_request).json_body = mock.PropertyMock(side_effect=ValueError())
+
+        with pytest.raises(PayloadError):
+            upsert(pyramid_request)
+
+    @pytest.fixture
+    def checkpoint_service(self, mock_service):
+        service = mock_service(CheckpointService)
+        service.upsert.return_value = mock.Mock(
+            id=123,
+            reveal_date=datetime(2026, 12, 25),  # noqa: DTZ001
+        )
+        return service


### PR DESCRIPTION
Stacked over: https://github.com/hypothesis/h/pull/10130
Stacked under:

Adds the h-side write path for Hide & Reveal checkpoints:

  - POST /api/checkpoints (h/views/api/checkpoints.py). Accepts { authority_provided_id, document_url, reveal_date } and upserts a checkpoint. Restricted to the LMS auth-client via a new Permission.API.CHECKPOINT_UPSERT (same predicate as the
  bulk API).
  - CheckpointService.upsert(...). Resolves the group by (authority, authority_provided_id), find-or-creates the Document
  from its URL, then upserts the root checkpoint for (group_id, document_id, previous_checkpoint_id=NULL), overwriting
  reveal_date.
  - Request schema (h/schemas/api/checkpoint.py), route, and a GroupNotFoundError -> 404 mapping.