### PR TITLE
Add separate nginx rate limit zone for service traffic and fix local timezone

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -38,7 +38,7 @@ http {
   # the per-user zone it collapses into a single 4r/s bucket.
   map $http_hypothesis_application $limit_per_service {
     ""      "";               # not app traffic: not counted in svc zone
-    default $http_authorization;
+    default $limit_per_user;  # IP-fallback key: no-auth app requests still limited
   }
   map $http_hypothesis_application $limit_per_user_final {
     ""      $limit_per_user;  # normal users: existing behavior

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -31,11 +31,30 @@ http {
     default $http_authorization;
   }
 
+  # Requests from our own applications (LMS sends
+  # "Hypothesis-Application: lms" on every request) get their own,
+  # higher rate limit bucket instead of sharing the per-user one:
+  # all LMS traffic carries the same Authorization header, so under
+  # the per-user zone it collapses into a single 4r/s bucket.
+  map $http_hypothesis_application $limit_per_service {
+    ""      "";               # not app traffic: not counted in svc zone
+    default $http_authorization;
+  }
+  map $http_hypothesis_application $limit_per_user_final {
+    ""      $limit_per_user;  # normal users: existing behavior
+    default "";               # app traffic: not counted in user zone
+  }
+
   # 1m stands for 1 megabyte so the zone can store ~8k users.
-  limit_req_zone $limit_per_user zone=badge_user_limit:1m rate=1r/s;
-  limit_req_zone $limit_per_user zone=assets_user_limit:1m rate=20r/s;
-  limit_req_zone $limit_per_user zone=create_ann_user_limit:1m rate=4r/s;
-  limit_req_zone $limit_per_user zone=user_limit:1m rate=4r/s;
+  # Only user_limit uses the _final key: its locations also carry the
+  # svc_limit directive, so app traffic stays capped there. The badge
+  # and annotation-creation locations have no svc_limit line, so keying
+  # them on _final would let a spoofed header bypass them entirely.
+  limit_req_zone $limit_per_user       zone=badge_user_limit:1m rate=1r/s;
+  limit_req_zone $limit_per_user       zone=assets_user_limit:1m rate=20r/s;
+  limit_req_zone $limit_per_user       zone=create_ann_user_limit:1m rate=4r/s;
+  limit_req_zone $limit_per_user_final zone=user_limit:1m rate=4r/s;
+  limit_req_zone $limit_per_service    zone=svc_limit:1m rate=50r/s;
   limit_req_status 429;
 
   # We set fail_timeout=0 so that the upstream isn't marked as down if a single
@@ -121,6 +140,7 @@ http {
 
       location /api {
         limit_req zone=user_limit burst=44 nodelay;
+        limit_req zone=svc_limit burst=100 nodelay;
         error_page 429 @api_error_429;
 
         proxy_pass http://web;
@@ -129,6 +149,7 @@ http {
       # An overall rate limit was chosen to allow reasonable usage while
       # preventing a single user from causing service disruption.
       limit_req zone=user_limit burst=44 nodelay;
+      limit_req zone=svc_limit burst=100 nodelay;
     }
   }
 

--- a/h/views/api/bulk/checkpoint.py
+++ b/h/views/api/bulk/checkpoint.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 
 from importlib_resources import files
 from pyramid.response import Response
@@ -19,8 +19,11 @@ def _is_revealed(checkpoint):
 
 
 def _reveal_date_isoformat(checkpoint):
+    # reveal_date is stored naive-UTC; emit it timezone-aware so the LMS
+    # frontend parses it as UTC and renders it in each viewer's local time
+    # (a naive string is misread as local time by JS `new Date`).
     if checkpoint and checkpoint.reveal_date:
-        return checkpoint.reveal_date.isoformat()
+        return checkpoint.reveal_date.replace(tzinfo=UTC).isoformat()
     return None
 
 

--- a/tests/unit/h/views/api/bulk/checkpoint_test.py
+++ b/tests/unit/h/views/api/bulk/checkpoint_test.py
@@ -158,7 +158,7 @@ class TestUpsertCheckpoints:
                 "document_uri": "http://example.com/1",
                 "created": True,
                 "revealed": True,
-                "reveal_date": "2020-01-01T10:00:00",
+                "reveal_date": "2020-01-01T10:00:00+00:00",
             },
         ]
 


### PR DESCRIPTION
This pull request introduces important improvements to both the Nginx configuration and the LMS checkpoint API. The main focus is on refining rate limiting to better handle traffic from LMS applications and ensuring that reveal dates are timezone-aware for correct frontend rendering.

**Nginx rate limiting improvements:**

* Added new maps and rate limit zones in `nginx.conf` to separate LMS application traffic (identified by the `Hypothesis-Application` header) from regular user traffic, preventing LMS traffic from being bottlenecked by per-user limits and assigning it a higher rate limit bucket.
* Updated the `/api` location and relevant endpoints to apply both the per-user (`user_limit`) and new per-service (`svc_limit`) rate limiting, ensuring both user and application traffic are appropriately capped. [[1]](diffhunk://#diff-8e371ad49c2a106a2f6b14d3cb01445c4f7d5c3694f50892d95932b48f42671cR143) [[2]](diffhunk://#diff-8e371ad49c2a106a2f6b14d3cb01445c4f7d5c3694f50892d95932b48f42671cR152)

**LMS checkpoint API improvements:**

* Changed the `_reveal_date_isoformat` function in `checkpoint.py` to emit timezone-aware UTC datetimes, ensuring the LMS frontend parses reveal dates as UTC and displays them correctly for all users. [[1]](diffhunk://#diff-8a7d11c67041b44374e68965941ba6bf8b663780f6632594da9a59767a3fb94eL2-R2) [[2]](diffhunk://#diff-8a7d11c67041b44374e68965941ba6bf8b663780f6632594da9a59767a3fb94eR22-R26)
* Updated the corresponding unit test to expect the new timezone-aware format for `reveal_date`.## Problem

All LMS traffic reaches h with the same `Authorization` header, so under the per-user `user_limit` zone it collapses into a single 4 r/s bucket shared by every LMS user.

## Change

Requests that carry a `Hypothesis-Application` header (LMS sends `Hypothesis-Application: lms` on every request) get their own rate limit zone — `svc_limit`, 50 r/s with burst 100 — instead of sharing the per-user one.

How it works: nginx skips rate-limit accounting when a zone's key is empty. Two maps split traffic on the `Hypothesis-Application` header:

- App requests get an **empty** key in `user_limit` and a **real** key (the `Authorization` header) in `svc_limit` → 50 r/s, burst 100, still capped if something loops.
- Everyone else keeps the exact existing behavior (empty key in `svc_limit`, existing key everywhere else).

Only `user_limit` switches to the header-aware key. `badge_user_limit`, `create_ann_user_limit`, and `assets_user_limit` keep the original per-user key on purpose: nginx only applies the `limit_req` directives of the most-specific matched location, and those locations carry no `svc_limit` directive — an empty key there would mean **no limit at all**, letting anyone bypass the badge and annotation-creation limits with a spoofed header. The LMS doesn't call those endpoints, so app traffic loses nothing.

## Caveats

- The `Hypothesis-Application` header is client-settable, so a third-party API client could opt into the 50 r/s bucket on `/api`. This is a limit **raise**, not a bypass — which is why app traffic is still rate limited rather than fully exempted.
- When multiple `limit_req` directives are in one location, nginx applies the most restrictive matching zone. That's fine here because each request only has a non-empty key in one of them.

## Testing

- `docker run --rm -v $(pwd)/conf/nginx.conf:/etc/nginx/nginx.conf nginx nginx -t` passes (syntax ok; full test passes once the pid directory exists, which is an artifact of the stock image, not this config).
- Staging validation still to do:
  - Hammer `/api/bulk` with the LMS's `Authorization` + `Hypothesis-Application: lms` headers past 4 r/s and confirm no 429 until ~50 r/s.
  - The same rate without the app header should still 429 at the old threshold.
  - `POST /api/annotations` with a spoofed `Hypothesis-Application` header should still 429 at 4 r/s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)