### PR TITLE
chore(dependabot): weekly schedule + raise PR limit to 20 (Phase 5)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,15 +2,17 @@ version: 2
 updates:
 - package-ecosystem: "pip"
   directory: "/"
+  open-pull-requests-limit: 20
   schedule:
-    interval: "monthly"
+    interval: "weekly"
     day: "sunday"
     time: "00:00"
     timezone: "Europe/London"
 - package-ecosystem: "npm"
   directory: "/"
+  open-pull-requests-limit: 20
   schedule:
-    interval: "monthly"
+    interval: "weekly"
     day: "sunday"
     time: "00:00"
     timezone: "Europe/London"
@@ -25,8 +27,9 @@ updates:
         - '@vitest/*'
 - package-ecosystem: "docker"
   directory: "/"
+  open-pull-requests-limit: 20
   schedule:
-    interval: "monthly"
+    interval: "weekly"
     day: "sunday"
     time: "00:00"
     timezone: "Europe/London"


### PR DESCRIPTION
## What
Dependabot config tuning for vuln-remediation **Phase 5** (recurrence prevention):

- `schedule: weekly` (was monthly) — surface dependency updates faster.
- `open-pull-requests-limit: 20` on every ecosystem — the default **5** caps *version-update* PRs and queues direct-dep bumps.

## Why
Most overdue Vanta findings are slow-surfacing or capped direct-dep updates. This reduces SLA drift. (Pure-transitive CVEs still need the manual `resolutions`/`pip-compile` sweep — Dependabot can't auto-fix those.)

Opened as **draft**: review + merge when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)