### PR TITLE
[1] HnR: Migrations only

### DIFF
--- a/h/migrations/versions/3794945d8e88_create_the_checkpoint_table.py
+++ b/h/migrations/versions/3794945d8e88_create_the_checkpoint_table.py
@@ -1,0 +1,54 @@
+"""Create the checkpoint table."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "3794945d8e88"
+down_revision = "a1b2c3d4e5f6"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "checkpoint",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("group_id", sa.Integer(), nullable=False),
+        sa.Column("document_id", sa.Integer(), nullable=False),
+        sa.Column("previous_checkpoint_id", sa.Integer(), nullable=True),
+        sa.Column("reveal_date", sa.DateTime(), nullable=True),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["group_id"],
+            ["group.id"],
+            name=op.f("fk__checkpoint__group_id__group"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["document_id"],
+            ["document.id"],
+            name=op.f("fk__checkpoint__document_id__document"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["previous_checkpoint_id"],
+            ["checkpoint.id"],
+            name=op.f("fk__checkpoint__previous_checkpoint_id__checkpoint"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__checkpoint")),
+        sa.UniqueConstraint(
+            "group_id",
+            "document_id",
+            "previous_checkpoint_id",
+            name="uq__checkpoint__group_id__document_id__previous_checkpoint_id",
+            postgresql_nulls_not_distinct=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("checkpoint")

--- a/h/migrations/versions/b6be2385d907_add_the_user_group_lms_role_column.py
+++ b/h/migrations/versions/b6be2385d907_add_the_user_group_lms_role_column.py
@@ -1,0 +1,28 @@
+"""Add the user_group.lms_role column."""
+
+from alembic import op
+from sqlalchemy import CheckConstraint, Column, UnicodeText
+
+revision = "b6be2385d907"
+down_revision = "3794945d8e88"
+
+
+def upgrade():
+    op.add_column(
+        "user_group",
+        Column(
+            "lms_role",
+            UnicodeText,
+            CheckConstraint(
+                " OR ".join(
+                    f"lms_role = '{role}'" for role in ["lms_instructor", "lms_student"]
+                ),
+                name="validate_lms_role",
+            ),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("user_group", "lms_role")


### PR DESCRIPTION
This pull request introduces two database schema migrations. The first migration creates a new `checkpoint` table with relationships to `group`, `document`, and itself (for checkpoint history). The second migration adds an `lms_role` column to the `user_group` table, allowing for role validation. These changes are foundational for supporting checkpoint tracking and user roles within groups.

**Database schema changes:**

* Created the `checkpoint` table with foreign keys to `group`, `document`, and itself (`previous_checkpoint_id`), supporting checkpoint history and cascade deletes. Includes unique and primary key constraints.
* Added the `lms_role` column to the `user_group` table, with a check constraint to allow only `"lms_instructor"` or `"lms_student"` values.