### PR TITLE
test: use >=32-byte HMAC signing keys in JWTService tests (unblocks pyjwt 2.13.0)

### DIFF
--- a/tests/unit/h/services/jwt_test.py
+++ b/tests/unit/h/services/jwt_test.py
@@ -198,7 +198,7 @@ class TestJWTService:
             expires_in=timedelta(hours=1),
             issuer="test_issuer",
             audience="test_audience",
-            _signing_key="invalid_key",
+            _signing_key="a_wrong_signing_key_at_least_32_bytes",
         )
 
         with pytest.raises(JWTDecodeError) as exc_info:
@@ -293,7 +293,7 @@ class TestJWTService:
 
     @pytest.fixture
     def service(self):
-        return JWTService(jwt_signing_key="test_jwt_signing_key")
+        return JWTService(jwt_signing_key="test_jwt_signing_key_at_least_32_bytes")
 
 
 class TestFactory:


### PR DESCRIPTION
**Unblocks the pyjwt 2.13.0 security bump ([#10132](https://github.com/hypothesis/h/pull/10132)).**

pyjwt 2.13.0 adds `InsecureKeyLengthWarning` for HS256 HMAC keys < 32 bytes (RFC 7518 §3.2). `JWTService` tests use `"test_jwt_signing_key"` (20B) and `"invalid_key"` (11B); pytest runs `filterwarnings=error`, so the warning **fails Tests** and blocks #10132.

Lengthens both signing keys to ≥32 bytes. The invalid-key test keeps using a *different* key, so it still exercises the signature-mismatch path. **Version-independent** (passes with the current pyjwt 2.10.1). Production unaffected — the warning is never an error there.

Same root cause + fix as lms [#7394](https://github.com/hypothesis/lms/pull/7394).

🤖 Generated with [Claude Code](https://claude.com/claude-code)