### PR TITLE
fix(search): bound Hide and Reveal's Elasticsearch clause count

### DIFF
--- a/h/search/query.py
+++ b/h/search/query.py
@@ -288,11 +288,14 @@ class HideRevealFilter:
         return search
 
     def _hidden_query(self, scope):
+        scope_keys = self.checkpoint_service.scope_keys(
+            scope.group_pubid, scope.document_id
+        )
         in_scope = Q(
             "bool",
             must=[
                 Q("term", group=scope.group_pubid),
-                Q("bool", should=self._uri_queries(scope.uris), minimum_should_match=1),
+                Q("terms", **{"target.scope": scope_keys}),
             ],
         )
 
@@ -317,14 +320,6 @@ class HideRevealFilter:
 
         # Hide annotations that are in scope but not in the visible set.
         return Q("bool", must=[in_scope], must_not=[visible])
-
-    @staticmethod
-    def _uri_queries(uris):
-        queries = []
-        for normalized in uris:
-            queries.append(Q("term", **{"target.scope": normalized}))
-            queries.append(Q("wildcard", **{"target.scope": f"{normalized}__v*"}))
-        return queries
 
 
 class UriCombinedWildcardFilter:

--- a/h/services/checkpoint.py
+++ b/h/services/checkpoint.py
@@ -15,6 +15,7 @@ from h.models import (
     User,
 )
 from h.models.group import LMSRole
+from h.util.uri import build_scope_key
 
 
 @dataclass
@@ -23,7 +24,6 @@ class HiddenScope:
 
     group_pubid: str
     document_id: int
-    uris: list[str]
     instructor_userids: list[str]
     own_annotation_ids: list[str]
 
@@ -266,14 +266,49 @@ class CheckpointService:
         self.db.flush()
         return checkpoint
 
+    def scope_keys(self, group_pubid: str, document_id: int) -> list[str]:
+        """
+        Return every `target.scope` value an in-scope annotation can carry.
+
+        An annotation indexes a single scope key: its normalized target URI,
+        suffixed with `__v<version>` when it annotates a specific document
+        version (see `build_scope_key`). Enumerating them all lets the search
+        filter match with one `terms` clause, which costs one clause against
+        Elasticsearch's 1024-clause budget however many URIs it holds. Matching
+        a wildcard per URI instead exhausts that budget on a document that has
+        accumulated many URIs, and Elasticsearch then rejects the whole query.
+
+        Versions are looked up within `group_pubid`: the filter only ever
+        matches annotations in that group, so a version used nowhere in it
+        cannot match, and `annotation.groupid` is indexed where
+        `annotation.document_id` is not.
+        """
+        # Distinct: a document has one document_uri row per (uri, type,
+        # content_type), so the same uri_normalized repeats many times over.
+        uris = self.db.scalars(
+            select(DocumentURI.uri_normalized)
+            .where(DocumentURI.document_id == document_id)
+            .distinct()
+        ).all()
+
+        versions = self.db.scalars(
+            select(Annotation.version)
+            .where(Annotation.groupid == group_pubid)
+            .where(Annotation.document_id == document_id)
+            .where(Annotation.version.is_not(None))
+            .distinct()
+        ).all()
+
+        keys = [
+            build_scope_key(uri_normalized, version)
+            for uri_normalized in uris
+            for version in [None, *versions]
+        ]
+        # build_scope_key(uri, 0) is just uri, so versions can collide.
+        return list(dict.fromkeys(keys))
+
     def _hidden_scope(self, user: User, checkpoint: Checkpoint) -> HiddenScope:
         group_pubid = checkpoint.group.pubid
-
-        uris = self.db.scalars(
-            select(DocumentURI.uri_normalized).where(
-                DocumentURI.document_id == checkpoint.document_id
-            )
-        ).all()
 
         # User.userid is a hybrid that compiles to a tuple, so it can't be
         # SELECTed directly: load the users and read it in Python.
@@ -294,7 +329,6 @@ class CheckpointService:
         return HiddenScope(
             group_pubid=group_pubid,
             document_id=checkpoint.document_id,
-            uris=list(uris),
             instructor_userids=instructor_userids,
             own_annotation_ids=list(own_annotation_ids),
         )

--- a/tests/unit/h/search/query_test.py
+++ b/tests/unit/h/search/query_test.py
@@ -1233,6 +1233,40 @@ class TestHideRevealFilter:
 
         assert peer.id in result.annotation_ids
 
+    def test_a_student_search_survives_a_document_with_many_uris(
+        self, search, factories, document, make_own
+    ):
+        # A long-lived document (e.g. a heavily annotated page, or a PDF that
+        # has been merged by fingerprint) accumulates many document_uri rows.
+        # The scope must cost a bounded number of Elasticsearch clauses, or the
+        # whole query is rejected and the student's search 500s.
+        for i in range(1200):
+            factories.DocumentURI(document=document, uri=f"http://example.com/p{i}")
+
+        own = make_own()
+
+        result = search.run(MultiDict({}))
+
+        assert own.id in result.annotation_ids
+
+    def test_it_hides_a_peers_versioned_annotation(
+        self, search, factories, index_annotations, group, other_student
+    ):
+        # An annotation on a specific document version indexes its scope as
+        # `<uri>__v<version>`, and must still be hidden from a peer.
+        peer = factories.Annotation(
+            userid=other_student.userid,
+            groupid=group.pubid,
+            target_uri="http://example.com/page",
+            shared=True,
+            version=2,
+        )
+        index_annotations(peer)
+
+        result = search.run(MultiDict({}))
+
+        assert peer.id not in result.annotation_ids
+
     def membership(self, db_session, group, user, lms_role):
         db_session.add(GroupMembership(user=user, group=group, lms_role=lms_role.value))
         db_session.flush()

--- a/tests/unit/h/services/checkpoint_test.py
+++ b/tests/unit/h/services/checkpoint_test.py
@@ -84,6 +84,60 @@ class TestActiveCheckpoint:
         return document
 
 
+class TestScopeKeys:
+    def test_it_returns_the_normalized_uris(self, svc, group, document):
+        assert svc.scope_keys(group.pubid, document.id) == [
+            uri_normalize("http://example.com/page")
+        ]
+
+    def test_it_expands_the_versions_used_in_the_group(
+        self, svc, group, document, annotation
+    ):
+        annotation(groupid=group.pubid, version=2)
+
+        uri = uri_normalize("http://example.com/page")
+        assert svc.scope_keys(group.pubid, document.id) == [uri, f"{uri}__v2"]
+
+    def test_it_ignores_versions_used_only_in_other_groups(
+        self, svc, group, document, factories, annotation
+    ):
+        annotation(groupid=factories.Group().pubid, version=2)
+
+        assert svc.scope_keys(group.pubid, document.id) == [
+            uri_normalize("http://example.com/page")
+        ]
+
+    def test_it_returns_empty_for_a_document_with_no_uris(self, svc, group, factories):
+        # An empty `terms` clause matches nothing, so such a checkpoint hides
+        # nothing rather than hiding the whole group.
+        assert svc.scope_keys(group.pubid, factories.Document().id) == []
+
+    @pytest.fixture
+    def group(self, factories):
+        return factories.Group()
+
+    @pytest.fixture
+    def document(self, factories, db_session):
+        document = factories.Document()
+        factories.DocumentURI(document=document, uri="http://example.com/page")
+        db_session.flush()
+        return document
+
+    @pytest.fixture
+    def annotation(self, factories, db_session, document):
+        def annotation(groupid, version):
+            # The Annotation factory resolves its own Document from target_uri,
+            # so re-point the relationship (not the FK, which the relationship
+            # would overwrite on flush) at the checkpoint's document.
+            annotation = factories.Annotation(groupid=groupid)
+            annotation.document = document
+            annotation.version = version
+            db_session.flush()
+            return annotation
+
+        return annotation
+
+
 class TestHiddenScopes:
     def test_it_returns_empty_for_a_none_user(self, svc):
         assert svc.hidden_scopes(None) == []
@@ -104,12 +158,11 @@ class TestHiddenScopes:
         assert svc.hidden_scopes(user) == []
 
     @pytest.mark.usefixtures("active_checkpoint", "student_membership")
-    def test_it_returns_a_scope_for_a_student(self, svc, user, group):
+    def test_it_returns_a_scope_for_a_student(self, svc, user, group, document):
         [scope] = svc.hidden_scopes(user)
 
         assert scope.group_pubid == group.pubid
-        # The scope carries the normalized URIs, matching ES `target.scope`.
-        assert scope.uris == [uri_normalize("http://example.com/page")]
+        assert scope.document_id == document.id
 
     @pytest.mark.usefixtures("active_checkpoint", "null_role_membership")
     def test_it_restricts_members_with_no_lms_role(self, svc, user):


### PR DESCRIPTION
This pull request refactors how annotation "scope" is calculated and filtered for hidden annotations, improving performance and reliability for documents with many URIs and supporting versioned annotations. Instead of matching with multiple wildcard queries (which could hit Elasticsearch's clause limit), the code now computes all possible scope keys (URIs and their versions) and matches them with a single `terms` clause. This change is accompanied by new and updated tests to ensure correctness and edge case coverage.

**Search query and scope calculation improvements:**

* Replaced the `_uri_queries` method and its usage with a single `terms` clause in the search filter, using precomputed scope keys to avoid exceeding Elasticsearch's clause limit on documents with many URIs. [[1]](diffhunk://#diff-59b54a8647ab52f5ab52fe63c876be35e5893da6296bb45854cefa103b1e7928R291-R298) [[2]](diffhunk://#diff-59b54a8647ab52f5ab52fe63c876be35e5893da6296bb45854cefa103b1e7928L321-L328)
* Added the `scope_keys` method to `CheckpointService`, which returns all possible `target.scope` values (including versioned keys) relevant to a group and document. This ensures efficient and correct filtering, even for versioned annotations.
* Updated the `HiddenScope` dataclass to remove the `uris` field, as scope keys are now computed dynamically. [[1]](diffhunk://#diff-5f193cc4426179766b196f9b1ad80a0d5c4e30ccb6c810ed0a1d1e685e5349b0L26) [[2]](diffhunk://#diff-5f193cc4426179766b196f9b1ad80a0d5c4e30ccb6c810ed0a1d1e685e5349b0L297)

**Test coverage enhancements:**

* Added comprehensive tests for the new `scope_keys` logic, including handling of many URIs, versioned annotations, group isolation, and empty documents.
* Updated search and checkpoint tests to reflect the new scope calculation and ensure correct hiding/revealing of annotations in various scenarios, including documents with many URIs and versioned annotations. [[1]](diffhunk://#diff-de14a3e5d38df4364fd1f009a5a132e7e24cf291ef3ba6f3d0ad1bd3bb588239R1236-R1269) [[2]](diffhunk://#diff-0b8b4bab7cd175e51f934ce06521c927947cac789b5df70aa7e4ccbf191dd5c3L107-R165)

**Dependency and import updates:**

* Added import of `build_scope_key` utility for constructing scope keys.