### PR TITLE
Exempt dependency/security PRs from the stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,3 +14,5 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           days-before-stale: 30
           days-before-close: 5
+          exempt-pr-labels: 'dependencies,security'
+          exempt-issue-labels: 'dependencies,security'


### PR DESCRIPTION
The stale bot has been closing **green Dependabot security PRs** unmerged since 2026-07-03 — and Dependabot then mutes the closed version ("OK, I won't notify you again about this release"), so the fix silently disappears until the next upstream release. Lost so far across lms/h/client: cryptography→48.0.1, mako→1.3.12, pyjwt, starlette, tornado, webob, idna, postcss bumps — all of which now require manual PRs.

This exempts anything labeled `dependencies` (every Dependabot PR) or `security` from the stale/close cycle. Context: `deployment/upgrades/vuln-remediation-2026-05/STATUS-2026-07-28.md` (Tier 5, process fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)