### PR TITLE
[HnR-Autograder:1] Due date

### DIFF
--- a/h/services/bulk_api/lms_stats.py
+++ b/h/services/bulk_api/lms_stats.py
@@ -37,6 +37,7 @@ class BulkLMSStatsService:
         groups: list[str],
         h_userids: list[str] | None = None,
         assignment_ids: list[str] | None = None,
+        due_date: datetime | None = None,
     ):
         query = (
             select(
@@ -89,6 +90,11 @@ class BulkLMSStatsService:
                 func.concat("acct:", User.username, "@", User.authority).in_(h_userids)
             )
 
+        if due_date:
+            # Inclusive: a due date is the last moment that counts, not the
+            # first that doesn't.
+            query = query.where(AnnotationSlim.created <= due_date)
+
         return query
 
     def _count_columns(self, counts_query) -> tuple:
@@ -111,6 +117,7 @@ class BulkLMSStatsService:
         group_by: CountsGroupBy,
         h_userids: list[str] | None = None,
         assignment_ids: list[str] | None = None,
+        due_date: datetime | None = None,
     ) -> list[AnnotationCounts]:
         """
         Get basic stats per user for an LMS assignment.
@@ -119,9 +126,15 @@ class BulkLMSStatsService:
         :param group_by: By which column to aggregate the data.
         :param h_userids: List of User.userid to filter annotations by
         :param assignment_ids: ID of the assignment to filter annotations by
+        :param due_date: Count only annotations created at or before this,
+            naive UTC. Annotations made after an assignment's due date exist and
+            stay visible, they just don't count towards its grade.
         """
         annos_query = self._annotation_query(
-            groups, h_userids=h_userids, assignment_ids=assignment_ids
+            groups,
+            h_userids=h_userids,
+            assignment_ids=assignment_ids,
+            due_date=due_date,
         ).cte("annotations")
 
         # Alias some columns

--- a/h/views/api/bulk/annotation_counts.json
+++ b/h/views/api/bulk/annotation_counts.json
@@ -40,6 +40,18 @@
               "type": "null"
             }
           ]
+        },
+        "due_date": {
+          "description": "Count only annotations created at or before this. Optional: without it every annotation counts, which is the behaviour of every caller that predates it.",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date-time"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [

--- a/h/views/api/bulk/stats.py
+++ b/h/views/api/bulk/stats.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime
 
 from importlib_resources import files
 from pyramid.response import Response
@@ -13,6 +14,18 @@ class AssignmentStatsSchema(JSONSchema):
     _SCHEMA_FILE = files("h.views.api.bulk") / "annotation_counts.json"
     schema_version = 7
     schema = json.loads(_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+def _parse_due_date(due_date: str | None) -> datetime | None:
+    """Normalise an ISO due date to the naive UTC the DB stores.
+
+    The schema's date-time format requires an offset, so there is no local time
+    to guess at here.
+    """
+    if not due_date:
+        return None
+
+    return datetime.fromisoformat(due_date).astimezone(UTC).replace(tzinfo=None)
 
 
 @api_config(
@@ -33,6 +46,7 @@ def get_annotation_counts(request):
         groups=query_filter["groups"],
         assignment_ids=query_filter.get("assignment_ids"),
         h_userids=query_filter.get("h_userids"),
+        due_date=_parse_due_date(query_filter.get("due_date")),
     )
 
     return Response(

--- a/tests/unit/h/services/bulk_api/lms_stats_test.py
+++ b/tests/unit/h/services/bulk_api/lms_stats_test.py
@@ -1,4 +1,5 @@
-from unittest.mock import sentinel  # noqa: INP001
+from datetime import datetime, timedelta  # noqa: INP001
+from unittest.mock import sentinel
 
 import pytest
 
@@ -8,6 +9,8 @@ from h.services.bulk_api.lms_stats import (
     CountsGroupBy,
     service_factory,
 )
+
+DUE_DATE = datetime(2026, 4, 5, 23, 59)  # noqa: DTZ001
 
 
 class TestBulkLMSStatsService:
@@ -103,6 +106,90 @@ class TestBulkLMSStatsService:
                 last_activity=annotation_reply.created,
             ),
         ]
+
+    def test_get_annotation_counts_filter_by_due_date(
+        self, svc, group, user, early_annotation, late_annotation
+    ):
+        stats = svc.get_annotation_counts(
+            groups=[group.authority_provided_id],
+            assignment_ids=["ASSIGNMENT_ID"],
+            group_by=CountsGroupBy.USER,
+            due_date=DUE_DATE,
+        )
+
+        # The late annotation still exists, it just doesn't count.
+        assert late_annotation.created > DUE_DATE
+        assert stats == [
+            AnnotationCounts(
+                userid=user.userid,
+                display_name=user.display_name,
+                annotations=1,
+                replies=0,
+                page_notes=0,
+                last_activity=early_annotation.created,
+            )
+        ]
+
+    @pytest.mark.usefixtures("early_annotation", "late_annotation")
+    def test_get_annotation_counts_counts_everything_without_a_due_date(
+        self, svc, group
+    ):
+        stats = svc.get_annotation_counts(
+            groups=[group.authority_provided_id],
+            assignment_ids=["ASSIGNMENT_ID"],
+            group_by=CountsGroupBy.ASSIGNMENT,
+        )
+
+        assert stats[0].annotations == 2
+
+    def test_get_annotation_counts_counts_an_annotation_made_on_the_due_date(
+        self, svc, group, on_time_annotation
+    ):
+        assert on_time_annotation.created == DUE_DATE
+
+        stats = svc.get_annotation_counts(
+            groups=[group.authority_provided_id],
+            assignment_ids=["ASSIGNMENT_ID"],
+            group_by=CountsGroupBy.ASSIGNMENT,
+            due_date=DUE_DATE,
+        )
+
+        assert stats[0].annotations == 1
+
+    @pytest.fixture
+    def early_annotation(self, factories, user, group):
+        return self._assignment_annotation(
+            factories, user, group, created=DUE_DATE - timedelta(days=1)
+        )
+
+    @pytest.fixture
+    def late_annotation(self, factories, user, group):
+        return self._assignment_annotation(
+            factories, user, group, created=DUE_DATE + timedelta(days=1)
+        )
+
+    @pytest.fixture
+    def on_time_annotation(self, factories, user, group):
+        return self._assignment_annotation(factories, user, group, created=DUE_DATE)
+
+    @staticmethod
+    def _assignment_annotation(factories, user, group, created):
+        anno = factories.Annotation(group=group)
+        anno_slim = factories.AnnotationSlim(
+            annotation=anno,
+            user=user,
+            deleted=False,
+            shared=True,
+            moderated=False,
+            group=group,
+            created=created,
+        )
+        factories.AnnotationMetadata(
+            annotation_slim=anno_slim,
+            data={"lms": {"assignment": {"resource_link_id": "ASSIGNMENT_ID"}}},
+        )
+
+        return anno_slim
 
     @pytest.fixture
     def group(self, factories):

--- a/tests/unit/h/views/api/bulk/stats_test.py
+++ b/tests/unit/h/views/api/bulk/stats_test.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytest
 
+from h.schemas.base import ValidationError
 from h.services.bulk_api.lms_stats import AnnotationCounts, CountsGroupBy
 from h.views.api.bulk.stats import AssignmentStatsSchema, get_annotation_counts
 
@@ -41,6 +42,7 @@ class TestBulkGroup:
             groups=assignment_request["filter"]["groups"],
             assignment_ids=assignment_request["filter"]["assignment_ids"],
             h_userids=assignment_request["filter"]["h_userids"],
+            due_date=None,
         )
         return_data = [
             {
@@ -57,6 +59,47 @@ class TestBulkGroup:
         assert response.json == return_data
         assert response.status_code == 200
         assert response.content_type == "application/x-ndjson"
+
+    @pytest.mark.parametrize(
+        ("due_date", "expected"),
+        [
+            # Offset-aware dates are normalised to the naive UTC the DB stores.
+            ("2026-04-05T23:59:00+00:00", datetime(2026, 4, 5, 23, 59)),  # noqa: DTZ001
+            ("2026-04-05T20:59:00-03:00", datetime(2026, 4, 5, 23, 59)),  # noqa: DTZ001
+            # What the LMS actually sends: JS toISOString().
+            (
+                "2026-04-05T23:59:00.000Z",
+                datetime(2026, 4, 5, 23, 59),  # noqa: DTZ001
+            ),
+            (None, None),
+        ],
+    )
+    def test_get_annotation_counts_passes_the_due_date(
+        self,
+        pyramid_request,
+        assignment_request,
+        bulk_stats_service,
+        due_date,
+        expected,
+    ):
+        assignment_request["filter"]["due_date"] = due_date
+        bulk_stats_service.get_annotation_counts.return_value = []
+
+        get_annotation_counts(pyramid_request)
+
+        assert (
+            bulk_stats_service.get_annotation_counts.call_args.kwargs["due_date"]
+            == expected
+        )
+
+    def test_get_annotation_counts_rejects_a_due_date_without_an_offset(
+        self, pyramid_request, assignment_request
+    ):
+        # An offset is required so there is never a local time to guess at.
+        assignment_request["filter"]["due_date"] = "2026-04-05T23:59:00"
+
+        with pytest.raises(ValidationError):
+            get_annotation_counts(pyramid_request)
 
     @pytest.fixture
     def assignment_request(self, pyramid_request):


### PR DESCRIPTION
This pull request adds support for filtering LMS assignment annotation statistics by a due date, ensuring only annotations created on or before a specified due date are counted. It introduces a new optional `due_date` parameter throughout the API, updates the schema and logic to handle it, and adds comprehensive tests for the new behavior.

**Due Date Filtering Support:**

* Added an optional `due_date` parameter to the annotation query logic in `BulkLMSStatsService` and its `_annotation_query` method, filtering results to include only annotations created at or before the specified due date. [[1]](diffhunk://#diff-12905d7386c30565f8190e0eb172dc01d28fe481a0b981b0d3e82eb49a3b5b61R40) [[2]](diffhunk://#diff-12905d7386c30565f8190e0eb172dc01d28fe481a0b981b0d3e82eb49a3b5b61R93-R97) [[3]](diffhunk://#diff-12905d7386c30565f8190e0eb172dc01d28fe481a0b981b0d3e82eb49a3b5b61R120) [[4]](diffhunk://#diff-12905d7386c30565f8190e0eb172dc01d28fe481a0b981b0d3e82eb49a3b5b61R129-R137)
* Updated the API schema (`annotation_counts.json`) to document and accept the new `due_date` parameter as an optional ISO 8601 date-time string.

**API and Data Normalization:**

* Implemented `_parse_due_date` in the API view to normalize incoming due dates to naive UTC datetimes, matching database storage, and integrated this into the `get_annotation_counts` endpoint. [[1]](diffhunk://#diff-78235c444d1dab447fc82e4a6594b0a30fc297b3320a5fe88448dbece95622e8R2) [[2]](diffhunk://#diff-78235c444d1dab447fc82e4a6594b0a30fc297b3320a5fe88448dbece95622e8R19-R30) [[3]](diffhunk://#diff-78235c444d1dab447fc82e4a6594b0a30fc297b3320a5fe88448dbece95622e8R49)

**Testing Enhancements:**

* Added unit tests to verify due date filtering, including edge cases (annotations before, on, and after the due date), and confirmed that the API rejects due dates without timezone offsets. [[1]](diffhunk://#diff-afc9513099f979b65c0b3aceed3b81358f52a210515c14366d0a4d88169e649fL1-R2) [[2]](diffhunk://#diff-afc9513099f979b65c0b3aceed3b81358f52a210515c14366d0a4d88169e649fR13-R14) [[3]](diffhunk://#diff-afc9513099f979b65c0b3aceed3b81358f52a210515c14366d0a4d88169e649fR110-R193) [[4]](diffhunk://#diff-4c1135726dd6c9aea1cae034bdebd38c5a975470ab70f350804c11e327bde37cR5) [[5]](diffhunk://#diff-4c1135726dd6c9aea1cae034bdebd38c5a975470ab70f350804c11e327bde37cR45) [[6]](diffhunk://#diff-4c1135726dd6c9aea1cae034bdebd38c5a975470ab70f350804c11e327bde37cR63-R103)